### PR TITLE
[codex] Add drag-and-drop pane reordering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roux",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roux",
-      "version": "0.1.0",
+      "version": "0.2.1",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/src/lib/components/PaneShell.svelte
+++ b/src/lib/components/PaneShell.svelte
@@ -8,6 +8,7 @@
   import { resizeSession, killSession, spawnTask, attachPtyOutput, createPtyOutputChannel } from "$lib/tauri";
   import { sessionState } from "$lib/stores/sessions";
   import { settings } from "$lib/stores/settings";
+  import { draggedPaneId, dropTarget, resetPaneDrag } from "$lib/stores/paneDrag";
   import { getXtermTheme } from "$lib/themes";
   import { reconnectSession } from "$lib/sessions/reconnect";
   import { log, logError } from "$lib/logging";
@@ -33,6 +34,8 @@
 
   const instance = $derived($paneInstances.get(paneId));
   const isFocused = $derived($focusedPaneId === paneId);
+  const isDraggingPane = $derived($draggedPaneId === paneId);
+  const isAnyPaneDragging = $derived($draggedPaneId !== null);
   const session = $derived($sessionState.sessions.find((s) => s.id === sessionId));
   const isDisconnected = $derived(instance?.type === "claude" && session?.status === "disconnected");
 
@@ -85,6 +88,35 @@
 
   function handleMouseDown() {
     setLogicalFocus(paneId);
+  }
+
+  function handleTitlebarDoubleClick() {
+    if (instance && !isAnyPaneDragging) {
+      startRenaming(instance.name ?? "");
+    }
+  }
+
+  function handleDragStart(event: DragEvent) {
+    const target = event.target;
+    if (
+      editingName ||
+      (target instanceof HTMLElement && target.closest("button, input, textarea"))
+    ) {
+      event.preventDefault();
+      return;
+    }
+
+    if (event.dataTransfer) {
+      event.dataTransfer.effectAllowed = "move";
+      event.dataTransfer.setData("text/plain", paneId);
+    }
+
+    draggedPaneId.set(paneId);
+    dropTarget.set(null);
+  }
+
+  function handleDragEnd() {
+    resetPaneDrag();
   }
 
   // Reconnect handlers for claude pane SessionPicker
@@ -273,13 +305,21 @@
   <div
     class="pane-shell relative flex flex-col flex-1 min-h-0 min-w-0 overflow-hidden bg-bg-deep"
     data-focused={isFocused}
+    data-pane-id={paneId}
+    data-dragging={isDraggingPane}
     onmousedown={handleMouseDown}
   >
     <!-- Mini title bar -->
     <div
       class="pane-shell__titlebar flex h-6 shrink-0 select-none items-center border-b border-hairline px-2 gap-1.5"
       class:shadow-[inset_0_2px_0_var(--color-accent-dim)]={isFocused && !suppressTitleAccent}
-      ondblclick={() => startRenaming(instance.name ?? "")}
+      class:cursor-grab={!editingName}
+      class:cursor-grabbing={isDraggingPane}
+      draggable={!editingName}
+      data-drag-handle="true"
+      ondragstart={handleDragStart}
+      ondragend={handleDragEnd}
+      ondblclick={handleTitlebarDoubleClick}
     >
       <span class="text-[10px] uppercase tracking-wider text-text-muted/60 shrink-0">{paneTypeLabel(instance.type)}</span>
       {#if editingName}
@@ -290,6 +330,7 @@
           placeholder="name this pane..."
           bind:value={nameInput}
           autofocus
+          draggable="false"
           onblur={() => commitRename()}
           onkeydown={(e) => {
             if (e.key === "Enter") commitRename();
@@ -305,9 +346,12 @@
         <button
           class="flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center rounded text-[12px] leading-none text-text-secondary transition-colors hover:bg-bg-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50"
           onclick={(e) => {
+            if (isAnyPaneDragging) return;
             e.stopPropagation();
             void closePane(sessionId, paneId);
           }}
+          disabled={isAnyPaneDragging}
+          draggable="false"
           title="Close pane"
         >
           &times;

--- a/src/lib/components/SessionTabs.svelte
+++ b/src/lib/components/SessionTabs.svelte
@@ -307,7 +307,7 @@
   {#if $sessionState.activeSessionId}
     {#if $settings.taskPanelCollapsed}
       <button
-        class="shrink-0 flex w-full items-center gap-1.5 border-t border-hairline bg-transparent px-3 py-2 text-left cursor-pointer hover:bg-bg-active/40 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50 focus-visible:ring-offset-1 focus-visible:ring-offset-bg-deep"
+        class="shrink-0 flex w-full items-center gap-1.5 border-t border-hairline bg-bg-deep/35 px-3 py-2 text-left cursor-pointer hover:bg-bg-active/40 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50 focus-visible:ring-offset-1 focus-visible:ring-offset-bg-deep"
         onclick={() => updateSetting("taskPanelCollapsed", false)}
       >
         <span class="text-[11px] text-text-secondary">&#9654;</span>
@@ -317,11 +317,11 @@
       <!-- svelte-ignore a11y_no_static_element_interactions -->
       <div class="group flex h-3 shrink-0 cursor-row-resize items-center px-2" onmousedown={handleDividerDown}>
         <div
-          class="h-px w-full rounded-full transition-all duration-150 {dragging ? 'bg-white/20' : 'bg-white/10 opacity-0 group-hover:opacity-100'}"
+          class="h-px w-full transition-all duration-150 {dragging ? 'bg-white/22' : 'bg-white/10 group-hover:bg-white/16'}"
         ></div>
       </div>
 
-      <div style="flex: {$settings.taskPanelSplit}; min-height: 0;">
+      <div class="min-h-0 bg-bg-deep/35" style="flex: {$settings.taskPanelSplit};">
         <TaskPanel onCollapse={() => updateSetting("taskPanelCollapsed", true)} />
       </div>
     {/if}

--- a/src/lib/components/SplitPane.svelte
+++ b/src/lib/components/SplitPane.svelte
@@ -3,7 +3,9 @@
   import PaneShell from "./PaneShell.svelte";
   import { fullscreenPaneId } from "$lib/panes/focus";
   import { paneInstances } from "$lib/panes/instances";
-  import { containsPaneId, setActiveStackIndex, type LayoutNode } from "$lib/panes/layout";
+  import { getDropSide } from "$lib/panes/dropTarget";
+  import { movePane, containsPaneId, setActiveStackIndex, type DropSide, type LayoutNode } from "$lib/panes/layout";
+  import { draggedPaneId, dropTarget, resetPaneDrag } from "$lib/stores/paneDrag";
 
   interface Props {
     node: LayoutNode;
@@ -20,10 +22,77 @@
     }
     return node.children.map(getStackDisplayLabel).join(" | ");
   }
+
+  function dropOverlayClass(side: DropSide): string {
+    switch (side) {
+      case "left":
+        return "left-0 top-0 h-full w-[28%] border-l-2";
+      case "right":
+        return "right-0 top-0 h-full w-[28%] border-r-2";
+      case "top":
+        return "left-0 top-0 h-[28%] w-full border-t-2";
+      case "bottom":
+        return "bottom-0 left-0 h-[28%] w-full border-b-2";
+    }
+  }
+
+  function handleLeafDragOver(event: DragEvent, paneId: string) {
+    if (!visible || !$draggedPaneId || $draggedPaneId === paneId) return;
+    if (!(event.currentTarget instanceof HTMLElement)) return;
+    event.preventDefault();
+    const side = getDropSide(
+      event.currentTarget.getBoundingClientRect(),
+      event.clientX,
+      event.clientY
+    );
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = "move";
+    }
+    dropTarget.set({ paneId, side });
+  }
+
+  function handleLeafDragLeave(event: DragEvent, paneId: string) {
+    const currentTarget = event.currentTarget;
+    const related = event.relatedTarget;
+    if (
+      currentTarget instanceof HTMLElement &&
+      related instanceof Node &&
+      currentTarget.contains(related)
+    ) {
+      return;
+    }
+    if ($dropTarget?.paneId === paneId) {
+      dropTarget.set(null);
+    }
+  }
+
+  function handleLeafDrop(event: DragEvent, paneId: string) {
+    event.preventDefault();
+    const dragged = $draggedPaneId;
+    const target = $dropTarget;
+    resetPaneDrag();
+    if (!visible || !dragged || dragged === paneId || target?.paneId !== paneId) return;
+    movePane(sessionId, dragged, paneId, target.side);
+  }
 </script>
 
 {#if node.kind === "leaf"}
-  <PaneShell paneId={node.paneId} {sessionId} {visible} />
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div
+    class="relative flex flex-1 min-h-0 min-w-0"
+    data-drop-pane-id={node.paneId}
+    ondragover={(event) => handleLeafDragOver(event, node.paneId)}
+    ondragleave={(event) => handleLeafDragLeave(event, node.paneId)}
+    ondrop={(event) => handleLeafDrop(event, node.paneId)}
+  >
+    <PaneShell paneId={node.paneId} {sessionId} {visible} />
+    {#if visible && $dropTarget?.paneId === node.paneId && $draggedPaneId !== node.paneId}
+      <div
+        class={`pointer-events-none absolute z-10 bg-accent/20 shadow-[inset_0_0_0_1px_var(--color-accent)] ${dropOverlayClass($dropTarget.side)}`}
+        data-drop-side={$dropTarget.side}
+      ></div>
+    {/if}
+  </div>
 {:else if node.stacked}
   <!-- Stacked view: Zellij-style with collapsed tabs and expanded active pane -->
   <!-- All children stay mounted (hidden via CSS) so terminals keep their state -->

--- a/src/lib/components/__tests__/SplitPane.drag.test.ts
+++ b/src/lib/components/__tests__/SplitPane.drag.test.ts
@@ -62,17 +62,32 @@ describe("SplitPane drag and drop", () => {
     expect(sourceHandle).toBeTruthy();
     expect(targetPane).toBeTruthy();
 
+    Object.defineProperty(targetPane!, "getBoundingClientRect", {
+      configurable: true,
+      value: () => ({
+        left: 0,
+        top: 0,
+        width: 120,
+        height: 80,
+        right: 120,
+        bottom: 80,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }),
+    });
+
     const dataTransfer = createDataTransfer();
     await fireEvent.dragStart(sourceHandle!, { dataTransfer });
     expect(get(draggedPaneId)).toBe("p2");
-    await fireEvent.dragOver(targetPane!, { clientX: 1, clientY: 50, dataTransfer });
+    await fireEvent.dragOver(targetPane!, { clientX: 2, clientY: 40, dataTransfer });
     expect(get(dropTarget)).toEqual({ paneId: "p1", side: "left" });
     await tick();
 
     const overlay = container.querySelector('[data-drop-side="left"]');
     expect(overlay).toBeTruthy();
 
-    await fireEvent.drop(targetPane!, { clientX: 1, clientY: 50, dataTransfer });
+    await fireEvent.drop(targetPane!, { clientX: 2, clientY: 40, dataTransfer });
 
     expect(collectLeafIds(getLayout("s1"))).toEqual(["p2", "p1"]);
     expect(container.querySelector('[data-drop-side="left"]')).toBeNull();

--- a/src/lib/components/__tests__/SplitPane.drag.test.ts
+++ b/src/lib/components/__tests__/SplitPane.drag.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { render, fireEvent } from "@testing-library/svelte";
+import { get } from "svelte/store";
+import { tick } from "svelte";
+import SplitPaneHarness from "./SplitPaneHarness.svelte";
+import { createPane, resetInstances } from "$lib/panes/instances";
+import {
+  collectLeafIds,
+  getLayout,
+  initSessionLayout,
+  insertLeaf,
+  resetLayouts,
+  sessionLayouts,
+} from "$lib/panes/layout";
+import { resetFocus } from "$lib/panes/focus";
+import { draggedPaneId, dropTarget, resetPaneDrag } from "$lib/stores/paneDrag";
+
+class ResizeObserverStub {
+  observe() {}
+  disconnect() {}
+}
+
+function createDataTransfer(): DataTransfer {
+  return {
+    dropEffect: "move",
+    effectAllowed: "all",
+    files: [] as unknown as FileList,
+    items: [] as unknown as DataTransferItemList,
+    types: [],
+    clearData() {},
+    getData() {
+      return "";
+    },
+    setData() {},
+    setDragImage() {},
+  } as DataTransfer;
+}
+
+describe("SplitPane drag and drop", () => {
+  beforeEach(() => {
+    globalThis.ResizeObserver = ResizeObserverStub as unknown as typeof ResizeObserver;
+    resetLayouts();
+    resetInstances();
+    resetFocus();
+    resetPaneDrag();
+
+    createPane({ id: "p1", type: "shell", ptyId: "pty-1", name: "one" });
+    createPane({ id: "p2", type: "shell", ptyId: "pty-2", name: "two" });
+
+    initSessionLayout("s1", "p1");
+    sessionLayouts.update((m) => {
+      m.set("s1", insertLeaf(getLayout("s1"), "p1", "h", "p2"));
+      return new Map(m);
+    });
+  });
+
+  it("shows an overlay and reorders panes on drop", async () => {
+    const { container } = render(SplitPaneHarness, { sessionId: "s1" });
+    const sourceHandle = container.querySelector('[data-pane-id="p2"] [data-drag-handle="true"]');
+    const targetPane = container.querySelector('[data-drop-pane-id="p1"]');
+
+    expect(sourceHandle).toBeTruthy();
+    expect(targetPane).toBeTruthy();
+
+    const dataTransfer = createDataTransfer();
+    await fireEvent.dragStart(sourceHandle!, { dataTransfer });
+    expect(get(draggedPaneId)).toBe("p2");
+    await fireEvent.dragOver(targetPane!, { clientX: 1, clientY: 50, dataTransfer });
+    expect(get(dropTarget)).toEqual({ paneId: "p1", side: "left" });
+    await tick();
+
+    const overlay = container.querySelector('[data-drop-side="left"]');
+    expect(overlay).toBeTruthy();
+
+    await fireEvent.drop(targetPane!, { clientX: 1, clientY: 50, dataTransfer });
+
+    expect(collectLeafIds(getLayout("s1"))).toEqual(["p2", "p1"]);
+    expect(container.querySelector('[data-drop-side="left"]')).toBeNull();
+  });
+});

--- a/src/lib/components/__tests__/SplitPaneHarness.svelte
+++ b/src/lib/components/__tests__/SplitPaneHarness.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import SplitPane from "../SplitPane.svelte";
+  import { sessionLayouts } from "$lib/panes/layout";
+
+  interface Props {
+    sessionId: string;
+  }
+
+  let { sessionId }: Props = $props();
+  const tree = $derived($sessionLayouts.get(sessionId));
+</script>
+
+{#if tree}
+  <SplitPane node={tree} {sessionId} />
+{/if}

--- a/src/lib/panes/__tests__/dropTarget.test.ts
+++ b/src/lib/panes/__tests__/dropTarget.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { getDropSide } from "../dropTarget";
+
+describe("getDropSide", () => {
+  const rect = { left: 100, top: 200, width: 200, height: 120 };
+
+  it("returns left for points closest to the left edge", () => {
+    expect(getDropSide(rect, 105, 250)).toBe("left");
+  });
+
+  it("returns right for points closest to the right edge", () => {
+    expect(getDropSide(rect, 295, 250)).toBe("right");
+  });
+
+  it("returns top for points closest to the top edge", () => {
+    expect(getDropSide(rect, 180, 205)).toBe("top");
+  });
+
+  it("returns bottom for points closest to the bottom edge", () => {
+    expect(getDropSide(rect, 180, 315)).toBe("bottom");
+  });
+
+  it("breaks corner ties consistently", () => {
+    expect(getDropSide(rect, 100, 200)).toBe("left");
+    expect(getDropSide(rect, 300, 320)).toBe("right");
+  });
+
+  it("stays stable for narrow panes", () => {
+    const narrowRect = { left: 0, top: 0, width: 18, height: 160 };
+    expect(getDropSide(narrowRect, 9, 3)).toBe("top");
+    expect(getDropSide(narrowRect, 9, 157)).toBe("bottom");
+    expect(getDropSide(narrowRect, 1, 80)).toBe("left");
+  });
+});

--- a/src/lib/panes/__tests__/layout.test.ts
+++ b/src/lib/panes/__tests__/layout.test.ts
@@ -27,6 +27,14 @@ function treeShape(node: LayoutNode): any {
   return { dir: node.direction, children: node.children.map(treeShape) };
 }
 
+function expectNormalizedTree(node: LayoutNode): void {
+  if (node.kind === "leaf") return;
+  expect(node.children.length).toBeGreaterThan(1);
+  for (const child of node.children) {
+    expectNormalizedTree(child);
+  }
+}
+
 describe("layout tree", () => {
   beforeEach(() => {
     resetLayouts();
@@ -375,9 +383,128 @@ describe("movePane (drag-and-drop)", () => {
       return new Map(m);
     });
     movePane("s1", "p3", "p1", "right");
+    expect(treeShape(getLayout("s1"))).toEqual({
+      dir: "h",
+      children: ["p1", "p3", "p2"],
+    });
+    expect(get(focusedPaneId)).toBe("p3");
+  });
+
+  it("moves a pane to the left of another", () => {
+    initSessionLayout("s1", "p1");
+    sessionLayouts.update((m) => {
+      let t = getLayout("s1");
+      t = insertLeaf(t, "p1", "h", "p2");
+      t = insertLeaf(t, "p2", "h", "p3");
+      m.set("s1", t);
+      return new Map(m);
+    });
+    movePane("s1", "p3", "p1", "left");
+    expect(treeShape(getLayout("s1"))).toEqual({
+      dir: "h",
+      children: ["p3", "p1", "p2"],
+    });
+  });
+
+  it("moves a pane above another", () => {
+    initSessionLayout("s1", "p1");
+    sessionLayouts.update((m) => {
+      let t = getLayout("s1");
+      t = insertLeaf(t, "p1", "v", "p2");
+      t = insertLeaf(t, "p2", "v", "p3");
+      m.set("s1", t);
+      return new Map(m);
+    });
+    movePane("s1", "p3", "p1", "top");
+    expect(treeShape(getLayout("s1"))).toEqual({
+      dir: "v",
+      children: ["p3", "p1", "p2"],
+    });
+  });
+
+  it("moves a pane below another", () => {
+    initSessionLayout("s1", "p1");
+    sessionLayouts.update((m) => {
+      let t = getLayout("s1");
+      t = insertLeaf(t, "p1", "v", "p2");
+      t = insertLeaf(t, "p2", "v", "p3");
+      m.set("s1", t);
+      return new Map(m);
+    });
+    movePane("s1", "p3", "p1", "bottom");
+    expect(treeShape(getLayout("s1"))).toEqual({
+      dir: "v",
+      children: ["p1", "p3", "p2"],
+    });
+  });
+
+  it("moves a pane into a nested split and flattens same-direction structure", () => {
+    initSessionLayout("s1", "p1");
+    sessionLayouts.update((m) => {
+      let t = getLayout("s1");
+      t = insertLeaf(t, "p1", "h", "p2");
+      t = insertLeaf(t, "p2", "v", "p3");
+      m.set("s1", t);
+      return new Map(m);
+    });
+    movePane("s1", "p1", "p2", "bottom");
+    expect(treeShape(getLayout("s1"))).toEqual({
+      dir: "v",
+      children: ["p2", "p1", "p3"],
+    });
+    expectNormalizedTree(getLayout("s1"));
+  });
+
+  it("moves a pane out of a nested subtree into an ancestor split", () => {
+    initSessionLayout("s1", "p1");
+    sessionLayouts.update((m) => {
+      let t = getLayout("s1");
+      t = insertLeaf(t, "p1", "h", "p2");
+      t = insertLeaf(t, "p2", "v", "p3");
+      m.set("s1", t);
+      return new Map(m);
+    });
+    movePane("s1", "p3", "p1", "left");
+    expect(treeShape(getLayout("s1"))).toEqual({
+      dir: "h",
+      children: ["p3", "p1", "p2"],
+    });
+    expectNormalizedTree(getLayout("s1"));
+  });
+
+  it("keeps all pane ids present exactly once after repeated moves", () => {
+    initSessionLayout("s1", "p1");
+    sessionLayouts.update((m) => {
+      let t = getLayout("s1");
+      t = insertLeaf(t, "p1", "h", "p2");
+      t = insertLeaf(t, "p2", "v", "p3");
+      t = insertLeaf(t, "p3", "h", "p4");
+      m.set("s1", t);
+      return new Map(m);
+    });
+
+    movePane("s1", "p4", "p1", "left");
+    movePane("s1", "p2", "p3", "bottom");
+    movePane("s1", "p1", "p2", "right");
+
     const ids = collectLeafIds(getLayout("s1"));
-    expect(ids).toContain("p1");
-    expect(ids).toContain("p2");
-    expect(ids).toContain("p3");
+    expect(ids.sort()).toEqual(["p1", "p2", "p3", "p4"]);
+    expect(new Set(ids).size).toBe(ids.length);
+    expectNormalizedTree(getLayout("s1"));
+  });
+
+  it("treats self-drop as a no-op", () => {
+    initSessionLayout("s1", "p1");
+    sessionLayouts.update((m) => {
+      let t = getLayout("s1");
+      t = insertLeaf(t, "p1", "h", "p2");
+      m.set("s1", t);
+      return new Map(m);
+    });
+    setLogicalFocus("p2");
+    const before = getLayout("s1");
+    movePane("s1", "p2", "p2", "left");
+    expect(getLayout("s1")).toEqual(before);
+    expect(get(focusedPaneId)).toBe("p2");
   });
 });

--- a/src/lib/panes/dropTarget.ts
+++ b/src/lib/panes/dropTarget.ts
@@ -1,0 +1,32 @@
+import type { DropSide } from "./layout";
+
+type RectLike = Pick<DOMRect, "left" | "top" | "width" | "height">;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+/**
+ * Resolve which side of a pane the pointer is closest to.
+ * The result is always stable, even for very small panes.
+ */
+export function getDropSide(
+  rect: RectLike,
+  clientX: number,
+  clientY: number
+): DropSide {
+  const width = Math.max(rect.width, 1);
+  const height = Math.max(rect.height, 1);
+  const x = clamp(clientX - rect.left, 0, width);
+  const y = clamp(clientY - rect.top, 0, height);
+
+  const distances: Array<{ side: DropSide; distance: number }> = [
+    { side: "left", distance: x },
+    { side: "right", distance: width - x },
+    { side: "top", distance: y },
+    { side: "bottom", distance: height - y },
+  ];
+
+  distances.sort((a, b) => a.distance - b.distance);
+  return distances[0].side;
+}

--- a/src/lib/panes/layout.ts
+++ b/src/lib/panes/layout.ts
@@ -625,6 +625,7 @@ export function movePane(
   sessionLayouts.update((m) => {
     const tree = m.get(sessionId);
     if (!tree) return m;
+    if (!containsPaneId(tree, paneId)) return m;
 
     const afterRemove = removeLeaf(tree, paneId);
     if (!afterRemove) return m;

--- a/src/lib/panes/layout.ts
+++ b/src/lib/panes/layout.ts
@@ -47,26 +47,36 @@ export function insertLeaf(
   direction: SplitDirection,
   newPaneId: string
 ): LayoutNode {
+  return insertLeafRelative(
+    node,
+    targetId,
+    direction,
+    { kind: "leaf", paneId: newPaneId },
+    false
+  );
+}
+
+function insertLeafRelative(
+  node: LayoutNode,
+  targetId: string,
+  direction: SplitDirection,
+  newLeaf: LayoutNode & { kind: "leaf" },
+  insertBefore: boolean
+): LayoutNode {
   if (node.kind === "leaf") {
     if (node.paneId !== targetId) return node;
-    // Wrap this leaf and the new leaf in a split node
+    const children = insertBefore ? [newLeaf, node] : [node, newLeaf];
     return {
       kind: "split",
       direction,
-      children: [
-        { kind: "leaf", paneId: targetId },
-        { kind: "leaf", paneId: newPaneId },
-      ],
+      children,
     };
   }
 
-  // node is a split — recurse into children
   const newChildren = node.children.map((child) =>
-    insertLeaf(child, targetId, direction, newPaneId)
+    insertLeafRelative(child, targetId, direction, newLeaf, insertBefore)
   );
 
-  // Check if any child was transformed into a same-direction split that
-  // should be flattened into this level
   const flatChildren: LayoutNode[] = [];
   let changed = false;
 
@@ -77,9 +87,10 @@ export function insertLeaf(
     if (
       next !== orig &&
       next.kind === "split" &&
+      !node.stacked &&
+      !next.stacked &&
       next.direction === node.direction
     ) {
-      // Flatten: inline the new split's children at this level
       flatChildren.push(...next.children);
       changed = true;
     } else {
@@ -88,9 +99,16 @@ export function insertLeaf(
     }
   }
 
-  if (!changed) return node;
-
-  return { ...node, children: flatChildren, sizes: undefined };
+  return changed
+    ? {
+        ...node,
+        children: flatChildren,
+        sizes: undefined,
+        activeIndex: node.stacked && node.activeIndex !== undefined
+          ? Math.min(node.activeIndex, flatChildren.length - 1)
+          : node.activeIndex,
+      }
+    : node;
 }
 
 /**
@@ -265,41 +283,6 @@ function replaceSplitInTree(
   const mapped = root.children.map((c) => replaceSplitInTree(c, target, replacement));
   if (mapped.every((c, i) => c === root.children[i])) return root;
   return { ...root, children: mapped };
-}
-
-/** Remove a leaf from a subtree (mirrors removeLeaf but avoids size/activeIndex adjustments). */
-function removeLeafFromSubtree(node: LayoutNode, paneId: string): LayoutNode | null {
-  if (node.kind === "leaf") {
-    return node.paneId === paneId ? null : node;
-  }
-  const mapped = node.children.map((c) => removeLeafFromSubtree(c, paneId));
-  const remaining = mapped.filter((c): c is LayoutNode => c !== null);
-  if (remaining.length === 0) return null;
-  if (remaining.length === 1) return remaining[0];
-  return { ...node, children: remaining };
-}
-
-/** Insert a new leaf next to target, creating a split of the given direction. */
-function insertLeafAtTarget(
-  node: LayoutNode,
-  targetId: string,
-  direction: SplitDirection,
-  newLeaf: LayoutNode,
-  insertBefore: boolean
-): LayoutNode {
-  if (node.kind === "leaf") {
-    if (node.paneId === targetId) {
-      const children = insertBefore ? [newLeaf, node] : [node, newLeaf];
-      return { kind: "split", direction, children };
-    }
-    return node;
-  }
-  return {
-    ...node,
-    children: node.children.map((child) =>
-      insertLeafAtTarget(child, targetId, direction, newLeaf, insertBefore)
-    ),
-  };
 }
 
 // ── Stacked panes helpers ────────────────────────────────────────────────────
@@ -604,7 +587,7 @@ function movePaneInTree(
       const paneLeaf: LayoutNode = { kind: "leaf", paneId };
 
       const subtree = parent.children[childIndex];
-      const subtreeAfterRemove = removeLeafFromSubtree(subtree, paneId);
+      const subtreeAfterRemove = removeLeaf(subtree, paneId);
 
       const newChildren: LayoutNode[] = [];
       let subtreePos = -1;
@@ -640,22 +623,23 @@ export function movePane(
   if (paneId === targetPaneId) return;
 
   sessionLayouts.update((m) => {
-    let tree = m.get(sessionId);
+    const tree = m.get(sessionId);
     if (!tree) return m;
 
-    // 1. Remove pane from current position
-    const afterRemove = removeLeafFromSubtree(tree, paneId);
+    const afterRemove = removeLeaf(tree, paneId);
     if (!afterRemove) return m;
 
-    // 2. Verify target still exists
     if (!containsPaneId(afterRemove, targetPaneId)) return m;
 
-    // 3. Insert at new position
     const direction = dropSideToDirection[side];
     const insertBefore = side === "left" || side === "top";
-    const newLeaf: LayoutNode = { kind: "leaf", paneId };
-
-    const afterInsert = insertLeafAtTarget(afterRemove, targetPaneId, direction, newLeaf, insertBefore);
+    const afterInsert = insertLeafRelative(
+      afterRemove,
+      targetPaneId,
+      direction,
+      { kind: "leaf", paneId },
+      insertBefore
+    );
     const next = new Map(m);
     next.set(sessionId, afterInsert);
     return next;

--- a/src/lib/stores/paneDrag.ts
+++ b/src/lib/stores/paneDrag.ts
@@ -6,3 +6,9 @@ export const draggedPaneId = writable<string | null>(null);
 
 /** Which pane + side is currently hovered as a drop target. */
 export const dropTarget = writable<{ paneId: string; side: DropSide } | null>(null);
+
+/** Clear all transient pane drag state. */
+export function resetPaneDrag(): void {
+  draggedPaneId.set(null);
+  dropTarget.set(null);
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,10 @@
 import { defineConfig } from "vitest/config";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
+import { svelteTesting } from "@testing-library/svelte/vite";
 import path from "path";
 
 export default defineConfig({
-  plugins: [svelte({ hot: false })],
+  plugins: [svelte({ hot: false }), svelteTesting()],
   test: {
     environment: "jsdom",
     include: ["src/**/*.test.ts"],


### PR DESCRIPTION
## What changed

This adds drag-and-drop pane reordering to the pane layout UI without introducing a drag-and-drop library.

The change makes pane title bars draggable, adds leaf-pane drop target overlays, and routes drops through the existing layout mutation layer. It also hardens pane move normalization so repeated drags preserve a valid split tree.

A small visual tweak in the session sidebar task panel is included in this diff, along with a lockfile sync that updates the root package version metadata to match `package.json`.

## Why

The pane model already had layout mutation support for directional moves, but the UI had no direct manipulation path for rearranging panes. The existing drag/drop move helper also needed stronger normalization guarantees before exposing it to user-driven repeated moves.

## Impact

Users can now reorder visible panes by dragging a pane title bar onto the left, right, top, or bottom edge of another visible pane.

This keeps terminal instances intact while only changing the layout tree, and adds pure and component-level tests around the new behavior.

## Validation

- `npm run test`
- `npm run check`
