### PR TITLE
[codex] introduce typed backend errors

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3742,6 +3742,7 @@ dependencies = [
 name = "roux"
 version = "0.2.2"
 dependencies = [
+ "anyhow",
  "base64 0.22.1",
  "clap",
  "dirs",
@@ -3759,6 +3760,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-shell",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "uuid",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,6 +23,7 @@ path = "src/cli.rs"
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
+anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 tauri = { version = "2", features = [] }
 tauri-plugin-shell = "2"
@@ -41,6 +42,7 @@ tokio-util = "0.7"
 reqwest = { version = "0.12", features = ["json"] }
 octocrab = "0.44"
 tauri-plugin-opener = "2.5.3"
+thiserror = "2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -4,6 +4,7 @@ use std::fs;
 use std::io::Read;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
+use thiserror::Error;
 
 #[derive(Parser)]
 #[command(name = "roux-cli", about = "Roux terminal manager CLI")]
@@ -92,41 +93,84 @@ fn socket_path() -> PathBuf {
     home.join(".config").join("roux").join("roux.sock")
 }
 
-fn send_socket_command(request: Value) -> Result<Value, String> {
+#[derive(Debug, Error)]
+enum CliError {
+    #[error("Roux is not running")]
+    RouxNotRunning,
+    #[error("Failed to connect to Roux: {source}")]
+    Connect {
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("Failed to set timeout: {source}")]
+    SetTimeout {
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("Failed to serialize command: {source}")]
+    SerializeCommand {
+        #[source]
+        source: serde_json::Error,
+    },
+    #[error("Failed to send command: {source}")]
+    SendCommand {
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("Failed to shutdown write: {source}")]
+    ShutdownWrite {
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("Failed to read response: {source}")]
+    ReadResponse {
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("Invalid response: {source}")]
+    InvalidResponse {
+        #[source]
+        source: serde_json::Error,
+    },
+}
+
+fn send_socket_command(request: Value) -> Result<Value, CliError> {
     use std::io::Write;
     use std::os::unix::net::UnixStream;
     use std::time::Duration;
 
     let path = socket_path();
     let stream = UnixStream::connect(&path).map_err(|e| {
-        if e.kind() == std::io::ErrorKind::NotFound || e.kind() == std::io::ErrorKind::ConnectionRefused {
-            "Roux is not running".to_string()
+        if e.kind() == std::io::ErrorKind::NotFound
+            || e.kind() == std::io::ErrorKind::ConnectionRefused
+        {
+            CliError::RouxNotRunning
         } else {
-            format!("Failed to connect to Roux: {}", e)
+            CliError::Connect { source: e }
         }
     })?;
 
-    stream.set_read_timeout(Some(Duration::from_secs(5)))
-        .map_err(|e| format!("Failed to set timeout: {}", e))?;
-    stream.set_write_timeout(Some(Duration::from_secs(5)))
-        .map_err(|e| format!("Failed to set timeout: {}", e))?;
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .map_err(|source| CliError::SetTimeout { source })?;
+    stream
+        .set_write_timeout(Some(Duration::from_secs(5)))
+        .map_err(|source| CliError::SetTimeout { source })?;
 
-    let json = serde_json::to_string(&request).unwrap();
+    let json =
+        serde_json::to_string(&request).map_err(|source| CliError::SerializeCommand { source })?;
     let mut stream_ref = &stream;
-    stream_ref.write_all(json.as_bytes())
-        .map_err(|e| format!("Failed to send command: {}", e))?;
-    stream_ref.write_all(b"\n")
-        .map_err(|e| format!("Failed to send command: {}", e))?;
-    stream.shutdown(std::net::Shutdown::Write)
-        .map_err(|e| format!("Failed to shutdown write: {}", e))?;
+    stream_ref.write_all(json.as_bytes()).map_err(|source| CliError::SendCommand { source })?;
+    stream_ref.write_all(b"\n").map_err(|source| CliError::SendCommand { source })?;
+    stream
+        .shutdown(std::net::Shutdown::Write)
+        .map_err(|source| CliError::ShutdownWrite { source })?;
 
     let mut response = String::new();
     let mut reader = std::io::BufReader::new(&stream);
-    reader.read_to_string(&mut response)
-        .map_err(|e| format!("Failed to read response: {}", e))?;
+    reader.read_to_string(&mut response).map_err(|source| CliError::ReadResponse { source })?;
 
-    serde_json::from_str(&response)
-        .map_err(|e| format!("Invalid response: {}", e))
+    serde_json::from_str(&response).map_err(|source| CliError::InvalidResponse { source })
 }
 
 fn get_session_id() -> Option<String> {
@@ -146,9 +190,8 @@ fn run_socket_command(request: Value) {
                     println!("{}", serde_json::to_string_pretty(data).unwrap());
                 }
             } else {
-                let error = response.get("error")
-                    .and_then(|e| e.as_str())
-                    .unwrap_or("unknown error");
+                let error =
+                    response.get("error").and_then(|e| e.as_str()).unwrap_or("unknown error");
                 eprintln!("Error: {}", error);
                 std::process::exit(1);
             }

--- a/src-tauri/src/hooks.rs
+++ b/src-tauri/src/hooks.rs
@@ -1,10 +1,71 @@
 use serde_json::{json, Value};
 use std::fs;
 use std::path::PathBuf;
+use thiserror::Error;
 
 const ROUX_HOOK_MARKER: &str = "roux-cli hook";
 
-fn roux_cli_path() -> Result<String, String> {
+#[derive(Debug, Error)]
+pub enum HooksError {
+    #[error("roux-cli binary not found. Run 'cargo install --path src-tauri' or copy roux-cli to ~/.local/bin/")]
+    RouxCliBinaryNotFound,
+    #[error("Could not determine home directory")]
+    HomeDirUnavailable,
+    #[error("Could not find roux-cli next to roux binary")]
+    RouxCliBinaryNextToRouxNotFound,
+    #[error("Failed to create ~/.local/bin: {source}")]
+    CreateBinDir {
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("Failed to copy roux-cli: {source}")]
+    CopyCliBinary {
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("{source}")]
+    ReadInstalledBinaryMetadata {
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("{source}")]
+    SetInstalledBinaryPermissions {
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("Failed to create status dir: {source}")]
+    CreateStatusDir {
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("Failed to read settings: {source}")]
+    ReadSettings {
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("Failed to parse settings: {source}")]
+    ParseSettings {
+        #[source]
+        source: serde_json::Error,
+    },
+    #[error("Failed to create .claude dir: {source}")]
+    CreateClaudeDir {
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("Failed to serialize settings: {source}")]
+    SerializeSettings {
+        #[source]
+        source: serde_json::Error,
+    },
+    #[error("Failed to write settings: {source}")]
+    WriteSettings {
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+fn roux_cli_path() -> Result<String, HooksError> {
     // Look for roux-cli in common locations
     let candidates = [
         // Primary install location
@@ -31,7 +92,7 @@ fn roux_cli_path() -> Result<String, String> {
         }
     }
 
-    Err("roux-cli binary not found. Run 'cargo install --path src-tauri' or copy roux-cli to ~/.local/bin/".to_string())
+    Err(HooksError::RouxCliBinaryNotFound)
 }
 
 /// Check if roux-cli is already installed at ~/.local/bin/
@@ -42,10 +103,10 @@ pub fn cli_is_installed() -> bool {
 }
 
 /// Install roux-cli to ~/.local/bin/ on first app load
-pub fn install_cli_binary() -> Result<String, String> {
+pub fn install_cli_binary() -> Result<String, HooksError> {
     let bin_dir =
-        dirs::home_dir().ok_or("Could not determine home directory")?.join(".local").join("bin");
-    fs::create_dir_all(&bin_dir).map_err(|e| format!("Failed to create ~/.local/bin: {}", e))?;
+        dirs::home_dir().ok_or(HooksError::HomeDirUnavailable)?.join(".local").join("bin");
+    fs::create_dir_all(&bin_dir).map_err(|source| HooksError::CreateBinDir { source })?;
 
     let target = bin_dir.join("roux-cli");
 
@@ -53,7 +114,7 @@ pub fn install_cli_binary() -> Result<String, String> {
     let source = std::env::current_exe()
         .ok()
         .and_then(|p| p.parent().map(|d| d.join("roux-cli")))
-        .ok_or("Could not find roux-cli next to roux binary")?;
+        .ok_or(HooksError::RouxCliBinaryNextToRouxNotFound)?;
 
     if source.exists() {
         // Only copy if source is newer or target doesn't exist
@@ -69,13 +130,16 @@ pub fn install_cli_binary() -> Result<String, String> {
         };
 
         if should_copy {
-            fs::copy(&source, &target).map_err(|e| format!("Failed to copy roux-cli: {}", e))?;
+            fs::copy(&source, &target).map_err(|source| HooksError::CopyCliBinary { source })?;
             #[cfg(unix)]
             {
                 use std::os::unix::fs::PermissionsExt;
-                let mut perms = fs::metadata(&target).map_err(|e| e.to_string())?.permissions();
+                let mut perms = fs::metadata(&target)
+                    .map_err(|source| HooksError::ReadInstalledBinaryMetadata { source })?
+                    .permissions();
                 perms.set_mode(0o755);
-                fs::set_permissions(&target, perms).map_err(|e| e.to_string())?;
+                fs::set_permissions(&target, perms)
+                    .map_err(|source| HooksError::SetInstalledBinaryPermissions { source })?;
             }
             eprintln!("Installed roux-cli to {}", target.display());
         }
@@ -86,15 +150,15 @@ pub fn install_cli_binary() -> Result<String, String> {
     roux_cli_path()
 }
 
-fn claude_settings_path() -> Result<PathBuf, String> {
-    let home = dirs::home_dir().ok_or("Could not determine home directory")?;
+fn claude_settings_path() -> Result<PathBuf, HooksError> {
+    let home = dirs::home_dir().ok_or(HooksError::HomeDirUnavailable)?;
     Ok(home.join(".claude").join("settings.json"))
 }
 
-fn status_dir() -> Result<(), String> {
-    let home = dirs::home_dir().ok_or("Could not determine home directory")?;
+fn status_dir() -> Result<(), HooksError> {
+    let home = dirs::home_dir().ok_or(HooksError::HomeDirUnavailable)?;
     let dir = home.join(".config").join("roux").join("status");
-    fs::create_dir_all(&dir).map_err(|e| format!("Failed to create status dir: {}", e))?;
+    fs::create_dir_all(&dir).map_err(|source| HooksError::CreateStatusDir { source })?;
     Ok(())
 }
 
@@ -191,7 +255,7 @@ fn roux_hooks_config(cli_path: &str) -> Value {
     })
 }
 
-fn merge_hooks(settings: &mut Value, cli_path: &str) -> Result<(), String> {
+fn merge_hooks(settings: &mut Value, cli_path: &str) {
     let roux = roux_hooks_config(cli_path);
     let roux_hooks = roux.get("hooks").unwrap().as_object().unwrap();
 
@@ -232,11 +296,9 @@ fn merge_hooks(settings: &mut Value, cli_path: &str) -> Result<(), String> {
         filtered.extend(roux_entries.iter().cloned());
         settings["hooks"][event_name] = Value::Array(filtered);
     }
-
-    Ok(())
 }
 
-pub fn install_hooks() -> Result<(), String> {
+pub fn install_hooks() -> Result<(), HooksError> {
     status_dir()?;
 
     let cli_path = install_cli_binary().or_else(|_| roux_cli_path())?;
@@ -244,22 +306,71 @@ pub fn install_hooks() -> Result<(), String> {
 
     let mut settings: Value = if settings_path.exists() {
         let content = fs::read_to_string(&settings_path)
-            .map_err(|e| format!("Failed to read settings: {}", e))?;
-        serde_json::from_str(&content).map_err(|e| format!("Failed to parse settings: {}", e))?
+            .map_err(|source| HooksError::ReadSettings { source })?;
+        serde_json::from_str(&content).map_err(|source| HooksError::ParseSettings { source })?
     } else {
         if let Some(parent) = settings_path.parent() {
-            fs::create_dir_all(parent)
-                .map_err(|e| format!("Failed to create .claude dir: {}", e))?;
+            fs::create_dir_all(parent).map_err(|source| HooksError::CreateClaudeDir { source })?;
         }
         json!({})
     };
 
-    merge_hooks(&mut settings, &cli_path)?;
+    merge_hooks(&mut settings, &cli_path);
 
     let output = serde_json::to_string_pretty(&settings)
-        .map_err(|e| format!("Failed to serialize settings: {}", e))?;
-    fs::write(&settings_path, output).map_err(|e| format!("Failed to write settings: {}", e))?;
+        .map_err(|source| HooksError::SerializeSettings { source })?;
+    fs::write(&settings_path, output).map_err(|source| HooksError::WriteSettings { source })?;
 
     eprintln!("Roux hooks installed (using {})", cli_path);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io;
+
+    #[test]
+    fn hooks_error_display_keeps_existing_messages() {
+        let error = HooksError::WriteSettings { source: io::Error::other("read-only file system") };
+
+        assert_eq!(error.to_string(), "Failed to write settings: read-only file system");
+    }
+
+    #[test]
+    fn merge_hooks_replaces_existing_roux_entries() {
+        let mut settings = json!({
+            "hooks": {
+                "Stop": [
+                    {
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "/tmp/roux-cli hook idle"
+                            }
+                        ]
+                    },
+                    {
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "echo keep-me"
+                            }
+                        ]
+                    }
+                ]
+            }
+        });
+
+        merge_hooks(&mut settings, "/usr/local/bin/roux-cli");
+
+        let stop_hooks = settings["hooks"]["Stop"].as_array().unwrap();
+        assert_eq!(stop_hooks.len(), 2);
+        assert!(stop_hooks.iter().any(|entry| {
+            entry["hooks"][0]["command"] == json!("/usr/local/bin/roux-cli hook idle")
+        }));
+        assert!(stop_hooks
+            .iter()
+            .any(|entry| entry["hooks"][0]["command"] == json!("echo keep-me")));
+    }
 }

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -1,8 +1,8 @@
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::PathBuf;
-use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
 
 static LOG_FILE: Mutex<Option<PathBuf>> = Mutex::new(None);
 static ENABLED: AtomicBool = AtomicBool::new(false);
@@ -55,9 +55,8 @@ pub fn set_enabled(enabled: bool) {
 }
 
 fn chrono_now() -> String {
-    let dur = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default();
+    let dur =
+        std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap_or_default();
     let secs = dur.as_secs();
     let hours = (secs % 86400) / 3600;
     let mins = (secs % 3600) / 60;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -60,7 +60,7 @@ fn update_settings(
 ) -> Result<(), String> {
     let settings = settings.normalized();
     logging::set_enabled(settings.enable_logging);
-    settings::save_settings(&settings)?;
+    settings::save_settings(&settings).map_err(|e| e.to_string())?;
     *state.settings.lock().unwrap() = settings.clone();
     app.emit("settings-changed", &settings).map_err(|e| e.to_string())
 }
@@ -73,17 +73,17 @@ fn cmd_create_worktree(
 ) -> Result<String, String> {
     let settings = state.settings.lock().unwrap();
     let base_path = settings.worktree_base_path.as_deref();
-    worktree::create_worktree(&repo_path, &branch, base_path)
+    worktree::create_worktree(&repo_path, &branch, base_path).map_err(|e| e.to_string())
 }
 
 #[tauri::command]
 fn cmd_remove_worktree(worktree_path: String) -> Result<(), String> {
-    worktree::remove_worktree(&worktree_path)
+    worktree::remove_worktree(&worktree_path).map_err(|e| e.to_string())
 }
 
 #[tauri::command]
 fn cmd_list_worktrees(repo_path: String) -> Result<Vec<worktree::Worktree>, String> {
-    worktree::list_worktrees(&repo_path)
+    worktree::list_worktrees(&repo_path).map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -117,7 +117,7 @@ fn cmd_open_in_editor(path: String) -> Result<(), String> {
 // We accept String and convert to bytes server-side for simplicity.
 #[tauri::command]
 fn write_to_session(id: String, data: String, state: tauri::State<AppState>) -> Result<(), String> {
-    state.pty_manager.write(&id, data.as_bytes())
+    state.pty_manager.write(&id, data.as_bytes()).map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -127,7 +127,7 @@ fn resize_session(
     rows: u16,
     state: tauri::State<AppState>,
 ) -> Result<(), String> {
-    state.pty_manager.resize(&id, cols, rows)
+    state.pty_manager.resize(&id, cols, rows).map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -136,7 +136,8 @@ fn attach_pty_output(
     on_event: tauri::ipc::Channel<tauri::ipc::Response>,
     state: tauri::State<AppState>,
 ) -> Result<(), String> {
-    state.pty_manager.attach_output_channel(&id, on_event)
+    state.pty_manager.attach_output_channel(&id, on_event);
+    Ok(())
 }
 
 #[tauri::command]
@@ -146,7 +147,7 @@ fn spawn_shell(
     state: tauri::State<AppState>,
     app: tauri::AppHandle,
 ) -> Result<(), String> {
-    state.pty_manager.spawn_shell(&id, &working_dir, None, app.clone())
+    state.pty_manager.spawn_shell(&id, &working_dir, None, app.clone()).map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -157,12 +158,15 @@ fn spawn_task(
     state: tauri::State<AppState>,
     app: tauri::AppHandle,
 ) -> Result<(), String> {
-    state.pty_manager.spawn_task(&id, &command, &working_dir, None, app.clone())
+    state
+        .pty_manager
+        .spawn_task(&id, &command, &working_dir, None, app.clone())
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]
 fn kill_session(id: String, state: tauri::State<AppState>) -> Result<(), String> {
-    state.pty_manager.kill(&id)?;
+    state.pty_manager.kill(&id);
     state.session_store.remove(&id);
     Ok(())
 }
@@ -195,7 +199,8 @@ fn create_session(
     } else if let Some(br) = branch {
         // Create new worktree
         let base = settings.worktree_base_path.as_deref();
-        let wt_path = worktree::create_worktree(&repo_path, &br, base)?;
+        let wt_path =
+            worktree::create_worktree(&repo_path, &br, base).map_err(|e| e.to_string())?;
         (wt_path, br, true)
     } else {
         // Use repo directly
@@ -210,7 +215,12 @@ fn create_session(
     }
 
     rlog!("Creating session '{}' (id={}) in '{}'", name, session_id, work_dir);
-    rlog!("  branch={}, flags={:?}, claude_binary={:?}", actual_branch, all_flags, settings.claude_binary_path);
+    rlog!(
+        "  branch={}, flags={:?}, claude_binary={:?}",
+        actual_branch,
+        all_flags,
+        settings.claude_binary_path
+    );
 
     // Spawn PTY
     let spawn_result = state.pty_manager.spawn(
@@ -224,12 +234,13 @@ fn create_session(
     );
 
     // Rollback worktree on spawn failure
-    if let Err(ref e) = spawn_result {
-        rlog!("Session spawn failed: {}", e);
+    if let Err(e) = spawn_result {
+        let message = e.to_string();
+        rlog!("Session spawn failed: {}", message);
         if is_wt {
             let _ = worktree::remove_worktree(&work_dir);
         }
-        return Err(e.clone());
+        return Err(message);
     }
     rlog!("Session '{}' spawned successfully", session_id);
 
@@ -261,13 +272,13 @@ fn reconnect_session(
     state: tauri::State<AppState>,
     app: tauri::AppHandle,
 ) -> Result<Session, String> {
-    let session = state.session_store.get(&id)
-        .ok_or_else(|| format!("Session {} not found", id))?;
+    let session =
+        state.session_store.get(&id).ok_or_else(|| format!("Session {} not found", id))?;
 
     let settings = state.settings.lock().unwrap().clone();
 
     // Kill existing PTY (ignore errors — it may already be dead)
-    let _ = state.pty_manager.kill(&id);
+    state.pty_manager.kill(&id);
 
     // Merge settings flags with per-call extra flags
     let mut all_flags = settings.additional_flags.clone();
@@ -278,15 +289,18 @@ fn reconnect_session(
     rlog!("Reconnecting session '{}' (id={}) in '{}'", session.name, id, session.worktree_path);
 
     // Spawn new Claude PTY under the same session ID
-    state.pty_manager.spawn(
-        &id,
-        &session.worktree_path,
-        settings.default_model.as_deref(),
-        &all_flags,
-        None,
-        settings.claude_binary_path.as_deref(),
-        app.clone(),
-    )?;
+    state
+        .pty_manager
+        .spawn(
+            &id,
+            &session.worktree_path,
+            settings.default_model.as_deref(),
+            &all_flags,
+            None,
+            settings.claude_binary_path.as_deref(),
+            app.clone(),
+        )
+        .map_err(|e| e.to_string())?;
 
     // Update status to idle
     state.session_store.update_status(&id, "idle");
@@ -401,10 +415,7 @@ fn check_setup_status() -> SetupStatus {
         .map(|o| o.status.success())
         .unwrap_or(false);
 
-    SetupStatus {
-        cli_installed: hooks::cli_is_installed(),
-        gh_available,
-    }
+    SetupStatus { cli_installed: hooks::cli_is_installed(), gh_available }
 }
 
 // Backwards compat: kept as alias used nowhere else
@@ -415,7 +426,7 @@ fn check_setup_needed() -> bool {
 
 #[tauri::command]
 fn run_setup() -> Result<(), String> {
-    hooks::install_hooks()
+    hooks::install_hooks().map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -527,10 +538,7 @@ fn list_projects(state: tauri::State<AppState>) -> Vec<Project> {
 
 #[tauri::command]
 fn create_project(name: String, state: tauri::State<AppState>) -> Project {
-    let project = Project {
-        id: uuid::Uuid::new_v4().to_string(),
-        name,
-    };
+    let project = Project { id: uuid::Uuid::new_v4().to_string(), name };
     state.project_store.add(project.clone());
     project
 }
@@ -568,7 +576,8 @@ fn get_project_notes(project_id: String) -> Result<String, String> {
 fn set_project_notes(project_id: String, content: String) -> Result<(), String> {
     let path = notes_path(&project_id);
     if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent).map_err(|e| format!("Failed to create notes dir: {}", e))?;
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create notes dir: {}", e))?;
     }
     std::fs::write(&path, &content).map_err(|e| format!("Failed to write notes: {}", e))
 }
@@ -735,8 +744,10 @@ fn main() {
             // Clean up orphaned watches and start active ones
             {
                 let state = app.state::<AppState>();
-                let session_ids: Vec<String> = state.session_store.list().iter().map(|s| s.id.clone()).collect();
-                let project_ids: Vec<String> = state.project_store.list().iter().map(|p| p.id.clone()).collect();
+                let session_ids: Vec<String> =
+                    state.session_store.list().iter().map(|s| s.id.clone()).collect();
+                let project_ids: Vec<String> =
+                    state.project_store.list().iter().map(|p| p.id.clone()).collect();
                 state.watch_manager.store().cleanup_orphans(&session_ids, &project_ids);
                 let app_handle = app.handle().clone();
                 let watch_mgr = state.watch_manager.clone();

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -6,7 +6,11 @@ use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
-use tauri::{ipc::{Channel, Response}, Emitter};
+use tauri::{
+    ipc::{Channel, Response},
+    Emitter,
+};
+use thiserror::Error;
 
 enum PtyChunk {
     Data(Vec<u8>),
@@ -24,11 +28,7 @@ struct PtyOutputState {
 
 impl PtyOutputState {
     fn new() -> Self {
-        Self {
-            channel: None,
-            backlog: VecDeque::new(),
-            backlog_bytes: 0,
-        }
+        Self { channel: None, backlog: VecDeque::new(), backlog_bytes: 0 }
     }
 
     fn buffer(&mut self, bytes: Vec<u8>) {
@@ -76,9 +76,7 @@ struct PtyOutput {
 
 impl PtyOutput {
     fn new() -> Self {
-        Self {
-            state: Arc::new(Mutex::new(PtyOutputState::new())),
-        }
+        Self { state: Arc::new(Mutex::new(PtyOutputState::new())) }
     }
 
     fn send(&self, bytes: Vec<u8>) {
@@ -94,7 +92,7 @@ impl PtyOutput {
 /// at ~16ms intervals. Returns the sender for the reader thread to push data into.
 fn spawn_flusher(
     output: PtyOutput,
-    exit_event: Option<(String, u64)>,  // (event_name, generation)
+    exit_event: Option<(String, u64)>, // (event_name, generation)
     app: tauri::AppHandle,
 ) -> mpsc::Sender<PtyChunk> {
     let (tx, rx) = mpsc::channel::<PtyChunk>();
@@ -140,7 +138,10 @@ fn spawn_flusher(
                         output.send(std::mem::take(&mut batch));
                     }
                     if let Some((evt, gen)) = &exit_event {
-                        let _ = app.emit(evt, serde_json::json!({"code": null, "generation": gen, "reason": "exit"}));
+                        let _ = app.emit(
+                            evt,
+                            serde_json::json!({"code": null, "generation": gen, "reason": "exit"}),
+                        );
                     }
                     break;
                 }
@@ -218,6 +219,57 @@ struct PtySession {
     generation: u64,
 }
 
+#[derive(Debug, Error)]
+pub enum PtyError {
+    #[error("Failed to open PTY: {source}")]
+    OpenPty {
+        #[source]
+        source: anyhow::Error,
+    },
+    #[error("Failed to spawn claude: {source}")]
+    SpawnClaude {
+        #[source]
+        source: anyhow::Error,
+    },
+    #[error("Failed to spawn shell: {source}")]
+    SpawnShell {
+        #[source]
+        source: anyhow::Error,
+    },
+    #[error("Failed to spawn task: {source}")]
+    SpawnTask {
+        #[source]
+        source: anyhow::Error,
+    },
+    #[error("Failed to get PTY writer: {source}")]
+    GetWriter {
+        #[source]
+        source: anyhow::Error,
+    },
+    #[error("Failed to get PTY reader: {source}")]
+    GetReader {
+        #[source]
+        source: anyhow::Error,
+    },
+    #[error("Session {session_id} not found")]
+    SessionNotFound { session_id: String },
+    #[error("Write failed: {source}")]
+    WriteFailed {
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("Flush failed: {source}")]
+    FlushFailed {
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("Resize failed: {source}")]
+    ResizeFailed {
+        #[source]
+        source: anyhow::Error,
+    },
+}
+
 pub struct PtyManager {
     sessions: Mutex<HashMap<String, PtySession>>,
     pending_outputs: Mutex<HashMap<String, Channel<Response>>>,
@@ -248,16 +300,21 @@ impl PtyManager {
         nono_profile: Option<&str>,
         claude_binary_path: Option<&str>,
         app: tauri::AppHandle,
-    ) -> Result<(), String> {
+    ) -> Result<(), PtyError> {
         let pty_system = native_pty_system();
 
         let pair = pty_system
             .openpty(PtySize { rows: 24, cols: 80, pixel_width: 0, pixel_height: 0 })
-            .map_err(|e| format!("Failed to open PTY: {}", e))?;
+            .map_err(|source| PtyError::OpenPty { source })?;
 
         let user_path = get_user_path();
         let claude_cmd = resolve_claude_command(claude_binary_path);
-        rlog!("Spawning claude session '{}' in '{}' with cmd='{}'", session_id, working_dir, claude_cmd);
+        rlog!(
+            "Spawning claude session '{}' in '{}' with cmd='{}'",
+            session_id,
+            working_dir,
+            claude_cmd
+        );
         rlog!("  PATH: {}", user_path);
 
         let mut cmd = if let Some(profile) = nono_profile {
@@ -290,20 +347,23 @@ impl PtyManager {
         cmd.cwd(working_dir);
 
         let child =
-            pair.slave.spawn_command(cmd).map_err(|e| format!("Failed to spawn claude: {}", e))?;
+            pair.slave.spawn_command(cmd).map_err(|source| PtyError::SpawnClaude { source })?;
 
-        let writer =
-            pair.master.take_writer().map_err(|e| format!("Failed to get PTY writer: {}", e))?;
+        let writer = pair.master.take_writer().map_err(|source| PtyError::GetWriter { source })?;
 
-        let reader = pair
-            .master
-            .try_clone_reader()
-            .map_err(|e| format!("Failed to get PTY reader: {}", e))?;
+        let reader =
+            pair.master.try_clone_reader().map_err(|source| PtyError::GetReader { source })?;
 
         let output = PtyOutput::new();
         let gen = self.generation.fetch_add(1, Ordering::Relaxed);
 
-        let session = PtySession { master: pair.master, child, writer: Arc::new(Mutex::new(writer)), output: output.clone(), generation: gen };
+        let session = PtySession {
+            master: pair.master,
+            child,
+            writer: Arc::new(Mutex::new(writer)),
+            output: output.clone(),
+            generation: gen,
+        };
         self.sessions.lock().unwrap().insert(session_id.to_string(), session);
         self.attach_pending_output(session_id, &output);
 
@@ -323,12 +383,12 @@ impl PtyManager {
         working_dir: &str,
         session_id: Option<&str>,
         app: tauri::AppHandle,
-    ) -> Result<(), String> {
+    ) -> Result<(), PtyError> {
         let pty_system = native_pty_system();
 
         let pair = pty_system
             .openpty(PtySize { rows: 24, cols: 80, pixel_width: 0, pixel_height: 0 })
-            .map_err(|e| format!("Failed to open PTY: {}", e))?;
+            .map_err(|source| PtyError::OpenPty { source })?;
 
         let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
         let user_path = get_user_path();
@@ -345,32 +405,31 @@ impl PtyManager {
         }
         cmd.cwd(working_dir);
 
-        let child =
-            pair.slave.spawn_command(cmd).map_err(|e| {
-                rlog!("Failed to spawn shell: {}", e);
-                format!("Failed to spawn shell: {}", e)
-            })?;
+        let child = pair.slave.spawn_command(cmd).map_err(|source| {
+            rlog!("Failed to spawn shell: {}", source);
+            PtyError::SpawnShell { source }
+        })?;
 
-        let writer =
-            pair.master.take_writer().map_err(|e| format!("Failed to get PTY writer: {}", e))?;
+        let writer = pair.master.take_writer().map_err(|source| PtyError::GetWriter { source })?;
 
-        let reader = pair
-            .master
-            .try_clone_reader()
-            .map_err(|e| format!("Failed to get PTY reader: {}", e))?;
+        let reader =
+            pair.master.try_clone_reader().map_err(|source| PtyError::GetReader { source })?;
 
         let output = PtyOutput::new();
         let gen = self.generation.fetch_add(1, Ordering::Relaxed);
 
-        let session = PtySession { master: pair.master, child, writer: Arc::new(Mutex::new(writer)), output: output.clone(), generation: gen };
+        let session = PtySession {
+            master: pair.master,
+            child,
+            writer: Arc::new(Mutex::new(writer)),
+            output: output.clone(),
+            generation: gen,
+        };
         self.sessions.lock().unwrap().insert(id.to_string(), session);
         self.attach_pending_output(id, &output);
 
-        let tx = spawn_flusher(
-            output.clone(),
-            Some((format!("session-exit:{}", id), gen)),
-            app.clone(),
-        );
+        let tx =
+            spawn_flusher(output.clone(), Some((format!("session-exit:{}", id), gen)), app.clone());
         spawn_reader(reader, tx);
 
         Ok(())
@@ -385,12 +444,12 @@ impl PtyManager {
         working_dir: &str,
         session_id: Option<&str>,
         app: tauri::AppHandle,
-    ) -> Result<(), String> {
+    ) -> Result<(), PtyError> {
         let pty_system = native_pty_system();
 
         let pair = pty_system
             .openpty(PtySize { rows: 24, cols: 80, pixel_width: 0, pixel_height: 0 })
-            .map_err(|e| format!("Failed to open PTY: {}", e))?;
+            .map_err(|source| PtyError::OpenPty { source })?;
 
         let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
         let user_path = get_user_path();
@@ -408,15 +467,12 @@ impl PtyManager {
         cmd.cwd(working_dir);
 
         let mut child =
-            pair.slave.spawn_command(cmd).map_err(|e| format!("Failed to spawn task: {}", e))?;
+            pair.slave.spawn_command(cmd).map_err(|source| PtyError::SpawnTask { source })?;
 
-        let writer =
-            pair.master.take_writer().map_err(|e| format!("Failed to get PTY writer: {}", e))?;
+        let writer = pair.master.take_writer().map_err(|source| PtyError::GetWriter { source })?;
 
-        let reader = pair
-            .master
-            .try_clone_reader()
-            .map_err(|e| format!("Failed to get PTY reader: {}", e))?;
+        let reader =
+            pair.master.try_clone_reader().map_err(|source| PtyError::GetReader { source })?;
 
         let output = PtyOutput::new();
         let gen = self.generation.fetch_add(1, Ordering::Relaxed);
@@ -432,76 +488,60 @@ impl PtyManager {
         self.sessions.lock().unwrap().insert(id.to_string(), session);
         self.attach_pending_output(id, &output);
 
-        let tx = spawn_flusher(
-            output.clone(),
-            None,
-            app.clone(),
-        );
+        let tx = spawn_flusher(output.clone(), None, app.clone());
         spawn_reader(reader, tx);
 
         // Wait for the child process in a background thread and emit exit code
         let exit_event_name = format!("session-exit:{}", id);
         thread::spawn(move || {
-            let code = child
-                .wait()
-                .ok()
-                .map(|status| status.exit_code());
-            let _ = app.emit(&exit_event_name, serde_json::json!({ "code": code, "generation": gen, "reason": "exit" }));
+            let code = child.wait().ok().map(|status| status.exit_code());
+            let _ = app.emit(
+                &exit_event_name,
+                serde_json::json!({ "code": code, "generation": gen, "reason": "exit" }),
+            );
         });
 
         Ok(())
     }
 
-    pub fn attach_output_channel(
-        &self,
-        session_id: &str,
-        channel: Channel<Response>,
-    ) -> Result<(), String> {
+    pub fn attach_output_channel(&self, session_id: &str, channel: Channel<Response>) {
         self.cleanup_stale_pending();
-        let output = self
-            .sessions
-            .lock()
-            .unwrap()
-            .get(session_id)
-            .map(|session| session.output.clone());
+        let output =
+            self.sessions.lock().unwrap().get(session_id).map(|session| session.output.clone());
         if let Some(output) = output {
             output.attach(channel);
         } else {
-            self.pending_outputs
-                .lock()
-                .unwrap()
-                .insert(session_id.to_string(), channel);
+            self.pending_outputs.lock().unwrap().insert(session_id.to_string(), channel);
         }
-        Ok(())
     }
 
-    pub fn write(&self, session_id: &str, data: &[u8]) -> Result<(), String> {
+    pub fn write(&self, session_id: &str, data: &[u8]) -> Result<(), PtyError> {
         let writer = {
             let sessions = self.sessions.lock().unwrap();
             let session = sessions
                 .get(session_id)
-                .ok_or_else(|| format!("Session {} not found", session_id))?;
+                .ok_or_else(|| PtyError::SessionNotFound { session_id: session_id.to_string() })?;
             Arc::clone(&session.writer)
         };
         // Global lock released — only per-session writer lock held
         let mut writer = writer.lock().unwrap();
         use std::io::Write;
-        writer.write_all(data).map_err(|e| format!("Write failed: {}", e))?;
-        writer.flush().map_err(|e| format!("Flush failed: {}", e))
+        writer.write_all(data).map_err(|source| PtyError::WriteFailed { source })?;
+        writer.flush().map_err(|source| PtyError::FlushFailed { source })
     }
 
-    pub fn resize(&self, session_id: &str, cols: u16, rows: u16) -> Result<(), String> {
+    pub fn resize(&self, session_id: &str, cols: u16, rows: u16) -> Result<(), PtyError> {
         let master = {
             let sessions = self.sessions.lock().unwrap();
             let session = sessions
                 .get(session_id)
-                .ok_or_else(|| format!("Session {} not found", session_id))?;
+                .ok_or_else(|| PtyError::SessionNotFound { session_id: session_id.to_string() })?;
             // MasterPty doesn't impl Clone, so we need to keep the lock for resize.
             // However, we can at least use try_lock to avoid blocking other sessions.
             session
                 .master
                 .resize(PtySize { rows, cols, pixel_width: 0, pixel_height: 0 })
-                .map_err(|e| format!("Resize failed: {}", e))
+                .map_err(|source| PtyError::ResizeFailed { source })
         };
         master
     }
@@ -514,7 +554,7 @@ impl PtyManager {
         pending.retain(|id, _| sessions.contains_key(id));
     }
 
-    pub fn kill(&self, session_id: &str) -> Result<(), String> {
+    pub fn kill(&self, session_id: &str) {
         let session = self.sessions.lock().unwrap().remove(session_id);
         self.pending_outputs.lock().unwrap().remove(session_id);
         if let Some(mut session) = session {
@@ -540,7 +580,6 @@ impl PtyManager {
                 }
             }
         }
-        Ok(())
     }
 
     pub fn get_generation(&self, session_id: &str) -> Option<u64> {
@@ -560,15 +599,9 @@ pub fn get_user_path() -> String {
     let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
     // Fish outputs $PATH as a space-separated list; other shells use colons.
     // Use fish's `string join` to get colon-separated output.
-    let path_cmd = if shell.contains("fish") {
-        "string join : $PATH"
-    } else {
-        "echo $PATH"
-    };
+    let path_cmd = if shell.contains("fish") { "string join : $PATH" } else { "echo $PATH" };
     rlog!("Resolving PATH via login shell: {} -l -c '{}'", shell, path_cmd);
-    let result = std::process::Command::new(&shell)
-        .args(["-l", "-c", path_cmd])
-        .output();
+    let result = std::process::Command::new(&shell).args(["-l", "-c", path_cmd]).output();
     match &result {
         Ok(o) => {
             if !o.status.success() {
@@ -602,6 +635,7 @@ pub fn resolve_claude_command(custom_path: Option<&str>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io;
     use std::sync::{Arc, Mutex};
     use tauri::ipc::{Channel, InvokeResponseBody, Response};
 
@@ -625,10 +659,7 @@ mod tests {
         let received = Arc::new(Mutex::new(Vec::new()));
         output.attach(raw_channel(received.clone()));
 
-        assert_eq!(
-            *received.lock().unwrap(),
-            vec![vec![1, 2, 3], vec![4, 5, 6]]
-        );
+        assert_eq!(*received.lock().unwrap(), vec![vec![1, 2, 3], vec![4, 5, 6]]);
     }
 
     #[test]
@@ -687,7 +718,19 @@ mod tests {
         let path = get_user_path();
         assert!(!path.is_empty(), "PATH should not be empty");
         // Should contain at least /usr/bin which is always on PATH
-        assert!(path.contains("/usr/bin") || path.contains("/bin"),
-            "PATH should contain standard bin directories, got: {}", path);
+        assert!(
+            path.contains("/usr/bin") || path.contains("/bin"),
+            "PATH should contain standard bin directories, got: {}",
+            path
+        );
+    }
+
+    #[test]
+    fn pty_error_display_keeps_existing_messages() {
+        let error = PtyError::SessionNotFound { session_id: "session-123".to_string() };
+        assert_eq!(error.to_string(), "Session session-123 not found");
+
+        let io_error = PtyError::WriteFailed { source: io::Error::other("broken pipe") };
+        assert_eq!(io_error.to_string(), "Write failed: broken pipe");
     }
 }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
+use thiserror::Error;
 
 const DEFAULT_THEME: &str = "deep-blue";
 
@@ -104,6 +105,25 @@ fn settings_path() -> PathBuf {
     config_dir().join("settings.json")
 }
 
+#[derive(Debug, Error)]
+pub enum SettingsError {
+    #[error("{source}")]
+    CreateSettingsDir {
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("{source}")]
+    Serialize {
+        #[source]
+        source: serde_json::Error,
+    },
+    #[error("{source}")]
+    Write {
+        #[source]
+        source: std::io::Error,
+    },
+}
+
 pub fn load_settings() -> RouxSettings {
     let path = settings_path();
     if path.exists() {
@@ -114,17 +134,19 @@ pub fn load_settings() -> RouxSettings {
     }
 }
 
-pub fn save_settings(settings: &RouxSettings) -> Result<(), String> {
+pub fn save_settings(settings: &RouxSettings) -> Result<(), SettingsError> {
     let path = settings_path();
-    fs::create_dir_all(path.parent().unwrap()).map_err(|e| e.to_string())?;
-    let json =
-        serde_json::to_string_pretty(&settings.clone().normalized()).map_err(|e| e.to_string())?;
-    fs::write(&path, json).map_err(|e| e.to_string())
+    fs::create_dir_all(path.parent().unwrap())
+        .map_err(|source| SettingsError::CreateSettingsDir { source })?;
+    let json = serde_json::to_string_pretty(&settings.clone().normalized())
+        .map_err(|source| SettingsError::Serialize { source })?;
+    fs::write(&path, json).map_err(|source| SettingsError::Write { source })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io;
 
     #[test]
     fn default_settings_has_no_claude_binary_path() {
@@ -167,5 +189,12 @@ mod tests {
         }"#;
         let settings: RouxSettings = serde_json::from_str(json).unwrap();
         assert_eq!(settings.claude_binary_path, None);
+    }
+
+    #[test]
+    fn settings_error_display_keeps_user_facing_message_shape() {
+        let error = SettingsError::Write { source: io::Error::other("disk full") };
+
+        assert_eq!(error.to_string(), "disk full");
     }
 }

--- a/src-tauri/src/socket.rs
+++ b/src-tauri/src/socket.rs
@@ -124,12 +124,13 @@ async fn handle_request(req: Request, app: &tauri::AppHandle) -> Response {
 }
 
 fn handle_split(req: Request, app: &tauri::AppHandle) -> Response {
-    let direction = req.args.get("direction")
-        .and_then(|d| d.as_str())
-        .unwrap_or("horizontal");
+    let direction = req.args.get("direction").and_then(|d| d.as_str()).unwrap_or("horizontal");
 
     if direction != "horizontal" && direction != "vertical" {
-        return Response::err(format!("invalid direction: {}, must be horizontal or vertical", direction));
+        return Response::err(format!(
+            "invalid direction: {}, must be horizontal or vertical",
+            direction
+        ));
     }
 
     let session_id = match req.session_id.as_deref() {
@@ -138,12 +139,15 @@ fn handle_split(req: Request, app: &tauri::AppHandle) -> Response {
     };
 
     use tauri::Emitter;
-    let _ = app.emit("roux-command", serde_json::json!({
-        "action": "split",
-        "sessionId": session_id,
-        "paneId": req.pane_id,
-        "direction": direction,
-    }));
+    let _ = app.emit(
+        "roux-command",
+        serde_json::json!({
+            "action": "split",
+            "sessionId": session_id,
+            "paneId": req.pane_id,
+            "direction": direction,
+        }),
+    );
 
     Response::ok()
 }
@@ -151,14 +155,9 @@ fn handle_split(req: Request, app: &tauri::AppHandle) -> Response {
 fn handle_session_create(req: Request, app: &tauri::AppHandle) -> Response {
     let state: tauri::State<AppState> = app.state();
 
-    let name = req.args.get("name")
-        .and_then(|n| n.as_str())
-        .unwrap_or("New Session")
-        .to_string();
+    let name = req.args.get("name").and_then(|n| n.as_str()).unwrap_or("New Session").to_string();
 
-    let working_dir = req.args.get("working_dir")
-        .and_then(|d| d.as_str())
-        .map(|s| s.to_string());
+    let working_dir = req.args.get("working_dir").and_then(|d| d.as_str()).map(|s| s.to_string());
 
     // Use the working_dir as repo_path, or fall back to current session's repo
     let repo_path = match working_dir {
@@ -192,10 +191,7 @@ fn handle_session_create(req: Request, app: &tauri::AppHandle) -> Response {
         return Response::err(format!("Failed to spawn session: {}", e));
     }
 
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
+    let now = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
 
     let is_git = crate::is_git_repo(&work_dir);
     let branch = crate::get_current_branch(&work_dir).unwrap_or_else(|| "main".to_string());
@@ -219,10 +215,13 @@ fn handle_session_create(req: Request, app: &tauri::AppHandle) -> Response {
 
     // Tell frontend about the new session
     use tauri::Emitter;
-    let _ = app.emit("roux-command", serde_json::json!({
-        "action": "session-created",
-        "sessionId": session_id,
-    }));
+    let _ = app.emit(
+        "roux-command",
+        serde_json::json!({
+            "action": "session-created",
+            "sessionId": session_id,
+        }),
+    );
 
     Response::success(serde_json::json!({ "session_id": session_id }))
 }
@@ -235,12 +234,12 @@ fn handle_shell(req: Request, app: &tauri::AppHandle) -> Response {
 
     let state: tauri::State<AppState> = app.state();
 
-    let working_dir = req.args.get("working_dir")
+    let working_dir = req
+        .args
+        .get("working_dir")
         .and_then(|d| d.as_str())
         .map(|s| s.to_string())
-        .or_else(|| {
-            state.session_store.get(session_id).map(|s| s.worktree_path.clone())
-        });
+        .or_else(|| state.session_store.get(session_id).map(|s| s.worktree_path.clone()));
 
     let working_dir = match working_dir {
         Some(dir) => dir,
@@ -250,28 +249,36 @@ fn handle_shell(req: Request, app: &tauri::AppHandle) -> Response {
     let pane_id = crypto_random_uuid();
     let pty_id = crypto_random_uuid();
 
-    if let Err(e) = state.pty_manager.spawn_shell(&pty_id, &working_dir, Some(session_id), app.clone()) {
+    if let Err(e) =
+        state.pty_manager.spawn_shell(&pty_id, &working_dir, Some(session_id), app.clone())
+    {
         return Response::err(format!("Failed to spawn shell: {}", e));
     }
 
     use tauri::Emitter;
-    let _ = app.emit("roux-command", serde_json::json!({
-        "action": "shell-opened",
-        "sessionId": session_id,
-        "paneId": pane_id,
-        "ptyId": pty_id,
-    }));
+    let _ = app.emit(
+        "roux-command",
+        serde_json::json!({
+            "action": "shell-opened",
+            "sessionId": session_id,
+            "paneId": pane_id,
+            "ptyId": pty_id,
+        }),
+    );
 
     Response::success(serde_json::json!({ "pane_id": pane_id, "pty_id": pty_id }))
 }
 
 fn handle_focus(req: Request, app: &tauri::AppHandle) -> Response {
     use tauri::Emitter;
-    let _ = app.emit("roux-command", serde_json::json!({
-        "action": "focus",
-        "sessionId": req.session_id,
-        "paneId": req.pane_id,
-    }));
+    let _ = app.emit(
+        "roux-command",
+        serde_json::json!({
+            "action": "focus",
+            "sessionId": req.session_id,
+            "paneId": req.pane_id,
+        }),
+    );
 
     Response::ok()
 }
@@ -289,12 +296,12 @@ fn handle_run(req: Request, app: &tauri::AppHandle) -> Response {
 
     let state: tauri::State<AppState> = app.state();
 
-    let working_dir = req.args.get("working_dir")
+    let working_dir = req
+        .args
+        .get("working_dir")
         .and_then(|d| d.as_str())
         .map(|s| s.to_string())
-        .or_else(|| {
-            state.session_store.get(session_id).map(|s| s.worktree_path.clone())
-        });
+        .or_else(|| state.session_store.get(session_id).map(|s| s.worktree_path.clone()));
 
     let working_dir = match working_dir {
         Some(dir) => dir,
@@ -302,22 +309,30 @@ fn handle_run(req: Request, app: &tauri::AppHandle) -> Response {
     };
 
     let pane_id = format!("cmd-{}", crypto_random_uuid());
-    let pty_id = format!("{}-{}", pane_id, std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH).unwrap().as_millis());
+    let pty_id = format!(
+        "{}-{}",
+        pane_id,
+        std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_millis()
+    );
 
-    if let Err(e) = state.pty_manager.spawn_task(&pty_id, &command, &working_dir, Some(session_id), app.clone()) {
+    if let Err(e) =
+        state.pty_manager.spawn_task(&pty_id, &command, &working_dir, Some(session_id), app.clone())
+    {
         return Response::err(format!("Failed to spawn task: {}", e));
     }
 
     use tauri::Emitter;
-    let _ = app.emit("roux-command", serde_json::json!({
-        "action": "command-opened",
-        "sessionId": session_id,
-        "paneId": pane_id,
-        "ptyId": pty_id,
-        "command": command,
-        "workingDir": working_dir,
-    }));
+    let _ = app.emit(
+        "roux-command",
+        serde_json::json!({
+            "action": "command-opened",
+            "sessionId": session_id,
+            "paneId": pane_id,
+            "ptyId": pty_id,
+            "command": command,
+            "workingDir": working_dir,
+        }),
+    );
 
     Response::success(serde_json::json!({ "pane_id": pane_id, "pty_id": pty_id }))
 }
@@ -364,7 +379,11 @@ mod tests {
     fn socket_path_is_under_config() {
         let path = socket_path();
         let path_str = path.to_string_lossy();
-        assert!(path_str.contains(".config/roux/roux.sock"), "Expected .config/roux/roux.sock, got {}", path_str);
+        assert!(
+            path_str.contains(".config/roux/roux.sock"),
+            "Expected .config/roux/roux.sock, got {}",
+            path_str
+        );
     }
 
     #[test]

--- a/src-tauri/src/status_watcher.rs
+++ b/src-tauri/src/status_watcher.rs
@@ -8,6 +8,7 @@ use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
 use tauri::Emitter;
+use thiserror::Error;
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -20,10 +21,31 @@ struct StatusUpdate {
     message: Option<String>,
 }
 
-fn status_dir() -> Result<PathBuf, String> {
-    let home = dirs::home_dir().ok_or("Could not determine home directory")?;
+#[derive(Debug, Error)]
+pub enum StatusWatcherError {
+    #[error("Could not determine home directory")]
+    HomeDirUnavailable,
+    #[error("Failed to create status dir: {source}")]
+    CreateStatusDir {
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("Failed to create watcher: {source}")]
+    CreateWatcher {
+        #[source]
+        source: notify::Error,
+    },
+    #[error("Failed to watch status dir: {source}")]
+    WatchStatusDir {
+        #[source]
+        source: notify::Error,
+    },
+}
+
+fn status_dir() -> Result<PathBuf, StatusWatcherError> {
+    let home = dirs::home_dir().ok_or(StatusWatcherError::HomeDirUnavailable)?;
     let dir = home.join(".config").join("roux").join("status");
-    fs::create_dir_all(&dir).map_err(|e| format!("Failed to create status dir: {}", e))?;
+    fs::create_dir_all(&dir).map_err(|source| StatusWatcherError::CreateStatusDir { source })?;
     Ok(dir)
 }
 
@@ -38,17 +60,17 @@ fn map_status(raw: &str) -> &str {
     }
 }
 
-pub fn start_watching(app: tauri::AppHandle) -> Result<(), String> {
+pub fn start_watching(app: tauri::AppHandle) -> Result<(), StatusWatcherError> {
     let watch_dir = status_dir()?;
 
     let (tx, rx) = mpsc::channel::<notify::Result<Event>>();
 
     let mut watcher = RecommendedWatcher::new(tx, notify::Config::default())
-        .map_err(|e| format!("Failed to create watcher: {}", e))?;
+        .map_err(|source| StatusWatcherError::CreateWatcher { source })?;
 
     watcher
         .watch(&watch_dir, RecursiveMode::NonRecursive)
-        .map_err(|e| format!("Failed to watch status dir: {}", e))?;
+        .map_err(|source| StatusWatcherError::WatchStatusDir { source })?;
 
     thread::spawn(move || {
         // Keep watcher alive for the lifetime of this thread
@@ -144,4 +166,24 @@ pub fn start_watching(app: tauri::AppHandle) -> Result<(), String> {
     });
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io;
+
+    #[test]
+    fn maps_known_status_values() {
+        assert_eq!(map_status("working"), "generating");
+        assert_eq!(map_status("idle"), "idle");
+    }
+
+    #[test]
+    fn status_watcher_error_display_keeps_existing_messages() {
+        let error =
+            StatusWatcherError::CreateStatusDir { source: io::Error::other("permission denied") };
+
+        assert_eq!(error.to_string(), "Failed to create status dir: permission denied");
+    }
 }

--- a/src-tauri/src/watches.rs
+++ b/src-tauri/src/watches.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use tauri::Emitter;
 use tauri_plugin_notification::NotificationExt;
 use tokio::process::Command as TokioCommand;
-use tokio::time::{timeout, sleep};
+use tokio::time::{sleep, timeout};
 use tokio_util::sync::CancellationToken;
 
 // ── Core Types ──────────────────────────────────────────────
@@ -194,11 +194,7 @@ pub struct NotifyConfig {
 
 impl Default for NotifyConfig {
     fn default() -> Self {
-        Self {
-            desktop_notification: true,
-            on_failure: true,
-            on_success: false,
-        }
+        Self { desktop_notification: true, on_failure: true, on_success: false }
     }
 }
 
@@ -431,11 +427,7 @@ impl WatchManager {
 
     fn emit_watch_update(&self, id: &str, app: &tauri::AppHandle) {
         if let Some(watch) = self.store.get(id) {
-            let event = WatchUpdateEvent {
-                watch,
-                changed: false,
-                previous_outcome: None,
-            };
+            let event = WatchUpdateEvent { watch, changed: false, previous_outcome: None };
             let _ = app.emit("watch-update", &event);
         }
     }
@@ -447,7 +439,12 @@ impl WatchManager {
         }
     }
 
-    fn spawn_watch(&self, watch_id: String, initial_delay: Option<Duration>, app: tauri::AppHandle) {
+    fn spawn_watch(
+        &self,
+        watch_id: String,
+        initial_delay: Option<Duration>,
+        app: tauri::AppHandle,
+    ) {
         // Cancel any existing task for this watch before spawning a new one
         self.cancel_watch(&watch_id);
 
@@ -508,11 +505,8 @@ impl WatchManager {
                 });
 
                 if let Some(updated_watch) = store.get(&watch_id) {
-                    let event = WatchUpdateEvent {
-                        watch: updated_watch,
-                        changed,
-                        previous_outcome,
-                    };
+                    let event =
+                        WatchUpdateEvent { watch: updated_watch, changed, previous_outcome };
                     let _ = app.emit("watch-update", &event);
                 }
 
@@ -524,18 +518,24 @@ impl WatchManager {
                         // Update flap tracker and check if flapping
                         let suppress = {
                             let mut trackers = flap_trackers.lock().unwrap();
-                            let tracker = trackers.entry(watch_id.clone()).or_insert_with(FlapTracker::new);
+                            let tracker =
+                                trackers.entry(watch_id.clone()).or_insert_with(FlapTracker::new);
                             if let Some(ref o) = outcome {
                                 tracker.record((*o).clone(), now);
                             }
                             tracker.is_flapping()
                         };
 
-                        let should_notify = !suppress && match outcome {
-                            Some(WatchOutcome::Failure) => updated.notify.desktop_notification && updated.notify.on_failure,
-                            Some(WatchOutcome::Success) => updated.notify.desktop_notification && updated.notify.on_success,
-                            _ => false,
-                        };
+                        let should_notify = !suppress
+                            && match outcome {
+                                Some(WatchOutcome::Failure) => {
+                                    updated.notify.desktop_notification && updated.notify.on_failure
+                                }
+                                Some(WatchOutcome::Success) => {
+                                    updated.notify.desktop_notification && updated.notify.on_success
+                                }
+                                _ => false,
+                            };
                         if should_notify {
                             let title = match outcome {
                                 Some(WatchOutcome::Failure) => format!("❌ {}", updated.name),
@@ -544,26 +544,40 @@ impl WatchManager {
                             };
                             let body = match &updated.last_result {
                                 Some(WatchResult::GithubRun { conclusion, url, .. }) => {
-                                    format!("{} — {}", conclusion.as_deref().unwrap_or("unknown"), url)
+                                    format!(
+                                        "{} — {}",
+                                        conclusion.as_deref().unwrap_or("unknown"),
+                                        url
+                                    )
                                 }
-                                Some(WatchResult::HttpCheck { status_code, response_time_ms, .. }) => {
+                                Some(WatchResult::HttpCheck {
+                                    status_code,
+                                    response_time_ms,
+                                    ..
+                                }) => {
                                     format!("HTTP {} ({}ms)", status_code, response_time_ms)
                                 }
                                 Some(WatchResult::CommandRun { exit_code, .. }) => {
                                     format!("Exit code: {}", exit_code)
                                 }
                                 Some(WatchResult::GithubPr { state, checks, reviews, .. }) => {
-                                    let passed = checks.iter().filter(|c| c.conclusion.as_deref() == Some("success")).count();
-                                    let approvals = reviews.iter().filter(|r| r.state == "approved").count();
-                                    format!("{} — {}/{} checks passed, {} approval(s)", state, passed, checks.len(), approvals)
+                                    let passed = checks
+                                        .iter()
+                                        .filter(|c| c.conclusion.as_deref() == Some("success"))
+                                        .count();
+                                    let approvals =
+                                        reviews.iter().filter(|r| r.state == "approved").count();
+                                    format!(
+                                        "{} — {}/{} checks passed, {} approval(s)",
+                                        state,
+                                        passed,
+                                        checks.len(),
+                                        approvals
+                                    )
                                 }
                                 None => String::new(),
                             };
-                            let _ = app.notification()
-                                .builder()
-                                .title(&title)
-                                .body(&body)
-                                .show();
+                            let _ = app.notification().builder().title(&title).body(&body).show();
                         }
                     }
                 }
@@ -572,7 +586,10 @@ impl WatchManager {
                 let should_stop = matches!(watch.mode, WatchMode::OneShot)
                     || matches!(
                         (&watch.kind, &new_outcome),
-                        (WatchKind::GithubAction { .. }, WatchOutcome::Success | WatchOutcome::Failure)
+                        (
+                            WatchKind::GithubAction { .. },
+                            WatchOutcome::Success | WatchOutcome::Failure
+                        )
                     )
                     || matches!(
                         (&watch.kind, &result),
@@ -664,9 +681,7 @@ async fn execute_check(kind: &WatchKind) -> WatchResult {
         WatchKind::Task { command, working_dir, .. } => {
             execute_shell_check(command, Some(working_dir.as_str()), 0).await
         }
-        WatchKind::GithubPr { repo, pr_number } => {
-            execute_github_pr_check(repo, *pr_number).await
-        }
+        WatchKind::GithubPr { repo, pr_number } => execute_github_pr_check(repo, *pr_number).await,
     }
 }
 
@@ -675,18 +690,20 @@ async fn execute_check(kind: &WatchKind) -> WatchResult {
 /// Try to get a GitHub token from `gh auth token`, cached for the process lifetime.
 fn github_token() -> Option<&'static str> {
     static TOKEN: OnceLock<Option<String>> = OnceLock::new();
-    TOKEN.get_or_init(|| {
-        let user_path = crate::pty::get_user_path();
-        let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
-        std::process::Command::new(&shell)
-            .args(["-c", "gh auth token"])
-            .env("PATH", &user_path)
-            .output()
-            .ok()
-            .filter(|o| o.status.success())
-            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
-            .filter(|t| !t.is_empty())
-    }).as_deref()
+    TOKEN
+        .get_or_init(|| {
+            let user_path = crate::pty::get_user_path();
+            let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
+            std::process::Command::new(&shell)
+                .args(["-c", "gh auth token"])
+                .env("PATH", &user_path)
+                .output()
+                .ok()
+                .filter(|o| o.status.success())
+                .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+                .filter(|t| !t.is_empty())
+        })
+        .as_deref()
 }
 
 fn build_octocrab() -> octocrab::Octocrab {
@@ -725,31 +742,27 @@ async fn execute_github_check(
         id
     } else {
         // List the most recent run
-        let page = crab
-            .workflows(owner, repo_name)
-            .list_all_runs()
-            .per_page(1)
-            .send()
-            .await;
+        let page = crab.workflows(owner, repo_name).list_all_runs().per_page(1).send().await;
         match page {
-            Ok(page) => {
-                match page.items.first() {
-                    Some(run) => run.id.0,
-                    None => return WatchResult::GithubRun {
-                        run_id: 0, status: "unknown".into(), conclusion: None,
-                        url: String::new(), jobs: vec![], outcome: WatchOutcome::Failure,
-                    },
+            Ok(page) => match page.items.first() {
+                Some(run) => run.id.0,
+                None => {
+                    return WatchResult::GithubRun {
+                        run_id: 0,
+                        status: "unknown".into(),
+                        conclusion: None,
+                        url: String::new(),
+                        jobs: vec![],
+                        outcome: WatchOutcome::Failure,
+                    }
                 }
-            }
+            },
             Err(e) => return github_error_result(format!("GitHub API error: {}", e)),
         }
     };
 
     // Get the run details
-    let run = crab
-        .workflows(owner, repo_name)
-        .get(target_run_id.into())
-        .await;
+    let run = crab.workflows(owner, repo_name).get(target_run_id.into()).await;
 
     let run = match run {
         Ok(r) => r,
@@ -761,31 +774,46 @@ async fn execute_github_check(
     let url = run.html_url.to_string();
 
     // Get jobs for the run
-    let jobs_result = crab
-        .workflows(owner, repo_name)
-        .list_jobs(target_run_id.into())
-        .send()
-        .await;
+    let jobs_result = crab.workflows(owner, repo_name).list_jobs(target_run_id.into()).send().await;
 
     let jobs: Vec<GithubJob> = match jobs_result {
-        Ok(jobs_page) => {
-            jobs_page.items.iter().map(|j: &octocrab::models::workflows::Job| {
-                let job_conclusion = j.conclusion.as_ref().map(|c| serde_json::to_value(c).ok().and_then(|v| v.as_str().map(|s| s.to_string())).unwrap_or_default());
+        Ok(jobs_page) => jobs_page
+            .items
+            .iter()
+            .map(|j: &octocrab::models::workflows::Job| {
+                let job_conclusion = j.conclusion.as_ref().map(|c| {
+                    serde_json::to_value(c)
+                        .ok()
+                        .and_then(|v| v.as_str().map(|s| s.to_string()))
+                        .unwrap_or_default()
+                });
                 let is_failure = job_conclusion.as_deref() == Some("failure");
                 let failed_step = if is_failure {
-                    j.steps.iter()
-                        .find(|s| s.conclusion.as_ref().and_then(|c| serde_json::to_value(c).ok()).and_then(|v| v.as_str().map(|s| s == "failure")).unwrap_or(false))
+                    j.steps
+                        .iter()
+                        .find(|s| {
+                            s.conclusion
+                                .as_ref()
+                                .and_then(|c| serde_json::to_value(c).ok())
+                                .and_then(|v| v.as_str().map(|s| s == "failure"))
+                                .unwrap_or(false)
+                        })
                         .map(|s| s.name.clone())
-                } else { None };
-                let job_status = serde_json::to_value(&j.status).ok().and_then(|v| v.as_str().map(|s| s.to_string())).unwrap_or_default();
+                } else {
+                    None
+                };
+                let job_status = serde_json::to_value(&j.status)
+                    .ok()
+                    .and_then(|v| v.as_str().map(|s| s.to_string()))
+                    .unwrap_or_default();
                 GithubJob {
                     name: j.name.clone(),
                     status: job_status,
                     conclusion: job_conclusion,
                     failed_step,
                 }
-            }).collect()
-        }
+            })
+            .collect(),
         Err(_) => vec![],
     };
 
@@ -827,22 +855,24 @@ async fn execute_github_pr_check(repo: &str, pr_number: u64) -> WatchResult {
     let draft = pr.draft.unwrap_or(false);
 
     // 2. Get reviews (deduplicate to latest per reviewer)
-    let reviews_result = crab.pulls(owner, repo_name)
-        .list_reviews(pr_number)
-        .per_page(100)
-        .send()
-        .await;
+    let reviews_result =
+        crab.pulls(owner, repo_name).list_reviews(pr_number).per_page(100).send().await;
 
     let reviews: Vec<PrReview> = match reviews_result {
         Ok(page) => {
-            let mut latest: std::collections::HashMap<String, PrReview> = std::collections::HashMap::new();
+            let mut latest: std::collections::HashMap<String, PrReview> =
+                std::collections::HashMap::new();
             for review in &page.items {
-                let reviewer = review.user.as_ref()
+                let reviewer = review
+                    .user
+                    .as_ref()
                     .map(|u| u.login.clone())
                     .unwrap_or_else(|| "unknown".to_string());
                 let state_str = match review.state {
                     Some(octocrab::models::pulls::ReviewState::Approved) => "approved",
-                    Some(octocrab::models::pulls::ReviewState::ChangesRequested) => "changes_requested",
+                    Some(octocrab::models::pulls::ReviewState::ChangesRequested) => {
+                        "changes_requested"
+                    }
                     Some(octocrab::models::pulls::ReviewState::Commented) => "commented",
                     Some(octocrab::models::pulls::ReviewState::Dismissed) => "dismissed",
                     Some(octocrab::models::pulls::ReviewState::Pending) => "pending",
@@ -852,19 +882,17 @@ async fn execute_github_pr_check(repo: &str, pr_number: u64) -> WatchResult {
                 let review_url = Some(review.html_url.to_string());
                 if state_str == "commented" || state_str == "pending" {
                     if !latest.contains_key(&reviewer) {
-                        latest.insert(reviewer.clone(), PrReview {
-                            reviewer,
-                            state: state_str.to_string(),
-                            url: review_url,
-                        });
+                        latest.insert(
+                            reviewer.clone(),
+                            PrReview { reviewer, state: state_str.to_string(), url: review_url },
+                        );
                     }
                     continue;
                 }
-                latest.insert(reviewer.clone(), PrReview {
-                    reviewer,
-                    state: state_str.to_string(),
-                    url: review_url,
-                });
+                latest.insert(
+                    reviewer.clone(),
+                    PrReview { reviewer, state: state_str.to_string(), url: review_url },
+                );
             }
             latest.into_values().collect()
         }
@@ -872,22 +900,23 @@ async fn execute_github_pr_check(repo: &str, pr_number: u64) -> WatchResult {
     };
 
     // 3. Get check runs for the head commit
-    let checks_result = crab.checks(owner, repo_name)
+    let checks_result = crab
+        .checks(owner, repo_name)
         .list_check_runs_for_git_ref(octocrab::params::repos::Commitish(head_sha.clone()))
         .per_page(100)
         .send()
         .await;
 
     let checks: Vec<PrCheckRun> = match checks_result {
-        Ok(list) => {
-            list.check_runs.iter().map(|cr| {
-                PrCheckRun {
-                    name: cr.name.clone(),
-                    conclusion: cr.conclusion.clone(),
-                    url: cr.html_url.clone(),
-                }
-            }).collect()
-        }
+        Ok(list) => list
+            .check_runs
+            .iter()
+            .map(|cr| PrCheckRun {
+                name: cr.name.clone(),
+                conclusion: cr.conclusion.clone(),
+                url: cr.html_url.clone(),
+            })
+            .collect(),
         Err(_) => vec![],
     };
 
@@ -895,13 +924,25 @@ async fn execute_github_pr_check(repo: &str, pr_number: u64) -> WatchResult {
     let outcome = compute_pr_outcome(&state, &reviews, &checks);
 
     WatchResult::GithubPr {
-        pr_number, state, title, url, head_sha, draft, reviews, checks, outcome,
+        pr_number,
+        state,
+        title,
+        url,
+        head_sha,
+        draft,
+        reviews,
+        checks,
+        outcome,
     }
 }
 
 fn compute_pr_outcome(state: &str, reviews: &[PrReview], checks: &[PrCheckRun]) -> WatchOutcome {
-    if state == "merged" { return WatchOutcome::Success; }
-    if state == "closed" { return WatchOutcome::Failure; }
+    if state == "merged" {
+        return WatchOutcome::Success;
+    }
+    if state == "closed" {
+        return WatchOutcome::Failure;
+    }
 
     let any_check_running = checks.iter().any(|c| c.conclusion.is_none());
     let any_check_failed = checks.iter().any(|c| c.conclusion.as_deref() == Some("failure"));
@@ -920,20 +961,23 @@ fn compute_pr_outcome(state: &str, reviews: &[PrReview], checks: &[PrCheckRun]) 
 }
 
 async fn execute_http_check(url: &str, expected_status: u16) -> WatchResult {
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(10))
-        .build()
-        .unwrap_or_default();
+    let client =
+        reqwest::Client::builder().timeout(Duration::from_secs(10)).build().unwrap_or_default();
     let start = std::time::Instant::now();
     match client.get(url).send().await {
         Ok(resp) => {
             let status_code = resp.status().as_u16();
             let response_time_ms = start.elapsed().as_millis() as u64;
-            let outcome = if status_code == expected_status { WatchOutcome::Success } else { WatchOutcome::Failure };
+            let outcome = if status_code == expected_status {
+                WatchOutcome::Success
+            } else {
+                WatchOutcome::Failure
+            };
             WatchResult::HttpCheck { status_code, response_time_ms, outcome }
         }
         Err(_e) => WatchResult::HttpCheck {
-            status_code: 0, response_time_ms: start.elapsed().as_millis() as u64,
+            status_code: 0,
+            response_time_ms: start.elapsed().as_millis() as u64,
             outcome: WatchOutcome::Failure,
         },
     }
@@ -995,12 +1039,20 @@ pub fn cmd_pause_watch(id: String, state: tauri::State<AppState>, app: tauri::Ap
 }
 
 #[tauri::command]
-pub async fn cmd_resume_watch(id: String, state: tauri::State<'_, AppState>, app: tauri::AppHandle) -> Result<(), String> {
+pub async fn cmd_resume_watch(
+    id: String,
+    state: tauri::State<'_, AppState>,
+    app: tauri::AppHandle,
+) -> Result<(), String> {
     state.watch_manager.resume_watch(&id, app);
     Ok(())
 }
 
-async fn execute_shell_check(command: &str, working_dir: Option<&str>, success_exit_code: i32) -> WatchResult {
+async fn execute_shell_check(
+    command: &str,
+    working_dir: Option<&str>,
+    success_exit_code: i32,
+) -> WatchResult {
     let shell = if cfg!(target_os = "windows") { "cmd" } else { "sh" };
     let flag = if cfg!(target_os = "windows") { "/C" } else { "-c" };
     let mut cmd = TokioCommand::new(shell);
@@ -1014,11 +1066,16 @@ async fn execute_shell_check(command: &str, working_dir: Option<&str>, success_e
             let exit_code = output.status.code().unwrap_or(-1);
             let stdout = truncate_output(String::from_utf8_lossy(&output.stdout).to_string());
             let stderr = truncate_output(String::from_utf8_lossy(&output.stderr).to_string());
-            let outcome = if exit_code == success_exit_code { WatchOutcome::Success } else { WatchOutcome::Failure };
+            let outcome = if exit_code == success_exit_code {
+                WatchOutcome::Success
+            } else {
+                WatchOutcome::Failure
+            };
             WatchResult::CommandRun { exit_code, stdout, stderr, outcome }
         }
         Err(e) => WatchResult::CommandRun {
-            exit_code: -1, stdout: String::new(),
+            exit_code: -1,
+            stdout: String::new(),
             stderr: format!("Failed to execute: {}", e),
             outcome: WatchOutcome::Failure,
         },

--- a/src-tauri/src/worktree.rs
+++ b/src-tauri/src/worktree.rs
@@ -1,6 +1,7 @@
 use serde::Serialize;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use thiserror::Error;
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -8,6 +9,21 @@ pub struct Worktree {
     pub path: String,
     pub branch: String,
     pub is_main: bool,
+}
+
+#[derive(Debug, Error)]
+pub enum WorktreeError {
+    #[error("Failed to run git: {source}")]
+    RunGit {
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("git worktree add failed: {stderr}")]
+    AddFailed { stderr: String },
+    #[error("git worktree remove failed: {stderr}")]
+    RemoveFailed { stderr: String },
+    #[error("git worktree list failed: {stderr}")]
+    ListFailed { stderr: String },
 }
 
 fn sanitize_branch_for_path(branch: &str) -> String {
@@ -67,7 +83,7 @@ pub fn create_worktree(
     repo_path: &str,
     branch: &str,
     base_path: Option<&str>,
-) -> Result<String, String> {
+) -> Result<String, WorktreeError> {
     // Check if the branch is already checked out in an existing worktree
     if let Ok(worktrees) = list_worktrees(repo_path) {
         if let Some(wt) = worktrees.iter().find(|wt| wt.branch == branch) {
@@ -83,50 +99,54 @@ pub fn create_worktree(
             .args(["worktree", "add", &target_str, branch])
             .current_dir(repo_path)
             .output()
-            .map_err(|e| format!("Failed to run git: {}", e))?
+            .map_err(|source| WorktreeError::RunGit { source })?
     } else {
         Command::new("git")
             .args(["worktree", "add", "-b", branch, &target_str])
             .current_dir(repo_path)
             .output()
-            .map_err(|e| format!("Failed to run git: {}", e))?
+            .map_err(|source| WorktreeError::RunGit { source })?
     };
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!("git worktree add failed: {}", stderr));
+        return Err(WorktreeError::AddFailed { stderr: stderr.to_string() });
     }
 
     Ok(target_str)
 }
 
-pub fn remove_worktree(worktree_path: &str) -> Result<(), String> {
+pub fn remove_worktree(worktree_path: &str) -> Result<(), WorktreeError> {
     let output = Command::new("git")
         .args(["worktree", "remove", worktree_path, "--force"])
         .output()
-        .map_err(|e| format!("Failed to run git: {}", e))?;
+        .map_err(|source| WorktreeError::RunGit { source })?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!("git worktree remove failed: {}", stderr));
+        return Err(WorktreeError::RemoveFailed { stderr: stderr.to_string() });
     }
 
     Ok(())
 }
 
-pub fn list_worktrees(repo_path: &str) -> Result<Vec<Worktree>, String> {
+pub fn list_worktrees(repo_path: &str) -> Result<Vec<Worktree>, WorktreeError> {
     let output = Command::new("git")
         .args(["worktree", "list", "--porcelain"])
         .current_dir(repo_path)
         .output()
-        .map_err(|e| format!("Failed to run git: {}", e))?;
+        .map_err(|source| WorktreeError::RunGit { source })?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!("git worktree list failed: {}", stderr));
+        return Err(WorktreeError::ListFailed { stderr: stderr.to_string() });
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(parse_porcelain(&stdout))
+}
+
+fn parse_porcelain(stdout: &str) -> Vec<Worktree> {
     let mut worktrees = Vec::new();
     let mut current_path: Option<String> = None;
     let mut current_branch: Option<String> = None;
@@ -165,12 +185,13 @@ pub fn list_worktrees(repo_path: &str) -> Result<Vec<Worktree>, String> {
         }
     }
 
-    Ok(worktrees)
+    worktrees
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io;
 
     #[test]
     fn test_sanitize_simple_branch() {
@@ -276,44 +297,10 @@ mod tests {
         assert_eq!(worktrees.len(), 1);
     }
 
-    /// Helper to parse porcelain output without calling git
-    fn parse_porcelain(stdout: &str) -> Vec<Worktree> {
-        let mut worktrees = Vec::new();
-        let mut current_path: Option<String> = None;
-        let mut current_branch: Option<String> = None;
-        let mut is_bare = false;
+    #[test]
+    fn worktree_error_display_keeps_existing_messages() {
+        let error = WorktreeError::RunGit { source: io::Error::other("boom") };
 
-        for line in stdout.lines() {
-            if let Some(path) = line.strip_prefix("worktree ") {
-                current_path = Some(path.to_string());
-                current_branch = None;
-                is_bare = false;
-            } else if let Some(branch_ref) = line.strip_prefix("branch ") {
-                current_branch =
-                    Some(branch_ref.strip_prefix("refs/heads/").unwrap_or(branch_ref).to_string());
-            } else if line == "bare" {
-                is_bare = true;
-            } else if line.is_empty() {
-                if let Some(path) = current_path.take() {
-                    if !is_bare {
-                        let branch = current_branch.take().unwrap_or_else(|| "HEAD".to_string());
-                        let is_main = worktrees.is_empty();
-                        worktrees.push(Worktree { path, branch, is_main });
-                    }
-                }
-                current_branch = None;
-                is_bare = false;
-            }
-        }
-
-        if let Some(path) = current_path {
-            if !is_bare {
-                let branch = current_branch.unwrap_or_else(|| "HEAD".to_string());
-                let is_main = worktrees.is_empty();
-                worktrees.push(Worktree { path, branch, is_main });
-            }
-        }
-
-        worktrees
+        assert_eq!(error.to_string(), "Failed to run git: boom");
     }
 }


### PR DESCRIPTION
## Summary
- introduce typed backend error enums in the Rust backend and keep string conversion at the Tauri/CLI boundary
- cover PTY, worktree, settings/hooks, status watcher, and CLI socket flows with structured errors and regression tests for user-facing messages
- add `thiserror` and the direct `anyhow` dependency needed to model PTY operation failures accurately

## Why
The backend was returning `Result<_, String>` from internal modules, which made error handling harder to reason about and encouraged stringly-typed control flow.

## Impact
Frontend behavior stays the same because the Tauri command layer still returns strings, but backend modules now preserve typed sources internally.

## Validation
- `cargo test --manifest-path src-tauri/Cargo.toml --all-targets`