### PR TITLE
docs: add versioned Material docs and PR previews

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,0 +1,136 @@
+name: Preview docs
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to update with the preview link
+        required: true
+        type: number
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+  issues: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      PREVIEW_PREFIX: previews/pr-${{ inputs.pr_number }}
+      PREVIEW_URL: https://phin-tech.github.io/roux/previews/pr-${{ inputs.pr_number }}/
+    steps:
+      - name: Checkout selected ref
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: docs/requirements.txt
+
+      - name: Install dependencies
+        run: pip install -r docs/requirements.txt
+
+      - name: Configure Git author
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
+      - name: Fetch existing published docs
+        run: |
+          if git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
+            git fetch origin gh-pages --depth=1
+          fi
+
+      - name: Publish preview docs
+        run: |
+          mike deploy --branch gh-pages --deploy-prefix "$PREVIEW_PREFIX" preview
+          mike set-default --branch gh-pages --deploy-prefix "$PREVIEW_PREFIX" preview
+
+      - name: Archive published site
+        run: |
+          rm -rf site
+          mkdir -p site
+          git archive gh-pages | tar -x -C site
+
+      - name: Push gh-pages history
+        run: git push origin gh-pages
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+  comment:
+    needs: deploy
+    runs-on: ubuntu-latest
+    env:
+      PR_NUMBER: ${{ inputs.pr_number }}
+      PREVIEW_URL: https://phin-tech.github.io/roux/previews/pr-${{ inputs.pr_number }}/
+    steps:
+      - name: Comment on pull request
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- docs-preview-comment -->';
+            const issue_number = Number(process.env.PR_NUMBER);
+            const shortSha = context.sha.slice(0, 7);
+            const branch = context.ref.replace('refs/heads/', '');
+            const body = [
+              marker,
+              `Docs preview updated for \`${branch}\`: [Open preview](${process.env.PREVIEW_URL})`,
+              '',
+              `Commit: \`${shortSha}\``,
+            ].join('\n');
+
+            const { owner, repo } = context.repo;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+
+            const existing = comments.find((comment) =>
+              comment.user?.login === 'github-actions[bot]' &&
+              comment.body?.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,14 +4,15 @@ on:
   push:
     branches:
       - main
+    tags:
+      - "v*"
     paths:
       - docs/**
       - mkdocs.yml
       - .github/workflows/docs.yml
-  workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 
@@ -25,6 +26,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -36,8 +39,44 @@ jobs:
       - name: Install dependencies
         run: pip install -r docs/requirements.txt
 
-      - name: Build site
-        run: mkdocs build --strict
+      - name: Configure Git author
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
+      - name: Fetch existing versioned docs
+        run: |
+          if git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
+            git fetch origin gh-pages --depth=1
+          fi
+
+      - name: Publish dev docs
+        if: github.ref_type != 'tag'
+        run: |
+          mike deploy dev
+          if mike list latest >/dev/null 2>&1; then
+            echo "latest alias already exists; keeping it as the default."
+          else
+            mike set-default dev
+          fi
+
+      - name: Publish release docs
+        if: github.ref_type == 'tag'
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          VERSION="${VERSION#v}"
+          mike deploy --update-aliases "$VERSION" latest
+          mike set-default latest
+
+      - name: Archive versioned site
+        run: |
+          rm -rf site
+          mkdir -p site
+          git archive gh-pages | tar -x -C site
+
+      - name: Push gh-pages history
+        run: git push origin gh-pages
 
       - name: Configure Pages
         uses: actions/configure-pages@v5

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 mkdocs-material==9.5.39
+mike==2.1.4

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,10 @@ theme:
   icon:
     repo: fontawesome/brands/github
 
+extra:
+  version:
+    provider: mike
+
 markdown_extensions:
   - admonition
   - attr_list


### PR DESCRIPTION
## Summary
- add Material for MkDocs versioning via mike
- publish dev docs from main and release docs from version tags
- add a manual PR preview workflow that comments the preview URL on the PR

## Verification
- mkdocs build --strict
- parsed .github/workflows/docs.yml and .github/workflows/docs-preview.yml with PyYAML
- disposable local repo: mike deploy --branch gh-pages --ignore-remote-status --deploy-prefix previews/pr-123 preview
- disposable local repo: mike set-default --branch gh-pages --ignore-remote-status --deploy-prefix previews/pr-123 preview