### PR TITLE
feat: convert SessionStore to handle + channel service pattern

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,7 +37,7 @@ tauri-plugin-dialog = "2"
 tauri-plugin-notification = "2"
 notify = "7"
 serde_yaml = "0.9"
-tokio = { version = "1", features = ["net", "io-util", "macros", "rt-multi-thread", "process", "time"] }
+tokio = { version = "1", features = ["net", "io-util", "macros", "rt-multi-thread", "process", "time", "sync"] }
 tokio-util = "0.7"
 reqwest = { version = "0.12", features = ["json"] }
 octocrab = "0.44"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6,6 +6,7 @@ mod logging;
 mod projects;
 mod pty;
 mod session;
+mod session_service;
 mod settings;
 mod socket;
 mod status_watcher;
@@ -18,7 +19,8 @@ use tauri::{Emitter, Manager};
 
 use crate::projects::{Project, ProjectStore};
 use crate::pty::PtyManager;
-use crate::session::{Session, SessionStore};
+use crate::session::Session;
+use crate::session_service::SessionHandle;
 
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -32,7 +34,7 @@ struct DocFile {
 struct AppState {
     settings: Mutex<settings::RouxSettings>,
     pty_manager: PtyManager,
-    session_store: SessionStore,
+    session_handle: SessionHandle,
     project_store: ProjectStore,
     watch_manager: watches::WatchManager,
 }
@@ -165,9 +167,10 @@ fn spawn_task(
 }
 
 #[tauri::command]
-fn kill_session(id: String, state: tauri::State<AppState>) -> Result<(), String> {
+async fn kill_session(id: String, state: tauri::State<'_, AppState>) -> Result<(), String> {
     state.pty_manager.kill(&id);
-    state.session_store.remove(&id);
+    let handle = state.session_handle.clone();
+    handle.remove(&id).await.map_err(|e| e.to_string())?;
     Ok(())
 }
 
@@ -177,14 +180,14 @@ fn get_pty_generation(id: String, state: tauri::State<AppState>) -> Option<u64> 
 }
 
 #[tauri::command]
-fn create_session(
+async fn create_session(
     repo_path: String,
     name: String,
     worktree_path: Option<String>,
     branch: Option<String>,
     extra_flags: Option<Vec<String>>,
     nono_profile: Option<String>,
-    state: tauri::State<AppState>,
+    state: tauri::State<'_, AppState>,
     app: tauri::AppHandle,
 ) -> Result<Session, String> {
     let settings = state.settings.lock().unwrap().clone();
@@ -261,19 +264,31 @@ fn create_session(
         is_git_repo: is_git_repo(&repo_path),
     };
 
-    state.session_store.add(session.clone());
+    let handle = state.session_handle.clone();
+    if let Err(e) = handle.add(session.clone()).await {
+        // Rollback: kill the PTY we just spawned and remove worktree if we created one
+        state.pty_manager.kill(&session.id);
+        if is_wt {
+            let _ = worktree::remove_worktree(&session.worktree_path);
+        }
+        return Err(e.to_string());
+    }
     Ok(session)
 }
 
 #[tauri::command]
-fn reconnect_session(
+async fn reconnect_session(
     id: String,
     extra_flags: Option<Vec<String>>,
-    state: tauri::State<AppState>,
+    state: tauri::State<'_, AppState>,
     app: tauri::AppHandle,
 ) -> Result<Session, String> {
-    let session =
-        state.session_store.get(&id).ok_or_else(|| format!("Session {} not found", id))?;
+    let handle = state.session_handle.clone();
+    let session = handle
+        .get(&id)
+        .await
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("Session {} not found", id))?;
 
     let settings = state.settings.lock().unwrap().clone();
 
@@ -303,7 +318,7 @@ fn reconnect_session(
         .map_err(|e| e.to_string())?;
 
     // Update status to idle
-    state.session_store.update_status(&id, "idle");
+    handle.update_status(&id, "idle").await.map_err(|e| e.to_string())?;
 
     rlog!("Session '{}' reconnected successfully", id);
 
@@ -481,22 +496,26 @@ fn git_init(path: String) -> Result<(), String> {
 }
 
 #[tauri::command]
-fn refresh_session_git_status(id: String, state: tauri::State<AppState>) -> bool {
-    let session = state.session_store.get(&id);
+async fn refresh_session_git_status(id: String, state: tauri::State<'_, AppState>) -> Result<bool, String> {
+    let handle = state.session_handle.clone();
+    let session = handle.get(&id).await.map_err(|e| e.to_string())?;
     if let Some(s) = session {
         let is_git = is_git_repo(&s.worktree_path);
         if is_git != s.is_git_repo {
-            state.session_store.set_git_repo(&id, is_git);
+            handle.set_git_repo(&id, is_git).await.map_err(|e| e.to_string())?;
         }
-        is_git
+        Ok(is_git)
     } else {
-        false
+        Ok(false)
     }
 }
 
 #[tauri::command]
-fn quit_app(app: tauri::AppHandle) {
+async fn quit_app(state: tauri::State<'_, AppState>, app: tauri::AppHandle) -> Result<(), String> {
+    let handle = state.session_handle.clone();
+    handle.shutdown().await;
     app.exit(0);
+    Ok(())
 }
 
 pub fn is_git_repo(path: &str) -> bool {
@@ -527,8 +546,9 @@ fn get_current_branch(repo_path: &str) -> Option<String> {
 }
 
 #[tauri::command]
-fn list_sessions(state: tauri::State<AppState>) -> Vec<Session> {
-    state.session_store.list()
+async fn list_sessions(state: tauri::State<'_, AppState>) -> Result<Vec<Session>, String> {
+    let handle = state.session_handle.clone();
+    Ok(handle.list().await.map_err(|e| e.to_string())?)
 }
 
 #[tauri::command]
@@ -554,12 +574,14 @@ fn rename_project(id: String, name: String, state: tauri::State<AppState>) {
 }
 
 #[tauri::command]
-fn set_session_project(
+async fn set_session_project(
     session_id: String,
     project_id: Option<String>,
-    state: tauri::State<AppState>,
-) {
-    state.session_store.set_project(&session_id, project_id);
+    state: tauri::State<'_, AppState>,
+) -> Result<(), String> {
+    let handle = state.session_handle.clone();
+    handle.set_project(&session_id, project_id).await.map_err(|e| e.to_string())?;
+    Ok(())
 }
 
 #[tauri::command]
@@ -668,6 +690,9 @@ fn main() {
 
     let watch_store = std::sync::Arc::new(watches::WatchStore::load_persisted());
 
+    let persisted_sessions = session::load_persisted_sessions();
+    let (session_handle, _session_join) = session_service::spawn(persisted_sessions);
+
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
@@ -675,7 +700,7 @@ fn main() {
         .manage(AppState {
             settings: Mutex::new(initial_settings),
             pty_manager: PtyManager::new(),
-            session_store: SessionStore::load_persisted(),
+            session_handle,
             project_store: ProjectStore::load_persisted(),
             watch_manager: watches::WatchManager::new(watch_store),
         })
@@ -744,14 +769,24 @@ fn main() {
             // Clean up orphaned watches and start active ones
             {
                 let state = app.state::<AppState>();
-                let session_ids: Vec<String> =
-                    state.session_store.list().iter().map(|s| s.id.clone()).collect();
+                let session_handle = state.session_handle.clone();
                 let project_ids: Vec<String> =
                     state.project_store.list().iter().map(|p| p.id.clone()).collect();
-                state.watch_manager.store().cleanup_orphans(&session_ids, &project_ids);
                 let app_handle = app.handle().clone();
                 let watch_mgr = state.watch_manager.clone();
                 tauri::async_runtime::spawn(async move {
+                    match session_handle.list().await {
+                        Ok(sessions) => {
+                            let session_ids: Vec<String> =
+                                sessions.iter().map(|s| s.id.clone()).collect();
+                            watch_mgr.store().cleanup_orphans(&session_ids, &project_ids);
+                        }
+                        Err(_) => {
+                            // Skip orphan cleanup if session service is unavailable —
+                            // better to keep stale watches than delete valid ones.
+                            eprintln!("Warning: session service unavailable, skipping watch orphan cleanup");
+                        }
+                    }
                     watch_mgr.start_all(app_handle);
                 });
             }

--- a/src-tauri/src/session.rs
+++ b/src-tauri/src/session.rs
@@ -1,10 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
-use std::thread;
-use std::time::Duration;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -25,105 +21,24 @@ pub struct Session {
     pub is_git_repo: bool,
 }
 
-pub struct SessionStore {
-    sessions: Arc<Mutex<Vec<Session>>>,
-    dirty: Arc<AtomicBool>,
+/// Load persisted sessions from disk. All restored sessions are marked as "disconnected".
+pub fn load_persisted_sessions() -> Vec<Session> {
+    let path = persistence_path();
+    if path.exists() {
+        let content = fs::read_to_string(&path).unwrap_or_default();
+        let mut sessions: Vec<Session> = serde_json::from_str(&content).unwrap_or_default();
+        for s in &mut sessions {
+            s.status = "disconnected".to_string();
+        }
+        sessions
+    } else {
+        Vec::new()
+    }
 }
 
-impl SessionStore {
-    pub fn load_persisted() -> Self {
-        let path = Self::persistence_path();
-        let sessions = if path.exists() {
-            let content = fs::read_to_string(&path).unwrap_or_default();
-            let mut sessions: Vec<Session> = serde_json::from_str(&content).unwrap_or_default();
-            // Mark all restored sessions as disconnected
-            for s in &mut sessions {
-                s.status = "disconnected".to_string();
-            }
-            sessions
-        } else {
-            Vec::new()
-        };
-        let store = Self {
-            sessions: Arc::new(Mutex::new(sessions)),
-            dirty: Arc::new(AtomicBool::new(true)),
-        };
-        store.start_persist_thread();
-        store
-    }
-
-    /// Background thread that writes to disk at most every 500ms when dirty.
-    fn start_persist_thread(&self) {
-        let sessions = Arc::clone(&self.sessions);
-        let dirty = Arc::clone(&self.dirty);
-        thread::spawn(move || loop {
-            thread::sleep(Duration::from_millis(500));
-            if dirty.swap(false, Ordering::AcqRel) {
-                let snapshot = {
-                    let guard = sessions.lock().unwrap();
-                    guard.clone()
-                };
-                Self::write_to_disk(&snapshot);
-            }
-        });
-    }
-
-    pub fn add(&self, session: Session) {
-        let mut sessions = self.sessions.lock().unwrap();
-        sessions.push(session);
-        self.dirty.store(true, Ordering::Release);
-    }
-
-    pub fn remove(&self, id: &str) {
-        let mut sessions = self.sessions.lock().unwrap();
-        sessions.retain(|s| s.id != id);
-        self.dirty.store(true, Ordering::Release);
-    }
-
-    pub fn get(&self, id: &str) -> Option<Session> {
-        self.sessions.lock().unwrap().iter().find(|s| s.id == id).cloned()
-    }
-
-    pub fn update_status(&self, id: &str, status: &str) {
-        let mut sessions = self.sessions.lock().unwrap();
-        if let Some(s) = sessions.iter_mut().find(|s| s.id == id) {
-            s.status = status.to_string();
-        }
-        self.dirty.store(true, std::sync::atomic::Ordering::Release);
-    }
-
-    pub fn set_git_repo(&self, id: &str, is_git_repo: bool) {
-        let mut sessions = self.sessions.lock().unwrap();
-        if let Some(s) = sessions.iter_mut().find(|s| s.id == id) {
-            s.is_git_repo = is_git_repo;
-        }
-        self.dirty.store(true, Ordering::Release);
-    }
-
-    pub fn set_project(&self, id: &str, project_id: Option<String>) {
-        let mut sessions = self.sessions.lock().unwrap();
-        if let Some(s) = sessions.iter_mut().find(|s| s.id == id) {
-            s.project_id = project_id;
-        }
-        self.dirty.store(true, Ordering::Release);
-    }
-
-    pub fn list(&self) -> Vec<Session> {
-        self.sessions.lock().unwrap().clone()
-    }
-
-    fn persistence_path() -> PathBuf {
-        let base = dirs::config_dir().unwrap_or_else(|| PathBuf::from("."));
-        base.join("roux").join("sessions.json")
-    }
-
-    fn write_to_disk(sessions: &[Session]) {
-        let path = Self::persistence_path();
-        if let Some(parent) = path.parent() {
-            let _ = fs::create_dir_all(parent);
-        }
-        if let Ok(json) = serde_json::to_string_pretty(sessions) {
-            let _ = fs::write(&path, json);
-        }
-    }
+pub fn persistence_path() -> PathBuf {
+    let base = dirs::config_dir().unwrap_or_else(|| PathBuf::from("."));
+    base.join("roux").join("sessions.json")
 }
+
+

--- a/src-tauri/src/session_service.rs
+++ b/src-tauri/src/session_service.rs
@@ -1,0 +1,416 @@
+//! # Session Service — Handle + Channel Pattern
+//!
+//! This module implements the session service using a handle + channel model:
+//!
+//! - **`SessionHandle`**: A cheap, cloneable handle that wraps an `mpsc::UnboundedSender`.
+//!   Callers send messages through the handle and await responses via `oneshot` channels.
+//!
+//! - **`SessionMsg`**: An enum of all operations the service supports. Every variant carries
+//!   a `oneshot::Sender` for the reply, preserving synchronous ordering guarantees.
+//!
+//! - **Service loop**: A single `tokio::spawn` task that owns all state (`Vec<Session>`).
+//!   No Mutex — thread safety comes from channel serialization. A 500ms timer triggers
+//!   periodic persistence via `spawn_blocking`.
+//!
+//! ## Replicating this pattern for other subsystems
+//!
+//! 1. Define a message enum with a variant per operation, each carrying a `oneshot::Sender<T>`
+//! 2. Create a `Handle` struct wrapping `mpsc::UnboundedSender<Msg>` and implement async methods
+//! 3. Write a `spawn()` function that creates the channel, spawns the service loop, returns the handle
+//! 4. The service loop owns all state and uses `tokio::select!` over the receiver + any timers
+//! 5. Include a `Shutdown` variant for graceful cleanup
+
+use std::path::PathBuf;
+use tokio::sync::{mpsc, oneshot};
+use tokio::task::JoinHandle;
+use tokio::time::{interval, Duration};
+
+use crate::session::Session;
+
+enum SessionMsg {
+    Add {
+        session: Session,
+        reply: oneshot::Sender<()>,
+    },
+    Remove {
+        id: String,
+        reply: oneshot::Sender<()>,
+    },
+    Get {
+        id: String,
+        reply: oneshot::Sender<Option<Session>>,
+    },
+    List {
+        reply: oneshot::Sender<Vec<Session>>,
+    },
+    UpdateStatus {
+        id: String,
+        status: String,
+        reply: oneshot::Sender<()>,
+    },
+    SetGitRepo {
+        id: String,
+        is_git_repo: bool,
+        reply: oneshot::Sender<()>,
+    },
+    SetProject {
+        id: String,
+        project_id: Option<String>,
+        reply: oneshot::Sender<()>,
+    },
+    Shutdown {
+        reply: oneshot::Sender<()>,
+    },
+}
+
+/// Error returned when the session service is unavailable (task exited or channel closed).
+#[derive(Debug, thiserror::Error)]
+#[error("session service unavailable")]
+pub struct ServiceError;
+
+#[derive(Clone)]
+pub struct SessionHandle {
+    tx: mpsc::UnboundedSender<SessionMsg>,
+}
+
+impl SessionHandle {
+    fn send(&self, msg: SessionMsg) -> Result<(), ServiceError> {
+        self.tx.send(msg).map_err(|_| ServiceError)
+    }
+
+    pub async fn add(&self, session: Session) -> Result<(), ServiceError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.send(SessionMsg::Add { session, reply: reply_tx })?;
+        reply_rx.await.map_err(|_| ServiceError)
+    }
+
+    pub async fn remove(&self, id: &str) -> Result<(), ServiceError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.send(SessionMsg::Remove { id: id.to_string(), reply: reply_tx })?;
+        reply_rx.await.map_err(|_| ServiceError)
+    }
+
+    pub async fn get(&self, id: &str) -> Result<Option<Session>, ServiceError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.send(SessionMsg::Get { id: id.to_string(), reply: reply_tx })?;
+        reply_rx.await.map_err(|_| ServiceError)
+    }
+
+    pub async fn list(&self) -> Result<Vec<Session>, ServiceError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.send(SessionMsg::List { reply: reply_tx })?;
+        reply_rx.await.map_err(|_| ServiceError)
+    }
+
+    pub async fn update_status(&self, id: &str, status: &str) -> Result<(), ServiceError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.send(SessionMsg::UpdateStatus {
+            id: id.to_string(),
+            status: status.to_string(),
+            reply: reply_tx,
+        })?;
+        reply_rx.await.map_err(|_| ServiceError)
+    }
+
+    pub async fn set_git_repo(&self, id: &str, is_git_repo: bool) -> Result<(), ServiceError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.send(SessionMsg::SetGitRepo {
+            id: id.to_string(),
+            is_git_repo,
+            reply: reply_tx,
+        })?;
+        reply_rx.await.map_err(|_| ServiceError)
+    }
+
+    pub async fn set_project(&self, id: &str, project_id: Option<String>) -> Result<(), ServiceError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.send(SessionMsg::SetProject {
+            id: id.to_string(),
+            project_id,
+            reply: reply_tx,
+        })?;
+        reply_rx.await.map_err(|_| ServiceError)
+    }
+
+    pub async fn shutdown(&self) {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        // Shutdown is best-effort — if the service is already gone, that's fine.
+        let _ = self.tx.send(SessionMsg::Shutdown { reply: reply_tx });
+        let _ = reply_rx.await;
+    }
+}
+
+/// Spawn the session service. Returns a handle for sending messages and a JoinHandle for the task.
+pub fn spawn(initial_sessions: Vec<Session>) -> (SessionHandle, JoinHandle<()>) {
+    spawn_with_path(initial_sessions, crate::session::persistence_path())
+}
+
+/// Spawn with an explicit persistence path (for testing).
+pub fn spawn_with_path(
+    initial_sessions: Vec<Session>,
+    persist_path: PathBuf,
+) -> (SessionHandle, JoinHandle<()>) {
+    let (tx, rx) = mpsc::unbounded_channel();
+    let join = tokio::spawn(service_loop(rx, initial_sessions, persist_path));
+    (SessionHandle { tx }, join)
+}
+
+async fn service_loop(
+    mut rx: mpsc::UnboundedReceiver<SessionMsg>,
+    mut sessions: Vec<Session>,
+    persist_path: PathBuf,
+) {
+    let mut dirty = false;
+    let mut tick = interval(Duration::from_millis(500));
+    // The first tick fires immediately — consume it so we don't persist on startup.
+    tick.tick().await;
+
+    loop {
+        tokio::select! {
+            msg = rx.recv() => {
+                match msg {
+                    Some(SessionMsg::Add { session, reply }) => {
+                        sessions.push(session);
+                        dirty = true;
+                        let _ = reply.send(());
+                    }
+                    Some(SessionMsg::Remove { id, reply }) => {
+                        sessions.retain(|s| s.id != id);
+                        dirty = true;
+                        let _ = reply.send(());
+                    }
+                    Some(SessionMsg::Get { id, reply }) => {
+                        let found = sessions.iter().find(|s| s.id == id).cloned();
+                        let _ = reply.send(found);
+                    }
+                    Some(SessionMsg::List { reply }) => {
+                        let _ = reply.send(sessions.clone());
+                    }
+                    Some(SessionMsg::UpdateStatus { id, status, reply }) => {
+                        if let Some(s) = sessions.iter_mut().find(|s| s.id == id) {
+                            s.status = status;
+                        }
+                        dirty = true;
+                        let _ = reply.send(());
+                    }
+                    Some(SessionMsg::SetGitRepo { id, is_git_repo, reply }) => {
+                        if let Some(s) = sessions.iter_mut().find(|s| s.id == id) {
+                            s.is_git_repo = is_git_repo;
+                        }
+                        dirty = true;
+                        let _ = reply.send(());
+                    }
+                    Some(SessionMsg::SetProject { id, project_id, reply }) => {
+                        if let Some(s) = sessions.iter_mut().find(|s| s.id == id) {
+                            s.project_id = project_id;
+                        }
+                        dirty = true;
+                        let _ = reply.send(());
+                    }
+                    Some(SessionMsg::Shutdown { reply }) => {
+                        if dirty {
+                            persist_to_disk(&sessions, &persist_path);
+                        }
+                        let _ = reply.send(());
+                        break;
+                    }
+                    None => break, // all senders dropped
+                }
+            }
+            _ = tick.tick() => {
+                if dirty {
+                    let snapshot = sessions.clone();
+                    let path = persist_path.clone();
+                    // Await the write so it completes before processing more messages
+                    // or handling shutdown — prevents stale overwrites.
+                    let _ = tokio::task::spawn_blocking(move || {
+                        write_to_path(&snapshot, &path);
+                    }).await;
+                    dirty = false;
+                }
+            }
+        }
+    }
+}
+
+/// Synchronous disk write — used from `spawn_blocking` and from shutdown (where blocking is fine).
+fn persist_to_disk(sessions: &[Session], path: &PathBuf) {
+    write_to_path(sessions, path);
+}
+
+fn write_to_path(sessions: &[Session], path: &std::path::Path) {
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Ok(json) = serde_json::to_string_pretty(sessions) {
+        let _ = std::fs::write(path, json);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_session(id: &str) -> Session {
+        Session {
+            id: id.to_string(),
+            name: format!("Session {}", id),
+            repo_root: "/tmp/repo".to_string(),
+            worktree_path: "/tmp/repo".to_string(),
+            branch: "main".to_string(),
+            is_worktree: false,
+            status: "idle".to_string(),
+            model: None,
+            cost: None,
+            created_at: 0,
+            project_id: None,
+            is_git_repo: false,
+        }
+    }
+
+    fn temp_persist_path() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sessions.json");
+        (dir, path)
+    }
+
+    #[tokio::test]
+    async fn add_and_list() {
+        let (_dir, path) = temp_persist_path();
+        let (handle, _join) = spawn_with_path(vec![], path);
+
+        handle.add(make_session("s1")).await.unwrap();
+        handle.add(make_session("s2")).await.unwrap();
+
+        let sessions = handle.list().await.unwrap();
+        assert_eq!(sessions.len(), 2);
+        assert_eq!(sessions[0].id, "s1");
+        assert_eq!(sessions[1].id, "s2");
+    }
+
+    #[tokio::test]
+    async fn remove() {
+        let (_dir, path) = temp_persist_path();
+        let (handle, _join) = spawn_with_path(vec![make_session("s1"), make_session("s2")], path);
+
+        handle.remove("s1").await.unwrap();
+
+        let sessions = handle.list().await.unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].id, "s2");
+    }
+
+    #[tokio::test]
+    async fn get_existing() {
+        let (_dir, path) = temp_persist_path();
+        let (handle, _join) = spawn_with_path(vec![make_session("s1")], path);
+
+        let session = handle.get("s1").await.unwrap();
+        assert!(session.is_some());
+        assert_eq!(session.unwrap().id, "s1");
+    }
+
+    #[tokio::test]
+    async fn get_missing() {
+        let (_dir, path) = temp_persist_path();
+        let (handle, _join) = spawn_with_path(vec![], path);
+
+        let session = handle.get("nonexistent").await.unwrap();
+        assert!(session.is_none());
+    }
+
+    #[tokio::test]
+    async fn update_status() {
+        let (_dir, path) = temp_persist_path();
+        let (handle, _join) = spawn_with_path(vec![make_session("s1")], path);
+
+        handle.update_status("s1", "generating").await.unwrap();
+
+        let session = handle.get("s1").await.unwrap().unwrap();
+        assert_eq!(session.status, "generating");
+    }
+
+    #[tokio::test]
+    async fn set_git_repo() {
+        let (_dir, path) = temp_persist_path();
+        let (handle, _join) = spawn_with_path(vec![make_session("s1")], path);
+
+        handle.set_git_repo("s1", true).await.unwrap();
+
+        let session = handle.get("s1").await.unwrap().unwrap();
+        assert!(session.is_git_repo);
+    }
+
+    #[tokio::test]
+    async fn set_project() {
+        let (_dir, path) = temp_persist_path();
+        let (handle, _join) = spawn_with_path(vec![make_session("s1")], path);
+
+        handle.set_project("s1", Some("proj-1".to_string())).await.unwrap();
+
+        let session = handle.get("s1").await.unwrap().unwrap();
+        assert_eq!(session.project_id.as_deref(), Some("proj-1"));
+    }
+
+    #[tokio::test]
+    async fn shutdown_persists_dirty_state() {
+        let (_dir, path) = temp_persist_path();
+        let (handle, join) = spawn_with_path(vec![], path.clone());
+
+        handle.add(make_session("s1")).await.unwrap();
+        handle.add(make_session("s2")).await.unwrap();
+        handle.shutdown().await;
+        join.await.unwrap();
+
+        // Read back from disk
+        let content = std::fs::read_to_string(&path).unwrap();
+        let persisted: Vec<Session> = serde_json::from_str(&content).unwrap();
+        assert_eq!(persisted.len(), 2);
+        assert_eq!(persisted[0].id, "s1");
+        assert_eq!(persisted[1].id, "s2");
+    }
+
+    #[tokio::test]
+    async fn shutdown_after_mutation_persists() {
+        let (_dir, path) = temp_persist_path();
+        let (handle, join) = spawn_with_path(vec![make_session("s1")], path.clone());
+
+        handle.update_status("s1", "generating").await.unwrap();
+        handle.shutdown().await;
+        join.await.unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let persisted: Vec<Session> = serde_json::from_str(&content).unwrap();
+        assert_eq!(persisted[0].status, "generating");
+    }
+
+    #[tokio::test]
+    async fn shutdown_without_dirty_does_not_write() {
+        let (_dir, path) = temp_persist_path();
+        let (handle, join) = spawn_with_path(vec![], path.clone());
+
+        handle.shutdown().await;
+        join.await.unwrap();
+
+        // No file should be created since nothing was dirty
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn operations_after_shutdown_return_error() {
+        let (_dir, path) = temp_persist_path();
+        let (handle, join) = spawn_with_path(vec![], path);
+
+        handle.shutdown().await;
+        join.await.unwrap();
+
+        // All operations should now return ServiceError
+        assert!(handle.add(make_session("s1")).await.is_err());
+        assert!(handle.list().await.is_err());
+        assert!(handle.get("s1").await.is_err());
+        assert!(handle.remove("s1").await.is_err());
+        assert!(handle.update_status("s1", "idle").await.is_err());
+        assert!(handle.set_git_repo("s1", true).await.is_err());
+        assert!(handle.set_project("s1", None).await.is_err());
+    }
+}

--- a/src-tauri/src/socket.rs
+++ b/src-tauri/src/socket.rs
@@ -114,10 +114,10 @@ pub fn start_socket_server(app: tauri::AppHandle) {
 async fn handle_request(req: Request, app: &tauri::AppHandle) -> Response {
     match req.command.as_str() {
         "split" => handle_split(req, app),
-        "session-create" => handle_session_create(req, app),
-        "shell" => handle_shell(req, app),
+        "session-create" => handle_session_create(req, app).await,
+        "shell" => handle_shell(req, app).await,
         "focus" => handle_focus(req, app),
-        "run" => handle_run(req, app),
+        "run" => handle_run(req, app).await,
         "send" => handle_send(req, app),
         _ => Response::err(format!("unknown command: {}", req.command)),
     }
@@ -152,8 +152,9 @@ fn handle_split(req: Request, app: &tauri::AppHandle) -> Response {
     Response::ok()
 }
 
-fn handle_session_create(req: Request, app: &tauri::AppHandle) -> Response {
+async fn handle_session_create(req: Request, app: &tauri::AppHandle) -> Response {
     let state: tauri::State<AppState> = app.state();
+    let handle = state.session_handle.clone();
 
     let name = req.args.get("name").and_then(|n| n.as_str()).unwrap_or("New Session").to_string();
 
@@ -164,8 +165,12 @@ fn handle_session_create(req: Request, app: &tauri::AppHandle) -> Response {
         Some(ref dir) => dir.clone(),
         None => {
             // Try to get repo path from the requesting session
-            match req.session_id.as_deref().and_then(|id| state.session_store.get(id)) {
-                Some(session) => session.repo_root.clone(),
+            match req.session_id.as_deref() {
+                Some(id) => match handle.get(id).await {
+                    Ok(Some(session)) => session.repo_root.clone(),
+                    Ok(None) => return Response::err("working_dir or session_id required"),
+                    Err(e) => return Response::err(format!("{}", e)),
+                },
                 None => return Response::err("working_dir or session_id required"),
             }
         }
@@ -211,7 +216,9 @@ fn handle_session_create(req: Request, app: &tauri::AppHandle) -> Response {
         is_git_repo: is_git,
     };
 
-    state.session_store.add(session);
+    if let Err(e) = handle.add(session).await {
+        return Response::err(format!("{}", e));
+    }
 
     // Tell frontend about the new session
     use tauri::Emitter;
@@ -226,24 +233,27 @@ fn handle_session_create(req: Request, app: &tauri::AppHandle) -> Response {
     Response::success(serde_json::json!({ "session_id": session_id }))
 }
 
-fn handle_shell(req: Request, app: &tauri::AppHandle) -> Response {
+async fn handle_shell(req: Request, app: &tauri::AppHandle) -> Response {
     let session_id = match req.session_id.as_deref() {
         Some(id) => id,
         None => return Response::err("session_id required"),
     };
 
     let state: tauri::State<AppState> = app.state();
+    let handle = state.session_handle.clone();
 
     let working_dir = req
         .args
         .get("working_dir")
         .and_then(|d| d.as_str())
-        .map(|s| s.to_string())
-        .or_else(|| state.session_store.get(session_id).map(|s| s.worktree_path.clone()));
-
+        .map(|s| s.to_string());
     let working_dir = match working_dir {
         Some(dir) => dir,
-        None => return Response::err("could not determine working directory"),
+        None => match handle.get(session_id).await {
+            Ok(Some(s)) => s.worktree_path.clone(),
+            Ok(None) => return Response::err("could not determine working directory"),
+            Err(e) => return Response::err(format!("{}", e)),
+        },
     };
 
     let pane_id = crypto_random_uuid();
@@ -283,7 +293,7 @@ fn handle_focus(req: Request, app: &tauri::AppHandle) -> Response {
     Response::ok()
 }
 
-fn handle_run(req: Request, app: &tauri::AppHandle) -> Response {
+async fn handle_run(req: Request, app: &tauri::AppHandle) -> Response {
     let session_id = match req.session_id.as_deref() {
         Some(id) => id,
         None => return Response::err("session_id required"),
@@ -295,17 +305,20 @@ fn handle_run(req: Request, app: &tauri::AppHandle) -> Response {
     };
 
     let state: tauri::State<AppState> = app.state();
+    let handle = state.session_handle.clone();
 
     let working_dir = req
         .args
         .get("working_dir")
         .and_then(|d| d.as_str())
-        .map(|s| s.to_string())
-        .or_else(|| state.session_store.get(session_id).map(|s| s.worktree_path.clone()));
-
+        .map(|s| s.to_string());
     let working_dir = match working_dir {
         Some(dir) => dir,
-        None => return Response::err("could not determine working directory"),
+        None => match handle.get(session_id).await {
+            Ok(Some(s)) => s.worktree_path.clone(),
+            Ok(None) => return Response::err("could not determine working directory"),
+            Err(e) => return Response::err(format!("{}", e)),
+        },
     };
 
     let pane_id = format!("cmd-{}", crypto_random_uuid());


### PR DESCRIPTION
## Summary

- Converts `SessionStore` from direct `Mutex`-based shared state to a handle + channel service pattern, as described in #10
- `SessionHandle` sends typed messages through an `mpsc` channel; a single tokio task owns all session state (no Mutex)
- All handle methods return `Result<T, ServiceError>` so channel failures surface to callers
- Periodic persistence awaits `spawn_blocking` (no stale-overwrite race)
- Explicit shutdown with final flush in `quit_app`
- Command handlers and socket handlers converted to async
- Watch orphan cleanup safely skips when session service is unavailable
- 11 unit tests covering CRUD, persistence, shutdown, and error paths

## Test plan

- [x] `cargo build` — compiles with only pre-existing warnings
- [x] `cargo test` — 67 tests pass (11 new session_service tests)
- [ ] Manual: start app, create session, kill session, close/reopen, verify persist/restore
- [ ] Manual: socket `session-create` command works from CLI
- [ ] Manual: quit via Cmd+Q triggers shutdown persist

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)