### PR TITLE
feat(cli): expand roux-cli for scripting and agent-to-agent control

### DIFF
--- a/crates/roux-core/src/models/events.rs
+++ b/crates/roux-core/src/models/events.rs
@@ -34,7 +34,7 @@ pub struct RouxCommand {
     pub command: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub working_dir: Option<String>,
-    /// Profile id for pane/session creation (e.g. "claude", "shell", user profile id)
+    /// Profile id for pane/session creation (e.g. "claude", "plain-shell", "codex", user profile id)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub profile_id: Option<String>,
     /// Correlation id for request/response round-trips with the frontend

--- a/crates/roux-core/src/models/events.rs
+++ b/crates/roux-core/src/models/events.rs
@@ -34,6 +34,12 @@ pub struct RouxCommand {
     pub command: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub working_dir: Option<String>,
+    /// Profile id for pane/session creation (e.g. "claude", "shell", user profile id)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile_id: Option<String>,
+    /// Correlation id for request/response round-trips with the frontend
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
 }
 
 impl RouxCommand {
@@ -46,7 +52,19 @@ impl RouxCommand {
             direction: None,
             command: None,
             working_dir: None,
+            profile_id: None,
+            request_id: None,
         }
+    }
+
+    pub fn profile_id(mut self, id: impl Into<String>) -> Self {
+        self.profile_id = Some(id.into());
+        self
+    }
+
+    pub fn request_id(mut self, id: impl Into<String>) -> Self {
+        self.request_id = Some(id.into());
+        self
     }
 
     pub fn session_id(mut self, id: impl Into<String>) -> Self {

--- a/crates/roux-core/src/models/layout.rs
+++ b/crates/roux-core/src/models/layout.rs
@@ -686,6 +686,8 @@ fn parse_inline_profile(
         cwd_override: None,
         icon: None,
         provider: kind,
+        nono_profile: None,
+        nono_allow_dirs: None,
         source: ProfileSource::Inline,
     })
 }

--- a/crates/roux-core/src/models/profile.rs
+++ b/crates/roux-core/src/models/profile.rs
@@ -75,6 +75,10 @@ pub struct SpawnProfile {
     pub icon: Option<String>,
     #[serde(default)]
     pub provider: Option<Provider>,
+    #[serde(default)]
+    pub nono_profile: Option<String>,
+    #[serde(default)]
+    pub nono_allow_dirs: Option<Vec<String>>,
     pub source: ProfileSource,
 }
 
@@ -91,6 +95,8 @@ impl SpawnProfile {
             cwd_override: None,
             icon: None,
             provider: None,
+            nono_profile: None,
+            nono_allow_dirs: None,
             source: ProfileSource::Builtin,
         }
     }

--- a/docs/features/cli.md
+++ b/docs/features/cli.md
@@ -17,24 +17,56 @@ Then `roux --help` should work from any terminal.
 
 ## What it can do
 
-- Create a new session in a given project
-- Split the active pane horizontally or vertically
-- Send text to a target pane (useful for pasting a prompt from a script)
-- Focus a pane by id or direction
-- Run a shell command in a new pane
+- Open / focus a session for a directory and raise the app window (`roux app .`)
+- Create, list, and poll sessions (`roux session create|list|poll`)
+- Send keystrokes to a specific session's PTY (`roux session send`)
+- List and create panes inside a session (`roux session panes list|create`)
+- Split the active pane horizontally or vertically (`roux split`)
+- Focus a pane by id (`roux focus`)
+- Run a shell command in a new pane (`roux run`)
+- Push notifications (`roux notify`)
 
-## Example
+## Scripting & agent-to-agent examples
 
-Open a new session in the current directory:
-
-```sh
-roux session new "$PWD"
-```
-
-Split the active pane and run `npm run test:watch` inside it:
+Open (or focus) Roux at the current directory:
 
 ```sh
-roux split --direction vertical --command "npm run test:watch"
+roux app .
 ```
+
+Create a new session with a fresh worktree:
+
+```sh
+roux session create --name "review" --worktree-branch feat/review
+```
+
+Poll a session's status from another agent:
+
+```sh
+status=$(roux session poll -s "$OTHER_SESSION_ID" | jq -r .status)
+if [ "$status" = "idle" ]; then
+    roux session send "review this PR" -s "$OTHER_SESSION_ID"
+fi
+```
+
+Send raw bytes without appending Enter:
+
+```sh
+roux session send $'\x03' -s "$SID" --no-enter   # ctrl-c
+```
+
+List panes in a session (live snapshot from the UI):
+
+```sh
+roux session panes list -s "$SID"
+```
+
+Open a new shell pane alongside the main agent:
+
+```sh
+roux session panes create -s "$SID" --profile plain-shell --direction vertical
+```
+
+Inside a Roux-managed PTY, `$ROUX_SESSION_ID` and `$ROUX_PANE_ID` are set, so most `-s` / `-p` flags are optional.
 
 See `roux --help` and `roux <subcommand> --help` for the authoritative list of commands and flags.

--- a/docs/plans/2026-04-11-nono-layouts-and-legacy-removal-impl.md
+++ b/docs/plans/2026-04-11-nono-layouts-and-legacy-removal-impl.md
@@ -1,0 +1,145 @@
+# Nono in Layouts + Remove Legacy Claude Path — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Unify all session creation/reconnect onto the shell-spawn path, add nono sandbox support to `spawn_shell` so it works for any profile and layout, and delete the legacy Claude-specific spawn path.
+
+**Architecture:** Every pane spawns a shell (optionally nono-wrapped), then `runProfileInPane` types commands into it. Nono config comes from layout KDL leaves, `SpawnProfile` fields, or the dialog dropdown — resolved in that priority order. Continue/Resume/New for Claude reconnects works by appending flags to the startup command typed into the shell, not by passing them to the PTY spawn. Persistence gains nono fields so wrapping survives restart.
+
+**Tech Stack:** Rust (portable-pty, specta, serde, kdl), Svelte 5, Tauri 2, existing xterm/PTY stack.
+
+**Spec:** `docs/plans/2026-04-11-nono-layouts-and-legacy-removal.md`
+
+---
+
+## Phase 1: Backend — NonoConfig + nono on spawn_shell
+
+Add `NonoConfig` struct and optional nono parameter to `PtyManager::spawn_shell`. Purely additive.
+
+**Files:**
+- Modify: `src-tauri/src/pty.rs`
+- Modify: `src-tauri/src/services/sessions.rs` (fix callers to pass `None`)
+- Modify: `src-tauri/src/commands/sessions.rs` (fix callers to pass `None`)
+
+**Steps:** Add NonoConfig with path normalization (~/ expansion, relative resolution), add nono param to spawn_shell, fix all callers to pass None, add unit tests for path resolution. See full spec for NonoConfig struct and spawn_shell implementation.
+
+---
+
+## Phase 2: Backend — Nono on create_session_shell + reconnect_session_shell + spawn_shell command
+
+Add optional nono params to the Tauri commands. Additive — existing frontend callers pass undefined.
+
+**Files:**
+- Modify: `src-tauri/src/services/sessions.rs`
+- Modify: `src-tauri/src/commands/sessions.rs`
+
+**Steps:** Add nono_profile + nono_allow_dirs to create_session_shell, reconnect_session_shell, and spawn_shell Tauri commands. Thread through to spawn_shell backend.
+
+---
+
+## Phase 3: Nono on SpawnProfile + regenerate bindings
+
+**Files:**
+- Modify: `crates/roux-core/src/models/profile.rs`
+- Regenerate: `src/lib/bindings.ts`
+- Modify: `src/lib/tauri.ts`
+
+**Steps:** Add nono_profile and nono_allow_dirs to SpawnProfile. Regenerate bindings. Update frontend spawnShell/createSessionShell/reconnectSessionShell wrappers with optional nono params.
+
+---
+
+## Phase 4: Parser — nono attributes on layout KDL leaves
+
+**Files:**
+- Modify: `crates/roux-core/src/models/layout.rs`
+
+**Steps:** Add nono_profile and nono_allow_dirs to LayoutPaneNode::Leaf. Parse `nono` attribute and `nono_flags { allow_dir "..." }` child block. Implement body disambiguation (registered profile + nono_flags is OK, registered + inline fields is rejected). TDD with ~5 new tests.
+
+---
+
+## Phase 5: Persistence — nono on PaneDescriptor
+
+**Files:**
+- Modify: `src/lib/panes/persistence.ts`
+- Modify: `src/lib/panes/instances.ts`
+
+**Steps:** Add nonoProfile and nonoAllowDirs to PaneDescriptor and PaneInstance/CreatePaneOpts. Bump schema version 3→4.
+
+---
+
+## Phase 6: Walker — thread nono through layout runner
+
+**Files:**
+- Modify: `src/lib/panes/layoutRunner.ts`
+- Modify: `src/lib/panes/__tests__/layoutRunner.test.ts`
+
+**Steps:** Update LeafInfo with nono fields. Implement nono resolution (layout leaf > profile > none). Pass nono to spawnShell calls. Store nono on pane instances. Add 4 tests (nono from leaf, from profile, leaf overrides profile, allow_dirs merge).
+
+---
+
+## Phase 7: Migrate all createSession callers
+
+Replace every `createSession` call with `createSessionShell` + `initSessionWithProfile` + `runProfileInPane`.
+
+**Files:**
+- Modify: `src/lib/components/NewSessionDialog.svelte`
+- Modify: `src/lib/components/SessionTabs.svelte`
+- Modify: `src/lib/commands/sessions.ts`
+- Modify: `src/App.svelte` (socket handler)
+- Modify: `src-tauri/src/socket.rs`
+
+**Steps:**
+1. NewSessionDialog: delete useLegacyClaudePath branch, all sessions use createSessionShell. Delete skip-permissions checkbox. Ungate nono dropdown to `nonoInstalled && !selectedLayout`. Thread nono from dialog.
+2. SessionTabs: switch worktree creation to createSessionShell + profile replay.
+3. commands/sessions.ts: same migration for session.new-worktree command.
+4. socket.rs: switch to svc::create_session_shell.
+5. App.svelte socket handler: add runProfileInPane after terminal init.
+
+---
+
+## Phase 8: Migrate all reconnectSession callers
+
+Replace every `reconnectSession` call with `reconnectSessionShell` + flag appending.
+
+**Files:**
+- Modify: `src/lib/sessions/reconnect.ts`
+- Modify: `src/lib/components/PaneShell.svelte`
+- Modify: `src/lib/commands/sessions.ts`
+
+**Steps:**
+1. reconnect.ts: update reconnectSessionShell to accept optional extraStartupFlags, append them to startup command before runProfileInPane. Pass nono from persisted pane state.
+2. PaneShell.svelte: change Claude reconnect handlers to use reconnectSessionShell with extra flags. Keep SessionPicker UI.
+3. commands/sessions.ts: switch session.reconnect to reconnectSessionShell.
+4. reconnect.ts full restore: switch reconnectPrimaryPaneOnly to use shell path + profile replay.
+5. rehydratePane: pass nono from persisted descriptor to spawnShell.
+
+---
+
+## Phase 9: Thread nono through remaining spawnShell callers
+
+**Files:**
+- Modify: `src/lib/commands/panes.ts`
+- Modify: `src/lib/sessions/reconnect.ts` (retryShellPane)
+
+**Steps:** Split-pane commands read nono from SpawnProfile and pass to spawnShell. retryShellPane reads nono from PaneInstance.
+
+---
+
+## Phase 10: Delete legacy backend
+
+**Files:**
+- Modify: `src-tauri/src/pty.rs` — delete PtyManager::spawn() + resolve_claude_command()
+- Modify: `src-tauri/src/services/sessions.rs` — delete svc::create_session + svc::reconnect_session
+- Modify: `src-tauri/src/commands/sessions.rs` — delete Tauri commands
+- Modify: `src-tauri/src/main.rs` — remove from collect_commands! + generate_handler!
+- Regenerate: `src/lib/bindings.ts`
+- Modify: `src/lib/tauri.ts` — delete dead wrappers
+
+---
+
+## Phase 11: Docs + polish
+
+**Files:**
+- Modify: `docs/features/layouts.md`
+
+**Steps:** Add nono section to layout docs. Remove "Claude panes inside layouts are not nono-wrapped" from limitations. Note that --dangerously-skip-permissions is a profile concern. Run full test suite.

--- a/docs/plans/2026-04-11-nono-layouts-and-legacy-removal.md
+++ b/docs/plans/2026-04-11-nono-layouts-and-legacy-removal.md
@@ -1,0 +1,17 @@
+# Nono Wrapping in Layouts + Remove Legacy Claude Path
+
+## Summary
+
+Unify session creation onto a single spawn path (`createSessionShell` + `runProfileInPane`) and move nono sandbox wrapping to the shell-spawn layer so it works for all profiles and layouts — not just the legacy Claude built-in.
+
+## Goals
+
+1. **Nono works in layouts.** A leaf pane can specify `nono="profile-name"` and optional `nono_flags { allow_dir "..." }` to sandbox the shell.
+2. **Nono works for any profile**, not just Claude. The nono dropdown in `NewSessionDialog` is ungated from `useLegacyClaudePath`.
+3. **Remove the legacy Claude spawn path.** `createSession` (the one that launches the Claude binary directly in a PTY) is deleted. All sessions use `createSessionShell` → `runProfileInPane`. The built-in Claude provider module already builds the correct `startup_command` from settings.
+4. **`--dangerously-skip-permissions` becomes a profile concern**, not a dialog checkbox. Users who want it create a profile with the flag in `startup_command` or `additional_flags`.
+5. **Continue/Resume/New UX preserved.** The SessionPicker component and `listClaudeSessions` stay. The extra flags (`--continue`, `--resume <id>`) are appended to the startup command typed into the shell, instead of being passed as spawn args.
+
+## Spec and implementation plan
+
+See `docs/plans/2026-04-11-nono-layouts-and-legacy-removal-impl.md` for the full implementation plan.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roux",
-  "version": "0.2.4",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roux",
-      "version": "0.2.4",
+      "version": "0.3.2",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -26,13 +26,19 @@ enum Commands {
     Clear,
 
     // ── Socket commands ──────────────────────────────────────
+    /// Open (or focus) a Roux session for a directory, then bring the app to front
+    App {
+        /// Directory path. Defaults to the current directory.
+        #[arg(default_value = ".")]
+        path: String,
+    },
     /// Split the current pane
     Split {
         /// Direction: horizontal or vertical
         #[arg(short, long, default_value = "horizontal")]
         direction: String,
     },
-    /// Create a new Claude session
+    /// Session management and introspection
     Session {
         #[command(subcommand)]
         action: SessionAction,
@@ -59,11 +65,6 @@ enum Commands {
         /// Working directory
         #[arg(short, long)]
         working_dir: Option<String>,
-    },
-    /// Send text to the active Claude pane
-    Send {
-        /// The text to send
-        text: String,
     },
     /// Push a notification into Roux's notification service
     Notify {
@@ -102,7 +103,74 @@ enum SessionAction {
         /// Session name
         #[arg(short, long)]
         name: Option<String>,
-        /// Working directory
+        /// Working directory (existing worktree path or repo path). Default: cwd
+        #[arg(short, long)]
+        working_dir: Option<String>,
+        /// Create a new worktree from this branch. Uses --working-dir (or cwd) as the repo to branch from.
+        #[arg(long)]
+        worktree_branch: Option<String>,
+        /// Spawn profile id (e.g. "claude", "plain-shell", "codex", user profile id). Default: claude
+        #[arg(short = 'P', long)]
+        profile: Option<String>,
+        /// Extra flag passed to the agent binary (repeatable; values may begin with --)
+        #[arg(short = 'f', long = "flag", allow_hyphen_values = true)]
+        flags: Vec<String>,
+        /// Nono sandbox profile name
+        #[arg(long)]
+        nono_profile: Option<String>,
+        /// Extra directory to allow under nono (repeatable)
+        #[arg(long = "nono-allow-dir")]
+        nono_allow_dirs: Vec<String>,
+    },
+    /// Send text to a session's PTY (appends \r by default; use --no-enter for raw)
+    Send {
+        /// The text to send
+        text: String,
+        /// Session id (falls back to $ROUX_SESSION_ID)
+        #[arg(short, long)]
+        session: Option<String>,
+        /// Pane id (falls back to $ROUX_PANE_ID)
+        #[arg(short, long)]
+        pane: Option<String>,
+        /// Send raw text without appending \r (Enter). By default Enter is sent.
+        #[arg(long = "no-enter")]
+        no_enter: bool,
+    },
+    /// Get the current state of a session (JSON)
+    Poll {
+        /// Session id (falls back to $ROUX_SESSION_ID)
+        #[arg(short, long)]
+        session: Option<String>,
+    },
+    /// List all sessions (JSON)
+    List,
+    /// Pane commands for a session
+    Panes {
+        #[command(subcommand)]
+        action: PaneAction,
+    },
+}
+
+#[derive(Subcommand)]
+enum PaneAction {
+    /// List panes for a session (JSON)
+    List {
+        /// Session id (falls back to $ROUX_SESSION_ID)
+        #[arg(short, long)]
+        session: Option<String>,
+    },
+    /// Create a new pane in a session
+    Create {
+        /// Session id (falls back to $ROUX_SESSION_ID)
+        #[arg(short, long)]
+        session: Option<String>,
+        /// Spawn profile id (e.g. "plain-shell", "claude", "codex", user profile id). Default: plain-shell
+        #[arg(short = 'P', long)]
+        profile: Option<String>,
+        /// Split direction from the active pane (horizontal|vertical). Default: horizontal
+        #[arg(short, long, default_value = "horizontal")]
+        direction: String,
+        /// Working directory for the new pane. Default: session's worktree_path
         #[arg(short, long)]
         working_dir: Option<String>,
     },
@@ -199,6 +267,20 @@ fn send_socket_command(request: Value) -> Result<Value, CliError> {
     reader.read_to_string(&mut response).map_err(|source| CliError::ReadResponse { source })?;
 
     serde_json::from_str(&response).map_err(|source| CliError::InvalidResponse { source })
+}
+
+fn resolve_path(path: &str) -> String {
+    let p = std::path::PathBuf::from(path);
+    let absolute = if p.is_absolute() {
+        p
+    } else {
+        std::env::current_dir().unwrap_or_default().join(p)
+    };
+    absolute
+        .canonicalize()
+        .unwrap_or(absolute)
+        .to_string_lossy()
+        .to_string()
 }
 
 fn get_session_id() -> Option<String> {
@@ -349,12 +431,267 @@ fn clear_status() {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    // ── resolve_path ────────────────────────────────────────
+
+    #[test]
+    fn resolve_path_keeps_absolute_path_as_is() {
+        // "/" always exists on Unix, canonicalize succeeds.
+        let got = resolve_path("/");
+        assert!(got.starts_with('/'));
+    }
+
+    #[test]
+    fn resolve_path_turns_relative_into_absolute() {
+        let got = resolve_path(".");
+        assert!(std::path::Path::new(&got).is_absolute(), "got {}", got);
+    }
+
+    #[test]
+    fn resolve_path_nonexistent_falls_back_to_uncanonicalized_absolute() {
+        // canonicalize() fails on missing paths; resolve_path must still
+        // return an absolute string rather than panicking or returning "".
+        let got = resolve_path("/definitely/not/a/real/path/roux-test");
+        assert!(std::path::Path::new(&got).is_absolute(), "got {}", got);
+        assert!(got.contains("roux-test"));
+    }
+
+    // ── Cli parsing ─────────────────────────────────────────
+
+    #[test]
+    fn cli_parses_app_with_default_path() {
+        let cli = Cli::try_parse_from(["roux-cli", "app"]).unwrap();
+        match cli.command {
+            Commands::App { path } => assert_eq!(path, "."),
+            other => panic!("expected App, got {:?}", std::mem::discriminant(&other)),
+        }
+    }
+
+    #[test]
+    fn cli_parses_app_with_explicit_path() {
+        let cli = Cli::try_parse_from(["roux-cli", "app", "/tmp/foo"]).unwrap();
+        match cli.command {
+            Commands::App { path } => assert_eq!(path, "/tmp/foo"),
+            _ => panic!("expected App"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_session_list() {
+        let cli = Cli::try_parse_from(["roux-cli", "session", "list"]).unwrap();
+        match cli.command {
+            Commands::Session { action: SessionAction::List } => {}
+            _ => panic!("expected Session::List"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_session_poll_with_session_id() {
+        let cli =
+            Cli::try_parse_from(["roux-cli", "session", "poll", "-s", "sid-1"]).unwrap();
+        match cli.command {
+            Commands::Session { action: SessionAction::Poll { session } } => {
+                assert_eq!(session.as_deref(), Some("sid-1"));
+            }
+            _ => panic!("expected Session::Poll"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_session_send_default_has_enter_true() {
+        let cli = Cli::try_parse_from(["roux-cli", "session", "send", "hello"]).unwrap();
+        match cli.command {
+            Commands::Session {
+                action: SessionAction::Send { text, no_enter, .. },
+            } => {
+                assert_eq!(text, "hello");
+                assert!(!no_enter, "--no-enter not passed, so no_enter must be false");
+            }
+            _ => panic!("expected Session::Send"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_session_send_with_no_enter_flag() {
+        let cli = Cli::try_parse_from([
+            "roux-cli", "session", "send", "hello", "--no-enter",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Session {
+                action: SessionAction::Send { no_enter, .. },
+            } => assert!(no_enter),
+            _ => panic!("expected Session::Send"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_session_send_with_session_and_pane() {
+        let cli = Cli::try_parse_from([
+            "roux-cli", "session", "send", "hi",
+            "-s", "sid", "-p", "pid",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Session {
+                action: SessionAction::Send { session, pane, .. },
+            } => {
+                assert_eq!(session.as_deref(), Some("sid"));
+                assert_eq!(pane.as_deref(), Some("pid"));
+            }
+            _ => panic!("expected Session::Send"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_session_create_with_full_options() {
+        let cli = Cli::try_parse_from([
+            "roux-cli", "session", "create",
+            "--name", "feat-x",
+            "--worktree-branch", "feat/x",
+            "--profile", "claude",
+            "-f", "--debug",
+            "-f", "--model=opus",
+            "--nono-profile", "strict",
+            "--nono-allow-dir", "~/work",
+            "--nono-allow-dir", "/tmp",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Session {
+                action:
+                    SessionAction::Create {
+                        name,
+                        worktree_branch,
+                        profile,
+                        flags,
+                        nono_profile,
+                        nono_allow_dirs,
+                        working_dir,
+                    },
+            } => {
+                assert_eq!(name.as_deref(), Some("feat-x"));
+                assert_eq!(worktree_branch.as_deref(), Some("feat/x"));
+                assert_eq!(profile.as_deref(), Some("claude"));
+                assert_eq!(flags, vec!["--debug", "--model=opus"]);
+                assert_eq!(nono_profile.as_deref(), Some("strict"));
+                assert_eq!(nono_allow_dirs, vec!["~/work", "/tmp"]);
+                assert!(working_dir.is_none());
+            }
+            _ => panic!("expected Session::Create"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_session_panes_list_with_session() {
+        let cli = Cli::try_parse_from([
+            "roux-cli", "session", "panes", "list", "-s", "sid",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Session {
+                action: SessionAction::Panes { action: PaneAction::List { session } },
+            } => {
+                assert_eq!(session.as_deref(), Some("sid"));
+            }
+            _ => panic!("expected Session::Panes::List"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_session_panes_create_defaults() {
+        let cli = Cli::try_parse_from([
+            "roux-cli", "session", "panes", "create", "-s", "sid",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Session {
+                action:
+                    SessionAction::Panes {
+                        action:
+                            PaneAction::Create {
+                                session,
+                                profile,
+                                direction,
+                                working_dir,
+                            },
+                    },
+            } => {
+                assert_eq!(session.as_deref(), Some("sid"));
+                assert!(profile.is_none());
+                assert_eq!(direction, "horizontal");
+                assert!(working_dir.is_none());
+            }
+            _ => panic!("expected Session::Panes::Create"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_session_panes_create_with_all_options() {
+        let cli = Cli::try_parse_from([
+            "roux-cli", "session", "panes", "create",
+            "-s", "sid",
+            "-P", "shell",
+            "-d", "vertical",
+            "-w", "/tmp",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Session {
+                action:
+                    SessionAction::Panes {
+                        action:
+                            PaneAction::Create {
+                                profile,
+                                direction,
+                                working_dir,
+                                ..
+                            },
+                    },
+            } => {
+                assert_eq!(profile.as_deref(), Some("shell"));
+                assert_eq!(direction, "vertical");
+                assert_eq!(working_dir.as_deref(), Some("/tmp"));
+            }
+            _ => panic!("expected Session::Panes::Create"),
+        }
+    }
+
+    #[test]
+    fn cli_rejects_removed_top_level_send() {
+        // `roux send "x"` used to work; now it must live under `session`.
+        let err = Cli::try_parse_from(["roux-cli", "send", "x"]);
+        assert!(err.is_err(), "top-level `send` must no longer parse");
+    }
+
+    #[test]
+    fn cli_split_still_parses_with_direction() {
+        let cli = Cli::try_parse_from(["roux-cli", "split", "-d", "vertical"]).unwrap();
+        match cli.command {
+            Commands::Split { direction } => assert_eq!(direction, "vertical"),
+            _ => panic!("expected Split"),
+        }
+    }
+}
+
 fn main() {
     let cli = Cli::parse();
     match cli.command {
         Commands::Hook { status } => handle_hook(&status),
         Commands::Status => show_status(),
         Commands::Clear => clear_status(),
+
+        Commands::App { path } => {
+            let resolved = resolve_path(&path);
+            run_socket_command(serde_json::json!({
+                "command": "app-open",
+                "args": { "path": resolved },
+            }));
+        }
 
         Commands::Split { direction } => {
             run_socket_command(serde_json::json!({
@@ -366,13 +703,51 @@ fn main() {
         }
 
         Commands::Session { action } => match action {
-            SessionAction::Create { name, working_dir } => {
+            SessionAction::Create {
+                name,
+                working_dir,
+                worktree_branch,
+                profile,
+                flags,
+                nono_profile,
+                nono_allow_dirs,
+            } => {
+                // Default working_dir to the current directory when the caller
+                // is not already inside a Roux session (which lets the backend
+                // inherit repo_root from $ROUX_SESSION_ID). With --worktree-branch
+                // the working_dir still becomes the repo to branch off.
+                let working_dir = match working_dir {
+                    Some(d) => Some(d),
+                    None if get_session_id().is_some() => None,
+                    None => Some(resolve_path(".")),
+                };
                 let mut args = serde_json::Map::new();
                 if let Some(n) = name {
                     args.insert("name".into(), Value::String(n));
                 }
                 if let Some(d) = working_dir {
                     args.insert("working_dir".into(), Value::String(d));
+                }
+                if let Some(b) = worktree_branch {
+                    args.insert("worktree_branch".into(), Value::String(b));
+                }
+                if let Some(p) = profile {
+                    args.insert("profile".into(), Value::String(p));
+                }
+                if !flags.is_empty() {
+                    args.insert(
+                        "flags".into(),
+                        Value::Array(flags.into_iter().map(Value::String).collect()),
+                    );
+                }
+                if let Some(p) = nono_profile {
+                    args.insert("nono_profile".into(), Value::String(p));
+                }
+                if !nono_allow_dirs.is_empty() {
+                    args.insert(
+                        "nono_allow_dirs".into(),
+                        Value::Array(nono_allow_dirs.into_iter().map(Value::String).collect()),
+                    );
                 }
                 run_socket_command(serde_json::json!({
                     "command": "session-create",
@@ -381,6 +756,48 @@ fn main() {
                     "args": args,
                 }));
             }
+            SessionAction::Send { text, session, pane, no_enter } => {
+                run_socket_command(serde_json::json!({
+                    "command": "send",
+                    "session_id": session.or_else(get_session_id),
+                    "pane_id": pane.or_else(get_pane_id),
+                    "args": { "text": text, "enter": !no_enter },
+                }));
+            }
+            SessionAction::Poll { session } => {
+                run_socket_command(serde_json::json!({
+                    "command": "session-poll",
+                    "session_id": session.or_else(get_session_id),
+                }));
+            }
+            SessionAction::List => {
+                run_socket_command(serde_json::json!({
+                    "command": "session-list",
+                }));
+            }
+            SessionAction::Panes { action } => match action {
+                PaneAction::List { session } => {
+                    run_socket_command(serde_json::json!({
+                        "command": "session-panes-list",
+                        "session_id": session.or_else(get_session_id),
+                    }));
+                }
+                PaneAction::Create { session, profile, direction, working_dir } => {
+                    let mut args = serde_json::Map::new();
+                    args.insert("direction".into(), Value::String(direction));
+                    if let Some(p) = profile {
+                        args.insert("profile".into(), Value::String(p));
+                    }
+                    if let Some(d) = working_dir {
+                        args.insert("working_dir".into(), Value::String(d));
+                    }
+                    run_socket_command(serde_json::json!({
+                        "command": "session-panes-create",
+                        "session_id": session.or_else(get_session_id),
+                        "args": args,
+                    }));
+                }
+            },
         },
 
         Commands::Shell { working_dir } => {
@@ -414,15 +831,6 @@ fn main() {
                 "session_id": get_session_id(),
                 "pane_id": get_pane_id(),
                 "args": args,
-            }));
-        }
-
-        Commands::Send { text } => {
-            run_socket_command(serde_json::json!({
-                "command": "send",
-                "session_id": get_session_id(),
-                "pane_id": get_pane_id(),
-                "args": { "text": text },
             }));
         }
 

--- a/src-tauri/src/commands/sessions.rs
+++ b/src-tauri/src/commands/sessions.rs
@@ -8,6 +8,30 @@ pub(crate) fn write_to_session(id: String, data: String, state: tauri::State<App
     state.pty_manager.write(&id, data.as_bytes()).map_err(|e| e.to_string())
 }
 
+/// Frontend reply for a socket-initiated round-trip (e.g. panes list / create).
+/// `request_id` was sent in the matching `roux-command` event; the frontend
+/// answers by calling this command with the serialized data.
+// No #[specta::specta] — serde_json::Value produces invalid TypeScript.
+#[tauri::command]
+pub(crate) fn submit_roux_reply(
+    request_id: String,
+    data: serde_json::Value,
+    state: tauri::State<AppState>,
+) -> Result<(), String> {
+    let sender = {
+        let mut map = state.pending_replies.lock().map_err(|e| e.to_string())?;
+        map.remove(&request_id)
+    };
+    match sender {
+        Some(tx) => tx.send(data).map_err(|_| {
+            // Receiver dropped — the socket handler already timed out and
+            // cleaned its end. The frontend reply arrived too late to matter.
+            format!("reply for request_id {} arrived after timeout", request_id)
+        }),
+        None => Err(format!("no pending reply for request_id {}", request_id)),
+    }
+}
+
 #[tauri::command]
 #[specta::specta]
 pub(crate) fn resize_session(id: String, cols: u16, rows: u16, state: tauri::State<AppState>) -> Result<(), String> {

--- a/src-tauri/src/commands/sessions.rs
+++ b/src-tauri/src/commands/sessions.rs
@@ -28,12 +28,19 @@ pub(crate) fn spawn_shell(
     working_dir: String,
     session_id: Option<String>,
     pane_id: Option<String>,
+    nono_profile: Option<String>,
+    nono_allow_dirs: Option<Vec<String>>,
     state: tauri::State<AppState>,
     app: tauri::AppHandle,
 ) -> Result<(), String> {
+    use crate::pty::NonoConfig;
+    let nono = nono_profile.map(|profile| NonoConfig {
+        profile,
+        allow_dirs: nono_allow_dirs.unwrap_or_default(),
+    });
     state
         .pty_manager
-        .spawn_shell(&id, &working_dir, session_id.as_deref(), pane_id.as_deref(), None, app.clone())
+        .spawn_shell(&id, &working_dir, session_id.as_deref(), pane_id.as_deref(), nono.as_ref(), app.clone())
         .map_err(|e| e.to_string())
 }
 
@@ -146,11 +153,18 @@ pub(crate) async fn create_session_shell(
     name: String,
     worktree_path: Option<String>,
     branch: Option<String>,
+    nono_profile: Option<String>,
+    nono_allow_dirs: Option<Vec<String>>,
     state: tauri::State<'_, AppState>,
     app: tauri::AppHandle,
 ) -> Result<Session, String> {
+    use crate::pty::NonoConfig;
     // Clone before await — the MutexGuard is not Send.
     let settings = state.settings.lock().unwrap().clone();
+    let nono = nono_profile.map(|profile| NonoConfig {
+        profile,
+        allow_dirs: nono_allow_dirs.unwrap_or_default(),
+    });
 
     let target = if let Some(ref wt_path) = worktree_path {
         svc::SessionTarget::ExistingWorktree { path: wt_path }
@@ -167,6 +181,7 @@ pub(crate) async fn create_session_shell(
         &repo_path,
         &name,
         target,
+        nono.as_ref(),
         &app,
     )
     .await
@@ -204,10 +219,17 @@ pub(crate) async fn reconnect_session(
 #[specta::specta]
 pub(crate) async fn reconnect_session_shell(
     id: String,
+    nono_profile: Option<String>,
+    nono_allow_dirs: Option<Vec<String>>,
     state: tauri::State<'_, AppState>,
     app: tauri::AppHandle,
 ) -> Result<Session, String> {
-    svc::reconnect_session_shell(&state.pty_manager, &state.session_handle, &id, &app)
+    use crate::pty::NonoConfig;
+    let nono = nono_profile.map(|profile| NonoConfig {
+        profile,
+        allow_dirs: nono_allow_dirs.unwrap_or_default(),
+    });
+    svc::reconnect_session_shell(&state.pty_manager, &state.session_handle, &id, nono.as_ref(), &app)
         .await
         .map_err(|e| e.to_string())
 }

--- a/src-tauri/src/commands/sessions.rs
+++ b/src-tauri/src/commands/sessions.rs
@@ -33,7 +33,7 @@ pub(crate) fn spawn_shell(
 ) -> Result<(), String> {
     state
         .pty_manager
-        .spawn_shell(&id, &working_dir, session_id.as_deref(), pane_id.as_deref(), app.clone())
+        .spawn_shell(&id, &working_dir, session_id.as_deref(), pane_id.as_deref(), None, app.clone())
         .map_err(|e| e.to_string())
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -143,6 +143,7 @@ fn main() {
             project_handle,
             watch_manager: watches::WatchManager::new(watch_store_handle),
             notification_manager: notifications::NotificationManager::new(),
+            pending_replies: Mutex::new(std::collections::HashMap::new()),
         })
         .invoke_handler(tauri::generate_handler![
             commands::misc::get_log_path,
@@ -211,6 +212,7 @@ fn main() {
             commands::pane_state::load_pane_state,
             commands::pane_state::save_pane_state,
             commands::pane_state::delete_pane_state,
+            commands::sessions::submit_roux_reply,
         ])
         .setup(|app| {
             // Install the roux-cli shim dir (~/.config/roux/bin) with

--- a/src-tauri/src/providers/claude.rs
+++ b/src-tauri/src/providers/claude.rs
@@ -26,6 +26,8 @@ pub fn default_profiles(settings: &RouxSettings) -> Vec<SpawnProfile> {
         cwd_override: None,
         icon: None,
         provider: Some(Provider::Claude),
+        nono_profile: None,
+        nono_allow_dirs: None,
         source: ProfileSource::Builtin,
     }]
 }

--- a/src-tauri/src/providers/codex.rs
+++ b/src-tauri/src/providers/codex.rs
@@ -29,6 +29,8 @@ pub fn default_profiles(_settings: &RouxSettings) -> Vec<SpawnProfile> {
         cwd_override: None,
         icon: None,
         provider: Some(Provider::Codex),
+        nono_profile: None,
+        nono_allow_dirs: None,
         source: ProfileSource::Builtin,
     }]
 }

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -49,6 +49,8 @@ fn plain_shell_profile() -> SpawnProfile {
         cwd_override: None,
         icon: None,
         provider: None,
+        nono_profile: None,
+        nono_allow_dirs: None,
         source: ProfileSource::Builtin,
     }
 }

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -367,6 +367,43 @@ pub fn cwd_for_pid(_pid: u32) -> Option<String> {
     None
 }
 
+/// Nono sandbox configuration for a shell PTY. When present, the shell
+/// is spawned inside `nono run` with the given profile and directory
+/// allowances.
+#[derive(Debug, Clone)]
+pub struct NonoConfig {
+    pub profile: String,
+    pub allow_dirs: Vec<String>,
+}
+
+impl NonoConfig {
+    /// Resolve `~` to the user's home directory and relative paths
+    /// against `working_dir`. Nono receives arguments via CommandBuilder
+    /// (no shell expansion), so tilde must be expanded here.
+    pub fn resolved_allow_dirs(&self, working_dir: &str) -> Vec<String> {
+        let home = dirs::home_dir().unwrap_or_default();
+        self.allow_dirs
+            .iter()
+            .map(|d| {
+                if d == "~" {
+                    home.to_string_lossy().into_owned()
+                } else if d.starts_with("~/") {
+                    home.join(d.strip_prefix("~/").unwrap())
+                        .to_string_lossy()
+                        .into_owned()
+                } else if !d.starts_with('/') {
+                    std::path::Path::new(working_dir)
+                        .join(d)
+                        .to_string_lossy()
+                        .into_owned()
+                } else {
+                    d.clone()
+                }
+            })
+            .collect()
+    }
+}
+
 pub struct PtyManager {
     sessions: Mutex<HashMap<String, PtySession>>,
     pending_outputs: Mutex<HashMap<String, Channel<Response>>>,
@@ -481,6 +518,7 @@ impl PtyManager {
         working_dir: &str,
         session_id: Option<&str>,
         pane_id: Option<&str>,
+        nono: Option<&NonoConfig>,
         app: tauri::AppHandle,
     ) -> Result<(), PtyError> {
         let pty_system = native_pty_system();
@@ -491,9 +529,25 @@ impl PtyManager {
 
         let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
         let user_path = get_user_path();
-        rlog!("Spawning shell '{}' for pane '{}' in '{}'", shell, id, working_dir);
+        let nono_label = nono.map(|n| format!(" (nono profile={})", n.profile)).unwrap_or_default();
+        rlog!("Spawning shell '{}' for pane '{}' in '{}'{}", shell, id, working_dir, nono_label);
 
-        let mut cmd = CommandBuilder::new(&shell);
+        let mut cmd = if let Some(nono) = nono {
+            let mut c = CommandBuilder::new("nono");
+            c.arg("run");
+            c.arg("--profile");
+            c.arg(&nono.profile);
+            c.arg("--allow-cwd");
+            for dir in &nono.resolved_allow_dirs(working_dir) {
+                c.arg("--allow-dir");
+                c.arg(dir);
+            }
+            c.arg("--");
+            c.arg(&shell);
+            c
+        } else {
+            CommandBuilder::new(&shell)
+        };
         apply_roux_env(&mut cmd, &user_path, session_id, pane_id);
         cmd.cwd(working_dir);
 
@@ -974,5 +1028,63 @@ mod tests {
     fn cwd_for_pid_returns_none_for_nonexistent_pid() {
         // PID 0 is never a real process on macOS or Linux.
         assert!(cwd_for_pid(0).is_none());
+    }
+}
+
+#[cfg(test)]
+mod nono_tests {
+    use super::*;
+
+    #[test]
+    fn resolved_allow_dirs_expands_tilde() {
+        let nono = NonoConfig {
+            profile: "test".into(),
+            allow_dirs: vec!["~/data".into()],
+        };
+        let resolved = nono.resolved_allow_dirs("/work");
+        assert!(resolved[0].starts_with('/'), "should be absolute: {}", resolved[0]);
+        assert!(resolved[0].ends_with("/data"), "should end with /data: {}", resolved[0]);
+        assert!(!resolved[0].contains('~'), "should not contain tilde: {}", resolved[0]);
+    }
+
+    #[test]
+    fn resolved_allow_dirs_resolves_relative() {
+        let nono = NonoConfig {
+            profile: "test".into(),
+            allow_dirs: vec!["local/dir".into()],
+        };
+        let resolved = nono.resolved_allow_dirs("/work/project");
+        assert_eq!(resolved[0], "/work/project/local/dir");
+    }
+
+    #[test]
+    fn resolved_allow_dirs_passes_absolute_through() {
+        let nono = NonoConfig {
+            profile: "test".into(),
+            allow_dirs: vec!["/tmp/scratch".into()],
+        };
+        let resolved = nono.resolved_allow_dirs("/work");
+        assert_eq!(resolved[0], "/tmp/scratch");
+    }
+
+    #[test]
+    fn resolved_allow_dirs_handles_bare_tilde() {
+        let nono = NonoConfig {
+            profile: "test".into(),
+            allow_dirs: vec!["~".into()],
+        };
+        let resolved = nono.resolved_allow_dirs("/work");
+        let home = dirs::home_dir().unwrap();
+        assert_eq!(resolved[0], home.to_string_lossy());
+    }
+
+    #[test]
+    fn resolved_allow_dirs_handles_empty() {
+        let nono = NonoConfig {
+            profile: "test".into(),
+            allow_dirs: vec![],
+        };
+        let resolved = nono.resolved_allow_dirs("/work");
+        assert!(resolved.is_empty());
     }
 }

--- a/src-tauri/src/services/sessions.rs
+++ b/src-tauri/src/services/sessions.rs
@@ -148,6 +148,7 @@ pub(crate) async fn create_session_shell(
     repo_path: &str,
     name: &str,
     target: SessionTarget<'_>,
+    nono: Option<&crate::pty::NonoConfig>,
     app: &tauri::AppHandle,
 ) -> anyhow::Result<Session> {
     let session_id = uuid::Uuid::new_v4().to_string();
@@ -188,7 +189,7 @@ pub(crate) async fn create_session_shell(
         &work_dir,
         Some(&session_id),
         Some(&pane_id),
-        None,
+        nono,
         app.clone(),
     );
 
@@ -288,6 +289,7 @@ pub(crate) async fn reconnect_session_shell(
     pty_manager: &PtyManager,
     session_handle: &SessionHandle,
     id: &str,
+    nono: Option<&crate::pty::NonoConfig>,
     app: &tauri::AppHandle,
 ) -> anyhow::Result<Session> {
     let session = session_handle
@@ -314,7 +316,7 @@ pub(crate) async fn reconnect_session_shell(
             &session.worktree_path,
             Some(id),
             Some(&pane_id),
-            None,
+            nono,
             app.clone(),
         )
         .map_err(|e| anyhow!("{}", e))?;

--- a/src-tauri/src/services/sessions.rs
+++ b/src-tauri/src/services/sessions.rs
@@ -188,6 +188,7 @@ pub(crate) async fn create_session_shell(
         &work_dir,
         Some(&session_id),
         Some(&pane_id),
+        None,
         app.clone(),
     );
 
@@ -313,6 +314,7 @@ pub(crate) async fn reconnect_session_shell(
             &session.worktree_path,
             Some(id),
             Some(&pane_id),
+            None,
             app.clone(),
         )
         .map_err(|e| anyhow!("{}", e))?;

--- a/src-tauri/src/socket.rs
+++ b/src-tauri/src/socket.rs
@@ -119,8 +119,337 @@ async fn handle_request(req: Request, app: &tauri::AppHandle) -> Response {
         "run" => handle_run(req, app).await,
         "send" => handle_send(req, app),
         "notify" => handle_notify(req, app).await,
+        "session-list" => handle_session_list(req, app).await,
+        "session-poll" => handle_session_poll(req, app).await,
+        "session-panes-list" => handle_session_panes_list(req, app).await,
+        "session-panes-create" => handle_session_panes_create(req, app).await,
+        "app-open" => handle_app_open(req, app).await,
         _ => Response::err(format!("unknown command: {}", req.command)),
     }
+}
+
+async fn handle_session_list(_req: Request, app: &tauri::AppHandle) -> Response {
+    let state: tauri::State<AppState> = app.state();
+    match state.session_handle.list().await {
+        Ok(sessions) => match serde_json::to_value(&sessions) {
+            Ok(v) => Response::success(v),
+            Err(e) => Response::err(format!("failed to serialize sessions: {}", e)),
+        },
+        Err(e) => Response::err(format!("{}", e)),
+    }
+}
+
+async fn handle_session_poll(req: Request, app: &tauri::AppHandle) -> Response {
+    let session_id = match req.session_id.as_deref() {
+        Some(id) => id,
+        None => return Response::err("session_id required"),
+    };
+    let state: tauri::State<AppState> = app.state();
+    match state.session_handle.get(session_id).await {
+        Ok(Some(s)) => match serde_json::to_value(&s) {
+            Ok(v) => Response::success(v),
+            Err(e) => Response::err(format!("failed to serialize session: {}", e)),
+        },
+        Ok(None) => Response::err("session not found"),
+        Err(e) => Response::err(format!("{}", e)),
+    }
+}
+
+/// Register a pending-reply oneshot channel and return its request_id + receiver.
+/// Pure over the `PendingReplies` map so it's testable without an AppState.
+fn register_pending_reply_in(
+    map: &crate::state::PendingReplies,
+) -> (String, tokio::sync::oneshot::Receiver<serde_json::Value>) {
+    let request_id = uuid::Uuid::new_v4().to_string();
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    map.lock().unwrap().insert(request_id.clone(), tx);
+    (request_id, rx)
+}
+
+fn register_pending_reply(
+    app: &tauri::AppHandle,
+) -> (String, tokio::sync::oneshot::Receiver<serde_json::Value>) {
+    let state: tauri::State<AppState> = app.state();
+    register_pending_reply_in(&state.pending_replies)
+}
+
+fn drop_pending_reply_in(map: &crate::state::PendingReplies, request_id: &str) {
+    map.lock().unwrap().remove(request_id);
+}
+
+fn drop_pending_reply(app: &tauri::AppHandle, request_id: &str) {
+    let state: tauri::State<AppState> = app.state();
+    drop_pending_reply_in(&state.pending_replies, request_id);
+}
+
+async fn await_frontend_reply_in(
+    map: &crate::state::PendingReplies,
+    request_id: String,
+    rx: tokio::sync::oneshot::Receiver<serde_json::Value>,
+    timeout_ms: u64,
+) -> Response {
+    match tokio::time::timeout(std::time::Duration::from_millis(timeout_ms), rx).await {
+        Ok(Ok(data)) => {
+            // The frontend conventionally replies with `{ error: "..." }` on
+            // failure so the CLI sees a non-zero exit, rather than succeeding
+            // with a bogus payload. Any other shape is treated as success.
+            if let Some(err) = data.get("error").and_then(|e| e.as_str()) {
+                Response::err(err.to_string())
+            } else {
+                Response::success(data)
+            }
+        }
+        Ok(Err(_)) => {
+            drop_pending_reply_in(map, &request_id);
+            Response::err("frontend dropped reply channel")
+        }
+        Err(_) => {
+            drop_pending_reply_in(map, &request_id);
+            Response::err("timed out waiting for frontend reply")
+        }
+    }
+}
+
+async fn await_frontend_reply(
+    app: &tauri::AppHandle,
+    request_id: String,
+    rx: tokio::sync::oneshot::Receiver<serde_json::Value>,
+    timeout_ms: u64,
+) -> Response {
+    let state: tauri::State<AppState> = app.state();
+    // Need to clone the Arc-like Mutex handle reference but tauri::State is a ref;
+    // bind explicitly so the borrow lives through the await.
+    let map = &state.pending_replies;
+    await_frontend_reply_in(map, request_id, rx, timeout_ms).await
+}
+
+async fn handle_session_panes_list(req: Request, app: &tauri::AppHandle) -> Response {
+    let session_id = match req.session_id.as_deref() {
+        Some(id) => id.to_string(),
+        None => return Response::err("session_id required"),
+    };
+
+    // Verify the session exists before asking the frontend — otherwise a bad
+    // id would return a successful empty snapshot, which is a confusing UX
+    // for CLI scripts ("session not found" beats a misleading empty list).
+    {
+        let state: tauri::State<AppState> = app.state();
+        match state.session_handle.get(&session_id).await {
+            Ok(Some(_)) => {}
+            Ok(None) => return Response::err("session not found"),
+            Err(e) => return Response::err(format!("{}", e)),
+        }
+    }
+
+    let (request_id, rx) = register_pending_reply(app);
+
+    use tauri::Emitter;
+    let cmd = roux_core::RouxCommand::new("panes-list-request")
+        .session_id(&session_id)
+        .request_id(&request_id);
+    if let Err(e) = app.emit("roux-command", &cmd) {
+        drop_pending_reply(app, &request_id);
+        return Response::err(format!("failed to emit event: {}", e));
+    }
+
+    await_frontend_reply(app, request_id, rx, 2_000).await
+}
+
+async fn handle_session_panes_create(req: Request, app: &tauri::AppHandle) -> Response {
+    let session_id = match req.session_id.as_deref() {
+        Some(id) => id.to_string(),
+        None => return Response::err("session_id required"),
+    };
+
+    // Verify session exists before round-tripping to the frontend.
+    {
+        let state: tauri::State<AppState> = app.state();
+        match state.session_handle.get(&session_id).await {
+            Ok(Some(_)) => {}
+            Ok(None) => return Response::err("session not found"),
+            Err(e) => return Response::err(format!("{}", e)),
+        }
+    }
+
+    let profile =
+        req.args.get("profile").and_then(|p| p.as_str()).unwrap_or("plain-shell").to_string();
+
+    // Validate against known builtins + user profiles. Rejects typos like
+    // "shell" (correct id is "plain-shell") instead of silently falling back.
+    {
+        let state: tauri::State<AppState> = app.state();
+        let settings = state.settings.lock().unwrap().clone();
+        if let Err(e) = validate_profile_id(&profile, &settings) {
+            return Response::err(e);
+        }
+    }
+
+    let direction = req
+        .args
+        .get("direction")
+        .and_then(|d| d.as_str())
+        .unwrap_or("horizontal")
+        .to_string();
+    if direction != "horizontal" && direction != "vertical" {
+        return Response::err("direction must be horizontal or vertical");
+    }
+    let working_dir = req.args.get("working_dir").and_then(|d| d.as_str()).map(String::from);
+
+    let (request_id, rx) = register_pending_reply(app);
+
+    use tauri::Emitter;
+    let mut cmd = roux_core::RouxCommand::new("pane-create")
+        .session_id(&session_id)
+        .direction(&direction)
+        .profile_id(&profile)
+        .request_id(&request_id);
+    if let Some(ref wd) = working_dir {
+        cmd = cmd.working_dir(wd);
+    }
+    if let Err(e) = app.emit("roux-command", &cmd) {
+        drop_pending_reply(app, &request_id);
+        return Response::err(format!("failed to emit event: {}", e));
+    }
+
+    await_frontend_reply(app, request_id, rx, 5_000).await
+}
+
+fn bring_window_to_front(app: &tauri::AppHandle) {
+    for window in app.webview_windows().values() {
+        let _ = window.unminimize();
+        let _ = window.show();
+        let _ = window.set_focus();
+    }
+}
+
+/// Validate that a profile id is known — either a built-in or a user-defined
+/// profile in settings. Returns the normalized id on success so callers get
+/// a clear error when a typo like "shell" is used instead of "plain-shell".
+fn validate_profile_id(
+    id: &str,
+    settings: &crate::settings::RouxSettings,
+) -> Result<(), String> {
+    let builtin_ids: Vec<String> = crate::providers::builtin_profiles(settings)
+        .into_iter()
+        .map(|p| p.id)
+        .collect();
+    if builtin_ids.iter().any(|b| b == id) {
+        return Ok(());
+    }
+    if settings.spawn_profiles.iter().any(|p| p.id == id) {
+        return Ok(());
+    }
+    Err(format!(
+        "unknown profile id '{}'. Known built-ins: {}",
+        id,
+        builtin_ids.join(", ")
+    ))
+}
+
+/// Canonicalize a path to an absolute form, falling back to the input if
+/// the path doesn't exist on disk. Used to compare directory arguments
+/// against persisted session paths without false negatives from `.`,
+/// trailing slashes, or symlink differences.
+fn canonicalize_or_passthrough(path: &str) -> String {
+    let p = std::path::PathBuf::from(path);
+    p.canonicalize()
+        .map(|c| c.to_string_lossy().to_string())
+        .unwrap_or_else(|_| path.to_string())
+}
+
+/// Find the first session whose worktree_path or repo_root matches `path`.
+/// Compares canonicalized forms so `/foo/bar`, `/foo/bar/`, and a symlink
+/// resolving to the same directory all match. Extracted for unit tests.
+fn find_session_for_path(
+    sessions: &[crate::session::Session],
+    path: &str,
+) -> Option<crate::session::Session> {
+    let target = canonicalize_or_passthrough(path);
+    sessions
+        .iter()
+        .find(|s| {
+            canonicalize_or_passthrough(&s.worktree_path) == target
+                || canonicalize_or_passthrough(&s.repo_root) == target
+        })
+        .cloned()
+}
+
+/// Derive a default session name from a directory path (basename, or
+/// "New Session" if the path has no basename).
+fn default_session_name_for_path(path: &str) -> String {
+    std::path::Path::new(path)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| "New Session".to_string())
+}
+
+async fn handle_app_open(req: Request, app: &tauri::AppHandle) -> Response {
+    use crate::services::sessions::{self as svc, SessionTarget};
+
+    let path = match req.args.get("path").and_then(|p| p.as_str()) {
+        Some(p) if !p.is_empty() => p.to_string(),
+        _ => return Response::err("path required"),
+    };
+
+    let state: tauri::State<AppState> = app.state();
+    let handle = state.session_handle.clone();
+
+    let sessions = match handle.list().await {
+        Ok(s) => s,
+        Err(e) => return Response::err(format!("{}", e)),
+    };
+
+    // Match against worktree_path or repo_root (first match wins).
+    if let Some(existing) = find_session_for_path(&sessions, &path) {
+        use tauri::Emitter;
+        let _ = app.emit(
+            "roux-command",
+            &roux_core::RouxCommand::new("focus").session_id(&existing.id),
+        );
+        bring_window_to_front(app);
+        return Response::success(serde_json::json!({
+            "session_id": existing.id,
+            "created": false,
+            "focused": true,
+        }));
+    }
+
+    // No match — create a new session at this path.
+    let name = default_session_name_for_path(&path);
+
+    let settings = state.settings.lock().unwrap().clone();
+
+    let session = match svc::create_session(
+        &state.pty_manager,
+        &state.session_handle,
+        &settings,
+        &path,
+        &name,
+        SessionTarget::Repo,
+        &[],
+        None,
+        app,
+    )
+    .await
+    {
+        Ok(s) => s,
+        Err(e) => return Response::err(format!("{}", e)),
+    };
+
+    use tauri::Emitter;
+    let _ = app.emit(
+        "roux-command",
+        &roux_core::RouxCommand::new("session-created").session_id(&session.id),
+    );
+
+    bring_window_to_front(app);
+
+    Response::success(serde_json::json!({
+        "session_id": session.id,
+        "created": true,
+        "focused": true,
+    }))
 }
 
 fn handle_split(req: Request, app: &tauri::AppHandle) -> Response {
@@ -157,8 +486,24 @@ async fn handle_session_create(req: Request, app: &tauri::AppHandle) -> Response
     let handle = state.session_handle.clone();
 
     let name = req.args.get("name").and_then(|n| n.as_str()).unwrap_or("New Session").to_string();
-
     let working_dir = req.args.get("working_dir").and_then(|d| d.as_str()).map(|s| s.to_string());
+    let worktree_branch =
+        req.args.get("worktree_branch").and_then(|d| d.as_str()).map(|s| s.to_string());
+    let profile = req.args.get("profile").and_then(|p| p.as_str()).unwrap_or("claude").to_string();
+    let flags: Vec<String> = req
+        .args
+        .get("flags")
+        .and_then(|f| f.as_array())
+        .map(|a| a.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+        .unwrap_or_default();
+    let nono_profile =
+        req.args.get("nono_profile").and_then(|p| p.as_str()).map(|s| s.to_string());
+    let nono_allow_dirs: Vec<String> = req
+        .args
+        .get("nono_allow_dirs")
+        .and_then(|f| f.as_array())
+        .map(|a| a.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+        .unwrap_or_default();
 
     // Resolve repo_path: use the requesting session's repo_root, or the working_dir
     let repo_path = match req.session_id.as_deref() {
@@ -170,38 +515,73 @@ async fn handle_session_create(req: Request, app: &tauri::AppHandle) -> Response
     };
 
     if repo_path.is_empty() {
-        return Response::err("working_dir or session_id required");
+        return Response::err("working_dir, worktree_branch, or session_id required");
     }
 
     let settings = state.settings.lock().unwrap().clone();
 
-    // If working_dir differs from repo_path, treat it as an existing worktree
-    let target = match &working_dir {
-        Some(dir) if dir != &repo_path => SessionTarget::ExistingWorktree { path: dir },
-        _ => SessionTarget::Repo,
+    if let Err(e) = validate_profile_id(&profile, &settings) {
+        return Response::err(e);
+    }
+
+    // Build the session target. worktree_branch wins; else treat a distinct
+    // working_dir as an existing worktree; else use the repo directly.
+    let target = if let Some(branch) = worktree_branch.as_deref() {
+        SessionTarget::NewWorktree { branch }
+    } else {
+        match &working_dir {
+            Some(dir) if dir != &repo_path => SessionTarget::ExistingWorktree { path: dir },
+            _ => SessionTarget::Repo,
+        }
     };
 
-    let session = match svc::create_session(
-        &state.pty_manager,
-        &state.session_handle,
-        &settings,
-        &repo_path,
-        &name,
-        target,
-        &[],
-        None,
-        app,
-    )
-    .await
-    {
-        Ok(s) => s,
-        Err(e) => return Response::err(format!("{}", e)),
+    let nono_config = nono_profile.as_ref().map(|p| crate::pty::NonoConfig {
+        profile: p.clone(),
+        allow_dirs: nono_allow_dirs.clone(),
+    });
+
+    let session = if profile == "claude" {
+        match svc::create_session(
+            &state.pty_manager,
+            &state.session_handle,
+            &settings,
+            &repo_path,
+            &name,
+            target,
+            &flags,
+            nono_profile.as_deref(),
+            app,
+        )
+        .await
+        {
+            Ok(s) => s,
+            Err(e) => return Response::err(format!("{}", e)),
+        }
+    } else {
+        match svc::create_session_shell(
+            &state.pty_manager,
+            &state.session_handle,
+            &settings,
+            &repo_path,
+            &name,
+            target,
+            nono_config.as_ref(),
+            app,
+        )
+        .await
+        {
+            Ok(s) => s,
+            Err(e) => return Response::err(format!("{}", e)),
+        }
     };
 
     let session_id = session.id.clone();
 
     use tauri::Emitter;
-    let cmd = roux_core::RouxCommand::new("session-created").session_id(&session_id);
+    let mut cmd = roux_core::RouxCommand::new("session-created").session_id(&session_id);
+    if profile != "claude" {
+        cmd = cmd.profile_id(&profile);
+    }
     if let Err(e) = app.emit("roux-command", &cmd) {
         rlog!("Warning: failed to emit session-created event: {}", e);
     }
@@ -332,6 +712,13 @@ async fn handle_run(req: Request, app: &tauri::AppHandle) -> Response {
     Response::success(serde_json::json!({ "pane_id": pane_id, "pty_id": pty_id }))
 }
 
+/// Compose the bytes written to the PTY for a `send` request. Factored
+/// out so the enter/no-enter contract can be unit-tested without a real
+/// PtyManager.
+fn format_send_data(text: &str, enter: bool) -> String {
+    if enter { format!("{}\r", text) } else { text.to_string() }
+}
+
 fn handle_send(req: Request, app: &tauri::AppHandle) -> Response {
     let text = match req.args.get("text").and_then(|t| t.as_str()) {
         Some(t) => t.to_string(),
@@ -345,8 +732,9 @@ fn handle_send(req: Request, app: &tauri::AppHandle) -> Response {
     if let Some(session_id) = &req.session_id {
         // Write directly to the session's PTY (the main Claude pane uses session_id as pty_id)
         let target_id = req.pane_id.as_deref().unwrap_or(session_id);
-        // Append \r to simulate Enter
-        let data = format!("{}\r", text);
+        // Append \r to simulate Enter unless caller explicitly opts out.
+        let cr = req.args.get("enter").and_then(|v| v.as_bool()).unwrap_or(true);
+        let data = format_send_data(&text, cr);
         if let Err(e) = state.pty_manager.write(target_id, data.as_bytes()) {
             return Response::err(format!("Failed to write to session: {}", e));
         }
@@ -524,6 +912,396 @@ mod tests {
         let json = r#"{"command": "status"}"#;
         let req: Request = serde_json::from_str(json).unwrap();
         assert!(req.args.is_null());
+    }
+
+    // ── format_send_data ─────────────────────────────────────
+
+    #[test]
+    fn format_send_data_appends_cr_when_enter_true() {
+        assert_eq!(format_send_data("hi", true), "hi\r");
+    }
+
+    #[test]
+    fn format_send_data_returns_raw_when_enter_false() {
+        assert_eq!(format_send_data("hi", false), "hi");
+    }
+
+    #[test]
+    fn format_send_data_preserves_embedded_newlines() {
+        // Embedded newlines must survive verbatim; the flag only controls
+        // the *trailing* Enter.
+        assert_eq!(format_send_data("a\nb", true), "a\nb\r");
+        assert_eq!(format_send_data("a\nb", false), "a\nb");
+    }
+
+    #[test]
+    fn format_send_data_empty_text_still_appends_cr() {
+        assert_eq!(format_send_data("", true), "\r");
+        assert_eq!(format_send_data("", false), "");
+    }
+
+    // ── Request deserialization for new commands ─────────────
+
+    #[test]
+    fn request_send_with_enter_false_deserializes() {
+        let json = r#"{
+            "command": "send",
+            "session_id": "s1",
+            "args": {"text": "hi", "enter": false}
+        }"#;
+        let req: Request = serde_json::from_str(json).unwrap();
+        assert_eq!(req.command, "send");
+        assert_eq!(req.args["text"], "hi");
+        assert_eq!(req.args["enter"], false);
+    }
+
+    #[test]
+    fn request_send_without_enter_defaults_to_true_at_handler() {
+        // Request itself doesn't default enter; the handler does. Document
+        // that absence of the key is equivalent to true via the read pattern.
+        let json = r#"{"command": "send", "session_id": "s1", "args": {"text": "x"}}"#;
+        let req: Request = serde_json::from_str(json).unwrap();
+        let cr = req.args.get("enter").and_then(|v| v.as_bool()).unwrap_or(true);
+        assert!(cr);
+    }
+
+    #[test]
+    fn request_app_open_deserializes() {
+        let json = r#"{"command": "app-open", "args": {"path": "/tmp/x"}}"#;
+        let req: Request = serde_json::from_str(json).unwrap();
+        assert_eq!(req.command, "app-open");
+        assert_eq!(req.args["path"], "/tmp/x");
+    }
+
+    #[test]
+    fn request_session_list_deserializes_without_args() {
+        let json = r#"{"command": "session-list"}"#;
+        let req: Request = serde_json::from_str(json).unwrap();
+        assert_eq!(req.command, "session-list");
+        assert!(req.session_id.is_none());
+        assert!(req.args.is_null());
+    }
+
+    #[test]
+    fn request_session_poll_requires_session_id() {
+        let json = r#"{"command": "session-poll", "session_id": "sid-abc"}"#;
+        let req: Request = serde_json::from_str(json).unwrap();
+        assert_eq!(req.command, "session-poll");
+        assert_eq!(req.session_id.as_deref(), Some("sid-abc"));
+    }
+
+    #[test]
+    fn request_session_panes_list_deserializes() {
+        let json = r#"{"command": "session-panes-list", "session_id": "sid-1"}"#;
+        let req: Request = serde_json::from_str(json).unwrap();
+        assert_eq!(req.command, "session-panes-list");
+        assert_eq!(req.session_id.as_deref(), Some("sid-1"));
+    }
+
+    #[test]
+    fn request_session_panes_create_with_profile_deserializes() {
+        let json = r#"{
+            "command": "session-panes-create",
+            "session_id": "sid-1",
+            "args": {"profile": "shell", "direction": "vertical", "working_dir": "/tmp"}
+        }"#;
+        let req: Request = serde_json::from_str(json).unwrap();
+        assert_eq!(req.args["profile"], "shell");
+        assert_eq!(req.args["direction"], "vertical");
+        assert_eq!(req.args["working_dir"], "/tmp");
+    }
+
+    #[test]
+    fn request_session_create_with_full_args_deserializes() {
+        let json = r#"{
+            "command": "session-create",
+            "args": {
+                "name": "feat-x",
+                "worktree_branch": "feat/x",
+                "profile": "claude",
+                "flags": ["--debug", "--model=opus"],
+                "nono_profile": "strict",
+                "nono_allow_dirs": ["~/work", "/tmp"]
+            }
+        }"#;
+        let req: Request = serde_json::from_str(json).unwrap();
+        assert_eq!(req.args["name"], "feat-x");
+        assert_eq!(req.args["worktree_branch"], "feat/x");
+        assert_eq!(req.args["profile"], "claude");
+        assert_eq!(req.args["flags"].as_array().unwrap().len(), 2);
+        assert_eq!(req.args["nono_allow_dirs"].as_array().unwrap().len(), 2);
+    }
+
+    // ── Pending-reply round-trip primitives ──────────────────
+
+    // ── Frontend error replies propagate as errors, not successes ───
+
+    #[tokio::test]
+    async fn pending_reply_with_error_field_surfaces_as_err() {
+        // The frontend conventionally replies with `{ error: "..." }` on
+        // failure. The CLI caller must see exit 1, not exit 0 + an error blob.
+        let map: crate::state::PendingReplies =
+            std::sync::Mutex::new(std::collections::HashMap::new());
+        let (rid, rx) = register_pending_reply_in(&map);
+        let tx = map.lock().unwrap().remove(&rid).unwrap();
+        tx.send(serde_json::json!({"error": "pane-create failed"})).unwrap();
+
+        let resp = await_frontend_reply_in(&map, rid, rx, 500).await;
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["ok"], false);
+        assert_eq!(json["error"], "pane-create failed");
+    }
+
+    #[tokio::test]
+    async fn pending_reply_without_error_field_is_success() {
+        // A reply that happens to contain other fields but no `error` key
+        // remains a success — e.g. a pane snapshot with an `errors` array.
+        let map: crate::state::PendingReplies =
+            std::sync::Mutex::new(std::collections::HashMap::new());
+        let (rid, rx) = register_pending_reply_in(&map);
+        let tx = map.lock().unwrap().remove(&rid).unwrap();
+        tx.send(serde_json::json!({"descriptors": []})).unwrap();
+
+        let resp = await_frontend_reply_in(&map, rid, rx, 500).await;
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["ok"], true);
+    }
+
+    // ── Profile id validation ────────────────────────────────
+
+    #[test]
+    fn validate_profile_id_accepts_claude_builtin() {
+        let settings = crate::settings::RouxSettings::default();
+        assert!(validate_profile_id("claude", &settings).is_ok());
+    }
+
+    #[test]
+    fn validate_profile_id_accepts_plain_shell_builtin() {
+        let settings = crate::settings::RouxSettings::default();
+        assert!(validate_profile_id("plain-shell", &settings).is_ok());
+    }
+
+    #[test]
+    fn validate_profile_id_rejects_unknown_id_with_helpful_message() {
+        let settings = crate::settings::RouxSettings::default();
+        let err = validate_profile_id("shell", &settings).unwrap_err();
+        // Common typo: "shell" instead of "plain-shell". The message should
+        // point callers at the known builtins.
+        assert!(err.contains("shell"));
+        assert!(err.contains("plain-shell"), "error must list builtins: {}", err);
+    }
+
+    #[test]
+    fn validate_profile_id_accepts_user_profile() {
+        let mut settings = crate::settings::RouxSettings::default();
+        settings.spawn_profiles.push(roux_core::SpawnProfile {
+            id: "my-profile".into(),
+            name: "Mine".into(),
+            setup_command: None,
+            startup_command: None,
+            startup_behavior: None,
+            env: None,
+            cwd_override: None,
+            icon: None,
+            provider: None,
+            nono_profile: None,
+            nono_allow_dirs: None,
+            source: roux_core::ProfileSource::User,
+        });
+        assert!(validate_profile_id("my-profile", &settings).is_ok());
+    }
+
+    // ── Canonicalized path matching ──────────────────────────
+
+    #[test]
+    fn canonicalize_or_passthrough_returns_input_for_missing_path() {
+        // Non-existent path — cannot canonicalize, so the input is returned verbatim.
+        let got = canonicalize_or_passthrough("/nonexistent/roux-test-path");
+        assert_eq!(got, "/nonexistent/roux-test-path");
+    }
+
+    #[test]
+    fn canonicalize_or_passthrough_resolves_dot() {
+        let got = canonicalize_or_passthrough("/tmp/./");
+        // Whether it exists depends on platform, but on all supported ones /tmp resolves.
+        // Accept either /tmp or /private/tmp (macOS symlink) or the passthrough input.
+        assert!(got == "/tmp" || got == "/private/tmp" || got.contains("tmp"));
+    }
+
+    #[tokio::test]
+    async fn pending_reply_resolves_when_frontend_replies() {
+        let map: crate::state::PendingReplies =
+            std::sync::Mutex::new(std::collections::HashMap::new());
+        let (rid, rx) = register_pending_reply_in(&map);
+
+        // Pull the sender back out and deliver a reply, as `submit_roux_reply`
+        // would do from the frontend side.
+        let tx = map.lock().unwrap().remove(&rid).unwrap();
+        let payload = serde_json::json!({"pane_id": "p", "pty_id": "t"});
+        tx.send(payload.clone()).unwrap();
+
+        let resp = await_frontend_reply_in(&map, rid, rx, 500).await;
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["ok"], true);
+        assert_eq!(json["data"]["pane_id"], "p");
+        assert_eq!(json["data"]["pty_id"], "t");
+    }
+
+    #[tokio::test]
+    async fn pending_reply_times_out_and_cleans_up_map() {
+        let map: crate::state::PendingReplies =
+            std::sync::Mutex::new(std::collections::HashMap::new());
+        let (rid, rx) = register_pending_reply_in(&map);
+        assert_eq!(map.lock().unwrap().len(), 1);
+
+        let resp = await_frontend_reply_in(&map, rid.clone(), rx, 50).await;
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["ok"], false);
+        assert!(json["error"].as_str().unwrap().contains("timed out"));
+
+        // Timed-out entry must not leak.
+        assert!(map.lock().unwrap().is_empty(), "timeout must drop the entry");
+    }
+
+    #[tokio::test]
+    async fn pending_reply_reports_dropped_channel() {
+        let map: crate::state::PendingReplies =
+            std::sync::Mutex::new(std::collections::HashMap::new());
+        let (rid, rx) = register_pending_reply_in(&map);
+
+        // Drop the sender without sending — simulates a crashed frontend
+        // handler that never called submit_roux_reply.
+        let _ = map.lock().unwrap().remove(&rid);
+        // tx is dropped here when the HashMap entry goes out of scope.
+
+        let resp = await_frontend_reply_in(&map, rid, rx, 500).await;
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["ok"], false);
+        assert!(json["error"].as_str().unwrap().contains("dropped"));
+    }
+
+    #[test]
+    fn register_pending_reply_in_generates_unique_ids() {
+        let map: crate::state::PendingReplies =
+            std::sync::Mutex::new(std::collections::HashMap::new());
+        let (r1, _rx1) = register_pending_reply_in(&map);
+        let (r2, _rx2) = register_pending_reply_in(&map);
+        assert_ne!(r1, r2);
+        assert_eq!(map.lock().unwrap().len(), 2);
+    }
+
+    // ── app-open session matching ────────────────────────────
+
+    fn make_session(id: &str, repo: &str, worktree: &str) -> crate::session::Session {
+        crate::session::Session {
+            id: id.to_string(),
+            name: id.to_string(),
+            repo_root: repo.to_string(),
+            worktree_path: worktree.to_string(),
+            branch: "main".to_string(),
+            is_worktree: repo != worktree,
+            status: roux_core::SessionStatus::Idle,
+            model: None,
+            cost: None,
+            created_at: 0,
+            project_id: None,
+            is_git_repo: true,
+        }
+    }
+
+    #[test]
+    fn find_session_matches_on_worktree_path() {
+        let sessions = vec![
+            make_session("a", "/repo", "/repo"),
+            make_session("b", "/repo", "/wt/feat"),
+        ];
+        let got = find_session_for_path(&sessions, "/wt/feat").unwrap();
+        assert_eq!(got.id, "b");
+    }
+
+    #[test]
+    fn find_session_matches_on_repo_root_when_no_worktree_match() {
+        let sessions = vec![make_session("a", "/repo", "/repo")];
+        let got = find_session_for_path(&sessions, "/repo").unwrap();
+        assert_eq!(got.id, "a");
+    }
+
+    #[test]
+    fn find_session_returns_none_when_no_match() {
+        let sessions = vec![make_session("a", "/repo", "/wt/feat")];
+        assert!(find_session_for_path(&sessions, "/other").is_none());
+    }
+
+    #[test]
+    fn find_session_returns_first_on_multiple_matches() {
+        let sessions = vec![
+            make_session("a", "/repo", "/repo"),
+            make_session("b", "/repo", "/repo"),
+        ];
+        let got = find_session_for_path(&sessions, "/repo").unwrap();
+        assert_eq!(got.id, "a");
+    }
+
+    #[test]
+    fn default_session_name_uses_basename() {
+        assert_eq!(default_session_name_for_path("/tmp/my-repo"), "my-repo");
+    }
+
+    #[test]
+    fn default_session_name_handles_trailing_slash() {
+        assert_eq!(default_session_name_for_path("/tmp/my-repo/"), "my-repo");
+    }
+
+    #[test]
+    fn default_session_name_fallback_for_root() {
+        // "/" has no file_name on Unix.
+        let got = default_session_name_for_path("/");
+        assert!(got == "New Session" || got == "/");
+    }
+
+    // ── RouxCommand builder / serde ──────────────────────────
+
+    #[test]
+    fn roux_command_profile_id_and_request_id_builders() {
+        let cmd = roux_core::RouxCommand::new("pane-create")
+            .session_id("s")
+            .profile_id("claude")
+            .request_id("req-1")
+            .direction("horizontal");
+        assert_eq!(cmd.profile_id.as_deref(), Some("claude"));
+        assert_eq!(cmd.request_id.as_deref(), Some("req-1"));
+        assert_eq!(cmd.direction.as_deref(), Some("horizontal"));
+    }
+
+    #[test]
+    fn roux_command_serializes_camel_case_and_skips_none() {
+        let cmd = roux_core::RouxCommand::new("focus").session_id("sid-1");
+        let json = serde_json::to_value(&cmd).unwrap();
+        assert_eq!(json["action"], "focus");
+        assert_eq!(json["sessionId"], "sid-1");
+        assert!(json.get("profileId").is_none());
+        assert!(json.get("requestId").is_none());
+        assert!(json.get("paneId").is_none());
+    }
+
+    #[test]
+    fn roux_command_serializes_profile_and_request_id_as_camel_case() {
+        let cmd = roux_core::RouxCommand::new("pane-create")
+            .profile_id("shell")
+            .request_id("r1");
+        let json = serde_json::to_value(&cmd).unwrap();
+        assert_eq!(json["profileId"], "shell");
+        assert_eq!(json["requestId"], "r1");
+    }
+
+    #[test]
+    fn drop_pending_reply_in_removes_entry() {
+        let map: crate::state::PendingReplies =
+            std::sync::Mutex::new(std::collections::HashMap::new());
+        let (rid, _rx) = register_pending_reply_in(&map);
+        assert_eq!(map.lock().unwrap().len(), 1);
+        drop_pending_reply_in(&map, &rid);
+        assert!(map.lock().unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/src-tauri/src/socket.rs
+++ b/src-tauri/src/socket.rs
@@ -240,6 +240,7 @@ async fn handle_shell(req: Request, app: &tauri::AppHandle) -> Response {
         &working_dir,
         Some(session_id),
         Some(&pane_id),
+        None,
         app.clone(),
     ) {
         return Response::err(format!("Failed to spawn shell: {}", e));

--- a/src-tauri/src/socket.rs
+++ b/src-tauri/src/socket.rs
@@ -323,8 +323,9 @@ fn bring_window_to_front(app: &tauri::AppHandle) {
 }
 
 /// Validate that a profile id is known — either a built-in or a user-defined
-/// profile in settings. Returns the normalized id on success so callers get
-/// a clear error when a typo like "shell" is used instead of "plain-shell".
+/// profile in settings. Returns `Ok(())` on match, or a descriptive error
+/// listing every known id so a CLI caller can correct typos like "shell"
+/// (the correct built-in id is "plain-shell").
 fn validate_profile_id(
     id: &str,
     settings: &crate::settings::RouxSettings,
@@ -336,14 +337,20 @@ fn validate_profile_id(
     if builtin_ids.iter().any(|b| b == id) {
         return Ok(());
     }
-    if settings.spawn_profiles.iter().any(|p| p.id == id) {
+    let user_ids: Vec<String> =
+        settings.spawn_profiles.iter().map(|p| p.id.clone()).collect();
+    if user_ids.iter().any(|u| u == id) {
         return Ok(());
     }
-    Err(format!(
+    let mut msg = format!(
         "unknown profile id '{}'. Known built-ins: {}",
         id,
         builtin_ids.join(", ")
-    ))
+    );
+    if !user_ids.is_empty() {
+        msg.push_str(&format!(". User profiles: {}", user_ids.join(", ")));
+    }
+    Err(msg)
 }
 
 /// Canonicalize a path to an absolute form, falling back to the input if
@@ -534,6 +541,22 @@ async fn handle_session_create(req: Request, app: &tauri::AppHandle) -> Response
             _ => SessionTarget::Repo,
         }
     };
+
+    // Enforce the contract between args and the selected spawn path so
+    // data doesn't silently get dropped. `flags` are agent-binary-specific
+    // (claude-only for now); `nono_allow_dirs` needs a NonoConfig, which
+    // only the shell path wires through end-to-end.
+    if profile == "claude" && !nono_allow_dirs.is_empty() {
+        return Response::err(
+            "--nono-allow-dir is not supported with profile 'claude'; use a shell-based profile or omit allow-dirs",
+        );
+    }
+    if profile != "claude" && !flags.is_empty() {
+        return Response::err(format!(
+            "--flag/-f is only supported with profile 'claude', not '{}'",
+            profile
+        ));
+    }
 
     let nono_config = nono_profile.as_ref().map(|p| crate::pty::NonoConfig {
         profile: p.clone(),
@@ -1109,6 +1132,35 @@ mod tests {
             source: roux_core::ProfileSource::User,
         });
         assert!(validate_profile_id("my-profile", &settings).is_ok());
+    }
+
+    #[test]
+    fn validate_profile_id_error_lists_user_profiles_when_present() {
+        let mut settings = crate::settings::RouxSettings::default();
+        settings.spawn_profiles.push(roux_core::SpawnProfile {
+            id: "my-profile".into(),
+            name: "Mine".into(),
+            setup_command: None,
+            startup_command: None,
+            startup_behavior: None,
+            env: None,
+            cwd_override: None,
+            icon: None,
+            provider: None,
+            nono_profile: None,
+            nono_allow_dirs: None,
+            source: roux_core::ProfileSource::User,
+        });
+        let err = validate_profile_id("typo", &settings).unwrap_err();
+        assert!(err.contains("User profiles"), "err should mention user profiles: {}", err);
+        assert!(err.contains("my-profile"), "err should list user profile id: {}", err);
+    }
+
+    #[test]
+    fn validate_profile_id_error_omits_user_section_when_no_user_profiles() {
+        let settings = crate::settings::RouxSettings::default();
+        let err = validate_profile_id("typo", &settings).unwrap_err();
+        assert!(!err.contains("User profiles"), "err should not mention user profiles when empty: {}", err);
     }
 
     // ── Canonicalized path matching ──────────────────────────

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,9 +1,18 @@
+use std::collections::HashMap;
 use std::sync::Mutex;
+
+use tokio::sync::oneshot;
 
 use crate::notifications::NotificationManager;
 use crate::project_service::ProjectHandle;
 use crate::pty::PtyManager;
 use crate::session_service::SessionHandle;
+
+/// Correlation map for socket-driven request/response round-trips with the
+/// frontend. Used by `session-panes-list` / `session-panes-create` where the
+/// reply data lives in Svelte stores.
+pub(crate) type PendingReplies =
+    Mutex<HashMap<String, oneshot::Sender<serde_json::Value>>>;
 
 pub(crate) struct AppState {
     pub(crate) settings: Mutex<crate::settings::RouxSettings>,
@@ -12,4 +21,5 @@ pub(crate) struct AppState {
     pub(crate) project_handle: ProjectHandle,
     pub(crate) watch_manager: crate::watches::WatchManager,
     pub(crate) notification_manager: NotificationManager,
+    pub(crate) pending_replies: PendingReplies,
 }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -48,7 +48,10 @@
   } from "$lib/stores/customProfileModal";
   import { routeStatusUpdate, applyStatusRouting } from "$lib/panes/statusRouting";
   import { initAgentNotifications } from "$lib/panes/agentNotifications";
-  import { listSessions, checkSetupStatus, onRouxStatusUpdate, onRouxCommand, spawnShell, onWatchUpdate, listWatches, onNotificationEvent, quitApp } from "$lib/tauri";
+  import { listSessions, checkSetupStatus, onRouxStatusUpdate, onRouxCommand, spawnShell, onWatchUpdate, listWatches, onNotificationEvent, quitApp, submitRouxReply } from "$lib/tauri";
+  import { collectPaneTree } from "$lib/panes/query";
+  import { profileRegistry } from "$lib/panes/profiles";
+  import { runProfileInPane } from "$lib/panes/profileRunner";
   import type { RouxCommand } from "$lib/tauri";
   import { listen } from "@tauri-apps/api/event";
   import { registerCommands, registry } from "$lib/commands";
@@ -482,14 +485,32 @@
         }
         case "session-created": {
           // Reload sessions to pick up the newly created one
+          const profileId = cmd.profileId;
           listSessions().then(async (sessions) => {
             const newSession = sessions.find((s) => s.id === cmd.sessionId);
-            if (newSession) {
-              addSession(newSession);
-              const mainPaneId = initSession(newSession.id);
-              const { initTerminal, attachPtyListeners } = await import("$lib/panes/terminals");
-              initTerminal(mainPaneId);
-              await attachPtyListeners(mainPaneId);
+            if (!newSession) return;
+            addSession(newSession);
+            const mainPaneId = profileId
+              ? initSessionWithProfile(newSession.id, { kind: "registered", id: profileId })
+              : initSession(newSession.id);
+            const { initTerminal, attachPtyListeners } = await import("$lib/panes/terminals");
+            initTerminal(mainPaneId);
+            await attachPtyListeners(mainPaneId);
+            // Run profile startup commands for non-claude / non-plain-shell
+            // profiles. The backend spawned a bare shell via create_session_shell;
+            // the frontend is responsible for typing setup/startup into it.
+            if (profileId && profileId !== "claude" && profileId !== "plain-shell") {
+              const profile = get(profileRegistry).get(profileId);
+              if (profile) {
+                runProfileInPane(newSession.id, profile).catch((e) =>
+                  logError(`runProfileInPane failed for ${profileId}`, e),
+                );
+              } else {
+                logError(
+                  `session-created: profile '${profileId}' not in registry; startup commands skipped`,
+                  null,
+                );
+              }
             }
           });
           break;
@@ -541,6 +562,73 @@
           }
           if (cmd.paneId) {
             setLogicalFocus(cmd.paneId);
+          }
+          break;
+        }
+        case "panes-list-request": {
+          if (!cmd.sessionId || !cmd.requestId) break;
+          try {
+            const snapshot = collectPaneTree(cmd.sessionId);
+            await submitRouxReply(cmd.requestId, snapshot);
+          } catch (e) {
+            logError("panes-list-request failed", e);
+            await submitRouxReply(cmd.requestId, { error: String(e) }).catch(() => {});
+          }
+          break;
+        }
+        case "pane-create": {
+          if (!cmd.sessionId || !cmd.requestId) break;
+          const requestId = cmd.requestId;
+          const sessionId = cmd.sessionId;
+          try {
+            const session = $sessionState.sessions.find((s) => s.id === sessionId);
+            if (!session) throw new Error("session not found");
+            const workingDir = cmd.workingDir ?? session.worktreePath;
+            const direction = cmd.direction === "vertical" ? "v" : "h";
+            const profileId = cmd.profileId ?? "plain-shell";
+
+            const ptyId = crypto.randomUUID();
+            const paneId = crypto.randomUUID();
+            await spawnShell(ptyId, workingDir, sessionId, paneId);
+
+            // Bare shell marker — no profile startup commands. Any other id
+            // is backend-validated, so the registry lookup should succeed;
+            // throw if it doesn't so the CLI caller sees the failure.
+            let profile = null;
+            if (profileId !== "plain-shell") {
+              profile = get(profileRegistry).get(profileId) ?? null;
+              if (!profile) {
+                throw new Error(`profile '${profileId}' not found in registry`);
+              }
+            }
+
+            const newPaneId = splitPane(sessionId, direction, {
+              id: paneId,
+              type: "shell",
+              ptyId,
+              workingDir,
+              spawnProfileRef: profile
+                ? { kind: "registered", id: profile.id }
+                : undefined,
+            });
+            if (!newPaneId) throw new Error("splitPane returned null");
+
+            const { initTerminal, attachPtyListeners } = await import("$lib/panes/terminals");
+            initTerminal(newPaneId);
+            await attachPtyListeners(newPaneId);
+
+            if (profile) {
+              // Fire-and-forget: startup commands are typed into the live PTY;
+              // the CLI caller doesn't wait for them to finish running.
+              runProfileInPane(ptyId, profile).catch((e) =>
+                logError(`runProfileInPane failed for ${profile.id}`, e),
+              );
+            }
+
+            await submitRouxReply(requestId, { pane_id: paneId, pty_id: ptyId });
+          } catch (e) {
+            logError("pane-create failed", e);
+            await submitRouxReply(requestId, { error: String(e) }).catch(() => {});
           }
           break;
         }

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -13,7 +13,7 @@ export const commands = {
 	cmdListWorktrees: (repoPath: string) => typedError<Worktree[], string>(__TAURI_INVOKE("cmd_list_worktrees", { repoPath })),
 	writeToSession: (id: string, data: string) => typedError<null, string>(__TAURI_INVOKE("write_to_session", { id, data })),
 	resizeSession: (id: string, cols: number, rows: number) => typedError<null, string>(__TAURI_INVOKE("resize_session", { id, cols, rows })),
-	spawnShell: (id: string, workingDir: string, sessionId: string | null, paneId: string | null) => typedError<null, string>(__TAURI_INVOKE("spawn_shell", { id, workingDir, sessionId, paneId })),
+	spawnShell: (id: string, workingDir: string, sessionId: string | null, paneId: string | null, nonoProfile: string | null, nonoAllowDirs: string[] | null) => typedError<null, string>(__TAURI_INVOKE("spawn_shell", { id, workingDir, sessionId, paneId, nonoProfile, nonoAllowDirs })),
 	spawnTask: (id: string, command: string, workingDir: string, sessionId: string | null, paneId: string | null) => typedError<null, string>(__TAURI_INVOKE("spawn_task", { id, command, workingDir, sessionId, paneId })),
 	killSession: (id: string) => typedError<null, string>(__TAURI_INVOKE("kill_session", { id })),
 	/**
@@ -46,7 +46,7 @@ export const commands = {
 	 *  shell is ready. Used for every non-claude profile in the new-session
 	 *  picker (Codex, Plain shell, user profiles, inline Custom…).
 	 */
-	createSessionShell: (repoPath: string, name: string, worktreePath: string | null, branch: string | null) => typedError<Session, string>(__TAURI_INVOKE("create_session_shell", { repoPath, name, worktreePath, branch })),
+	createSessionShell: (repoPath: string, name: string, worktreePath: string | null, branch: string | null, nonoProfile: string | null, nonoAllowDirs: string[] | null) => typedError<Session, string>(__TAURI_INVOKE("create_session_shell", { repoPath, name, worktreePath, branch, nonoProfile, nonoAllowDirs })),
 	reconnectSession: (id: string, extraFlags: string[] | null) => typedError<Session, string>(__TAURI_INVOKE("reconnect_session", { id, extraFlags })),
 	/**
 	 *  Parallel to `reconnect_session`, but respawns a plain shell in the
@@ -55,7 +55,7 @@ export const commands = {
 	 *  this call returns, so agents come back up the same way they were
 	 *  originally launched via `create_session_shell`.
 	 */
-	reconnectSessionShell: (id: string) => typedError<Session, string>(__TAURI_INVOKE("reconnect_session_shell", { id })),
+	reconnectSessionShell: (id: string, nonoProfile: string | null, nonoAllowDirs: string[] | null) => typedError<Session, string>(__TAURI_INVOKE("reconnect_session_shell", { id, nonoProfile, nonoAllowDirs })),
 	listSessions: () => typedError<Session[], string>(__TAURI_INVOKE("list_sessions")),
 	listClaudeSessions: (cwd: string) => typedError<ClaudeSession[], string>(__TAURI_INVOKE("list_claude_sessions", { cwd })),
 	/**
@@ -389,6 +389,8 @@ export type SpawnProfile = {
 	cwdOverride?: string | null,
 	icon?: string | null,
 	provider?: Provider | null,
+	nonoProfile?: string | null,
+	nonoAllowDirs?: string[] | null,
 	source: ProfileSource,
 };
 

--- a/src/lib/panes/__tests__/query.test.ts
+++ b/src/lib/panes/__tests__/query.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { collectPaneTree } from "../query";
+import {
+  sessionLayouts,
+  initSessionLayout,
+  insertLeaf,
+  resetLayouts,
+  getLayout,
+  type LayoutNode,
+} from "../layout";
+import { createPane, resetInstances } from "../instances";
+import { resetFocus } from "../focus";
+
+describe("collectPaneTree", () => {
+  beforeEach(() => {
+    resetLayouts();
+    resetInstances();
+    resetFocus();
+  });
+
+  it("returns empty descriptors and null layout when session has no layout", () => {
+    const snap = collectPaneTree("nope");
+    expect(snap.sessionId).toBe("nope");
+    expect(snap.layout).toBeNull();
+    expect(snap.descriptors).toEqual([]);
+  });
+
+  it("serializes a single-leaf layout with the main pane", () => {
+    const sid = "s1";
+    const paneId = `${sid}-main`;
+    createPane({ id: paneId, type: "shell", ptyId: sid });
+    initSessionLayout(sid, paneId);
+
+    const snap = collectPaneTree(sid);
+    expect(snap.sessionId).toBe(sid);
+    expect(snap.layout?.kind).toBe("leaf");
+    expect(snap.descriptors).toHaveLength(1);
+    expect(snap.descriptors[0]).toMatchObject({
+      id: paneId,
+      type: "shell",
+      ptyId: sid,
+    });
+  });
+
+  it("walks a nested split tree in depth-first order", () => {
+    const sid = "s2";
+    createPane({ id: "a", type: "shell", ptyId: "pty-a" });
+    createPane({ id: "b", type: "shell", ptyId: "pty-b" });
+    createPane({ id: "c", type: "command", ptyId: "pty-c", command: "npm test" });
+    initSessionLayout(sid, "a");
+
+    // Split a → horizontal [a, b]
+    sessionLayouts.update((m) => {
+      const tree = getLayout(sid);
+      m.set(sid, insertLeaf(tree, "a", "h", "b"));
+      return new Map(m);
+    });
+    // Split b → vertical [b, c]
+    sessionLayouts.update((m) => {
+      const tree = getLayout(sid);
+      m.set(sid, insertLeaf(tree, "b", "v", "c"));
+      return new Map(m);
+    });
+
+    const snap = collectPaneTree(sid);
+    expect(snap.layout?.kind).toBe("split");
+    expect(snap.descriptors.map((d) => d.id)).toEqual(["a", "b", "c"]);
+    const cmd = snap.descriptors.find((d) => d.id === "c")!;
+    expect(cmd.type).toBe("command");
+    expect(cmd.command).toBe("npm test");
+  });
+
+  it("marks leaves with missing pane instances as unknown", () => {
+    const sid = "s3";
+    // Layout references a pane id that never got a PaneInstance
+    sessionLayouts.update((m) => {
+      m.set(sid, { kind: "leaf", paneId: "orphan" } as LayoutNode);
+      return new Map(m);
+    });
+    const snap = collectPaneTree(sid);
+    expect(snap.descriptors).toHaveLength(1);
+    expect(snap.descriptors[0]).toMatchObject({
+      id: "orphan",
+      type: "unknown",
+      ptyId: "",
+    });
+  });
+
+  it("captures registered spawnProfileRef as profileId", () => {
+    const sid = "s4";
+    createPane({
+      id: "p",
+      type: "shell",
+      ptyId: "pty",
+      spawnProfileRef: { kind: "registered", id: "claude" },
+    });
+    initSessionLayout(sid, "p");
+    const snap = collectPaneTree(sid);
+    expect(snap.descriptors[0].profileId).toBe("claude");
+  });
+
+  it("captures inline spawnProfileRef profile.id as profileId", () => {
+    const sid = "s5";
+    createPane({
+      id: "p",
+      type: "shell",
+      ptyId: "pty",
+      spawnProfileRef: {
+        kind: "inline",
+        profile: {
+          id: "custom-abc",
+          name: "Custom",
+          source: "builtin",
+        },
+      },
+    });
+    initSessionLayout(sid, "p");
+    const snap = collectPaneTree(sid);
+    expect(snap.descriptors[0].profileId).toBe("custom-abc");
+  });
+
+  it("omits profileId when no spawnProfileRef is attached", () => {
+    const sid = "s6";
+    createPane({ id: "p", type: "shell", ptyId: "pty" });
+    initSessionLayout(sid, "p");
+    const snap = collectPaneTree(sid);
+    expect(snap.descriptors[0].profileId).toBeUndefined();
+  });
+
+  it("carries workingDir and name through into descriptors", () => {
+    const sid = "s7";
+    createPane({
+      id: "p",
+      type: "shell",
+      ptyId: "pty",
+      name: "build",
+      workingDir: "/tmp/work",
+    });
+    initSessionLayout(sid, "p");
+    const snap = collectPaneTree(sid);
+    expect(snap.descriptors[0].name).toBe("build");
+    expect(snap.descriptors[0].workingDir).toBe("/tmp/work");
+  });
+});

--- a/src/lib/panes/query.ts
+++ b/src/lib/panes/query.ts
@@ -1,0 +1,64 @@
+import { get } from "svelte/store";
+import { sessionLayouts, type LayoutNode } from "./layout";
+import { paneInstances } from "./instances";
+
+export interface PaneDescriptorSnapshot {
+  id: string;
+  type: string;
+  ptyId: string;
+  name?: string;
+  workingDir?: string;
+  command?: string;
+  profileId?: string;
+}
+
+export interface PaneTreeSnapshot {
+  sessionId: string;
+  layout: LayoutNode | null;
+  descriptors: PaneDescriptorSnapshot[];
+}
+
+/**
+ * Walk the pane tree for a session and return a serializable snapshot
+ * combining the layout shape with the runtime metadata for each pane.
+ *
+ * Used by the CLI (`roux session panes list`) via a socket round-trip
+ * so external callers can see the live pane topology without reading
+ * stale on-disk state.
+ */
+export function collectPaneTree(sessionId: string): PaneTreeSnapshot {
+  const layout = get(sessionLayouts).get(sessionId) ?? null;
+  const instances = get(paneInstances);
+
+  const descriptors: PaneDescriptorSnapshot[] = [];
+  if (layout) {
+    const visit = (node: LayoutNode) => {
+      if (node.kind === "leaf") {
+        const inst = instances.get(node.paneId);
+        if (inst) {
+          descriptors.push({
+            id: inst.id,
+            type: inst.type,
+            ptyId: inst.ptyId,
+            name: inst.name,
+            workingDir: inst.workingDir,
+            command: inst.command,
+            profileId:
+              inst.spawnProfileRef?.kind === "registered"
+                ? inst.spawnProfileRef.id
+                : inst.spawnProfileRef?.kind === "inline"
+                  ? inst.spawnProfileRef.profile.id
+                  : undefined,
+          });
+        } else {
+          descriptors.push({ id: node.paneId, type: "unknown", ptyId: "" });
+        }
+      } else {
+        for (const child of node.children) visit(child);
+      }
+    };
+    visit(layout);
+  }
+
+  return { sessionId, layout, descriptors };
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -372,6 +372,20 @@ export interface RouxCommand {
   direction?: string;
   command?: string;
   workingDir?: string;
+  profileId?: string;
+  requestId?: string;
+}
+
+/**
+ * Reply to a socket-initiated request/response round-trip. The `requestId`
+ * comes from the matching `roux-command` event; `data` is the JSON payload
+ * the waiting CLI caller will receive.
+ */
+export async function submitRouxReply(
+  requestId: string,
+  data: unknown,
+): Promise<void> {
+  return invoke("submit_roux_reply", { requestId, data });
 }
 
 export function onRouxCommand(

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -44,12 +44,16 @@ export async function createSessionShell(
   name: string,
   worktreePath: string | null,
   branch: string | null,
+  nonoProfile?: string | null,
+  nonoAllowDirs?: string[] | null,
 ): Promise<Session> {
   return invoke("create_session_shell", {
     repoPath,
     name,
     worktreePath,
     branch,
+    nonoProfile: nonoProfile ?? null,
+    nonoAllowDirs: nonoAllowDirs ?? null,
   });
 }
 
@@ -79,8 +83,12 @@ export async function reconnectSessionPty(
  * spawn profiles — the caller replays the profile's setup / startup
  * commands into the fresh shell after this resolves.
  */
-export async function reconnectSessionShellPty(id: string): Promise<Session> {
-  return invoke("reconnect_session_shell", { id });
+export async function reconnectSessionShellPty(
+  id: string,
+  nonoProfile?: string | null,
+  nonoAllowDirs?: string[] | null,
+): Promise<Session> {
+  return invoke("reconnect_session_shell", { id, nonoProfile: nonoProfile ?? null, nonoAllowDirs: nonoAllowDirs ?? null });
 }
 
 export async function writeToSession(
@@ -120,8 +128,10 @@ export async function spawnShell(
   workingDir: string,
   sessionId: string | null,
   paneId: string | null,
+  nonoProfile?: string | null,
+  nonoAllowDirs?: string[] | null,
 ): Promise<void> {
-  return invoke("spawn_shell", { id, workingDir, sessionId, paneId });
+  return invoke("spawn_shell", { id, workingDir, sessionId, paneId, nonoProfile: nonoProfile ?? null, nonoAllowDirs: nonoAllowDirs ?? null });
 }
 
 export async function spawnTask(


### PR DESCRIPTION
## Summary

Expands `roux-cli` with the subcommands needed to drive Roux from bash scripts and to let agents running inside Roux sessions coordinate with each other.

- **`roux app [path]`** — open or focus a session for a directory and raise the window
- **`roux session list` / `poll` / `send` / `create`** — introspection + input for specific sessions (send adds `--no-enter` for raw bytes)
- **`roux session panes list` / `create`** — live pane topology via frontend round-trip; `create` spawns a new pane with a profile or plain shell
- **`roux session create`** — now accepts `--profile`, `--worktree-branch`, `--flag` (repeatable, hyphen values OK), `--nono-profile`, `--nono-allow-dir`; defaults `working_dir` to cwd when not inherited from `\$ROUX_SESSION_ID`

### Implementation notes

- Pane list/create round-trip through a new `pending_replies` map on `AppState` plus a `submit_roux_reply` Tauri command. `RouxCommand` carries `request_id` and `profile_id` for correlation.
- Profile ids are validated against builtins (`claude`, `codex`, `plain-shell`) plus user-defined profiles in settings. Typos like `shell` are rejected with a message listing known builtins.
- Frontend error replies (`{ error: \"...\" }`) now surface as non-zero CLI exits instead of successful payloads that happen to contain an error field.
- Path matching in `app-open` canonicalizes both sides so `.`, trailing slashes, and symlinks don't spawn duplicate sessions.

### Test coverage

- **+51 tests** (283 frontend + 191 backend, up from 275 + 140)
- Unit tests cover pure helpers: `format_send_data`, `collectPaneTree`, `find_session_for_path`, `validate_profile_id`, `default_session_name_for_path`, `canonicalize_or_passthrough`, `register_pending_reply_in` / `await_frontend_reply_in` (including timeout cleanup and error-reply propagation), `resolve_path`, and clap parsing for every new subcommand.
- Integration tests for the socket handlers themselves are not included; they'd need a \`tauri::test::mock_app\` fixture plus a fake frontend for the round-trips. The wiring is thin glue and the pure pieces are covered; smoke testing via \`task dev\` catches the rest.

### Reviewed by Codex

This diff was reviewed by \`codex exec\` (gpt-5.3-codex, high reasoning). High/medium findings that were fixed before this PR:

- Frontend error replies were being wrapped as \`Response::success\` → now propagate as \`Response::err\`
- \`session create\` had no cwd default despite help text saying \"Default: cwd\" → now defaults correctly
- Profile id \"shell\" didn't match the builtin id \"plain-shell\" → validated with helpful error
- \`submit_roux_reply\` silently dropped late-after-timeout replies → now returns an error
- \`session-panes-list\` succeeded for nonexistent session ids → now returns \"session not found\"
- \`app-open\` used exact-string path matching → now canonicalizes both sides

## Test plan

- [x] \`cargo test\` — 191 backend tests pass
- [x] \`npm run check\` — clean
- [x] \`npm run test\` — 283 frontend tests pass
- [ ] Manual smoke test with \`task dev\`: \`roux app .\`, \`roux session list\`, \`roux session poll -s <id>\`, \`roux session send \"echo hi\" -s <id>\`, \`roux session send \$'\\\\x03' -s <id> --no-enter\`, \`roux session panes list -s <id>\`, \`roux session panes create -s <id> --profile plain-shell\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)