### PR TITLE
feat: convert loose String fields to typed Rust enums

### DIFF
--- a/crates/roux-core/src/models/mod.rs
+++ b/crates/roux-core/src/models/mod.rs
@@ -5,9 +5,9 @@ mod worktree;
 mod watch;
 mod task;
 
-pub use session::Session;
+pub use session::{Session, SessionStatus};
 pub use project::Project;
-pub use settings::RouxSettings;
+pub use settings::{RouxSettings, CursorStyle, TabPosition, GroupBy};
 pub use worktree::Worktree;
 pub use watch::*;
-pub use task::{TaskDefinition, TaskGroup};
+pub use task::{TaskDefinition, TaskGroup, KeepOpen};

--- a/crates/roux-core/src/models/session.rs
+++ b/crates/roux-core/src/models/session.rs
@@ -1,5 +1,35 @@
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub enum SessionStatus {
+    Idle,
+    Thinking,
+    Generating,
+    Error,
+    Disconnected,
+    Attention,
+}
+
+impl Default for SessionStatus {
+    fn default() -> Self {
+        Self::Idle
+    }
+}
+
+impl std::fmt::Display for SessionStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Idle => write!(f, "idle"),
+            Self::Thinking => write!(f, "thinking"),
+            Self::Generating => write!(f, "generating"),
+            Self::Error => write!(f, "error"),
+            Self::Disconnected => write!(f, "disconnected"),
+            Self::Attention => write!(f, "attention"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
 #[serde(rename_all = "camelCase")]
 pub struct Session {
@@ -9,7 +39,7 @@ pub struct Session {
     pub worktree_path: String,
     pub branch: String,
     pub is_worktree: bool,
-    pub status: String,
+    pub status: SessionStatus,
     pub model: Option<String>,
     pub cost: Option<f64>,
     pub created_at: u64,

--- a/crates/roux-core/src/models/settings.rs
+++ b/crates/roux-core/src/models/settings.rs
@@ -10,14 +10,50 @@ fn default_true() -> bool {
     true
 }
 
-fn default_group_by() -> String {
-    "repo".to_string()
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub enum CursorStyle {
+    Block,
+    Underline,
+    Bar,
+}
+
+impl Default for CursorStyle {
+    fn default() -> Self {
+        Self::Block
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub enum TabPosition {
+    Left,
+    Right,
+}
+
+impl Default for TabPosition {
+    fn default() -> Self {
+        Self::Left
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub enum GroupBy {
+    Repo,
+    Project,
+}
+
+impl Default for GroupBy {
+    fn default() -> Self {
+        Self::Repo
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
 #[serde(rename_all = "camelCase")]
 pub struct RouxSettings {
-    pub tab_position: String,
+    pub tab_position: TabPosition,
     pub tab_width: u32,
     pub font_size: u32,
     pub font_family: String,
@@ -25,7 +61,7 @@ pub struct RouxSettings {
     pub ui_font_family: String,
     pub line_height: f64,
     pub scrollback: u32,
-    pub cursor_style: String,
+    pub cursor_style: CursorStyle,
     pub cursor_blink: bool,
     pub default_project_path: Option<String>,
     pub confirm_on_close: bool,
@@ -41,8 +77,8 @@ pub struct RouxSettings {
     pub task_panel_collapsed: bool,
     #[serde(default)]
     pub enable_logging: bool,
-    #[serde(default = "default_group_by")]
-    pub group_by: String,
+    #[serde(default)]
+    pub group_by: GroupBy,
     #[serde(default = "default_true")]
     pub confirm_on_quit: bool,
 }
@@ -50,14 +86,14 @@ pub struct RouxSettings {
 impl Default for RouxSettings {
     fn default() -> Self {
         Self {
-            tab_position: "left".to_string(),
+            tab_position: TabPosition::Left,
             tab_width: 260,
             font_size: 14,
             font_family: "JetBrains Mono, IBM Plex Mono, SFMono-Regular, monospace".to_string(),
             ui_font_family: default_ui_font_family(),
             line_height: 1.2,
             scrollback: 5000,
-            cursor_style: "block".to_string(),
+            cursor_style: CursorStyle::Block,
             cursor_blink: true,
             default_project_path: None,
             confirm_on_close: true,
@@ -71,7 +107,7 @@ impl Default for RouxSettings {
             task_panel_split: 0.5,
             task_panel_collapsed: true,
             enable_logging: false,
-            group_by: "repo".to_string(),
+            group_by: GroupBy::Repo,
             confirm_on_quit: true,
         }
     }

--- a/crates/roux-core/src/models/task.rs
+++ b/crates/roux-core/src/models/task.rs
@@ -1,5 +1,19 @@
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "kebab-case")]
+pub enum KeepOpen {
+    Always,
+    OnError,
+    Never,
+}
+
+impl Default for KeepOpen {
+    fn default() -> Self {
+        Self::OnError
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
 #[serde(rename_all = "camelCase")]
 pub struct TaskDefinition {
@@ -8,7 +22,7 @@ pub struct TaskDefinition {
     pub description: String,
     pub runner: String,
     pub command: String,
-    pub keep_open: String,
+    pub keep_open: KeepOpen,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]

--- a/src-tauri/src/services/sessions.rs
+++ b/src-tauri/src/services/sessions.rs
@@ -111,7 +111,7 @@ pub(crate) async fn create_session(
         worktree_path: work_dir,
         branch: actual_branch,
         is_worktree: is_wt,
-        status: "idle".to_string(),
+        status: roux_core::SessionStatus::Idle,
         model: None,
         cost: None,
         created_at: now,
@@ -161,12 +161,12 @@ pub(crate) async fn reconnect_session(
         )
         .map_err(|e| anyhow!("{}", e))?;
 
-    session_handle.update_status(id, "idle").await?;
+    session_handle.update_status(id, roux_core::SessionStatus::Idle).await?;
 
     rlog!("Session '{}' reconnected successfully", id);
 
     let mut updated = session;
-    updated.status = "idle".to_string();
+    updated.status = roux_core::SessionStatus::Idle;
     Ok(updated)
 }
 

--- a/src-tauri/src/session.rs
+++ b/src-tauri/src/session.rs
@@ -10,7 +10,7 @@ pub fn load_persisted_sessions() -> Vec<Session> {
         let content = fs::read_to_string(&path).unwrap_or_default();
         let mut sessions: Vec<Session> = serde_json::from_str(&content).unwrap_or_default();
         for s in &mut sessions {
-            s.status = "disconnected".to_string();
+            s.status = roux_core::SessionStatus::Disconnected;
         }
         sessions
     } else {

--- a/src-tauri/src/session_service.rs
+++ b/src-tauri/src/session_service.rs
@@ -45,7 +45,7 @@ enum SessionMsg {
     },
     UpdateStatus {
         id: String,
-        status: String,
+        status: roux_core::SessionStatus,
         reply: oneshot::Sender<()>,
     },
     SetGitRepo {
@@ -102,11 +102,11 @@ impl SessionHandle {
         reply_rx.await.map_err(|_| ServiceError)
     }
 
-    pub async fn update_status(&self, id: &str, status: &str) -> Result<(), ServiceError> {
+    pub async fn update_status(&self, id: &str, status: roux_core::SessionStatus) -> Result<(), ServiceError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.send(SessionMsg::UpdateStatus {
             id: id.to_string(),
-            status: status.to_string(),
+            status,
             reply: reply_tx,
         })?;
         reply_rx.await.map_err(|_| ServiceError)
@@ -259,7 +259,7 @@ mod tests {
             worktree_path: "/tmp/repo".to_string(),
             branch: "main".to_string(),
             is_worktree: false,
-            status: "idle".to_string(),
+            status: roux_core::SessionStatus::Idle,
             model: None,
             cost: None,
             created_at: 0,
@@ -324,10 +324,10 @@ mod tests {
         let (_dir, path) = temp_persist_path();
         let (handle, _join) = spawn_with_path(vec![make_session("s1")], path);
 
-        handle.update_status("s1", "generating").await.unwrap();
+        handle.update_status("s1", roux_core::SessionStatus::Generating).await.unwrap();
 
         let session = handle.get("s1").await.unwrap().unwrap();
-        assert_eq!(session.status, "generating");
+        assert_eq!(session.status, roux_core::SessionStatus::Generating);
     }
 
     #[tokio::test]
@@ -375,13 +375,13 @@ mod tests {
         let (_dir, path) = temp_persist_path();
         let (handle, join) = spawn_with_path(vec![make_session("s1")], path.clone());
 
-        handle.update_status("s1", "generating").await.unwrap();
+        handle.update_status("s1", roux_core::SessionStatus::Generating).await.unwrap();
         handle.shutdown().await;
         join.await.unwrap();
 
         let content = std::fs::read_to_string(&path).unwrap();
         let persisted: Vec<Session> = serde_json::from_str(&content).unwrap();
-        assert_eq!(persisted[0].status, "generating");
+        assert_eq!(persisted[0].status, roux_core::SessionStatus::Generating);
     }
 
     #[tokio::test]
@@ -409,7 +409,7 @@ mod tests {
         assert!(handle.list().await.is_err());
         assert!(handle.get("s1").await.is_err());
         assert!(handle.remove("s1").await.is_err());
-        assert!(handle.update_status("s1", "idle").await.is_err());
+        assert!(handle.update_status("s1", roux_core::SessionStatus::Idle).await.is_err());
         assert!(handle.set_git_repo("s1", true).await.is_err());
         assert!(handle.set_project("s1", None).await.is_err());
     }

--- a/src-tauri/src/tasks.rs
+++ b/src-tauri/src/tasks.rs
@@ -41,7 +41,7 @@ impl TaskDiscoverer for NpmDiscoverer {
                 description: String::new(),
                 runner: "npm".to_string(),
                 command: format!("npm run {}", name),
-                keep_open: "on-error".to_string(),
+                keep_open: roux_core::KeepOpen::OnError,
             })
             .collect();
 
@@ -92,7 +92,7 @@ impl TaskDiscoverer for TaskfileDiscoverer {
                 description: desc,
                 runner: "task".to_string(),
                 command: format!("task {}", name),
-                keep_open: "on-error".to_string(),
+                keep_open: roux_core::KeepOpen::OnError,
             })
             .collect();
 
@@ -180,7 +180,7 @@ impl TaskDiscoverer for MakeDiscoverer {
                 description: desc,
                 runner: "make".to_string(),
                 command: format!("make {}", name),
-                keep_open: "on-error".to_string(),
+                keep_open: roux_core::KeepOpen::OnError,
             })
             .collect();
 
@@ -281,7 +281,7 @@ impl TaskDiscoverer for JustDiscoverer {
                 description: desc,
                 runner: "just".to_string(),
                 command: format!("just {}", name),
-                keep_open: "on-error".to_string(),
+                keep_open: roux_core::KeepOpen::OnError,
             })
             .collect();
 
@@ -368,7 +368,7 @@ mod tests {
         assert_eq!(group.tasks[0].name, "build");
         assert_eq!(group.tasks[0].command, "npm run build");
         assert_eq!(group.tasks[0].id, "npm:build");
-        assert_eq!(group.tasks[0].keep_open, "on-error");
+        assert_eq!(group.tasks[0].keep_open, roux_core::KeepOpen::OnError);
 
         assert_eq!(group.tasks[1].name, "dev");
         assert_eq!(group.tasks[2].name, "test");
@@ -452,7 +452,7 @@ tasks:
         assert_eq!(group.tasks[0].description, "Compile the project");
         assert_eq!(group.tasks[0].command, "task build");
         assert_eq!(group.tasks[0].id, "taskfile:build");
-        assert_eq!(group.tasks[0].keep_open, "on-error");
+        assert_eq!(group.tasks[0].keep_open, roux_core::KeepOpen::OnError);
 
         assert_eq!(group.tasks[1].name, "lint");
         assert_eq!(group.tasks[1].description, "");
@@ -505,7 +505,7 @@ _internal:
         assert_eq!(group.tasks[0].description, "Build the project");
         assert_eq!(group.tasks[0].command, "make build");
         assert_eq!(group.tasks[0].id, "make:build");
-        assert_eq!(group.tasks[0].keep_open, "on-error");
+        assert_eq!(group.tasks[0].keep_open, roux_core::KeepOpen::OnError);
 
         assert_eq!(group.tasks[1].name, "lint");
         assert_eq!(group.tasks[1].description, "");
@@ -568,7 +568,7 @@ lint:
         assert_eq!(group.tasks[0].description, "Build the project");
         assert_eq!(group.tasks[0].command, "just build");
         assert_eq!(group.tasks[0].id, "just:build");
-        assert_eq!(group.tasks[0].keep_open, "on-error");
+        assert_eq!(group.tasks[0].keep_open, roux_core::KeepOpen::OnError);
 
         assert_eq!(group.tasks[1].name, "lint");
         assert_eq!(group.tasks[1].description, "");

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -67,6 +67,8 @@ export type CreateWatchConfig = {
 	notify: NotifyConfig | null,
 };
 
+export type CursorStyle = "block" | "underline" | "bar";
+
 export type DocFile = {
 	path: string,
 	name: string,
@@ -80,6 +82,10 @@ export type GithubJob = {
 	conclusion: string | null,
 	failedStep: string | null,
 };
+
+export type GroupBy = "repo" | "project";
+
+export type KeepOpen = "always" | "on-error" | "never";
 
 export type NotifyConfig = {
 	desktopNotification: boolean,
@@ -105,14 +111,14 @@ export type Project = {
 };
 
 export type RouxSettings = {
-	tabPosition: string,
+	tabPosition: TabPosition,
 	tabWidth: number,
 	fontSize: number,
 	fontFamily: string,
 	uiFontFamily?: string,
 	lineHeight: number,
 	scrollback: number,
-	cursorStyle: string,
+	cursorStyle: CursorStyle,
 	cursorBlink: boolean,
 	defaultProjectPath: string | null,
 	confirmOnClose: boolean,
@@ -126,7 +132,7 @@ export type RouxSettings = {
 	taskPanelSplit: number,
 	taskPanelCollapsed: boolean,
 	enableLogging?: boolean,
-	groupBy?: string,
+	groupBy?: GroupBy,
 	confirmOnQuit?: boolean,
 };
 
@@ -139,7 +145,7 @@ export type Session = {
 	worktreePath: string,
 	branch: string,
 	isWorktree: boolean,
-	status: string,
+	status: SessionStatus,
 	model: string | null,
 	cost: number | null,
 	createdAt: number,
@@ -147,10 +153,14 @@ export type Session = {
 	isGitRepo?: boolean,
 };
 
+export type SessionStatus = "idle" | "thinking" | "generating" | "error" | "disconnected" | "attention";
+
 export type SetupStatus = {
 	cliInstalled: boolean,
 	ghAvailable: boolean,
 };
+
+export type TabPosition = "left" | "right";
 
 export type TaskDefinition = {
 	id: string,
@@ -158,7 +168,7 @@ export type TaskDefinition = {
 	description: string,
 	runner: string,
 	command: string,
-	keepOpen: string,
+	keepOpen: KeepOpen,
 };
 
 export type TaskGroup = {


### PR DESCRIPTION
## Summary

- Replaces 5 loose `String` fields with proper Rust enums in `roux-core`:
  - `Session.status` → `SessionStatus` (idle/thinking/generating/error/disconnected/attention)
  - `RouxSettings.cursor_style` → `CursorStyle` (block/underline/bar)
  - `RouxSettings.tab_position` → `TabPosition` (left/right)
  - `RouxSettings.group_by` → `GroupBy` (repo/project)
  - `TaskDefinition.keep_open` → `KeepOpen` (always/on-error/never)
- Generated TypeScript bindings now produce union types instead of `string`
- All serde (de)serialization is backwards-compatible with existing persisted data
- Updates all Rust callers to use enum variants instead of string literals

## Test plan

- [x] `cargo build` — compiles clean
- [x] `cargo test` — 67 tests pass
- [x] `npm run check` — 0 errors
- [x] Generated bindings show proper union types

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)