### PR TITLE
feat: define event payload types in Rust

### DIFF
--- a/crates/roux-core/src/models/events.rs
+++ b/crates/roux-core/src/models/events.rs
@@ -1,0 +1,81 @@
+use serde::Serialize;
+
+/// Payload emitted when a PTY session exits (event: `session-exit:{id}`).
+#[derive(Debug, Clone, Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionExitPayload {
+    pub code: Option<u32>,
+    pub generation: u64,
+    pub reason: SessionExitReason,
+}
+
+#[derive(Debug, Clone, Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub enum SessionExitReason {
+    Exit,
+    IoError,
+    Killed,
+}
+
+/// Payload emitted for socket/CLI-initiated commands (event: `roux-command`).
+#[derive(Debug, Clone, Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct RouxCommand {
+    pub action: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pane_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pty_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub direction: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub working_dir: Option<String>,
+}
+
+impl RouxCommand {
+    pub fn new(action: &str) -> Self {
+        Self {
+            action: action.to_string(),
+            session_id: None,
+            pane_id: None,
+            pty_id: None,
+            direction: None,
+            command: None,
+            working_dir: None,
+        }
+    }
+
+    pub fn session_id(mut self, id: impl Into<String>) -> Self {
+        self.session_id = Some(id.into());
+        self
+    }
+
+    pub fn pane_id(mut self, id: impl Into<String>) -> Self {
+        self.pane_id = Some(id.into());
+        self
+    }
+
+    pub fn pty_id(mut self, id: impl Into<String>) -> Self {
+        self.pty_id = Some(id.into());
+        self
+    }
+
+    pub fn direction(mut self, dir: impl Into<String>) -> Self {
+        self.direction = Some(dir.into());
+        self
+    }
+
+    pub fn command(mut self, cmd: impl Into<String>) -> Self {
+        self.command = Some(cmd.into());
+        self
+    }
+
+    pub fn working_dir(mut self, dir: impl Into<String>) -> Self {
+        self.working_dir = Some(dir.into());
+        self
+    }
+}

--- a/crates/roux-core/src/models/mod.rs
+++ b/crates/roux-core/src/models/mod.rs
@@ -1,3 +1,4 @@
+mod events;
 mod session;
 mod project;
 mod settings;
@@ -5,6 +6,7 @@ mod worktree;
 mod watch;
 mod task;
 
+pub use events::{SessionExitPayload, SessionExitReason, RouxCommand};
 pub use session::{Session, SessionStatus};
 pub use project::Project;
 pub use settings::{RouxSettings, CursorStyle, TabPosition, GroupBy};

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -138,10 +138,11 @@ fn spawn_flusher(
                         output.send(std::mem::take(&mut batch));
                     }
                     if let Some((evt, gen)) = &exit_event {
-                        let _ = app.emit(
-                            evt,
-                            serde_json::json!({"code": null, "generation": gen, "reason": "exit"}),
-                        );
+                        let _ = app.emit(evt, &roux_core::SessionExitPayload {
+                            code: None,
+                            generation: *gen,
+                            reason: roux_core::SessionExitReason::Exit,
+                        });
                     }
                     break;
                 }
@@ -150,7 +151,11 @@ fn spawn_flusher(
                         output.send(std::mem::take(&mut batch));
                     }
                     if let Some((evt, gen)) = &exit_event {
-                        let _ = app.emit(evt, serde_json::json!({"code": null, "generation": gen, "reason": "io_error"}));
+                        let _ = app.emit(evt, &roux_core::SessionExitPayload {
+                            code: None,
+                            generation: *gen,
+                            reason: roux_core::SessionExitReason::IoError,
+                        });
                     }
                     break;
                 }
@@ -497,7 +502,11 @@ impl PtyManager {
             let code = child.wait().ok().map(|status| status.exit_code());
             let _ = app.emit(
                 &exit_event_name,
-                serde_json::json!({ "code": code, "generation": gen, "reason": "exit" }),
+                &roux_core::SessionExitPayload {
+                    code,
+                    generation: gen,
+                    reason: roux_core::SessionExitReason::Exit,
+                },
             );
         });
 

--- a/src-tauri/src/socket.rs
+++ b/src-tauri/src/socket.rs
@@ -139,15 +139,13 @@ fn handle_split(req: Request, app: &tauri::AppHandle) -> Response {
     };
 
     use tauri::Emitter;
-    let _ = app.emit(
-        "roux-command",
-        serde_json::json!({
-            "action": "split",
-            "sessionId": session_id,
-            "paneId": req.pane_id,
-            "direction": direction,
-        }),
-    );
+    let mut cmd = roux_core::RouxCommand::new("split")
+        .session_id(session_id)
+        .direction(direction);
+    if let Some(ref pane_id) = req.pane_id {
+        cmd = cmd.pane_id(pane_id);
+    }
+    let _ = app.emit("roux-command", &cmd);
 
     Response::ok()
 }
@@ -203,13 +201,8 @@ async fn handle_session_create(req: Request, app: &tauri::AppHandle) -> Response
     let session_id = session.id.clone();
 
     use tauri::Emitter;
-    if let Err(e) = app.emit(
-        "roux-command",
-        serde_json::json!({
-            "action": "session-created",
-            "sessionId": session_id,
-        }),
-    ) {
+    let cmd = roux_core::RouxCommand::new("session-created").session_id(&session_id);
+    if let Err(e) = app.emit("roux-command", &cmd) {
         rlog!("Warning: failed to emit session-created event: {}", e);
     }
 
@@ -251,12 +244,10 @@ async fn handle_shell(req: Request, app: &tauri::AppHandle) -> Response {
     use tauri::Emitter;
     let _ = app.emit(
         "roux-command",
-        serde_json::json!({
-            "action": "shell-opened",
-            "sessionId": session_id,
-            "paneId": pane_id,
-            "ptyId": pty_id,
-        }),
+        &roux_core::RouxCommand::new("shell-opened")
+            .session_id(session_id)
+            .pane_id(&pane_id)
+            .pty_id(&pty_id),
     );
 
     Response::success(serde_json::json!({ "pane_id": pane_id, "pty_id": pty_id }))
@@ -264,14 +255,14 @@ async fn handle_shell(req: Request, app: &tauri::AppHandle) -> Response {
 
 fn handle_focus(req: Request, app: &tauri::AppHandle) -> Response {
     use tauri::Emitter;
-    let _ = app.emit(
-        "roux-command",
-        serde_json::json!({
-            "action": "focus",
-            "sessionId": req.session_id,
-            "paneId": req.pane_id,
-        }),
-    );
+    let mut cmd = roux_core::RouxCommand::new("focus");
+    if let Some(ref id) = req.session_id {
+        cmd = cmd.session_id(id);
+    }
+    if let Some(ref pane_id) = req.pane_id {
+        cmd = cmd.pane_id(pane_id);
+    }
+    let _ = app.emit("roux-command", &cmd);
 
     Response::ok()
 }
@@ -320,14 +311,12 @@ async fn handle_run(req: Request, app: &tauri::AppHandle) -> Response {
     use tauri::Emitter;
     let _ = app.emit(
         "roux-command",
-        serde_json::json!({
-            "action": "command-opened",
-            "sessionId": session_id,
-            "paneId": pane_id,
-            "ptyId": pty_id,
-            "command": command,
-            "workingDir": working_dir,
-        }),
+        &roux_core::RouxCommand::new("command-opened")
+            .session_id(session_id)
+            .pane_id(&pane_id)
+            .pty_id(&pty_id)
+            .command(&command)
+            .working_dir(&working_dir),
     );
 
     Response::success(serde_json::json!({ "pane_id": pane_id, "pty_id": pty_id }))


### PR DESCRIPTION
## Summary

- Defines `SessionExitPayload` + `SessionExitReason` in roux-core for PTY exit events
- Defines `RouxCommand` with builder pattern in roux-core for socket command events
- Replaces all ad-hoc `serde_json::json!()` event emissions in `pty.rs` and `socket.rs` with typed structs
- Types derive `specta::Type` so they'll appear in generated bindings

## Test plan

- [x] `cargo build` — compiles clean
- [x] `cargo test` — 67 tests pass
- [ ] Manual: PTY exit events and socket commands work correctly

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)