### PR TITLE
feat: add vimish leader mode for pane commands

### DIFF
--- a/docs/features/panes.md
+++ b/docs/features/panes.md
@@ -22,6 +22,15 @@ Move focus between panes using Alt + vim direction keys:
 - ++alt+k++ up
 - ++alt+l++ right
 
+For structural pane commands, use leader mode with ++cmd+;++. The pane group under ++w++ gives you a compact, keyboard-first command surface for focus movement, splits, rename, close, fullscreen, and stack toggling. Context-sensitive actions only appear when they make sense for the currently focused pane.
+
+Examples:
+
+- ++cmd+; w s++ split horizontally
+- ++cmd+; w v++ split vertically
+- ++cmd+; w r++ rename the active pane inline
+- ++cmd+; w d++ close the active pane
+
 ## Closing
 
 ++cmd+w++ closes the focused pane. If a pane hosts a Claude session, the session is stopped. If it hosts a shell, the shell is terminated.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@ Roux lets you run multiple Claude Code sessions side-by-side with split panes, s
 - **Stacked panes** — Zellij-style tab stacking
 - **Shell terminals** — open shell panes alongside Claude for running commands
 - **Command palette** — quick access to every action via ++cmd+k++
+- **Leader mode** — Vimish pane and session actions via ++cmd+;++ with inline pane rename
 - **Layout persistence** — pane layouts survive app restarts; shell panes respawn automatically
 - **Projects** — tag sessions with projects to organize related work across repos and worktrees
 - **Project notes** — per-project plain-text notes sidebar (++cmd+b++) shared across all sessions in a project

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -19,6 +19,34 @@ The full set of built-in shortcuts. All shortcuts are also visible in the comman
 
 The pane-focus shortcuts target the Nth visible pane in the active session (depth-first, left-to-right). Hold ++alt++ on its own to see each pane's digit drawn centered over it.
 
+## Leader mode
+
+Roux also has a Vimish leader-mode surface for pane and session commands:
+
+- ++cmd+;++ — open leader mode
+- ++escape++ — cancel leader mode
+- ++backspace++ — move back up one leader level
+- ++space++ — expand into the full command palette
+
+### Pane leader keys
+
+- ++cmd+; w++ — pane commands
+- ++h++ / ++j++ / ++k++ / ++l++ — move focus between panes
+- ++s++ — split horizontally
+- ++v++ — split vertically
+- ++r++ — rename the active pane inline
+- ++d++ — close the active pane
+- ++f++ — toggle fullscreen on the active pane
+- ++t++ — toggle stack when the focused pane belongs to a splittable parent
+
+### Session leader keys
+
+- ++cmd+; b++ — session commands
+- ++n++ — new session
+- ++d++ — close session
+- ++r++ — reconnect session
+- ++e++ — open the session worktree in your editor
+
 ## Sessions and windows
 
 | Action | Shortcut |

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -10,8 +10,24 @@
   import WatchesPane from "$lib/components/WatchesPane.svelte";
   import NotificationsPane from "$lib/components/NotificationsPane.svelte";
   import CommandPalette from "$lib/components/CommandPalette.svelte";
+  import LeaderHud from "$lib/components/LeaderHud.svelte";
   import QuitDialog from "$lib/components/QuitDialog.svelte";
   import UpdateBanner from "$lib/components/UpdateBanner.svelte";
+  import {
+    getVisibleLeaderHints,
+    normalizeLeaderKey,
+    resolveLeaderSequence,
+  } from "$lib/commands/leader";
+  import {
+    closeCommandSurface,
+    commandSurface,
+    openCommandPalette,
+    openLeaderPrompt,
+    openLeaderMode,
+    setLeaderSequence,
+    setLeaderPromptValue,
+    toggleCommandSurface,
+  } from "$lib/stores/commandSurface";
   import { runStartupCheck, runManualCheck } from "$lib/stores/updater";
   import { initSettings, settings } from "$lib/stores/settings";
   import { projects } from "$lib/stores/projects";
@@ -36,6 +52,7 @@
   import { listen } from "@tauri-apps/api/event";
   import { registerCommands, registry } from "$lib/commands";
   import { closeFocusedPane } from "$lib/panes/actions";
+  import { queries } from "$lib/queries";
   import { normalizeTheme, isLightTheme } from "$lib/themes";
   import { initLogging, log, logError } from "$lib/logging";
   import {
@@ -52,7 +69,6 @@
   let showNotes = $state(false);
   let showWatches = $state(false);
   let showNotifications = $state(false);
-  let showPalette = $state(false);
   let showSetupPrompt = $state(false);
   let showQuitDialog = $state(false);
   let ghAvailable = $state(true);
@@ -114,6 +130,69 @@
     await handleQuitRequested();
   }
 
+  function executeCommandById(commandId: string) {
+    const cmd = registry.get(commandId);
+    if (!cmd) return;
+
+    if (cmd.id === "session.new") {
+      showNewSessionDialog = true;
+      return;
+    }
+    if (cmd.id === "app.settings") {
+      showSettings = !showSettings;
+      if (showSettings) showNotes = false;
+      return;
+    }
+    if (cmd.id === "ui.toggle-notes") {
+      showNotes = !showNotes;
+      if (showNotes) showSettings = false;
+      return;
+    }
+    if (cmd.id === "ui.toggle-watches") {
+      showWatches = !showWatches;
+      if (showWatches) { showSettings = false; showNotes = false; showNotifications = false; }
+      return;
+    }
+    if (cmd.id === "ui.toggle-notifications") {
+      showNotifications = !showNotifications;
+      if (showNotifications) { showSettings = false; showNotes = false; showWatches = false; }
+      return;
+    }
+    if (cmd.id === "app.command-palette") {
+      openCommandPalette();
+      return;
+    }
+    if (cmd.id === "app.leader-mode") {
+      openLeaderMode();
+      return;
+    }
+
+    if (cmd.execute) void cmd.execute();
+  }
+
+  function getLeaderPromptInitialValue(commandId: string): string {
+    if (commandId === "pane.rename") {
+      return queries.focusedPane()?.name ?? "";
+    }
+    return "";
+  }
+
+  function submitLeaderPrompt() {
+    const surface = get(commandSurface);
+    if (!surface.leaderPromptCommandId) return;
+    const cmd = registry.get(surface.leaderPromptCommandId);
+    if (!cmd?.onInput) return;
+    const value = surface.leaderPromptValue;
+    closeCommandSurface();
+    void cmd.onInput(value);
+  }
+
+  function isLeaderCommandAvailable(commandId: string): boolean {
+    const cmd = registry.get(commandId);
+    if (!cmd) return false;
+    return !cmd.available || cmd.available();
+  }
+
   function handleKeyDown(e: KeyboardEvent) {
     // Arm the session-hint overlay when Cmd is pressed on its own.
     // The store handles the 200ms delay; quick chords like Cmd+K or Cmd+1
@@ -137,12 +216,79 @@
     // Command palette toggle
     if (e.metaKey && e.key === "k") {
       e.preventDefault();
-      showPalette = !showPalette;
+      toggleCommandSurface("palette");
       return;
     }
 
-    // Don't intercept shortcuts when palette is open
-    if (showPalette) return;
+    // Leader mode
+    if (e.metaKey && e.key === ";") {
+      e.preventDefault();
+      toggleCommandSurface("leader");
+      return;
+    }
+
+    // Don't intercept shortcuts when a command surface is open
+    const surface = get(commandSurface);
+    if (surface.open) {
+      if (surface.mode === "leader") {
+        if (surface.leaderPromptCommandId) {
+          if (e.key === "Escape") {
+            e.preventDefault();
+            closeCommandSurface();
+            return;
+          }
+          if (e.key === "Enter") {
+            e.preventDefault();
+            submitLeaderPrompt();
+            return;
+          }
+          return;
+        }
+        if (e.key === "Escape") {
+          e.preventDefault();
+          closeCommandSurface();
+          return;
+        }
+        if (e.key === "Backspace") {
+          e.preventDefault();
+          if (surface.leaderSequence.length === 0) {
+            closeCommandSurface();
+            return;
+          }
+          setLeaderSequence(surface.leaderSequence.slice(0, -1));
+          return;
+        }
+        const key = normalizeLeaderKey(e);
+        if (!key) return;
+        e.preventDefault();
+        const nextSequence = [...surface.leaderSequence, key];
+        const resolution = resolveLeaderSequence(nextSequence);
+        if (resolution.kind === "pending") {
+          setLeaderSequence(nextSequence);
+          return;
+        }
+        if (resolution.kind === "palette") {
+          openCommandPalette();
+          return;
+        }
+        if (resolution.kind === "command") {
+          const resolvedCmd = registry.get(resolution.commandId);
+          if (resolvedCmd?.onInput) {
+            openLeaderPrompt(
+              resolution.commandId,
+              getLeaderPromptInitialValue(resolution.commandId),
+            );
+            return;
+          }
+          closeCommandSurface();
+          executeCommandById(resolution.commandId);
+          return;
+        }
+        closeCommandSurface();
+        return;
+      }
+      return;
+    }
 
     // Cmd+1..9 / Cmd+0: switch to the Nth session in sidebar visual order.
     // Cmd+0 maps to slot 10. Slots past the available session count are
@@ -204,38 +350,7 @@
     const cmd = registry.getByShortcut(shortcut);
     if (cmd) {
       e.preventDefault();
-
-      // Handle special commands that need local state
-      if (cmd.id === "session.new") {
-        showNewSessionDialog = true;
-        return;
-      }
-      if (cmd.id === "app.settings") {
-        showSettings = !showSettings;
-        if (showSettings) showNotes = false;
-        return;
-      }
-      if (cmd.id === "ui.toggle-notes") {
-        showNotes = !showNotes;
-        if (showNotes) showSettings = false;
-        return;
-      }
-      if (cmd.id === "ui.toggle-watches") {
-        showWatches = !showWatches;
-        if (showWatches) { showSettings = false; showNotes = false; showNotifications = false; }
-        return;
-      }
-      if (cmd.id === "ui.toggle-notifications") {
-        showNotifications = !showNotifications;
-        if (showNotifications) { showSettings = false; showNotes = false; showWatches = false; }
-        return;
-      }
-      if (cmd.id === "app.command-palette") {
-        showPalette = true;
-        return;
-      }
-
-      if (cmd.execute) void cmd.execute();
+      executeCommandById(cmd.id);
     }
   }
 
@@ -512,12 +627,32 @@
 />
 
 <CommandPalette
-  open={showPalette}
-  onclose={() => (showPalette = false)}
+  open={$commandSurface.open && $commandSurface.mode === "palette"}
+  onclose={closeCommandSurface}
   onNewSession={() => (showNewSessionDialog = true)}
   onSettings={() => (showSettings = !showSettings)}
   onCheckForUpdates={() => { showSettings = true; void runManualCheck(); }}
 />
+
+{#if $commandSurface.open && $commandSurface.mode === "leader"}
+  {@const leaderState = resolveLeaderSequence($commandSurface.leaderSequence)}
+  {@const visibleLeaderHints = getVisibleLeaderHints(
+    $commandSurface.leaderSequence,
+    isLeaderCommandAvailable,
+  )}
+  {#if leaderState.kind === "pending" || $commandSurface.leaderPromptCommandId}
+    <LeaderHud
+      title={leaderState.kind === "pending" ? leaderState.title : "Leader"}
+      sequence={$commandSurface.leaderSequence}
+      hints={leaderState.kind === "pending" ? visibleLeaderHints : []}
+      promptLabel={$commandSurface.leaderPromptCommandId ? registry.get($commandSurface.leaderPromptCommandId)?.label ?? "Input" : null}
+      promptPlaceholder={$commandSurface.leaderPromptCommandId ? registry.get($commandSurface.leaderPromptCommandId)?.inputPlaceholder ?? "" : null}
+      promptValue={$commandSurface.leaderPromptValue}
+      onPromptInput={setLeaderPromptValue}
+      onPromptSubmit={submitLeaderPrompt}
+    />
+  {/if}
+{/if}
 
 <UpdateBanner />
 

--- a/src/lib/commands/__tests__/leader.test.ts
+++ b/src/lib/commands/__tests__/leader.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import {
+  getVisibleLeaderHints,
+  normalizeLeaderKey,
+  resolveLeaderSequence,
+} from "../leader";
+
+describe("leader", () => {
+  it("returns root hints for an empty sequence", () => {
+    expect(resolveLeaderSequence([])).toEqual({
+      kind: "pending",
+      title: "Leader",
+      hints: [
+        { key: "w", label: "panes" },
+        { key: "b", label: "sessions" },
+        { key: "n", label: "notes" },
+        { key: "i", label: "inbox" },
+        { key: "t", label: "watches" },
+        { key: ",", label: "settings" },
+        { key: "SPC", label: "commands" },
+      ],
+    });
+  });
+
+  it("resolves pane prefix sequences as pending", () => {
+    expect(resolveLeaderSequence(["w"])).toEqual({
+      kind: "pending",
+      title: "Panes",
+      hints: [
+        { key: "h", label: "left" },
+        { key: "j", label: "down" },
+        { key: "k", label: "up" },
+        { key: "l", label: "right" },
+        { key: "s", label: "split" },
+        { key: "v", label: "vsplit" },
+        { key: "r", label: "rename" },
+        { key: "d", label: "close" },
+        { key: "f", label: "full" },
+        { key: "t", label: "stack" },
+      ],
+    });
+  });
+
+  it("resolves terminal actions to command ids", () => {
+    expect(resolveLeaderSequence(["w", "v"])).toEqual({
+      kind: "command",
+      commandId: "pane.split-vertical",
+    });
+    expect(resolveLeaderSequence(["w", "r"])).toEqual({
+      kind: "command",
+      commandId: "pane.rename",
+    });
+    expect(resolveLeaderSequence(["b", "n"])).toEqual({
+      kind: "command",
+      commandId: "session.new",
+    });
+  });
+
+  it("prunes pane hints by command availability without changing order", () => {
+    expect(
+      getVisibleLeaderHints(["w"], (commandId) =>
+        !["pane.rename", "pane.close", "pane.toggle-fullscreen", "pane.toggle-stack"].includes(commandId),
+      ),
+    ).toEqual([
+      { key: "h", label: "left" },
+      { key: "j", label: "down" },
+      { key: "k", label: "up" },
+      { key: "l", label: "right" },
+      { key: "s", label: "split" },
+      { key: "v", label: "vsplit" },
+    ]);
+  });
+
+  it("leaves root hints unpruned for now", () => {
+    expect(
+      getVisibleLeaderHints([], () => false),
+    ).toEqual([
+      { key: "w", label: "panes" },
+      { key: "b", label: "sessions" },
+      { key: "n", label: "notes" },
+      { key: "i", label: "inbox" },
+      { key: "t", label: "watches" },
+      { key: ",", label: "settings" },
+      { key: "SPC", label: "commands" },
+    ]);
+  });
+
+  it("resolves space to the full command palette", () => {
+    expect(resolveLeaderSequence(["space"])).toEqual({ kind: "palette" });
+  });
+
+  it("marks unknown sequences invalid", () => {
+    expect(resolveLeaderSequence(["x"])).toEqual({ kind: "invalid" });
+    expect(resolveLeaderSequence(["w", "x"])).toEqual({ kind: "invalid" });
+  });
+
+  it("normalizes plain leader keys", () => {
+    expect(normalizeLeaderKey(new KeyboardEvent("keydown", { key: "w" }))).toBe("w");
+    expect(normalizeLeaderKey(new KeyboardEvent("keydown", { key: " " }))).toBe("space");
+    expect(normalizeLeaderKey(new KeyboardEvent("keydown", { key: "," }))).toBe(",");
+  });
+
+  it("ignores modified keys inside leader mode", () => {
+    expect(normalizeLeaderKey(new KeyboardEvent("keydown", { key: "w", metaKey: true }))).toBeNull();
+    expect(normalizeLeaderKey(new KeyboardEvent("keydown", { key: "w", ctrlKey: true }))).toBeNull();
+  });
+});

--- a/src/lib/commands/leader.ts
+++ b/src/lib/commands/leader.ts
@@ -1,0 +1,150 @@
+export interface LeaderHint {
+  key: string;
+  label: string;
+}
+
+type LeaderAction =
+  | { kind: "command"; commandId: string }
+  | { kind: "palette" };
+
+interface LeaderNode {
+  title: string;
+  hints: LeaderHint[];
+  pruneUnavailableHints?: boolean;
+  children?: Record<string, LeaderNode | LeaderAction>;
+}
+
+export type LeaderResolution =
+  | { kind: "pending"; title: string; hints: LeaderHint[] }
+  | { kind: "command"; commandId: string }
+  | { kind: "palette" }
+  | { kind: "invalid" };
+
+const PANE_NODE: LeaderNode = {
+  title: "Panes",
+  pruneUnavailableHints: true,
+  hints: [
+    { key: "h", label: "left" },
+    { key: "j", label: "down" },
+    { key: "k", label: "up" },
+    { key: "l", label: "right" },
+    { key: "s", label: "split" },
+    { key: "v", label: "vsplit" },
+    { key: "r", label: "rename" },
+    { key: "d", label: "close" },
+    { key: "f", label: "full" },
+    { key: "t", label: "stack" },
+  ],
+  children: {
+    h: { kind: "command", commandId: "pane.focus-left" },
+    j: { kind: "command", commandId: "pane.focus-down" },
+    k: { kind: "command", commandId: "pane.focus-up" },
+    l: { kind: "command", commandId: "pane.focus-right" },
+    s: { kind: "command", commandId: "pane.split-horizontal" },
+    v: { kind: "command", commandId: "pane.split-vertical" },
+    r: { kind: "command", commandId: "pane.rename" },
+    d: { kind: "command", commandId: "pane.close" },
+    f: { kind: "command", commandId: "pane.toggle-fullscreen" },
+    t: { kind: "command", commandId: "pane.toggle-stack" },
+  },
+};
+
+const SESSION_NODE: LeaderNode = {
+  title: "Sessions",
+  hints: [
+    { key: "n", label: "new" },
+    { key: "d", label: "close" },
+    { key: "r", label: "reconnect" },
+    { key: "e", label: "editor" },
+  ],
+  children: {
+    n: { kind: "command", commandId: "session.new" },
+    d: { kind: "command", commandId: "session.close" },
+    r: { kind: "command", commandId: "session.reconnect" },
+    e: { kind: "command", commandId: "session.open-in-editor" },
+  },
+};
+
+const ROOT_NODE: LeaderNode = {
+  title: "Leader",
+  hints: [
+    { key: "w", label: "panes" },
+    { key: "b", label: "sessions" },
+    { key: "n", label: "notes" },
+    { key: "i", label: "inbox" },
+    { key: "t", label: "watches" },
+    { key: ",", label: "settings" },
+    { key: "SPC", label: "commands" },
+  ],
+  children: {
+    w: PANE_NODE,
+    b: SESSION_NODE,
+    n: { kind: "command", commandId: "ui.toggle-notes" },
+    i: { kind: "command", commandId: "ui.toggle-notifications" },
+    t: { kind: "command", commandId: "ui.toggle-watches" },
+    ",": { kind: "command", commandId: "app.settings" },
+    space: { kind: "palette" },
+  },
+};
+
+function isAction(node: LeaderNode | LeaderAction): node is LeaderAction {
+  return "kind" in node;
+}
+
+function hintKeyToChildKey(key: string): string {
+  return key === "SPC" ? "space" : key;
+}
+
+function resolveLeaderNode(sequence: string[]): LeaderNode | LeaderAction | null {
+  let current: LeaderNode | LeaderAction = ROOT_NODE;
+
+  for (const key of sequence) {
+    if (isAction(current)) return null;
+    const next: LeaderNode | LeaderAction | undefined = current.children?.[key];
+    if (!next) return null;
+    current = next;
+  }
+
+  return current;
+}
+
+export function resolveLeaderSequence(sequence: string[]): LeaderResolution {
+  const current = resolveLeaderNode(sequence);
+  if (!current) return { kind: "invalid" };
+
+  if (isAction(current)) {
+    return current.kind === "palette"
+      ? { kind: "palette" }
+      : { kind: "command", commandId: current.commandId };
+  }
+
+  return {
+    kind: "pending",
+    title: current.title,
+    hints: current.hints,
+  };
+}
+
+export function getVisibleLeaderHints(
+  sequence: string[],
+  isCommandAvailable: (commandId: string) => boolean,
+): LeaderHint[] {
+  const current = resolveLeaderNode(sequence);
+  if (!current || isAction(current)) return [];
+  if (!current.pruneUnavailableHints) return current.hints;
+
+  return current.hints.filter((hint) => {
+    const child = current.children?.[hintKeyToChildKey(hint.key)];
+    if (!child) return false;
+    if (!isAction(child)) return true;
+    if (child.kind === "palette") return true;
+    return isCommandAvailable(child.commandId);
+  });
+}
+
+export function normalizeLeaderKey(event: KeyboardEvent): string | null {
+  if (event.metaKey || event.ctrlKey || event.altKey) return null;
+  if (event.key === " ") return "space";
+  if (event.key.length === 1) return event.key.toLowerCase();
+  return null;
+}

--- a/src/lib/commands/panes.ts
+++ b/src/lib/commands/panes.ts
@@ -434,7 +434,7 @@ export function registerPaneCommands() {
     label: "Toggle Stack",
     shortcut: "cmd+shift+s",
     category: "Panes",
-    available: () => queries.canSplitPane(),
+    available: () => queries.canTogglePaneStack(),
     execute: () => {
       const activeId = queries.activeSessionId();
       if (activeId) toggleStack(activeId);

--- a/src/lib/commands/ui.ts
+++ b/src/lib/commands/ui.ts
@@ -89,6 +89,13 @@ export function registerUiCommands() {
   });
 
   registry.register({
+    id: "app.leader-mode",
+    label: "Leader Mode",
+    shortcut: "cmd+;",
+    category: "App",
+  });
+
+  registry.register({
     id: "app.check-updates",
     label: "Check for Updates",
     category: "App",

--- a/src/lib/components/CommandPalette.svelte
+++ b/src/lib/components/CommandPalette.svelte
@@ -11,7 +11,13 @@
     onCheckForUpdates: () => void;
   }
 
-  let { open, onclose, onNewSession, onSettings, onCheckForUpdates }: Props = $props();
+  let {
+    open,
+    onclose,
+    onNewSession,
+    onSettings,
+    onCheckForUpdates,
+  }: Props = $props();
 
   let stepStack = $state<{ label: string; items: CmdItem[]; sourceCmd?: Cmd }[]>([]);
   let inputValue = $state("");
@@ -205,7 +211,9 @@
         loop={true}
         vimBindings={true}
       >
-        <div class="flex items-center gap-2 border-b border-border-subtle bg-bg-surface/55 px-5 py-4">
+        <div
+          class="flex items-center gap-2 border-b border-border-subtle bg-bg-surface/55 px-5 py-4"
+        >
           {#if inDrillStep}
             <button
               class="text-text-muted hover:text-text-primary bg-transparent border-none cursor-pointer p-0 text-sm"

--- a/src/lib/components/LeaderHud.svelte
+++ b/src/lib/components/LeaderHud.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+  import type { LeaderHint } from "$lib/commands/leader";
+
+  interface Props {
+    title: string;
+    sequence: string[];
+    hints: LeaderHint[];
+    promptLabel?: string | null;
+    promptPlaceholder?: string | null;
+    promptValue?: string;
+    onPromptInput?: (value: string) => void;
+    onPromptSubmit?: () => void;
+  }
+
+  let {
+    title,
+    sequence,
+    hints,
+    promptLabel = null,
+    promptPlaceholder = null,
+    promptValue = "",
+    onPromptInput,
+    onPromptSubmit,
+  }: Props = $props();
+  let inputEl: HTMLInputElement | undefined = $state();
+
+  function formatKey(key: string): string {
+    return key === "SPC" ? "Space" : key;
+  }
+
+  function formatSequenceKey(key: string): string {
+    return key === "space" ? "Space" : key;
+  }
+
+  $effect(() => {
+    if (promptLabel) {
+      requestAnimationFrame(() => inputEl?.focus());
+    }
+  });
+</script>
+
+<div class="pointer-events-none fixed inset-x-0 bottom-4 z-50 flex justify-center px-4">
+  <div class="pointer-events-none flex max-w-[min(1080px,100%)] flex-wrap items-start gap-x-3 gap-y-2 rounded-2xl border border-border-subtle bg-bg-panel/92 px-4 py-3 shadow-[0_16px_40px_rgba(0,0,0,0.22),0_0_0_1px_rgba(255,255,255,0.03)] backdrop-blur-md">
+    <div class="flex items-center gap-2 text-[11px] uppercase tracking-[0.22em] text-text-muted">
+      {#if title !== "Leader"}
+        <span class="rounded-full border border-border-subtle bg-bg-surface/70 px-2 py-1 text-text-secondary">
+          {title}
+        </span>
+      {/if}
+      {#if sequence.length > 0}
+        <span class="rounded-full border border-border-subtle bg-bg-surface/70 px-2 py-1 tracking-normal text-text-secondary">
+          {sequence.map(formatSequenceKey).join(" ")}
+        </span>
+      {/if}
+    </div>
+
+    {#if promptLabel}
+      <div class="pointer-events-auto flex min-w-[min(420px,100%)] flex-1 items-center gap-2 rounded-xl border border-accent-dim/20 bg-bg-surface/70 px-3 py-2 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
+        <span class="text-[12px] font-medium text-text-secondary">{promptLabel}</span>
+        <input
+          bind:this={inputEl}
+          type="text"
+          value={promptValue}
+          placeholder={promptPlaceholder ?? ""}
+          class="min-w-0 flex-1 border-none bg-transparent text-[13px] text-text-primary outline-none placeholder:text-text-muted"
+          oninput={(e) => onPromptInput?.((e.currentTarget as HTMLInputElement).value)}
+          onkeydown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              onPromptSubmit?.();
+            }
+          }}
+        />
+      </div>
+    {:else}
+      <div class="flex min-w-0 flex-1 flex-wrap items-center gap-2 text-[12px] text-text-secondary">
+        {#each hints as hint (hint.key)}
+          <span class="flex items-center gap-1.5 rounded-xl border border-border-subtle bg-bg-surface/70 px-2.5 py-1 shadow-[inset_0_1px_0_rgba(255,255,255,0.025)]">
+            <kbd class="rounded border border-accent-dim/20 bg-accent-dim/12 px-1.5 py-0.5 text-[11px] font-mono font-semibold text-accent">
+              {formatKey(hint.key)}
+            </kbd>
+            <span>{hint.label}</span>
+          </span>
+        {/each}
+        <span class="rounded-xl bg-bg-surface/45 px-2.5 py-1 text-text-muted">
+          Esc cancel
+        </span>
+      </div>
+    {/if}
+  </div>
+</div>

--- a/src/lib/panes/layout.ts
+++ b/src/lib/panes/layout.ts
@@ -507,6 +507,18 @@ export function toggleStack(sessionId: string): void {
   setLogicalFocus(focused);
 }
 
+/** Whether the focused pane has a parent split whose stacked state can be toggled. */
+export function canToggleStack(sessionId: string): boolean {
+  const focused = get(focusedPaneId);
+  if (!focused) return false;
+  const tree = get(sessionLayouts).get(sessionId);
+  if (!tree) return false;
+
+  const path: number[] = [];
+  if (!buildSplitPath(tree, focused, path)) return false;
+  return ancestorSplitDepths(tree, path).length > 0;
+}
+
 /** Switch the active stack tab within a stacked split. */
 export function setActiveStackIndex(sessionId: string, index: number): void {
   const focused = get(focusedPaneId);

--- a/src/lib/queries/index.ts
+++ b/src/lib/queries/index.ts
@@ -1,6 +1,6 @@
 import { get } from "svelte/store";
 import { sessionState } from "$lib/stores/sessions";
-import { sessionLayouts } from "$lib/panes/layout";
+import { canToggleStack, sessionLayouts } from "$lib/panes/layout";
 import { focusedPaneId } from "$lib/panes/focus";
 import { getInstance } from "$lib/panes/instances";
 
@@ -36,6 +36,12 @@ export const queries = {
     const id = this.activeSessionId();
     if (!id) return false;
     return this.focusedPaneId() !== null;
+  },
+
+  canTogglePaneStack() {
+    const id = this.activeSessionId();
+    if (!id) return false;
+    return canToggleStack(id);
   },
 
   focusedPane() {

--- a/src/lib/stores/__tests__/commandSurface.test.ts
+++ b/src/lib/stores/__tests__/commandSurface.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { get } from "svelte/store";
+import { createPane, disposePane, resetInstances } from "$lib/panes/instances";
+import { focusedPaneId, resetFocus, setLogicalFocus } from "$lib/panes/focus";
+import {
+  closeCommandSurface,
+  commandSurface,
+  openCommandPalette,
+  openLeaderPrompt,
+  openLeaderMode,
+  resetCommandSurface,
+  setLeaderSequence,
+  setLeaderPromptValue,
+} from "../commandSurface";
+
+describe("commandSurface", () => {
+  beforeEach(() => {
+    resetInstances();
+    resetFocus();
+    resetCommandSurface();
+  });
+
+  it("captures the focused pane when leader mode opens", () => {
+    createPane({ id: "pane-1", type: "shell", ptyId: "pty-1" });
+    setLogicalFocus("pane-1");
+
+    openLeaderMode();
+
+    expect(get(commandSurface)).toEqual({
+      open: true,
+      mode: "leader",
+      returnFocusPaneId: "pane-1",
+      leaderSequence: [],
+      leaderPromptCommandId: null,
+      leaderPromptValue: "",
+    });
+  });
+
+  it("restores focus to the captured pane when leader mode closes", () => {
+    createPane({ id: "pane-1", type: "shell", ptyId: "pty-1" });
+    setLogicalFocus("pane-1");
+    openLeaderMode();
+    setLogicalFocus(null);
+
+    closeCommandSurface();
+
+    expect(get(focusedPaneId)).toBe("pane-1");
+    expect(get(commandSurface).open).toBe(false);
+  });
+
+  it("clears stale focus when the captured pane disappeared before close", () => {
+    createPane({ id: "pane-1", type: "shell", ptyId: "pty-1" });
+    setLogicalFocus("pane-1");
+    openLeaderMode();
+    disposePane("pane-1");
+
+    closeCommandSurface();
+
+    expect(get(focusedPaneId)).toBeNull();
+    expect(get(commandSurface)).toEqual({
+      open: false,
+      mode: "palette",
+      returnFocusPaneId: null,
+      leaderSequence: [],
+      leaderPromptCommandId: null,
+      leaderPromptValue: "",
+    });
+  });
+
+  it("tracks and clears leader sequence state", () => {
+    openLeaderMode();
+    setLeaderSequence(["w"]);
+    expect(get(commandSurface).leaderSequence).toEqual(["w"]);
+
+    openCommandPalette();
+    expect(get(commandSurface)).toEqual({
+      open: true,
+      mode: "palette",
+      returnFocusPaneId: null,
+      leaderSequence: [],
+      leaderPromptCommandId: null,
+      leaderPromptValue: "",
+    });
+  });
+
+  it("can step back through a nested leader sequence", () => {
+    openLeaderMode();
+    setLeaderSequence(["w", "v"]);
+    expect(get(commandSurface).leaderSequence).toEqual(["w", "v"]);
+
+    setLeaderSequence(["w"]);
+    expect(get(commandSurface).leaderSequence).toEqual(["w"]);
+  });
+
+  it("tracks inline leader prompt state", () => {
+    openLeaderMode();
+    setLeaderSequence(["w", "r"]);
+    openLeaderPrompt("pane.rename");
+    setLeaderPromptValue("docs");
+
+    expect(get(commandSurface)).toEqual({
+      open: true,
+      mode: "leader",
+      returnFocusPaneId: null,
+      leaderSequence: ["w", "r"],
+      leaderPromptCommandId: "pane.rename",
+      leaderPromptValue: "docs",
+    });
+
+    openCommandPalette();
+    expect(get(commandSurface)).toEqual({
+      open: true,
+      mode: "palette",
+      returnFocusPaneId: null,
+      leaderSequence: [],
+      leaderPromptCommandId: null,
+      leaderPromptValue: "",
+    });
+  });
+});

--- a/src/lib/stores/commandSurface.ts
+++ b/src/lib/stores/commandSurface.ts
@@ -1,0 +1,116 @@
+import { get, writable } from "svelte/store";
+import { focusedPaneId, setLogicalFocus } from "$lib/panes/focus";
+import { paneInstances } from "$lib/panes/instances";
+
+export type CommandSurfaceMode = "palette" | "leader";
+
+export interface CommandSurfaceState {
+  open: boolean;
+  mode: CommandSurfaceMode;
+  returnFocusPaneId: string | null;
+  leaderSequence: string[];
+  leaderPromptCommandId: string | null;
+  leaderPromptValue: string;
+}
+
+const INITIAL_STATE: CommandSurfaceState = {
+  open: false,
+  mode: "palette",
+  returnFocusPaneId: null,
+  leaderSequence: [],
+  leaderPromptCommandId: null,
+  leaderPromptValue: "",
+};
+
+export const commandSurface = writable<CommandSurfaceState>(INITIAL_STATE);
+
+function openCommandSurface(mode: CommandSurfaceMode): void {
+  const current = get(commandSurface);
+  if (current.open) {
+    commandSurface.set({
+      ...current,
+      mode,
+      leaderSequence: [],
+      leaderPromptCommandId: null,
+      leaderPromptValue: "",
+    });
+    return;
+  }
+
+  commandSurface.set({
+    open: true,
+    mode,
+    returnFocusPaneId: get(focusedPaneId),
+    leaderSequence: [],
+    leaderPromptCommandId: null,
+    leaderPromptValue: "",
+  });
+}
+
+export function openCommandPalette(): void {
+  openCommandSurface("palette");
+}
+
+export function openLeaderMode(): void {
+  openCommandSurface("leader");
+}
+
+export function toggleCommandSurface(mode: CommandSurfaceMode): void {
+  const current = get(commandSurface);
+  if (current.open && current.mode === mode) {
+    closeCommandSurface();
+    return;
+  }
+  openCommandSurface(mode);
+}
+
+export function setLeaderSequence(sequence: string[]): void {
+  commandSurface.update((current) => {
+    if (!current.open || current.mode !== "leader") return current;
+    return {
+      ...current,
+      leaderSequence: sequence,
+      leaderPromptCommandId: null,
+      leaderPromptValue: "",
+    };
+  });
+}
+
+export function openLeaderPrompt(commandId: string, initialValue: string = ""): void {
+  commandSurface.update((current) => {
+    if (!current.open || current.mode !== "leader") return current;
+    return {
+      ...current,
+      leaderPromptCommandId: commandId,
+      leaderPromptValue: initialValue,
+    };
+  });
+}
+
+export function setLeaderPromptValue(value: string): void {
+  commandSurface.update((current) => {
+    if (!current.open || current.mode !== "leader" || !current.leaderPromptCommandId) return current;
+    return {
+      ...current,
+      leaderPromptValue: value,
+    };
+  });
+}
+
+export function closeCommandSurface(): void {
+  const { returnFocusPaneId } = get(commandSurface);
+  commandSurface.set(INITIAL_STATE);
+
+  if (returnFocusPaneId && get(paneInstances).has(returnFocusPaneId)) {
+    setLogicalFocus(returnFocusPaneId);
+    return;
+  }
+
+  if (get(focusedPaneId) === returnFocusPaneId) {
+    setLogicalFocus(null);
+  }
+}
+
+export function resetCommandSurface(): void {
+  commandSurface.set(INITIAL_STATE);
+}


### PR DESCRIPTION
## Summary
- add a vimish leader-mode command surface entered with `cmd+;`
- add a lightweight leader HUD with inline prompt support for pane rename
- prune pane hints by real command availability and widen/wrap the HUD when needed

## Verification
- npm run test -- src/lib/commands/__tests__/leader.test.ts src/lib/stores/__tests__/commandSurface.test.ts
- npm run check