### PR TITLE
feat(ui): status bar spans main column, add top/bottom position setting

### DIFF
--- a/crates/roux-core/src/models/mod.rs
+++ b/crates/roux-core/src/models/mod.rs
@@ -21,7 +21,7 @@ pub use notification::{
 pub use profile::{ProfileSource, Provider, SpawnProfile, StartupBehavior};
 pub use session::{Session, SessionStatus};
 pub use project::Project;
-pub use settings::{RouxSettings, CursorStyle, TabPosition, GroupBy};
+pub use settings::{RouxSettings, CursorStyle, TabPosition, GroupBy, StatusBarPosition};
 pub use worktree::Worktree;
 pub use watch::*;
 pub use task::{TaskDefinition, TaskGroup, KeepOpen};

--- a/crates/roux-core/src/models/settings.rs
+++ b/crates/roux-core/src/models/settings.rs
@@ -41,6 +41,19 @@ impl Default for TabPosition {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, specta::Type)]
 #[serde(rename_all = "camelCase")]
+pub enum StatusBarPosition {
+    Top,
+    Bottom,
+}
+
+impl Default for StatusBarPosition {
+    fn default() -> Self {
+        Self::Bottom
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
 pub enum GroupBy {
     Repo,
     Project,
@@ -107,6 +120,8 @@ pub struct RouxSettings {
     /// settings schema bump when they arrive.
     #[serde(default)]
     pub trusted_workspaces: Vec<String>,
+    #[serde(default)]
+    pub status_bar_position: StatusBarPosition,
 }
 
 impl Default for RouxSettings {
@@ -140,6 +155,7 @@ impl Default for RouxSettings {
             update_check_on_launch: true,
             spawn_profiles: Vec::new(),
             trusted_workspaces: Vec::new(),
+            status_bar_position: StatusBarPosition::Bottom,
         }
     }
 }

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -338,7 +338,10 @@ export type RouxSettings = {
 	 *  settings schema bump when they arrive.
 	 */
 	trustedWorkspaces?: string[],
+	statusBarPosition?: StatusBarPosition,
 };
+
+export type StatusBarPosition = "top" | "bottom";
 
 export type RuntimeState = { type: "pending" } | { type: "active" } | { type: "paused" } | { type: "stopped" } | { type: "error"; message: string };
 

--- a/src/lib/components/Layout.svelte
+++ b/src/lib/components/Layout.svelte
@@ -18,6 +18,7 @@
 
   let dragging = $state(false);
   let sidebarWidth = $derived($settings.tabWidth);
+  let statusBarPosition = $derived($settings.statusBarPosition ?? "bottom");
 
   function onDragStart(e: MouseEvent) {
     dragging = true;
@@ -60,6 +61,9 @@
     {/if}
 
     <div class="relative flex min-w-0 flex-1 flex-col bg-bg-deep">
+      {#if statusBarPosition === "top"}
+        <StatusBar position="top" />
+      {/if}
       {#if $sessionState.sessions.length === 0}
         <div class="flex flex-1 flex-col items-center justify-center gap-4 text-center text-text-secondary">
           <div class="flex h-16 w-16 items-center justify-center rounded-2xl border border-border-subtle bg-bg-surface/80 text-accent shadow-[0_18px_40px_rgba(2,6,23,0.45)]">
@@ -98,8 +102,10 @@
       {#if settingsPanel}
         {@render settingsPanel()}
       {/if}
+
+      {#if statusBarPosition === "bottom"}
+        <StatusBar position="bottom" />
+      {/if}
     </div>
   </div>
-
-  <StatusBar />
 </div>

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -120,6 +120,17 @@
           <option value="right">Right</option>
         </select>
       </div>
+      <div class="flex items-center justify-between py-2">
+        <span class="text-[13px]">Status bar position</span>
+        <select
+          class="bg-bg-deep border border-border rounded px-2 py-1 font-mono text-xs text-text-primary outline-none cursor-pointer appearance-none pr-6"
+          value={$settings.statusBarPosition ?? "bottom"}
+          onchange={(e) => updateSetting("statusBarPosition", e.currentTarget.value as "top" | "bottom")}
+        >
+          <option value="top">Top</option>
+          <option value="bottom">Bottom</option>
+        </select>
+      </div>
     </section>
 
     <!-- Worktrees -->

--- a/src/lib/components/StatusBar.svelte
+++ b/src/lib/components/StatusBar.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
   import { activeSession } from "$lib/stores/sessions";
+  import type { StatusBarPosition } from "$lib/types";
+
+  interface Props {
+    position?: StatusBarPosition;
+  }
+  let { position = "bottom" }: Props = $props();
 
   const statusDotClass: Record<string, string> = {
     idle: "bg-green",
@@ -11,7 +17,12 @@
   };
 </script>
 
-<div class="flex h-6 items-center gap-3 border-t border-border-subtle bg-bg-base px-3 text-[11px] text-text-muted">
+<div
+  class="flex h-6 items-center gap-3 bg-bg-base px-3 text-[11px] text-text-muted"
+  class:border-t={position === "bottom"}
+  class:border-b={position === "top"}
+  class:border-border-subtle={true}
+>
   {#if $activeSession}
     <div class="flex items-center gap-1.5">
       <div class="w-1.5 h-1.5 rounded-full {statusDotClass[$activeSession.status] ?? 'bg-gray'}"></div>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -9,6 +9,7 @@ export type {
   Project,
   CursorStyle,
   TabPosition,
+  StatusBarPosition,
   GroupBy,
   Worktree,
   ClaudeSession,
@@ -89,6 +90,7 @@ export const DEFAULT_SETTINGS: RouxSettings = {
   updateCheckOnLaunch: true,
   spawnProfiles: [],
   trustedWorkspaces: [],
+  statusBarPosition: "bottom",
 };
 
 // Re-export frontend-only task types


### PR DESCRIPTION
## Summary
- Status bar now lives inside the main content column instead of spanning the full window, so it no longer extends under the sidebar.
- New `statusBarPosition` setting (top | bottom, default bottom) with a SettingsPanel toggle; border flips so it sits flush against the pane area either way.
- Scripting the contents is left for a follow-up.

## Test plan
- [x] `npm test` (287 pass)
- [x] `npm run check` (0 errors)
- [x] `cargo test -p roux-core` (43 pass)
- [x] `cargo check` (src-tauri)
- [ ] Manual: toggle position in Settings, confirm sidebar/tab-position-right cases look right

🤖 Generated with [Claude Code](https://claude.com/claude-code)