### PR TITLE
Add native Windows port with NSIS installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Roux lets you run multiple Claude Code sessions side-by-side with split panes, s
 - **Split panes** -- Horizontal and vertical splits with same-direction flattening
 - **Stacked panes** -- Zellij-style tab stacking where collapsed title bars show inactive panes
 - **Shell terminals** -- Open shell panes alongside Claude for running commands
-- **Command palette** -- Quick access to all actions via `cmd+k`
+- **Command palette** -- Quick access to all actions via the primary shortcut (`cmd+k` on macOS, `ctrl+k` on Windows/Linux)
 - **Layout persistence** -- Pane layouts survive app restarts; shell panes respawn automatically
 - **Themes** -- Multiple built-in color schemes
 - **Projects** -- Tag sessions with projects to organize related work across repos and worktrees
@@ -20,7 +20,7 @@ Roux lets you run multiple Claude Code sessions side-by-side with split panes, s
 - **Command panes** -- Run shell commands in dedicated panes with rerun support
 - **Task runner** -- Run predefined commands from configuration files
 - **Document viewer** -- Open markdown files in dedicated panes
-- **CLI** -- `roux-cli` for scripting: split panes, create sessions, run commands, send text, and focus panes from the terminal via Unix socket
+- **CLI** -- `roux-cli` for scripting: split panes, create sessions, run commands, send text, and focus panes from the terminal via the local Roux command channel
 
 ## Keybindings
 
@@ -55,10 +55,21 @@ task dev
 ### Tests
 
 ```bash
-npm run test          # run once
-npm run test:watch    # watch mode
+task test             # full frontend + Rust gate
+npm run test          # frontend tests only
+npm run test:watch    # frontend watch mode
 npm run check         # svelte type check
 ```
+
+### Windows
+
+Native Windows x64 builds are supported with a per-user NSIS installer:
+
+```powershell
+task windows:build
+```
+
+See [docs/windows-build.md](docs/windows-build.md) for prerequisites and runtime notes.
 
 ## Release
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -28,14 +28,18 @@ tasks:
         fi
 
   cli:install:
-    desc: "Build and install roux-cli to ~/.local/bin"
+    desc: "Build and prepare roux-cli for local development"
     cmds:
-      - cd src-tauri && cargo build --bin roux-cli
-      - |
-        mkdir -p ~/.local/bin
-        cp src-tauri/target/debug/roux-cli ~/.local/bin/roux-cli
-        chmod +x ~/.local/bin/roux-cli
-        echo "Installed roux-cli to ~/.local/bin/roux-cli"
+      - cargo build --manifest-path src-tauri/Cargo.toml --bin roux-cli
+      - cmd: |
+          cmd /c echo Built src-tauri\target\debug\roux-cli.exe for Windows dev use
+        platforms: [windows]
+      - cmd: |
+          mkdir -p ~/.local/bin
+          cp src-tauri/target/debug/roux-cli ~/.local/bin/roux-cli
+          chmod +x ~/.local/bin/roux-cli
+          echo "Installed roux-cli to ~/.local/bin/roux-cli"
+        platforms: [darwin, linux]
 
   dev:install:
     desc: "Build and install the desktop app and CLI locally"
@@ -55,7 +59,7 @@ tasks:
   build:
     desc: "Build the app for production"
     cmds:
-      - task: macos:prepare-cli
+      - task: bundle:prepare-cli
       - npm run tauri build
 
   build:frontend:
@@ -142,8 +146,33 @@ tasks:
   clean:status:
     desc: "Clear all session status files"
     cmds:
-      - rm -f ~/.config/roux/status/*.json
-      - echo "Cleared status files"
+      - cmd: |
+          cmd /c "set DIR=%APPDATA%\roux\status && if exist \"%DIR%\" del /Q \"%DIR%\*.json\" 2>nul & echo Cleared status files"
+        platforms: [windows]
+      - cmd: |
+          rm -f ~/.config/roux/status/*.json
+          echo "Cleared status files"
+        platforms: [darwin, linux]
+
+  bundle:prepare-cli:
+    desc: "Build roux-cli and stage it for bundling"
+    cmds:
+      - cargo build --manifest-path src-tauri/Cargo.toml --release --bin roux-cli
+      - cmd: |
+          cmd /c "if not exist src-tauri\binaries mkdir src-tauri\binaries && copy /Y src-tauri\target\release\roux-cli.exe src-tauri\binaries\roux-cli.exe >nul && echo Prepared bundled roux-cli.exe"
+        platforms: [windows]
+      - cmd: |
+          mkdir -p src-tauri/binaries
+          cp src-tauri/target/release/roux-cli src-tauri/binaries/roux-cli
+          chmod +x src-tauri/binaries/roux-cli
+          echo "Prepared bundled roux-cli"
+        platforms: [darwin, linux]
+
+  windows:build:
+    desc: "Build the Windows NSIS installer"
+    cmds:
+      - task: bundle:prepare-cli
+      - npm run tauri build -- --bundles nsis
 
   macos:prepare-cli:
     desc: "Build roux-cli and stage it for macOS bundling"

--- a/docs/windows-build.md
+++ b/docs/windows-build.md
@@ -1,0 +1,62 @@
+# Windows build
+
+Roux supports native Windows x64 local builds with an unsigned per-user NSIS installer.
+
+## Prerequisites
+
+- Windows x64.
+- Native Claude Code CLI installed for Windows and available as `claude` or `claude.exe`.
+- Git for Windows.
+- Node.js/npm.
+- Rust with the `x86_64-pc-windows-msvc` toolchain.
+- Go Task.
+- Optional: PowerShell 7 (`pwsh`). Roux falls back to Windows PowerShell and then `cmd.exe`.
+
+WSL session mode, ARM64 Windows, auto-update, code signing, and Windows `nono` profile support are not part of the first Windows milestone.
+
+## Development
+
+Install dependencies and run the app:
+
+```powershell
+npm install
+task dev
+```
+
+Run the full local test gate:
+
+```powershell
+task test
+```
+
+The Taskfile stages the internal `roux-cli.exe` sidecar before Tauri dev/build runs.
+
+## Installer
+
+Build the unsigned NSIS installer:
+
+```powershell
+task windows:build
+```
+
+The installer is written under:
+
+```text
+src-tauri\target\release\bundle\nsis\
+```
+
+The generated artifact is named with the app version and target architecture:
+
+```text
+src-tauri\target\release\bundle\nsis\Roux_<version>_x64-setup.exe
+```
+
+The NSIS installer uses Tauri's `currentUser` install mode, so it installs per user and does not require machine-wide installation by default.
+
+## Runtime Notes
+
+- `roux-cli.exe` is bundled internally and is not added to the user's `PATH`.
+- Claude hooks are installed by the app using an absolute quoted path to the bundled `roux-cli.exe`.
+- Uninstall leaves the user's Claude settings alone in v1.
+- Native Windows Claude is required. Roux does not fall back to WSL Claude in v1.
+- `nono` is checked opportunistically, but Windows `nono` profile support is deferred until a supported `nono.exe` flow is validated.

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -5,6 +5,8 @@ use std::io::Read;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+mod platform;
+
 #[derive(Parser)]
 #[command(name = "roux-cli", about = "Roux terminal manager CLI")]
 struct Cli {
@@ -80,8 +82,7 @@ enum SessionAction {
 }
 
 fn status_dir() -> PathBuf {
-    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
-    home.join(".config").join("roux").join("status")
+    platform::status_dir()
 }
 
 fn socket_path() -> PathBuf {

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -85,49 +85,93 @@ fn status_dir() -> PathBuf {
     platform::status_dir()
 }
 
-fn socket_path() -> PathBuf {
-    if let Ok(path) = std::env::var("ROUX_SOCKET") {
-        return PathBuf::from(path);
-    }
-    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
-    home.join(".config").join("roux").join("roux.sock")
-}
-
 fn send_socket_command(request: Value) -> Result<Value, String> {
-    use std::io::Write;
-    use std::os::unix::net::UnixStream;
-    use std::time::Duration;
+    #[cfg(windows)]
+    {
+        use std::io::{Read, Write};
+        use std::net::TcpStream;
+        use std::time::Duration;
 
-    let path = socket_path();
-    let stream = UnixStream::connect(&path).map_err(|e| {
-        if e.kind() == std::io::ErrorKind::NotFound || e.kind() == std::io::ErrorKind::ConnectionRefused {
-            "Roux is not running".to_string()
-        } else {
-            format!("Failed to connect to Roux: {}", e)
-        }
-    })?;
+        let endpoint =
+            platform::resolve_socket_endpoint().ok_or_else(|| "Roux is not running".to_string())?;
+        let mut stream = TcpStream::connect(&endpoint).map_err(|e| {
+            if matches!(
+                e.kind(),
+                std::io::ErrorKind::NotFound
+                    | std::io::ErrorKind::ConnectionRefused
+                    | std::io::ErrorKind::AddrNotAvailable
+            ) {
+                "Roux is not running".to_string()
+            } else {
+                format!("Failed to connect to Roux: {}", e)
+            }
+        })?;
 
-    stream.set_read_timeout(Some(Duration::from_secs(5)))
-        .map_err(|e| format!("Failed to set timeout: {}", e))?;
-    stream.set_write_timeout(Some(Duration::from_secs(5)))
-        .map_err(|e| format!("Failed to set timeout: {}", e))?;
+        stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .map_err(|e| format!("Failed to set timeout: {}", e))?;
+        stream
+            .set_write_timeout(Some(Duration::from_secs(5)))
+            .map_err(|e| format!("Failed to set timeout: {}", e))?;
 
-    let json = serde_json::to_string(&request).unwrap();
-    let mut stream_ref = &stream;
-    stream_ref.write_all(json.as_bytes())
-        .map_err(|e| format!("Failed to send command: {}", e))?;
-    stream_ref.write_all(b"\n")
-        .map_err(|e| format!("Failed to send command: {}", e))?;
-    stream.shutdown(std::net::Shutdown::Write)
-        .map_err(|e| format!("Failed to shutdown write: {}", e))?;
+        let json = serde_json::to_string(&request).unwrap();
+        stream.write_all(json.as_bytes()).map_err(|e| format!("Failed to send command: {}", e))?;
+        stream.write_all(b"\n").map_err(|e| format!("Failed to send command: {}", e))?;
+        stream
+            .shutdown(std::net::Shutdown::Write)
+            .map_err(|e| format!("Failed to shutdown write: {}", e))?;
 
-    let mut response = String::new();
-    let mut reader = std::io::BufReader::new(&stream);
-    reader.read_to_string(&mut response)
-        .map_err(|e| format!("Failed to read response: {}", e))?;
+        let mut response = String::new();
+        let mut reader = std::io::BufReader::new(stream);
+        reader
+            .read_to_string(&mut response)
+            .map_err(|e| format!("Failed to read response: {}", e))?;
 
-    serde_json::from_str(&response)
-        .map_err(|e| format!("Invalid response: {}", e))
+        return serde_json::from_str(&response).map_err(|e| format!("Invalid response: {}", e));
+    }
+
+    #[cfg(not(windows))]
+    {
+        use std::io::Write;
+        use std::os::unix::net::UnixStream;
+        use std::time::Duration;
+
+        let path = socket_path();
+        let stream = UnixStream::connect(&path).map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound
+                || e.kind() == std::io::ErrorKind::ConnectionRefused
+            {
+                "Roux is not running".to_string()
+            } else {
+                format!("Failed to connect to Roux: {}", e)
+            }
+        })?;
+
+        stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .map_err(|e| format!("Failed to set timeout: {}", e))?;
+        stream
+            .set_write_timeout(Some(Duration::from_secs(5)))
+            .map_err(|e| format!("Failed to set timeout: {}", e))?;
+
+        let json = serde_json::to_string(&request).unwrap();
+        let mut stream_ref = &stream;
+        stream_ref
+            .write_all(json.as_bytes())
+            .map_err(|e| format!("Failed to send command: {}", e))?;
+        stream_ref.write_all(b"\n").map_err(|e| format!("Failed to send command: {}", e))?;
+        stream
+            .shutdown(std::net::Shutdown::Write)
+            .map_err(|e| format!("Failed to shutdown write: {}", e))?;
+
+        let mut response = String::new();
+        let mut reader = std::io::BufReader::new(&stream);
+        reader
+            .read_to_string(&mut response)
+            .map_err(|e| format!("Failed to read response: {}", e))?;
+
+        serde_json::from_str(&response).map_err(|e| format!("Invalid response: {}", e))
+    }
 }
 
 fn get_session_id() -> Option<String> {
@@ -147,9 +191,8 @@ fn run_socket_command(request: Value) {
                     println!("{}", serde_json::to_string_pretty(data).unwrap());
                 }
             } else {
-                let error = response.get("error")
-                    .and_then(|e| e.as_str())
-                    .unwrap_or("unknown error");
+                let error =
+                    response.get("error").and_then(|e| e.as_str()).unwrap_or("unknown error");
                 eprintln!("Error: {}", error);
                 std::process::exit(1);
             }

--- a/src-tauri/src/hooks.rs
+++ b/src-tauri/src/hooks.rs
@@ -1,59 +1,64 @@
 use serde_json::{json, Value};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+use crate::platform;
 
 const ROUX_HOOK_MARKER: &str = "roux-cli hook";
 
-fn roux_cli_path() -> Result<String, String> {
-    // Look for roux-cli in common locations
-    let candidates = [
-        // Primary install location
-        dirs::home_dir().map(|h| h.join(".local").join("bin").join("roux-cli")),
-        // Next to the main roux binary (dev builds)
-        std::env::current_exe().ok().and_then(|p| p.parent().map(|d| d.join("roux-cli"))),
-        // Installed via cargo install
-        dirs::home_dir().map(|h| h.join(".cargo").join("bin").join("roux-cli")),
-    ];
+#[cfg(not(windows))]
+fn unix_cli_install_path() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(".local").join("bin").join(platform::roux_cli_file_name()))
+}
 
-    for candidate in candidates.iter().flatten() {
-        if candidate.exists() {
-            return Ok(candidate.to_string_lossy().to_string());
-        }
-    }
+fn cargo_cli_install_path() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(".cargo").join("bin").join(platform::roux_cli_file_name()))
+}
 
-    // Try PATH
-    if let Ok(output) = std::process::Command::new("which").arg("roux-cli").output() {
-        if output.status.success() {
-            let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            if !path.is_empty() {
-                return Ok(path);
-            }
-        }
-    }
+fn sibling_cli_path() -> Option<PathBuf> {
+    std::env::current_exe().ok().and_then(|p| platform::sibling_roux_cli_path(&p))
+}
 
-    Err("roux-cli binary not found. Run 'cargo install --path src-tauri' or copy roux-cli to ~/.local/bin/".to_string())
+fn first_existing_path(candidates: impl IntoIterator<Item = Option<PathBuf>>) -> Option<PathBuf> {
+    candidates.into_iter().flatten().find(|path| path.is_file())
+}
+
+fn roux_cli_path() -> Result<PathBuf, String> {
+    #[cfg(windows)]
+    let candidates = [sibling_cli_path(), cargo_cli_install_path()];
+    #[cfg(not(windows))]
+    let candidates = [unix_cli_install_path(), sibling_cli_path(), cargo_cli_install_path()];
+
+    first_existing_path(candidates)
+        .or_else(|| platform::find_executable_on_path(platform::roux_cli_file_name()))
+        .ok_or_else(|| {
+            format!(
+                "{} not found. Build the CLI companion binary before installing hooks.",
+                platform::roux_cli_file_name()
+            )
+        })
 }
 
 /// Check if roux-cli is already installed at ~/.local/bin/
 pub fn cli_is_installed() -> bool {
-    dirs::home_dir()
-        .map(|h| h.join(".local").join("bin").join("roux-cli").exists())
-        .unwrap_or(false)
+    roux_cli_path().is_ok()
 }
 
-/// Install roux-cli to ~/.local/bin/ on first app load
-pub fn install_cli_binary() -> Result<String, String> {
+#[cfg(windows)]
+fn install_cli_binary_path() -> Result<PathBuf, String> {
+    roux_cli_path()
+}
+
+#[cfg(not(windows))]
+fn install_cli_binary_path() -> Result<PathBuf, String> {
     let bin_dir =
         dirs::home_dir().ok_or("Could not determine home directory")?.join(".local").join("bin");
     fs::create_dir_all(&bin_dir).map_err(|e| format!("Failed to create ~/.local/bin: {}", e))?;
 
-    let target = bin_dir.join("roux-cli");
+    let target = bin_dir.join(platform::roux_cli_file_name());
 
     // Find the source binary (next to the running roux binary)
-    let source = std::env::current_exe()
-        .ok()
-        .and_then(|p| p.parent().map(|d| d.join("roux-cli")))
-        .ok_or("Could not find roux-cli next to roux binary")?;
+    let source = sibling_cli_path().ok_or("Could not find roux-cli next to roux binary")?;
 
     if source.exists() {
         // Only copy if source is newer or target doesn't exist
@@ -79,7 +84,7 @@ pub fn install_cli_binary() -> Result<String, String> {
             }
             eprintln!("Installed roux-cli to {}", target.display());
         }
-        return Ok(target.to_string_lossy().to_string());
+        return Ok(target);
     }
 
     // Fallback: try to find it anywhere
@@ -92,18 +97,26 @@ fn claude_settings_path() -> Result<PathBuf, String> {
 }
 
 fn status_dir() -> Result<(), String> {
-    let home = dirs::home_dir().ok_or("Could not determine home directory")?;
-    let dir = home.join(".config").join("roux").join("status");
-    fs::create_dir_all(&dir).map_err(|e| format!("Failed to create status dir: {}", e))?;
+    platform::ensure_status_dir()?;
     Ok(())
 }
 
+fn is_roux_hook_command(command: &str) -> bool {
+    command.contains(ROUX_HOOK_MARKER)
+        || (command.contains("roux-cli")
+            && [
+                " hook working",
+                " hook idle",
+                " hook attention",
+                " hook error",
+                " hook disconnected",
+            ]
+            .iter()
+            .any(|hook| command.contains(hook)))
+}
+
 fn is_roux_hook(hook_obj: &Value) -> bool {
-    hook_obj
-        .get("command")
-        .and_then(|c| c.as_str())
-        .map(|c| c.contains(ROUX_HOOK_MARKER))
-        .unwrap_or(false)
+    hook_obj.get("command").and_then(|c| c.as_str()).map(is_roux_hook_command).unwrap_or(false)
 }
 
 fn is_roux_hook_entry(entry: &Value) -> bool {
@@ -114,7 +127,11 @@ fn is_roux_hook_entry(entry: &Value) -> bool {
         .unwrap_or(false)
 }
 
-fn roux_hooks_config(cli_path: &str) -> Value {
+fn hook_command(cli_path: &Path, status: &str) -> String {
+    platform::command_string(cli_path, &["hook", status])
+}
+
+fn roux_hooks_config(cli_path: &Path) -> Value {
     json!({
         "hooks": {
             "UserPromptSubmit": [
@@ -122,7 +139,7 @@ fn roux_hooks_config(cli_path: &str) -> Value {
                     "hooks": [
                         {
                             "type": "command",
-                            "command": format!("{} hook working", cli_path)
+                            "command": hook_command(cli_path, "working")
                         }
                     ]
                 }
@@ -132,7 +149,7 @@ fn roux_hooks_config(cli_path: &str) -> Value {
                     "hooks": [
                         {
                             "type": "command",
-                            "command": format!("{} hook idle", cli_path)
+                            "command": hook_command(cli_path, "idle")
                         }
                     ]
                 }
@@ -142,7 +159,7 @@ fn roux_hooks_config(cli_path: &str) -> Value {
                     "hooks": [
                         {
                             "type": "command",
-                            "command": format!("{} hook attention", cli_path)
+                            "command": hook_command(cli_path, "attention")
                         }
                     ]
                 }
@@ -152,7 +169,7 @@ fn roux_hooks_config(cli_path: &str) -> Value {
                     "hooks": [
                         {
                             "type": "command",
-                            "command": format!("{} hook error", cli_path)
+                            "command": hook_command(cli_path, "error")
                         }
                     ]
                 }
@@ -162,7 +179,7 @@ fn roux_hooks_config(cli_path: &str) -> Value {
                     "hooks": [
                         {
                             "type": "command",
-                            "command": format!("{} hook disconnected", cli_path)
+                            "command": hook_command(cli_path, "disconnected")
                         }
                     ]
                 }
@@ -173,7 +190,7 @@ fn roux_hooks_config(cli_path: &str) -> Value {
                     "hooks": [
                         {
                             "type": "command",
-                            "command": format!("{} hook attention", cli_path)
+                            "command": hook_command(cli_path, "attention")
                         }
                     ]
                 },
@@ -182,7 +199,7 @@ fn roux_hooks_config(cli_path: &str) -> Value {
                     "hooks": [
                         {
                             "type": "command",
-                            "command": format!("{} hook idle", cli_path)
+                            "command": hook_command(cli_path, "idle")
                         }
                     ]
                 }
@@ -191,7 +208,7 @@ fn roux_hooks_config(cli_path: &str) -> Value {
     })
 }
 
-fn merge_hooks(settings: &mut Value, cli_path: &str) -> Result<(), String> {
+fn merge_hooks(settings: &mut Value, cli_path: &Path) -> Result<(), String> {
     let roux = roux_hooks_config(cli_path);
     let roux_hooks = roux.get("hooks").unwrap().as_object().unwrap();
 
@@ -239,7 +256,7 @@ fn merge_hooks(settings: &mut Value, cli_path: &str) -> Result<(), String> {
 pub fn install_hooks() -> Result<(), String> {
     status_dir()?;
 
-    let cli_path = install_cli_binary().or_else(|_| roux_cli_path())?;
+    let cli_path = install_cli_binary_path().or_else(|_| roux_cli_path())?;
     let settings_path = claude_settings_path()?;
 
     let mut settings: Value = if settings_path.exists() {
@@ -260,6 +277,106 @@ pub fn install_hooks() -> Result<(), String> {
         .map_err(|e| format!("Failed to serialize settings: {}", e))?;
     fs::write(&settings_path, output).map_err(|e| format!("Failed to write settings: {}", e))?;
 
-    eprintln!("Roux hooks installed (using {})", cli_path);
+    eprintln!("Roux hooks installed (using {})", cli_path.display());
     Ok(())
+}
+
+pub fn setup_is_complete() -> bool {
+    let Ok(cli_path) = roux_cli_path() else {
+        return false;
+    };
+    let Ok(settings_path) = claude_settings_path() else {
+        return false;
+    };
+    if !settings_path.exists() {
+        return false;
+    }
+    let Ok(content) = fs::read_to_string(settings_path) else {
+        return false;
+    };
+    let Ok(settings) = serde_json::from_str::<Value>(&content) else {
+        return false;
+    };
+
+    let expected = hook_command(&cli_path, "working");
+    settings
+        .get("hooks")
+        .and_then(|h| h.get("UserPromptSubmit"))
+        .and_then(|v| v.as_array())
+        .map(|entries| entries.iter().any(|entry| hook_entry_contains_command(entry, &expected)))
+        .unwrap_or(false)
+}
+
+fn hook_entry_contains_command(entry: &Value, expected: &str) -> bool {
+    entry
+        .get("hooks")
+        .and_then(|h| h.as_array())
+        .map(|hooks| {
+            hooks.iter().any(|hook| {
+                hook.get("command").and_then(|c| c.as_str()).map(|c| c == expected).unwrap_or(false)
+            })
+        })
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roux_hook_detection_matches_quoted_exe_commands() {
+        assert!(is_roux_hook_command(
+            "\"C:\\\\Program Files\\\\Roux\\\\roux-cli.exe\" hook working"
+        ));
+        assert!(is_roux_hook_command("/Users/sam/.local/bin/roux-cli hook idle"));
+        assert!(!is_roux_hook_command("echo roux-cli"));
+    }
+
+    #[test]
+    fn hook_command_quotes_paths_with_spaces() {
+        let command =
+            hook_command(Path::new("C:\\Users\\Sam\\App Data\\Roux\\roux-cli.exe"), "working");
+        assert_eq!(
+            command,
+            "\"C:\\\\Users\\\\Sam\\\\App Data\\\\Roux\\\\roux-cli.exe\" hook working"
+        );
+    }
+
+    #[test]
+    fn merge_hooks_replaces_existing_roux_entries() {
+        let mut settings = json!({
+            "hooks": {
+                "UserPromptSubmit": [
+                    {
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "/old/roux-cli hook working"
+                            }
+                        ]
+                    },
+                    {
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "echo keep-me"
+                            }
+                        ]
+                    }
+                ]
+            }
+        });
+
+        merge_hooks(&mut settings, Path::new("C:\\Program Files\\Roux\\roux-cli.exe")).unwrap();
+
+        let entries = settings["hooks"]["UserPromptSubmit"].as_array().unwrap();
+        assert_eq!(entries.len(), 2);
+        assert!(entries.iter().any(|entry| hook_entry_contains_command(
+            entry,
+            "\"C:\\\\Program Files\\\\Roux\\\\roux-cli.exe\" hook working"
+        )));
+        assert!(entries.iter().any(|entry| {
+            entry["hooks"].as_array().unwrap()[0]["command"].as_str() == Some("echo keep-me")
+        }));
+    }
 }

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -4,13 +4,10 @@ use std::path::PathBuf;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use crate::platform;
+
 static LOG_FILE: Mutex<Option<PathBuf>> = Mutex::new(None);
 static ENABLED: AtomicBool = AtomicBool::new(false);
-
-fn log_dir() -> PathBuf {
-    let base = dirs::config_dir().unwrap_or_else(|| PathBuf::from("."));
-    base.join("roux").join("logs")
-}
 
 /// Initialize logging. Call once at startup.
 pub fn init(enabled: bool) {
@@ -97,4 +94,8 @@ macro_rules! rlog {
     ($($arg:tt)*) => {
         $crate::logging::log(&format!($($arg)*))
     };
+}
+
+fn log_dir() -> PathBuf {
+    platform::log_dir()
 }

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -84,6 +84,7 @@ pub fn log_path() -> Option<PathBuf> {
 }
 
 /// Return whether logging is currently enabled.
+#[allow(dead_code)]
 pub fn is_enabled() -> bool {
     ENABLED.load(Ordering::Relaxed)
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,6 +3,7 @@
 mod hooks;
 #[macro_use]
 mod logging;
+mod platform;
 mod projects;
 mod pty;
 mod session;
@@ -602,7 +603,7 @@ fn list_docs(dir: String) -> Result<Vec<DocFile>, String> {
 fn main() {
     let initial_settings = settings::load_settings();
     logging::init(initial_settings.enable_logging);
-    rlog!("Settings loaded from {:?}", dirs::config_dir().map(|d| d.join("roux/settings.json")));
+    rlog!("Settings loaded from {:?}", platform::settings_path());
     if let Some(ref p) = initial_settings.claude_binary_path {
         rlog!("Claude binary path (from settings): {}", p);
     } else {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -410,7 +410,7 @@ fn check_setup_status() -> SetupStatus {
 // Backwards compat: kept as alias used nowhere else
 #[tauri::command]
 fn check_setup_needed() -> bool {
-    !hooks::cli_is_installed()
+    !hooks::setup_is_complete()
 }
 
 #[tauri::command]

--- a/src-tauri/src/platform.rs
+++ b/src-tauri/src/platform.rs
@@ -5,9 +5,7 @@ use std::path::{Path, PathBuf};
 const APP_DIR_NAME: &str = "roux";
 
 pub fn app_config_dir() -> PathBuf {
-    dirs::config_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(APP_DIR_NAME)
+    dirs::config_dir().unwrap_or_else(|| PathBuf::from(".")).join(APP_DIR_NAME)
 }
 
 pub fn status_dir() -> PathBuf {
@@ -44,6 +42,37 @@ pub fn log_dir() -> PathBuf {
     app_config_dir().join("logs")
 }
 
+pub fn socket_path() -> PathBuf {
+    app_config_dir().join("roux.sock")
+}
+
+#[cfg(windows)]
+pub fn socket_addr_file_path() -> PathBuf {
+    app_config_dir().join("roux-socket-addr")
+}
+
+pub fn resolve_socket_endpoint() -> Option<String> {
+    if let Ok(endpoint) = std::env::var("ROUX_SOCKET") {
+        let endpoint = endpoint.trim();
+        if !endpoint.is_empty() {
+            return Some(endpoint.to_string());
+        }
+    }
+
+    #[cfg(windows)]
+    {
+        return std::fs::read_to_string(socket_addr_file_path())
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+    }
+
+    #[cfg(not(windows))]
+    {
+        Some(socket_path().to_string_lossy().to_string())
+    }
+}
+
 pub fn roux_cli_file_name() -> &'static str {
     roux_cli_file_name_for_platform(cfg!(windows))
 }
@@ -65,10 +94,7 @@ pub fn quote_command_arg(arg: &str) -> String {
         return "\"\"".to_string();
     }
 
-    if !arg
-        .chars()
-        .any(|c| c.is_whitespace() || matches!(c, '"' | '\\'))
-    {
+    if !arg.chars().any(|c| c.is_whitespace() || matches!(c, '"' | '\\')) {
         return arg.to_string();
     }
 
@@ -85,9 +111,7 @@ pub fn command_string(program: &Path, args: &[&str]) -> String {
 
 pub fn find_executable_on_path(file_name: &str) -> Option<PathBuf> {
     let paths = std::env::var_os("PATH")?;
-    std::env::split_paths(&paths)
-        .map(|dir| dir.join(file_name))
-        .find(|path| path.is_file())
+    std::env::split_paths(&paths).map(|dir| dir.join(file_name)).find(|path| path.is_file())
 }
 
 #[cfg(test)]
@@ -97,10 +121,7 @@ mod tests {
 
     #[test]
     fn app_config_dir_ends_with_roux() {
-        assert_eq!(
-            app_config_dir().file_name().and_then(|n| n.to_str()),
-            Some("roux")
-        );
+        assert_eq!(app_config_dir().file_name().and_then(|n| n.to_str()), Some("roux"));
     }
 
     #[test]

--- a/src-tauri/src/platform.rs
+++ b/src-tauri/src/platform.rs
@@ -1,0 +1,139 @@
+#![allow(dead_code)]
+
+use std::path::{Path, PathBuf};
+
+const APP_DIR_NAME: &str = "roux";
+
+pub fn app_config_dir() -> PathBuf {
+    dirs::config_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(APP_DIR_NAME)
+}
+
+pub fn status_dir() -> PathBuf {
+    app_config_dir().join("status")
+}
+
+pub fn ensure_status_dir() -> Result<PathBuf, String> {
+    let dir = status_dir();
+    std::fs::create_dir_all(&dir).map_err(|e| format!("Failed to create status dir: {}", e))?;
+    Ok(dir)
+}
+
+pub fn settings_path() -> PathBuf {
+    app_config_dir().join("settings.json")
+}
+
+pub fn sessions_path() -> PathBuf {
+    app_config_dir().join("sessions.json")
+}
+
+pub fn projects_path() -> PathBuf {
+    app_config_dir().join("projects.json")
+}
+
+pub fn watches_path() -> PathBuf {
+    app_config_dir().join("watches.json")
+}
+
+pub fn task_overrides_path() -> PathBuf {
+    app_config_dir().join("task-overrides.json")
+}
+
+pub fn log_dir() -> PathBuf {
+    app_config_dir().join("logs")
+}
+
+pub fn roux_cli_file_name() -> &'static str {
+    roux_cli_file_name_for_platform(cfg!(windows))
+}
+
+fn roux_cli_file_name_for_platform(is_windows: bool) -> &'static str {
+    if is_windows {
+        "roux-cli.exe"
+    } else {
+        "roux-cli"
+    }
+}
+
+pub fn sibling_roux_cli_path(exe_path: &Path) -> Option<PathBuf> {
+    exe_path.parent().map(|dir| dir.join(roux_cli_file_name()))
+}
+
+pub fn quote_command_arg(arg: &str) -> String {
+    if arg.is_empty() {
+        return "\"\"".to_string();
+    }
+
+    if !arg
+        .chars()
+        .any(|c| c.is_whitespace() || matches!(c, '"' | '\\'))
+    {
+        return arg.to_string();
+    }
+
+    let escaped = arg.replace('\\', "\\\\").replace('"', "\\\"");
+    format!("\"{}\"", escaped)
+}
+
+pub fn command_string(program: &Path, args: &[&str]) -> String {
+    let mut parts = Vec::with_capacity(args.len() + 1);
+    parts.push(quote_command_arg(&program.to_string_lossy()));
+    parts.extend(args.iter().map(|arg| quote_command_arg(arg)));
+    parts.join(" ")
+}
+
+pub fn find_executable_on_path(file_name: &str) -> Option<PathBuf> {
+    let paths = std::env::var_os("PATH")?;
+    std::env::split_paths(&paths)
+        .map(|dir| dir.join(file_name))
+        .find(|path| path.is_file())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn app_config_dir_ends_with_roux() {
+        assert_eq!(
+            app_config_dir().file_name().and_then(|n| n.to_str()),
+            Some("roux")
+        );
+    }
+
+    #[test]
+    fn status_dir_lives_under_app_config_dir() {
+        assert_eq!(status_dir(), app_config_dir().join("status"));
+    }
+
+    #[test]
+    fn roux_cli_file_name_uses_exe_extension_on_windows() {
+        assert_eq!(roux_cli_file_name_for_platform(true), "roux-cli.exe");
+        assert_eq!(roux_cli_file_name_for_platform(false), "roux-cli");
+    }
+
+    #[test]
+    fn quote_command_arg_quotes_spaces_and_quotes() {
+        assert_eq!(quote_command_arg("roux-cli"), "roux-cli");
+        assert_eq!(quote_command_arg(""), "\"\"");
+        assert_eq!(
+            quote_command_arg("C:\\Program Files\\Roux\\roux-cli.exe"),
+            "\"C:\\\\Program Files\\\\Roux\\\\roux-cli.exe\""
+        );
+        assert_eq!(quote_command_arg("say \"hi\""), "\"say \\\"hi\\\"\"");
+    }
+
+    #[test]
+    fn command_string_quotes_program_path_and_args() {
+        let command = command_string(
+            Path::new("C:\\Users\\Sam\\App Data\\Roux\\roux-cli.exe"),
+            &["hook", "working"],
+        );
+        assert_eq!(
+            command,
+            "\"C:\\\\Users\\\\Sam\\\\App Data\\\\Roux\\\\roux-cli.exe\" hook working"
+        );
+    }
+}

--- a/src-tauri/src/projects.rs
+++ b/src-tauri/src/projects.rs
@@ -6,6 +6,8 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 
+use crate::platform;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Project {
     pub id: String,
@@ -74,8 +76,7 @@ impl ProjectStore {
     }
 
     fn persistence_path() -> PathBuf {
-        let base = dirs::config_dir().unwrap_or_else(|| PathBuf::from("."));
-        base.join("roux").join("projects.json")
+        platform::projects_path()
     }
 
     fn write_to_disk(projects: &[Project]) {

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -6,7 +6,12 @@ use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
-use tauri::{ipc::{Channel, Response}, Emitter};
+use tauri::{
+    ipc::{Channel, Response},
+    Emitter,
+};
+
+use crate::platform;
 
 enum PtyChunk {
     Data(Vec<u8>),
@@ -24,11 +29,7 @@ struct PtyOutputState {
 
 impl PtyOutputState {
     fn new() -> Self {
-        Self {
-            channel: None,
-            backlog: VecDeque::new(),
-            backlog_bytes: 0,
-        }
+        Self { channel: None, backlog: VecDeque::new(), backlog_bytes: 0 }
     }
 
     fn buffer(&mut self, bytes: Vec<u8>) {
@@ -76,9 +77,7 @@ struct PtyOutput {
 
 impl PtyOutput {
     fn new() -> Self {
-        Self {
-            state: Arc::new(Mutex::new(PtyOutputState::new())),
-        }
+        Self { state: Arc::new(Mutex::new(PtyOutputState::new())) }
     }
 
     fn send(&self, bytes: Vec<u8>) {
@@ -94,7 +93,7 @@ impl PtyOutput {
 /// at ~16ms intervals. Returns the sender for the reader thread to push data into.
 fn spawn_flusher(
     output: PtyOutput,
-    exit_event: Option<(String, u64)>,  // (event_name, generation)
+    exit_event: Option<(String, u64)>, // (event_name, generation)
     app: tauri::AppHandle,
 ) -> mpsc::Sender<PtyChunk> {
     let (tx, rx) = mpsc::channel::<PtyChunk>();
@@ -140,7 +139,10 @@ fn spawn_flusher(
                         output.send(std::mem::take(&mut batch));
                     }
                     if let Some((evt, gen)) = &exit_event {
-                        let _ = app.emit(evt, serde_json::json!({"code": null, "generation": gen, "reason": "exit"}));
+                        let _ = app.emit(
+                            evt,
+                            serde_json::json!({"code": null, "generation": gen, "reason": "exit"}),
+                        );
                     }
                     break;
                 }
@@ -207,6 +209,11 @@ impl portable_pty::Child for WaitedChild {
     fn process_id(&self) -> Option<u32> {
         None
     }
+
+    #[cfg(windows)]
+    fn as_raw_handle(&self) -> Option<*mut std::ffi::c_void> {
+        None
+    }
 }
 
 struct PtySession {
@@ -257,7 +264,12 @@ impl PtyManager {
 
         let user_path = get_user_path();
         let claude_cmd = resolve_claude_command(claude_binary_path);
-        rlog!("Spawning claude session '{}' in '{}' with cmd='{}'", session_id, working_dir, claude_cmd);
+        rlog!(
+            "Spawning claude session '{}' in '{}' with cmd='{}'",
+            session_id,
+            working_dir,
+            claude_cmd
+        );
         rlog!("  PATH: {}", user_path);
 
         let mut cmd = if let Some(profile) = nono_profile {
@@ -303,7 +315,13 @@ impl PtyManager {
         let output = PtyOutput::new();
         let gen = self.generation.fetch_add(1, Ordering::Relaxed);
 
-        let session = PtySession { master: pair.master, child, writer: Arc::new(Mutex::new(writer)), output: output.clone(), generation: gen };
+        let session = PtySession {
+            master: pair.master,
+            child,
+            writer: Arc::new(Mutex::new(writer)),
+            output: output.clone(),
+            generation: gen,
+        };
         self.sessions.lock().unwrap().insert(session_id.to_string(), session);
         self.attach_pending_output(session_id, &output);
 
@@ -330,11 +348,14 @@ impl PtyManager {
             .openpty(PtySize { rows: 24, cols: 80, pixel_width: 0, pixel_height: 0 })
             .map_err(|e| format!("Failed to open PTY: {}", e))?;
 
-        let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
+        let shell = resolve_interactive_shell();
         let user_path = get_user_path();
-        rlog!("Spawning shell '{}' for pane '{}' in '{}'", shell, id, working_dir);
+        rlog!("Spawning shell '{}' for pane '{}' in '{}'", shell.program, id, working_dir);
 
-        let mut cmd = CommandBuilder::new(&shell);
+        let mut cmd = CommandBuilder::new(&shell.program);
+        for arg in &shell.args {
+            cmd.arg(arg);
+        }
         cmd.env("PATH", &user_path);
         cmd.env("TERM", "xterm-256color");
         cmd.env("COLORTERM", "truecolor");
@@ -345,11 +366,10 @@ impl PtyManager {
         }
         cmd.cwd(working_dir);
 
-        let child =
-            pair.slave.spawn_command(cmd).map_err(|e| {
-                rlog!("Failed to spawn shell: {}", e);
-                format!("Failed to spawn shell: {}", e)
-            })?;
+        let child = pair.slave.spawn_command(cmd).map_err(|e| {
+            rlog!("Failed to spawn shell: {}", e);
+            format!("Failed to spawn shell: {}", e)
+        })?;
 
         let writer =
             pair.master.take_writer().map_err(|e| format!("Failed to get PTY writer: {}", e))?;
@@ -362,15 +382,18 @@ impl PtyManager {
         let output = PtyOutput::new();
         let gen = self.generation.fetch_add(1, Ordering::Relaxed);
 
-        let session = PtySession { master: pair.master, child, writer: Arc::new(Mutex::new(writer)), output: output.clone(), generation: gen };
+        let session = PtySession {
+            master: pair.master,
+            child,
+            writer: Arc::new(Mutex::new(writer)),
+            output: output.clone(),
+            generation: gen,
+        };
         self.sessions.lock().unwrap().insert(id.to_string(), session);
         self.attach_pending_output(id, &output);
 
-        let tx = spawn_flusher(
-            output.clone(),
-            Some((format!("session-exit:{}", id), gen)),
-            app.clone(),
-        );
+        let tx =
+            spawn_flusher(output.clone(), Some((format!("session-exit:{}", id), gen)), app.clone());
         spawn_reader(reader, tx);
 
         Ok(())
@@ -392,11 +415,13 @@ impl PtyManager {
             .openpty(PtySize { rows: 24, cols: 80, pixel_width: 0, pixel_height: 0 })
             .map_err(|e| format!("Failed to open PTY: {}", e))?;
 
-        let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
+        let shell = resolve_task_shell(command);
         let user_path = get_user_path();
 
-        let mut cmd = CommandBuilder::new(&shell);
-        cmd.args(["-c", command]);
+        let mut cmd = CommandBuilder::new(&shell.program);
+        for arg in &shell.args {
+            cmd.arg(arg);
+        }
         cmd.env("PATH", &user_path);
         cmd.env("TERM", "xterm-256color");
         cmd.env("COLORTERM", "truecolor");
@@ -432,21 +457,17 @@ impl PtyManager {
         self.sessions.lock().unwrap().insert(id.to_string(), session);
         self.attach_pending_output(id, &output);
 
-        let tx = spawn_flusher(
-            output.clone(),
-            None,
-            app.clone(),
-        );
+        let tx = spawn_flusher(output.clone(), None, app.clone());
         spawn_reader(reader, tx);
 
         // Wait for the child process in a background thread and emit exit code
         let exit_event_name = format!("session-exit:{}", id);
         thread::spawn(move || {
-            let code = child
-                .wait()
-                .ok()
-                .map(|status| status.exit_code());
-            let _ = app.emit(&exit_event_name, serde_json::json!({ "code": code, "generation": gen, "reason": "exit" }));
+            let code = child.wait().ok().map(|status| status.exit_code());
+            let _ = app.emit(
+                &exit_event_name,
+                serde_json::json!({ "code": code, "generation": gen, "reason": "exit" }),
+            );
         });
 
         Ok(())
@@ -458,19 +479,12 @@ impl PtyManager {
         channel: Channel<Response>,
     ) -> Result<(), String> {
         self.cleanup_stale_pending();
-        let output = self
-            .sessions
-            .lock()
-            .unwrap()
-            .get(session_id)
-            .map(|session| session.output.clone());
+        let output =
+            self.sessions.lock().unwrap().get(session_id).map(|session| session.output.clone());
         if let Some(output) = output {
             output.attach(channel);
         } else {
-            self.pending_outputs
-                .lock()
-                .unwrap()
-                .insert(session_id.to_string(), channel);
+            self.pending_outputs.lock().unwrap().insert(session_id.to_string(), channel);
         }
         Ok(())
     }
@@ -550,44 +564,108 @@ impl PtyManager {
 
 /// Get the socket path as a string for setting env vars.
 fn socket_path_str() -> String {
-    let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
-    home.join(".config").join("roux").join("roux.sock").to_string_lossy().to_string()
+    platform::resolve_socket_endpoint()
+        .unwrap_or_else(|| platform::socket_path().to_string_lossy().to_string())
 }
 
 /// Get the user's login shell PATH by invoking their actual shell (from $SHELL)
 /// instead of hardcoding /bin/bash. This ensures paths added in .zshrc etc. are found.
 pub fn get_user_path() -> String {
-    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
-    // Fish outputs $PATH as a space-separated list; other shells use colons.
-    // Use fish's `string join` to get colon-separated output.
-    let path_cmd = if shell.contains("fish") {
-        "string join : $PATH"
-    } else {
-        "echo $PATH"
-    };
-    rlog!("Resolving PATH via login shell: {} -l -c '{}'", shell, path_cmd);
-    let result = std::process::Command::new(&shell)
-        .args(["-l", "-c", path_cmd])
-        .output();
-    match &result {
-        Ok(o) => {
-            if !o.status.success() {
-                rlog!("  shell exited with status: {}", o.status);
-                let stderr = String::from_utf8_lossy(&o.stderr);
-                if !stderr.is_empty() {
-                    rlog!("  stderr: {}", stderr.chars().take(500).collect::<String>());
+    #[cfg(windows)]
+    {
+        std::env::var("PATH").unwrap_or_default()
+    }
+
+    #[cfg(not(windows))]
+    {
+        let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
+        // Fish outputs $PATH as a space-separated list; other shells use colons.
+        // Use fish's `string join` to get colon-separated output.
+        let path_cmd = if shell.contains("fish") { "string join : $PATH" } else { "echo $PATH" };
+        rlog!("Resolving PATH via login shell: {} -l -c '{}'", shell, path_cmd);
+        let result = std::process::Command::new(&shell).args(["-l", "-c", path_cmd]).output();
+        match &result {
+            Ok(o) => {
+                if !o.status.success() {
+                    rlog!("  shell exited with status: {}", o.status);
+                    let stderr = String::from_utf8_lossy(&o.stderr);
+                    if !stderr.is_empty() {
+                        rlog!("  stderr: {}", stderr.chars().take(500).collect::<String>());
+                    }
                 }
             }
+            Err(e) => rlog!("  failed to run shell: {}", e),
         }
-        Err(e) => rlog!("  failed to run shell: {}", e),
+        let path = result
+            .ok()
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .map(|s| s.trim().to_string())
+            .unwrap_or_else(|| std::env::var("PATH").unwrap_or_default());
+        rlog!("  resolved PATH: {}", path);
+        path
     }
-    let path = result
-        .ok()
-        .and_then(|o| String::from_utf8(o.stdout).ok())
-        .map(|s| s.trim().to_string())
-        .unwrap_or_else(|| std::env::var("PATH").unwrap_or_default());
-    rlog!("  resolved PATH: {}", path);
-    path
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ShellSpec {
+    program: String,
+    args: Vec<String>,
+}
+
+fn resolve_interactive_shell() -> ShellSpec {
+    #[cfg(windows)]
+    {
+        return ShellSpec { program: resolve_windows_shell_program(), args: Vec::new() };
+    }
+
+    #[cfg(not(windows))]
+    ShellSpec {
+        program: std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string()),
+        args: Vec::new(),
+    }
+}
+
+fn resolve_task_shell(command: &str) -> ShellSpec {
+    #[cfg(windows)]
+    {
+        let program = resolve_windows_shell_program();
+        let args = windows_task_shell_args(&program, command);
+        return ShellSpec { program, args };
+    }
+
+    #[cfg(not(windows))]
+    ShellSpec {
+        program: std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string()),
+        args: vec!["-c".to_string(), command.to_string()],
+    }
+}
+
+#[cfg(windows)]
+fn resolve_windows_shell_program() -> String {
+    if platform::find_executable_on_path("pwsh.exe").is_some()
+        || platform::find_executable_on_path("pwsh").is_some()
+    {
+        "pwsh".to_string()
+    } else if platform::find_executable_on_path("powershell.exe").is_some() {
+        "powershell.exe".to_string()
+    } else {
+        "cmd.exe".to_string()
+    }
+}
+
+fn windows_task_shell_args(program: &str, command: &str) -> Vec<String> {
+    if program.eq_ignore_ascii_case("cmd.exe") || program.eq_ignore_ascii_case("cmd") {
+        vec!["/C".to_string(), command.to_string()]
+    } else {
+        let mut args = vec!["-NoProfile".to_string()];
+        if program.eq_ignore_ascii_case("powershell.exe")
+            || program.eq_ignore_ascii_case("powershell")
+        {
+            args.extend(["-ExecutionPolicy".to_string(), "Bypass".to_string()]);
+        }
+        args.extend(["-Command".to_string(), command.to_string()]);
+        args
+    }
 }
 
 /// Resolve the claude binary command. If a custom path is configured, use it directly.
@@ -625,10 +703,7 @@ mod tests {
         let received = Arc::new(Mutex::new(Vec::new()));
         output.attach(raw_channel(received.clone()));
 
-        assert_eq!(
-            *received.lock().unwrap(),
-            vec![vec![1, 2, 3], vec![4, 5, 6]]
-        );
+        assert_eq!(*received.lock().unwrap(), vec![vec![1, 2, 3], vec![4, 5, 6]]);
     }
 
     #[test]
@@ -686,8 +761,18 @@ mod tests {
     fn get_user_path_returns_nonempty_string() {
         let path = get_user_path();
         assert!(!path.is_empty(), "PATH should not be empty");
-        // Should contain at least /usr/bin which is always on PATH
-        assert!(path.contains("/usr/bin") || path.contains("/bin"),
-            "PATH should contain standard bin directories, got: {}", path);
+        #[cfg(windows)]
+        assert!(
+            path.to_ascii_lowercase().contains("\\windows"),
+            "PATH should contain standard Windows directories, got: {}",
+            path
+        );
+
+        #[cfg(not(windows))]
+        assert!(
+            path.contains("/usr/bin") || path.contains("/bin"),
+            "PATH should contain standard bin directories, got: {}",
+            path
+        );
     }
 }

--- a/src-tauri/src/session.rs
+++ b/src-tauri/src/session.rs
@@ -6,6 +6,8 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 
+use crate::platform;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Session {
@@ -103,8 +105,7 @@ impl SessionStore {
     }
 
     fn persistence_path() -> PathBuf {
-        let base = dirs::config_dir().unwrap_or_else(|| PathBuf::from("."));
-        base.join("roux").join("sessions.json")
+        platform::sessions_path()
     }
 
     fn write_to_disk(sessions: &[Session]) {

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::fs;
-use std::path::PathBuf;
+
+use crate::platform;
 
 const DEFAULT_THEME: &str = "deep-blue";
 
@@ -88,17 +89,8 @@ impl RouxSettings {
     }
 }
 
-fn config_dir() -> PathBuf {
-    let base = dirs::config_dir().unwrap_or_else(|| PathBuf::from("."));
-    base.join("roux")
-}
-
-fn settings_path() -> PathBuf {
-    config_dir().join("settings.json")
-}
-
 pub fn load_settings() -> RouxSettings {
-    let path = settings_path();
+    let path = platform::settings_path();
     if path.exists() {
         let content = fs::read_to_string(&path).unwrap_or_default();
         serde_json::from_str::<RouxSettings>(&content).unwrap_or_default().normalized()
@@ -108,7 +100,7 @@ pub fn load_settings() -> RouxSettings {
 }
 
 pub fn save_settings(settings: &RouxSettings) -> Result<(), String> {
-    let path = settings_path();
+    let path = platform::settings_path();
     fs::create_dir_all(path.parent().unwrap()).map_err(|e| e.to_string())?;
     let json =
         serde_json::to_string_pretty(&settings.clone().normalized()).map_err(|e| e.to_string())?;

--- a/src-tauri/src/socket.rs
+++ b/src-tauri/src/socket.rs
@@ -398,6 +398,7 @@ fn crypto_random_uuid() -> String {
 }
 
 /// Clean up the socket file on shutdown.
+#[allow(dead_code)]
 pub fn cleanup_socket() {
     let path = socket_path();
     let _ = fs::remove_file(path);

--- a/src-tauri/src/socket.rs
+++ b/src-tauri/src/socket.rs
@@ -3,9 +3,12 @@ use std::fs;
 use std::path::PathBuf;
 use tauri::Manager;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+#[cfg(windows)]
+use tokio::net::TcpListener;
+#[cfg(not(windows))]
 use tokio::net::UnixListener;
 
-use crate::AppState;
+use crate::{platform, AppState};
 
 #[derive(Debug, Deserialize)]
 struct Request {
@@ -40,8 +43,7 @@ impl Response {
 }
 
 pub fn socket_path() -> PathBuf {
-    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
-    home.join(".config").join("roux").join("roux.sock")
+    platform::socket_path()
 }
 
 pub fn start_socket_server(app: tauri::AppHandle) {
@@ -53,15 +55,46 @@ pub fn start_socket_server(app: tauri::AppHandle) {
             let _ = fs::create_dir_all(parent);
         }
 
-        // Remove stale socket file
-        let _ = fs::remove_file(&path);
+        #[cfg(not(windows))]
+        let listener = {
+            let _ = fs::remove_file(&path);
+            match UnixListener::bind(&path) {
+                Ok(l) => l,
+                Err(e) => {
+                    rlog!("Failed to bind socket at {:?}: {}", path, e);
+                    return;
+                }
+            }
+        };
 
-        let listener = match UnixListener::bind(&path) {
-            Ok(l) => l,
-            Err(e) => {
-                rlog!("Failed to bind socket at {:?}: {}", path, e);
+        #[cfg(windows)]
+        let listener = {
+            let listener = match TcpListener::bind("127.0.0.1:0").await {
+                Ok(l) => l,
+                Err(e) => {
+                    rlog!("Failed to bind socket server on localhost: {}", e);
+                    return;
+                }
+            };
+
+            let addr = match listener.local_addr() {
+                Ok(addr) => addr.to_string(),
+                Err(e) => {
+                    rlog!("Failed to resolve socket listener address: {}", e);
+                    return;
+                }
+            };
+
+            if let Some(parent) = platform::socket_addr_file_path().parent() {
+                let _ = fs::create_dir_all(parent);
+            }
+            if let Err(e) = fs::write(platform::socket_addr_file_path(), &addr) {
+                rlog!("Failed to write socket address file: {}", e);
                 return;
             }
+
+            rlog!("Socket server listening on {}", addr);
+            listener
         };
 
         // Set permissions to owner-only (0600)
@@ -71,6 +104,7 @@ pub fn start_socket_server(app: tauri::AppHandle) {
             let _ = fs::set_permissions(&path, fs::Permissions::from_mode(0o600));
         }
 
+        #[cfg(not(windows))]
         rlog!("Socket server listening on {:?}", path);
 
         loop {
@@ -124,12 +158,13 @@ async fn handle_request(req: Request, app: &tauri::AppHandle) -> Response {
 }
 
 fn handle_split(req: Request, app: &tauri::AppHandle) -> Response {
-    let direction = req.args.get("direction")
-        .and_then(|d| d.as_str())
-        .unwrap_or("horizontal");
+    let direction = req.args.get("direction").and_then(|d| d.as_str()).unwrap_or("horizontal");
 
     if direction != "horizontal" && direction != "vertical" {
-        return Response::err(format!("invalid direction: {}, must be horizontal or vertical", direction));
+        return Response::err(format!(
+            "invalid direction: {}, must be horizontal or vertical",
+            direction
+        ));
     }
 
     let session_id = match req.session_id.as_deref() {
@@ -138,12 +173,15 @@ fn handle_split(req: Request, app: &tauri::AppHandle) -> Response {
     };
 
     use tauri::Emitter;
-    let _ = app.emit("roux-command", serde_json::json!({
-        "action": "split",
-        "sessionId": session_id,
-        "paneId": req.pane_id,
-        "direction": direction,
-    }));
+    let _ = app.emit(
+        "roux-command",
+        serde_json::json!({
+            "action": "split",
+            "sessionId": session_id,
+            "paneId": req.pane_id,
+            "direction": direction,
+        }),
+    );
 
     Response::ok()
 }
@@ -151,14 +189,9 @@ fn handle_split(req: Request, app: &tauri::AppHandle) -> Response {
 fn handle_session_create(req: Request, app: &tauri::AppHandle) -> Response {
     let state: tauri::State<AppState> = app.state();
 
-    let name = req.args.get("name")
-        .and_then(|n| n.as_str())
-        .unwrap_or("New Session")
-        .to_string();
+    let name = req.args.get("name").and_then(|n| n.as_str()).unwrap_or("New Session").to_string();
 
-    let working_dir = req.args.get("working_dir")
-        .and_then(|d| d.as_str())
-        .map(|s| s.to_string());
+    let working_dir = req.args.get("working_dir").and_then(|d| d.as_str()).map(|s| s.to_string());
 
     // Use the working_dir as repo_path, or fall back to current session's repo
     let repo_path = match working_dir {
@@ -192,10 +225,7 @@ fn handle_session_create(req: Request, app: &tauri::AppHandle) -> Response {
         return Response::err(format!("Failed to spawn session: {}", e));
     }
 
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
+    let now = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
 
     let branch = crate::get_current_branch(&work_dir).unwrap_or_else(|| "main".to_string());
 
@@ -217,10 +247,13 @@ fn handle_session_create(req: Request, app: &tauri::AppHandle) -> Response {
 
     // Tell frontend about the new session
     use tauri::Emitter;
-    let _ = app.emit("roux-command", serde_json::json!({
-        "action": "session-created",
-        "sessionId": session_id,
-    }));
+    let _ = app.emit(
+        "roux-command",
+        serde_json::json!({
+            "action": "session-created",
+            "sessionId": session_id,
+        }),
+    );
 
     Response::success(serde_json::json!({ "session_id": session_id }))
 }
@@ -233,12 +266,12 @@ fn handle_shell(req: Request, app: &tauri::AppHandle) -> Response {
 
     let state: tauri::State<AppState> = app.state();
 
-    let working_dir = req.args.get("working_dir")
+    let working_dir = req
+        .args
+        .get("working_dir")
         .and_then(|d| d.as_str())
         .map(|s| s.to_string())
-        .or_else(|| {
-            state.session_store.get(session_id).map(|s| s.worktree_path.clone())
-        });
+        .or_else(|| state.session_store.get(session_id).map(|s| s.worktree_path.clone()));
 
     let working_dir = match working_dir {
         Some(dir) => dir,
@@ -248,28 +281,36 @@ fn handle_shell(req: Request, app: &tauri::AppHandle) -> Response {
     let pane_id = crypto_random_uuid();
     let pty_id = crypto_random_uuid();
 
-    if let Err(e) = state.pty_manager.spawn_shell(&pty_id, &working_dir, Some(session_id), app.clone()) {
+    if let Err(e) =
+        state.pty_manager.spawn_shell(&pty_id, &working_dir, Some(session_id), app.clone())
+    {
         return Response::err(format!("Failed to spawn shell: {}", e));
     }
 
     use tauri::Emitter;
-    let _ = app.emit("roux-command", serde_json::json!({
-        "action": "shell-opened",
-        "sessionId": session_id,
-        "paneId": pane_id,
-        "ptyId": pty_id,
-    }));
+    let _ = app.emit(
+        "roux-command",
+        serde_json::json!({
+            "action": "shell-opened",
+            "sessionId": session_id,
+            "paneId": pane_id,
+            "ptyId": pty_id,
+        }),
+    );
 
     Response::success(serde_json::json!({ "pane_id": pane_id, "pty_id": pty_id }))
 }
 
 fn handle_focus(req: Request, app: &tauri::AppHandle) -> Response {
     use tauri::Emitter;
-    let _ = app.emit("roux-command", serde_json::json!({
-        "action": "focus",
-        "sessionId": req.session_id,
-        "paneId": req.pane_id,
-    }));
+    let _ = app.emit(
+        "roux-command",
+        serde_json::json!({
+            "action": "focus",
+            "sessionId": req.session_id,
+            "paneId": req.pane_id,
+        }),
+    );
 
     Response::ok()
 }
@@ -287,12 +328,12 @@ fn handle_run(req: Request, app: &tauri::AppHandle) -> Response {
 
     let state: tauri::State<AppState> = app.state();
 
-    let working_dir = req.args.get("working_dir")
+    let working_dir = req
+        .args
+        .get("working_dir")
         .and_then(|d| d.as_str())
         .map(|s| s.to_string())
-        .or_else(|| {
-            state.session_store.get(session_id).map(|s| s.worktree_path.clone())
-        });
+        .or_else(|| state.session_store.get(session_id).map(|s| s.worktree_path.clone()));
 
     let working_dir = match working_dir {
         Some(dir) => dir,
@@ -300,22 +341,30 @@ fn handle_run(req: Request, app: &tauri::AppHandle) -> Response {
     };
 
     let pane_id = format!("cmd-{}", crypto_random_uuid());
-    let pty_id = format!("{}-{}", pane_id, std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH).unwrap().as_millis());
+    let pty_id = format!(
+        "{}-{}",
+        pane_id,
+        std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_millis()
+    );
 
-    if let Err(e) = state.pty_manager.spawn_task(&pty_id, &command, &working_dir, Some(session_id), app.clone()) {
+    if let Err(e) =
+        state.pty_manager.spawn_task(&pty_id, &command, &working_dir, Some(session_id), app.clone())
+    {
         return Response::err(format!("Failed to spawn task: {}", e));
     }
 
     use tauri::Emitter;
-    let _ = app.emit("roux-command", serde_json::json!({
-        "action": "command-opened",
-        "sessionId": session_id,
-        "paneId": pane_id,
-        "ptyId": pty_id,
-        "command": command,
-        "workingDir": working_dir,
-    }));
+    let _ = app.emit(
+        "roux-command",
+        serde_json::json!({
+            "action": "command-opened",
+            "sessionId": session_id,
+            "paneId": pane_id,
+            "ptyId": pty_id,
+            "command": command,
+            "workingDir": working_dir,
+        }),
+    );
 
     Response::success(serde_json::json!({ "pane_id": pane_id, "pty_id": pty_id }))
 }
@@ -352,6 +401,8 @@ fn crypto_random_uuid() -> String {
 pub fn cleanup_socket() {
     let path = socket_path();
     let _ = fs::remove_file(path);
+    #[cfg(windows)]
+    let _ = fs::remove_file(platform::socket_addr_file_path());
 }
 
 #[cfg(test)]
@@ -362,7 +413,14 @@ mod tests {
     fn socket_path_is_under_config() {
         let path = socket_path();
         let path_str = path.to_string_lossy();
-        assert!(path_str.contains(".config/roux/roux.sock"), "Expected .config/roux/roux.sock, got {}", path_str);
+        #[cfg(windows)]
+        assert!(path_str.ends_with("roux.sock"), "Expected roux.sock suffix, got {}", path_str);
+        #[cfg(not(windows))]
+        assert!(
+            path_str.contains(".config/roux/roux.sock"),
+            "Expected .config/roux/roux.sock, got {}",
+            path_str
+        );
     }
 
     #[test]
@@ -426,12 +484,26 @@ mod tests {
     #[tokio::test]
     async fn socket_roundtrip() {
         use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-        use tokio::net::{UnixListener, UnixStream};
 
-        let dir = tempfile::tempdir().unwrap();
-        let sock_path = dir.path().join("test.sock");
+        #[cfg(not(windows))]
+        let tempdir = tempfile::tempdir().unwrap();
 
-        let listener = UnixListener::bind(&sock_path).unwrap();
+        #[cfg(not(windows))]
+        let listener = {
+            use tokio::net::UnixListener;
+            let sock_path = tempdir.path().join("test.sock");
+            (UnixListener::bind(&sock_path).unwrap(), sock_path)
+        };
+
+        #[cfg(windows)]
+        let listener = {
+            use tokio::net::TcpListener;
+            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let addr = listener.local_addr().unwrap();
+            (listener, addr)
+        };
+
+        let (listener, endpoint) = listener;
 
         // Spawn a simple echo server that reads a line and responds with a fixed response
         let server = tokio::spawn(async move {
@@ -453,7 +525,14 @@ mod tests {
         });
 
         // Client side
-        let mut stream = UnixStream::connect(&sock_path).await.unwrap();
+        #[cfg(not(windows))]
+        let mut stream = {
+            use tokio::net::UnixStream;
+            UnixStream::connect(&endpoint).await.unwrap()
+        };
+
+        #[cfg(windows)]
+        let mut stream = tokio::net::TcpStream::connect(endpoint).await.unwrap();
         let request = serde_json::json!({
             "command": "split",
             "session_id": "test-session",

--- a/src-tauri/src/status_watcher.rs
+++ b/src-tauri/src/status_watcher.rs
@@ -3,11 +3,12 @@ use serde::Serialize;
 use serde_json::Value;
 use std::collections::HashSet;
 use std::fs;
-use std::path::PathBuf;
 use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
 use tauri::Emitter;
+
+use crate::platform;
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -18,13 +19,6 @@ struct StatusUpdate {
     tool_name: Option<String>,
     tool_input: Option<serde_json::Value>,
     message: Option<String>,
-}
-
-fn status_dir() -> Result<PathBuf, String> {
-    let home = dirs::home_dir().ok_or("Could not determine home directory")?;
-    let dir = home.join(".config").join("roux").join("status");
-    fs::create_dir_all(&dir).map_err(|e| format!("Failed to create status dir: {}", e))?;
-    Ok(dir)
 }
 
 fn map_status(raw: &str) -> &str {
@@ -39,7 +33,7 @@ fn map_status(raw: &str) -> &str {
 }
 
 pub fn start_watching(app: tauri::AppHandle) -> Result<(), String> {
-    let watch_dir = status_dir()?;
+    let watch_dir = platform::ensure_status_dir()?;
 
     let (tx, rx) = mpsc::channel::<notify::Result<Event>>();
 

--- a/src-tauri/src/tasks.rs
+++ b/src-tauri/src/tasks.rs
@@ -3,6 +3,8 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
+use crate::platform;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TaskDefinition {
@@ -324,8 +326,7 @@ pub fn discover_tasks(dir: &Path) -> Vec<TaskGroup> {
 }
 
 fn overrides_path() -> std::path::PathBuf {
-    let base = dirs::config_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
-    base.join("roux").join("task-overrides.json")
+    platform::task_overrides_path()
 }
 
 #[tauri::command]

--- a/src-tauri/src/watches.rs
+++ b/src-tauri/src/watches.rs
@@ -12,6 +12,8 @@ use tokio::process::Command as TokioCommand;
 use tokio::time::{timeout, sleep};
 use tokio_util::sync::CancellationToken;
 
+use crate::platform;
+
 // ── Core Types ──────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -333,8 +335,7 @@ impl WatchStore {
     }
 
     fn persistence_path() -> PathBuf {
-        let base = dirs::config_dir().unwrap_or_else(|| PathBuf::from("."));
-        base.join("roux").join("watches.json")
+        platform::watches_path()
     }
 
     fn write_to_disk(watches: &[Watch]) {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -28,6 +28,14 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "externalBin": [
+      "binaries/roux-cli"
+    ],
+    "windows": {
+      "nsis": {
+        "installMode": "currentUser"
+      }
+    },
     "macOS": {
       "files": {
         "MacOS/roux-cli": "binaries/roux-cli"

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -25,6 +25,7 @@
   import { closeFocusedPane } from "$lib/panes/actions";
   import { normalizeTheme, isLightTheme } from "$lib/themes";
   import { initLogging, log, logError } from "$lib/logging";
+  import { hasPrimaryModifier, isMacPlatform } from "$lib/platform";
 
   let showNewSessionDialog = $state(false);
   let showSettings = $state(false);
@@ -36,10 +37,11 @@
 
   function buildShortcutString(e: KeyboardEvent): string {
     const parts: string[] = [];
-    if (e.metaKey) parts.push("cmd");
+    if (hasPrimaryModifier(e)) parts.push("cmd");
     if (e.shiftKey) parts.push("shift");
     if (e.altKey) parts.push("alt");
-    if (e.ctrlKey) parts.push("ctrl");
+    if (e.ctrlKey && isMacPlatform()) parts.push("ctrl");
+    if (e.metaKey && !isMacPlatform()) parts.push("meta");
     // On macOS, Alt produces special characters (e.g. Alt+h → ˙).
     // Use the physical key (e.code) when Alt is held so shortcuts work.
     let key = e.key.toLowerCase();
@@ -72,7 +74,7 @@
 
   function handleKeyDown(e: KeyboardEvent) {
     // Command palette toggle
-    if (e.metaKey && e.key === "k") {
+    if (hasPrimaryModifier(e) && e.key === "k") {
       e.preventDefault();
       showPalette = !showPalette;
       return;

--- a/src/lib/components/CommandPalette.svelte
+++ b/src/lib/components/CommandPalette.svelte
@@ -2,6 +2,7 @@
   import { fade, scale } from "svelte/transition";
   import { Command } from "bits-ui";
   import { registry, type Command as Cmd, type CommandItem as CmdItem } from "$lib/commands/registry";
+  import { formatShortcut } from "$lib/platform";
 
   interface Props {
     open: boolean;
@@ -42,21 +43,6 @@
       });
     }
   });
-
-  function formatShortcut(shortcut: string): string {
-    return shortcut
-      .split("+")
-      .map((part) => {
-        switch (part) {
-          case "cmd": return "\u2318";
-          case "shift": return "\u21e7";
-          case "alt": return "\u2325";
-          case "ctrl": return "\u2303";
-          default: return part.toUpperCase();
-        }
-      })
-      .join("");
-  }
 
   async function handleCommandSelect(cmd: Cmd) {
     if (cmd.getItems) {

--- a/src/lib/components/MarkdownPane.svelte
+++ b/src/lib/components/MarkdownPane.svelte
@@ -9,6 +9,7 @@
   import { vim } from "@replit/codemirror-vim";
   import { open, save } from "@tauri-apps/plugin-dialog";
   import { readFile, writeFile } from "$lib/tauri";
+  import { hasPrimaryModifier } from "$lib/platform";
   import { settings } from "$lib/stores/settings";
 
   interface Props {
@@ -201,7 +202,7 @@
 
   // Handle Cmd+S
   function handleKeydown(e: KeyboardEvent) {
-    if ((e.metaKey || e.ctrlKey) && e.key === "s") {
+    if (hasPrimaryModifier(e) && e.key === "s") {
       e.preventDefault();
       saveCurrentTab();
     }

--- a/src/lib/components/SetupPrompt.svelte
+++ b/src/lib/components/SetupPrompt.svelte
@@ -58,7 +58,7 @@
           This will:
         </p>
         <ul class="ml-4 list-disc text-sm leading-relaxed text-text-secondary space-y-1">
-          <li>Install <code class="rounded bg-bg-surface/60 px-1.5 py-0.5 text-xs text-text-primary">roux-cli</code> to <code class="rounded bg-bg-surface/60 px-1.5 py-0.5 text-xs text-text-primary">~/.local/bin/</code></li>
+          <li>Use the bundled <code class="rounded bg-bg-surface/60 px-1.5 py-0.5 text-xs text-text-primary">roux-cli</code> companion binary</li>
           <li>Add hooks to your Claude Code settings</li>
         </ul>
 
@@ -67,7 +67,7 @@
             <p class="text-xs text-amber">
               <span class="font-semibold">GitHub CLI not found.</span>
               GitHub Actions watches require <code class="rounded bg-bg-surface/60 px-1 py-0.5 text-[11px]">gh</code> to be installed.
-              You can install it later with <code class="rounded bg-bg-surface/60 px-1 py-0.5 text-[11px]">brew install gh</code>.
+              You can install it later and rerun setup when you need it.
             </p>
           </div>
         {/if}

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -1,0 +1,27 @@
+export function isMacPlatform(): boolean {
+  const platform = navigator.platform || "";
+  return /Mac|iPhone|iPad|iPod/i.test(platform);
+}
+
+export function hasPrimaryModifier(e: KeyboardEvent): boolean {
+  return isMacPlatform() ? e.metaKey : e.ctrlKey;
+}
+
+export function shortcutDisplayPart(part: string): string {
+  switch (part) {
+    case "cmd":
+      return isMacPlatform() ? "\u2318" : "Ctrl";
+    case "shift":
+      return isMacPlatform() ? "\u21e7" : "Shift";
+    case "alt":
+      return isMacPlatform() ? "\u2325" : "Alt";
+    case "ctrl":
+      return isMacPlatform() ? "\u2303" : "Ctrl";
+    default:
+      return part.toUpperCase();
+  }
+}
+
+export function formatShortcut(shortcut: string): string {
+  return shortcut.split("+").map(shortcutDisplayPart).join(isMacPlatform() ? "" : "+");
+}


### PR DESCRIPTION
## Summary
- Add native Windows platform helpers for config/status paths, CLI naming, hook command quoting, shell resolution, and nono detection.
- Bundle the internal roux-cli sidecar and add an unsigned per-user NSIS Windows build path via Task/Tauri.
- Map primary shortcuts to Ctrl on Windows/Linux, update setup copy, and document Windows build prerequisites and limitations.

## Verification
- task cli:install
- task test
- task windows:build

Generated local installer: src-tauri\\target\\release\\bundle\\nsis\\Roux_0.1.4_x64-setup.exe

## Notes
- The repo has no CONTRIBUTING.md or PR template on origin/main; README-documented test/build flows were used as the merge check.
- Windows v1 keeps roux-cli internal, does not mutate PATH, does not add WSL Claude fallback, and leaves Claude settings alone on uninstall.