### PR TITLE
feat(repo-roots): repo-root quick-pick settings + dev taskfile helpers

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,7 +4,9 @@ tasks:
   dev:
     desc: "Run Tauri in development mode (also rebuilds roux-cli)"
     cmds:
+      - task: frontend:ensure
       - task: cli:install
+      - task: cli:stage-dev-binary
       - npm run tauri dev
 
   dev:up:
@@ -40,6 +42,40 @@ tasks:
           chmod +x ~/.local/bin/roux-cli
           echo "Installed roux-cli to ~/.local/bin/roux-cli"
         platforms: [darwin, linux]
+
+  frontend:ensure:
+    desc: "Install frontend dependencies when node_modules is missing"
+    cmds:
+      - cmd: |
+          if [ ! -d node_modules ]; then
+            npm install
+          fi
+        platforms: [darwin, linux]
+      - cmd: |
+          cmd /c "if not exist node_modules npm install"
+        platforms: [windows]
+
+  cli:stage-dev-binary:
+    desc: "Stage debug roux-cli for Tauri externalBin in dev"
+    cmds:
+      - cmd: |
+          set -euo pipefail
+          TARGET="${TAURI_TARGET:-$(rustc -vV | sed -n 's/^host: //p')}"
+          mkdir -p src-tauri/binaries
+          cp target/debug/roux-cli src-tauri/binaries/roux-cli
+          cp target/debug/roux-cli "src-tauri/binaries/roux-cli-${TARGET}"
+          chmod +x src-tauri/binaries/roux-cli "src-tauri/binaries/roux-cli-${TARGET}"
+          echo "Prepared dev roux-cli binaries for ${TARGET}"
+        platforms: [darwin, linux]
+      - cmd: |
+          for /f "tokens=2 delims=: " %%a in ('rustc -vV ^| findstr /b "host:"') do set HOST=%%a
+          if not defined HOST set HOST=%TAURI_TARGET%
+          if not defined HOST set HOST=x86_64-pc-windows-msvc
+          if not exist src-tauri\binaries mkdir src-tauri\binaries
+          copy /Y target\debug\roux-cli.exe src-tauri\binaries\roux-cli.exe >nul
+          copy /Y target\debug\roux-cli.exe src-tauri\binaries\roux-cli-%HOST%.exe >nul
+          echo Prepared dev roux-cli binaries for %HOST%
+        platforms: [windows]
 
   dev:install:
     desc: "Build and install the desktop app and CLI locally (unsigned, no updater artifacts)"

--- a/src-tauri/src/commands/sessions.rs
+++ b/src-tauri/src/commands/sessions.rs
@@ -1,10 +1,14 @@
-use crate::session::Session;
 use crate::services::sessions as svc;
+use crate::session::Session;
 use crate::state::AppState;
 
 #[tauri::command]
 #[specta::specta]
-pub(crate) fn write_to_session(id: String, data: String, state: tauri::State<AppState>) -> Result<(), String> {
+pub(crate) fn write_to_session(
+    id: String,
+    data: String,
+    state: tauri::State<AppState>,
+) -> Result<(), String> {
     state.pty_manager.write(&id, data.as_bytes()).map_err(|e| e.to_string())
 }
 
@@ -34,13 +38,22 @@ pub(crate) fn submit_roux_reply(
 
 #[tauri::command]
 #[specta::specta]
-pub(crate) fn resize_session(id: String, cols: u16, rows: u16, state: tauri::State<AppState>) -> Result<(), String> {
+pub(crate) fn resize_session(
+    id: String,
+    cols: u16,
+    rows: u16,
+    state: tauri::State<AppState>,
+) -> Result<(), String> {
     state.pty_manager.resize(&id, cols, rows).map_err(|e| e.to_string())
 }
 
 // No #[specta::specta] — Channel<Response> doesn't implement specta::Type
 #[tauri::command]
-pub(crate) fn attach_pty_output(id: String, on_event: tauri::ipc::Channel<tauri::ipc::Response>, state: tauri::State<AppState>) -> Result<(), String> {
+pub(crate) fn attach_pty_output(
+    id: String,
+    on_event: tauri::ipc::Channel<tauri::ipc::Response>,
+    state: tauri::State<AppState>,
+) -> Result<(), String> {
     state.pty_manager.attach_output_channel(&id, on_event);
     Ok(())
 }
@@ -60,10 +73,8 @@ pub(crate) fn spawn_shell(
     app: tauri::AppHandle,
 ) -> Result<(), String> {
     use crate::pty::NonoConfig;
-    let nono = nono_profile.map(|profile| NonoConfig {
-        profile,
-        allow_dirs: nono_allow_dirs.unwrap_or_default(),
-    });
+    let nono = nono_profile
+        .map(|profile| NonoConfig { profile, allow_dirs: nono_allow_dirs.unwrap_or_default() });
     let initial_size = initial_cols.zip(initial_rows);
     state
         .pty_manager
@@ -125,7 +136,10 @@ pub(crate) fn get_pty_cwd(id: String, state: tauri::State<AppState>) -> Option<S
 
 #[tauri::command]
 #[specta::specta]
-pub(crate) async fn kill_session(id: String, state: tauri::State<'_, AppState>) -> Result<(), String> {
+pub(crate) async fn kill_session(
+    id: String,
+    state: tauri::State<'_, AppState>,
+) -> Result<(), String> {
     svc::kill_session(&state.pty_manager, &state.session_handle, &id)
         .await
         .map_err(|e| e.to_string())
@@ -171,10 +185,8 @@ pub(crate) async fn create_session_shell(
     use crate::pty::NonoConfig;
     // Clone before await — the MutexGuard is not Send.
     let settings = state.settings.lock().unwrap().clone();
-    let nono = nono_profile.map(|profile| NonoConfig {
-        profile,
-        allow_dirs: nono_allow_dirs.unwrap_or_default(),
-    });
+    let nono = nono_profile
+        .map(|profile| NonoConfig { profile, allow_dirs: nono_allow_dirs.unwrap_or_default() });
     let initial_size = initial_cols.zip(initial_rows);
 
     let target = if let Some(ref wt_path) = worktree_path {
@@ -216,10 +228,8 @@ pub(crate) async fn reconnect_session_shell(
     app: tauri::AppHandle,
 ) -> Result<Session, String> {
     use crate::pty::NonoConfig;
-    let nono = nono_profile.map(|profile| NonoConfig {
-        profile,
-        allow_dirs: nono_allow_dirs.unwrap_or_default(),
-    });
+    let nono = nono_profile
+        .map(|profile| NonoConfig { profile, allow_dirs: nono_allow_dirs.unwrap_or_default() });
     let initial_size = initial_cols.zip(initial_rows);
     svc::reconnect_session_shell(
         &state.pty_manager,
@@ -235,22 +245,34 @@ pub(crate) async fn reconnect_session_shell(
 
 #[tauri::command]
 #[specta::specta]
-pub(crate) async fn list_sessions(state: tauri::State<'_, AppState>) -> Result<Vec<Session>, String> {
+pub(crate) async fn list_sessions(
+    state: tauri::State<'_, AppState>,
+) -> Result<Vec<Session>, String> {
     state.session_handle.list().await.map_err(|e| e.to_string())
 }
 
 #[tauri::command]
 #[specta::specta]
-pub(crate) async fn refresh_session_git_status(id: String, state: tauri::State<'_, AppState>) -> Result<bool, String> {
-    svc::refresh_git_status(&state.session_handle, &id)
-        .await
-        .map_err(|e| e.to_string())
+pub(crate) async fn refresh_session_git_status(
+    id: String,
+    state: tauri::State<'_, AppState>,
+) -> Result<bool, String> {
+    svc::refresh_git_status(&state.session_handle, &id).await.map_err(|e| e.to_string())
 }
 
 #[tauri::command]
 #[specta::specta]
 pub(crate) fn check_is_git_repo(path: String) -> bool {
     svc::is_git_repo(&path)
+}
+
+#[tauri::command]
+#[specta::specta]
+pub(crate) fn list_git_repos_in_roots(
+    roots: Vec<String>,
+    exclude_worktrees: bool,
+) -> Vec<String> {
+    svc::list_git_repos_in_roots(&roots, exclude_worktrees)
 }
 
 #[tauri::command]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,18 +3,18 @@
 mod hooks;
 #[macro_use]
 mod logging;
-mod platform;
 mod commands;
 mod layouts;
 mod notifications;
 mod pane_state;
 mod paths;
-mod projects;
+mod platform;
 mod project_service;
+mod projects;
 mod providers;
-mod services;
 mod pty;
 mod pty_ready_gate;
+mod services;
 mod session;
 mod session_service;
 mod settings;
@@ -28,7 +28,7 @@ mod worktree;
 use std::sync::Mutex;
 use tauri::{Emitter, Manager};
 #[cfg(debug_assertions)]
-use tauri_specta::{Builder, collect_commands};
+use tauri_specta::{collect_commands, Builder};
 
 use crate::pty::PtyManager;
 use crate::state::AppState;
@@ -59,78 +59,75 @@ fn main() {
     let (project_handle, _project_join) = project_service::spawn(persisted_projects);
 
     #[cfg(debug_assertions)]
-    let builder = Builder::<tauri::Wry>::new()
-        .commands(collect_commands![
-            commands::misc::get_log_path,
-            commands::misc::frontend_log,
-            commands::settings::get_settings,
-            commands::settings::update_settings,
-            commands::worktrees::cmd_create_worktree,
-            commands::worktrees::cmd_remove_worktree,
-            commands::worktrees::cmd_list_worktrees,
-            commands::sessions::write_to_session,
-            commands::sessions::resize_session,
-            commands::sessions::spawn_shell,
-            commands::sessions::spawn_task,
-            commands::sessions::kill_session,
-            commands::sessions::kill_pty,
-            commands::sessions::get_pty_generation,
-            commands::sessions::get_pty_cwd,
-            commands::sessions::create_session_shell,
-            commands::sessions::reconnect_session_shell,
-            commands::sessions::list_sessions,
-            commands::sessions::list_claude_sessions,
-            commands::sessions::get_builtin_profiles,
-            commands::layouts::get_builtin_layouts,
-            commands::layouts::get_user_layouts,
-            commands::docs::read_file,
-            commands::docs::write_file,
-            commands::docs::list_docs,
-            commands::misc::cmd_open_in_editor,
-            commands::worktrees::cmd_list_branches,
-            commands::setup::check_setup_needed,
-            commands::setup::check_setup_status,
-            commands::setup::run_setup,
-            commands::setup::check_nono_installed,
-            commands::setup::list_nono_profiles,
-            tasks::cmd_discover_tasks,
-            tasks::cmd_load_task_overrides,
-            tasks::cmd_save_task_overrides,
-            commands::projects::list_projects,
-            commands::projects::create_project,
-            commands::projects::remove_project,
-            commands::projects::rename_project,
-            commands::projects::set_session_project,
-            commands::projects::get_project_notes,
-            commands::projects::set_project_notes,
-            watches::cmd_create_watch,
-            watches::cmd_remove_watch,
-            watches::cmd_list_watches,
-            watches::cmd_pause_watch,
-            watches::cmd_resume_watch,
-            notifications::notifications_list,
-            notifications::notifications_list_for_session,
-            notifications::notifications_unread_count,
-            notifications::notifications_mark_read,
-            notifications::notifications_mark_all_read,
-            notifications::notifications_remove,
-            notifications::notifications_clear,
-            notifications::notifications_push,
-            notifications::notifications_dismiss_source,
-            commands::sessions::check_is_git_repo,
-            commands::worktrees::git_init,
-            commands::sessions::refresh_session_git_status,
-            commands::misc::quit_app,
-            // pane_state commands are omitted from specta — serde_json::Value
-            // produces invalid TypeScript. They're called via raw invoke() instead.
-        ]);
+    let builder = Builder::<tauri::Wry>::new().commands(collect_commands![
+        commands::misc::get_log_path,
+        commands::misc::frontend_log,
+        commands::settings::get_settings,
+        commands::settings::update_settings,
+        commands::worktrees::cmd_create_worktree,
+        commands::worktrees::cmd_remove_worktree,
+        commands::worktrees::cmd_list_worktrees,
+        commands::sessions::write_to_session,
+        commands::sessions::resize_session,
+        commands::sessions::spawn_shell,
+        commands::sessions::spawn_task,
+        commands::sessions::kill_session,
+        commands::sessions::kill_pty,
+        commands::sessions::get_pty_generation,
+        commands::sessions::get_pty_cwd,
+        commands::sessions::create_session_shell,
+        commands::sessions::reconnect_session_shell,
+        commands::sessions::list_sessions,
+        commands::sessions::list_claude_sessions,
+        commands::sessions::get_builtin_profiles,
+        commands::layouts::get_builtin_layouts,
+        commands::layouts::get_user_layouts,
+        commands::docs::read_file,
+        commands::docs::write_file,
+        commands::docs::list_docs,
+        commands::misc::cmd_open_in_editor,
+        commands::worktrees::cmd_list_branches,
+        commands::setup::check_setup_needed,
+        commands::setup::check_setup_status,
+        commands::setup::run_setup,
+        commands::setup::check_nono_installed,
+        commands::setup::list_nono_profiles,
+        tasks::cmd_discover_tasks,
+        tasks::cmd_load_task_overrides,
+        tasks::cmd_save_task_overrides,
+        commands::projects::list_projects,
+        commands::projects::create_project,
+        commands::projects::remove_project,
+        commands::projects::rename_project,
+        commands::projects::set_session_project,
+        commands::projects::get_project_notes,
+        commands::projects::set_project_notes,
+        watches::cmd_create_watch,
+        watches::cmd_remove_watch,
+        watches::cmd_list_watches,
+        watches::cmd_pause_watch,
+        watches::cmd_resume_watch,
+        notifications::notifications_list,
+        notifications::notifications_list_for_session,
+        notifications::notifications_unread_count,
+        notifications::notifications_mark_read,
+        notifications::notifications_mark_all_read,
+        notifications::notifications_remove,
+        notifications::notifications_clear,
+        notifications::notifications_push,
+        notifications::notifications_dismiss_source,
+        commands::sessions::check_is_git_repo,
+        commands::sessions::list_git_repos_in_roots,
+        commands::worktrees::git_init,
+        commands::sessions::refresh_session_git_status,
+        commands::misc::quit_app,
+        // pane_state commands are omitted from specta — serde_json::Value
+        // produces invalid TypeScript. They're called via raw invoke() instead.
+    ]);
 
     #[cfg(debug_assertions)]
     builder
-        .export(
-            specta_typescript::Typescript::default(),
-            "../src/lib/bindings.ts",
-        )
+        .export(specta_typescript::Typescript::default(), "../src/lib/bindings.ts")
         .expect("Failed to export TypeScript bindings");
 
     tauri::Builder::default()
@@ -206,6 +203,7 @@ fn main() {
             notifications::notifications_push,
             notifications::notifications_dismiss_source,
             commands::sessions::check_is_git_repo,
+            commands::sessions::list_git_repos_in_roots,
             commands::worktrees::git_init,
             commands::sessions::refresh_session_git_status,
             commands::misc::quit_app,
@@ -240,9 +238,13 @@ fn main() {
                 let app_handle = app.handle().clone();
                 let watch_mgr = state.watch_manager.clone();
                 tauri::async_runtime::spawn(async move {
-                    let session_ids = session_handle.list().await
+                    let session_ids = session_handle
+                        .list()
+                        .await
                         .map(|s| s.iter().map(|s| s.id.clone()).collect::<Vec<_>>());
-                    let project_ids = project_handle.list().await
+                    let project_ids = project_handle
+                        .list()
+                        .await
                         .map(|p| p.iter().map(|p| p.id.clone()).collect::<Vec<_>>());
 
                     match (session_ids, project_ids) {
@@ -250,7 +252,9 @@ fn main() {
                             let _ = watch_mgr.store().cleanup_orphans(sids, pids).await;
                         }
                         _ => {
-                            eprintln!("Warning: service unavailable, skipping watch orphan cleanup");
+                            eprintln!(
+                                "Warning: service unavailable, skipping watch orphan cleanup"
+                            );
                         }
                     }
                     watch_mgr.start_all(app_handle);

--- a/src-tauri/src/services/sessions.rs
+++ b/src-tauri/src/services/sessions.rs
@@ -1,4 +1,6 @@
 use anyhow::anyhow;
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
 
 use crate::pty::PtyManager;
 use crate::session::Session;
@@ -106,10 +108,7 @@ pub(crate) async fn create_session_shell(
     }
     rlog!("Shell session '{}' spawned", session_id);
 
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
+    let now = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
 
     let session = Session {
         id: session_id,
@@ -149,10 +148,8 @@ pub(crate) async fn reconnect_session_shell(
     initial_size: Option<(u16, u16)>,
     app: &tauri::AppHandle,
 ) -> anyhow::Result<Session> {
-    let session = session_handle
-        .get(id)
-        .await?
-        .ok_or_else(|| anyhow!("Session {} not found", id))?;
+    let session =
+        session_handle.get(id).await?.ok_or_else(|| anyhow!("Session {} not found", id))?;
 
     pty_manager.kill(id);
 
@@ -179,9 +176,7 @@ pub(crate) async fn reconnect_session_shell(
         )
         .map_err(|e| anyhow!("{}", e))?;
 
-    session_handle
-        .update_status(id, roux_core::SessionStatus::Idle)
-        .await?;
+    session_handle.update_status(id, roux_core::SessionStatus::Idle).await?;
 
     rlog!("Shell session '{}' reconnected successfully", id);
 
@@ -299,4 +294,145 @@ pub(crate) fn list_claude_sessions(cwd: &str) -> anyhow::Result<Vec<ClaudeSessio
 
     sessions.sort_by(|a, b| b.modified_at.cmp(&a.modified_at));
     Ok(sessions)
+}
+
+pub(crate) fn list_git_repos_in_roots(roots: &[String], exclude_worktrees: bool) -> Vec<String> {
+    let mut repos = BTreeSet::new();
+    for root in roots {
+        let trimmed = root.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let root_path = PathBuf::from(trimmed);
+        if !root_path.is_dir() {
+            continue;
+        }
+        collect_git_repos(&root_path, 3, exclude_worktrees, &mut repos);
+    }
+    repos.into_iter().collect()
+}
+
+fn collect_git_repos(
+    start: &Path,
+    max_depth: usize,
+    exclude_worktrees: bool,
+    out: &mut BTreeSet<String>,
+) {
+    let mut stack = vec![(start.to_path_buf(), 0usize)];
+    while let Some((path, depth)) = stack.pop() {
+        if is_git_dir(&path) {
+            if exclude_worktrees && is_git_worktree(&path) {
+                continue;
+            }
+            out.insert(path.to_string_lossy().to_string());
+            continue;
+        }
+        if depth >= max_depth {
+            continue;
+        }
+        let entries = match std::fs::read_dir(&path) {
+            Ok(entries) => entries,
+            Err(_) => continue,
+        };
+        for entry in entries {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(_) => continue,
+            };
+            let child = entry.path();
+            if !child.is_dir() {
+                continue;
+            }
+            if should_skip_dir(&child) {
+                continue;
+            }
+            stack.push((child, depth + 1));
+        }
+    }
+}
+
+fn is_git_dir(path: &Path) -> bool {
+    let dot_git = path.join(".git");
+    dot_git.is_dir() || dot_git.is_file()
+}
+
+fn is_git_worktree(path: &Path) -> bool {
+    let dot_git = path.join(".git");
+    if !dot_git.is_file() {
+        return false;
+    }
+    let content = match std::fs::read_to_string(dot_git) {
+        Ok(content) => content,
+        Err(_) => return false,
+    };
+    let Some(gitdir) = content.strip_prefix("gitdir:") else {
+        return false;
+    };
+    let normalized = gitdir.trim().replace('\\', "/");
+    normalized.contains("/worktrees/")
+}
+
+fn should_skip_dir(path: &Path) -> bool {
+    let name = match path.file_name().and_then(|n| n.to_str()) {
+        Some(name) => name,
+        None => return true,
+    };
+    matches!(name, ".git" | "node_modules" | "target" | "dist" | ".svelte-kit" | ".next")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::list_git_repos_in_roots;
+
+    #[test]
+    fn list_git_repos_in_roots_finds_nested_repos() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("src");
+        std::fs::create_dir_all(root.join("org1/repo-a/.git")).unwrap();
+        std::fs::create_dir_all(root.join("org2/repo-b/.git")).unwrap();
+
+        let repos = list_git_repos_in_roots(&[root.to_string_lossy().to_string()], false);
+
+        assert_eq!(repos.len(), 2);
+        assert!(repos.iter().any(|p| p.ends_with("org1/repo-a")));
+        assert!(repos.iter().any(|p| p.ends_with("org2/repo-b")));
+    }
+
+    #[test]
+    fn list_git_repos_in_roots_dedupes_and_ignores_invalid_roots() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("repos");
+        std::fs::create_dir_all(root.join("repo/.git")).unwrap();
+
+        let root_str = root.to_string_lossy().to_string();
+        let missing = tmp.path().join("missing").to_string_lossy().to_string();
+        let repos =
+            list_git_repos_in_roots(&["".to_string(), root_str.clone(), root_str, missing], false);
+
+        assert_eq!(repos.len(), 1);
+        assert!(repos[0].ends_with("repos/repo"));
+    }
+
+    #[test]
+    fn list_git_repos_in_roots_excludes_worktree_repos_when_enabled() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("src");
+
+        std::fs::create_dir_all(root.join("repo-main/.git")).unwrap();
+        std::fs::create_dir_all(root.join("repo-wt")).unwrap();
+        std::fs::write(
+            root.join("repo-wt/.git"),
+            "gitdir: /tmp/project/.git/worktrees/repo-wt\n",
+        )
+        .unwrap();
+
+        let roots = [root.to_string_lossy().to_string()];
+        let included = list_git_repos_in_roots(&roots, false);
+        let excluded = list_git_repos_in_roots(&roots, true);
+
+        assert!(included.iter().any(|p| p.ends_with("repo-main")));
+        assert!(included.iter().any(|p| p.ends_with("repo-wt")));
+        assert!(excluded.iter().any(|p| p.ends_with("repo-main")));
+        assert!(!excluded.iter().any(|p| p.ends_with("repo-wt")));
+    }
 }

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -121,6 +121,7 @@ export const commands = {
 	 */
 	notificationsDismissSource: (source: NotificationSource) => typedError<number, string>(__TAURI_INVOKE("notifications_dismiss_source", { source })),
 	checkIsGitRepo: (path: string) => __TAURI_INVOKE<boolean>("check_is_git_repo", { path }),
+	listGitReposInRoots: (roots: string[], excludeWorktrees: boolean) => __TAURI_INVOKE<string[]>("list_git_repos_in_roots", { roots, excludeWorktrees }),
 	gitInit: (path: string) => typedError<null, string>(__TAURI_INVOKE("git_init", { path })),
 	refreshSessionGitStatus: (id: string) => typedError<boolean, string>(__TAURI_INVOKE("refresh_session_git_status", { id })),
 	quitApp: () => typedError<null, string>(__TAURI_INVOKE("quit_app")),
@@ -304,6 +305,8 @@ export type RouxSettings = {
 	cursorStyle: CursorStyle,
 	cursorBlink: boolean,
 	defaultProjectPath: string | null,
+	repoRoots?: string[],
+	excludeWorktreesFromRepoRoots?: boolean,
 	confirmOnClose: boolean,
 	restoreSessionsOnLaunch: boolean,
 	worktreeBasePath: string | null,

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -30,6 +30,7 @@
   let selected = $state<CategoryId>("general");
 
   let appVersion = $state<string>("…");
+  let repoRootDraft = $state("");
   onMount(async () => {
     try { appVersion = await getVersion(); } catch { appVersion = "unknown"; }
   });
@@ -96,6 +97,34 @@
   async function browseDefaultProject() {
     const selected = await open({ directory: true, title: "Select Default Project Directory" });
     if (selected) updateSetting("defaultProjectPath", selected as string);
+  }
+
+  function sanitizePathInput(path: string): string {
+    return path.trim();
+  }
+
+  function addRepoRoot(path: string) {
+    const nextPath = sanitizePathInput(path);
+    if (!nextPath) return;
+    const existing = $settings.repoRoots ?? [];
+    if (existing.includes(nextPath)) {
+      repoRootDraft = "";
+      return;
+    }
+    updateSetting("repoRoots", [...existing, nextPath]);
+    repoRootDraft = "";
+  }
+
+  function removeRepoRoot(path: string) {
+    updateSetting(
+      "repoRoots",
+      ($settings.repoRoots ?? []).filter((root) => root !== path),
+    );
+  }
+
+  async function browseAndAddRepoRoot() {
+    const selected = await open({ directory: true, title: "Select Repo Root Directory" });
+    if (selected) addRepoRoot(selected as string);
   }
 </script>
 
@@ -241,6 +270,60 @@
                   onclick={browseDefaultProject}
                 >...</button>
               </div>
+            </div>
+            <div class="py-2">
+              <div class="text-[13px]">Repository roots</div>
+              <div class="text-[11px] text-text-muted mt-0.5">Quick-pick sources for New Session (keeps file picker available)</div>
+              <div class="mt-2 flex gap-1">
+                <input
+                  class="bg-bg-deep border border-border rounded px-2 py-1 font-mono text-xs text-text-primary outline-none flex-1 focus:border-accent-dim"
+                  value={repoRootDraft}
+                  oninput={(e) => (repoRootDraft = e.currentTarget.value)}
+                  onkeydown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                      addRepoRoot(repoRootDraft);
+                    }
+                  }}
+                  placeholder="~/src"
+                />
+                <button
+                  class="px-2 py-1 bg-bg-elevated border border-border rounded text-text-secondary text-[10px] cursor-pointer hover:bg-bg-hover"
+                  onclick={() => addRepoRoot(repoRootDraft)}
+                >Add</button>
+                <button
+                  class="px-2 py-1 bg-bg-elevated border border-border rounded text-text-secondary text-[10px] cursor-pointer hover:bg-bg-hover"
+                  onclick={browseAndAddRepoRoot}
+                >...</button>
+              </div>
+              {#if ($settings.repoRoots ?? []).length > 0}
+                <div class="mt-2 flex flex-col gap-1">
+                  {#each ($settings.repoRoots ?? []) as root (root)}
+                    <div class="flex items-center gap-2 rounded border border-border-subtle bg-bg-surface/35 px-2 py-1">
+                      <span class="font-mono text-[11px] text-text-secondary flex-1 truncate" title={root}>{root}</span>
+                      <button
+                        class="text-[10px] text-text-muted hover:text-red cursor-pointer"
+                        onclick={() => removeRepoRoot(root)}
+                      >Remove</button>
+                    </div>
+                  {/each}
+                </div>
+              {/if}
+            </div>
+            <div class="flex items-center justify-between py-2">
+              <div>
+                <div class="text-[13px]">Exclude worktrees from roots</div>
+                <div class="text-[11px] text-text-muted mt-0.5">Hide linked git worktrees from root-folder quick-pick results</div>
+              </div>
+              <button
+                aria-label="Toggle excluding worktrees from root discovery"
+                class="w-9 h-5 rounded-full relative cursor-pointer transition-all border
+                  {($settings.excludeWorktreesFromRepoRoots ?? true) ? 'bg-accent-dim border-accent' : 'bg-bg-deep border-border'}"
+                onclick={() => updateSetting("excludeWorktreesFromRepoRoots", !($settings.excludeWorktreesFromRepoRoots ?? true))}
+              >
+                <div class="w-3.5 h-3.5 rounded-full absolute top-0.5 transition-all
+                  {($settings.excludeWorktreesFromRepoRoots ?? true) ? 'left-[18px] bg-accent' : 'left-0.5 bg-text-secondary'}"></div>
+              </button>
             </div>
             <div class="flex items-center justify-between py-2">
               <div>

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -200,6 +200,13 @@ export async function checkIsGitRepo(path: string): Promise<boolean> {
   return invoke("check_is_git_repo", { path });
 }
 
+export async function listGitReposInRoots(
+  roots: string[],
+  excludeWorktrees: boolean,
+): Promise<string[]> {
+  return invoke("list_git_repos_in_roots", { roots, excludeWorktrees });
+}
+
 export async function gitInit(path: string): Promise<void> {
   return invoke("git_init", { path });
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -72,6 +72,8 @@ export const DEFAULT_SETTINGS: RouxSettings = {
   cursorStyle: "block",
   cursorBlink: true,
   defaultProjectPath: null,
+  repoRoots: [],
+  excludeWorktreesFromRepoRoots: true,
   confirmOnClose: true,
   restoreSessionsOnLaunch: true,
   worktreeBasePath: null,


### PR DESCRIPTION
## Summary
- New backend command `list_git_repos_in_roots` (bounded-depth scan with optional worktree exclusion) + unit tests
- Settings: `repoRoots[]` and `excludeWorktreesFromRepoRoots` with SettingsPanel UI (add/remove/browse)
- Taskfile dev helpers: `frontend:ensure` (auto `npm install`) and `cli:stage-dev-binary` (copies debug CLI to Tauri externalBin for dev)
- Rustfmt churn in `main.rs` / `sessions.rs` / `commands/sessions.rs`

## Test plan
- [x] `npm run check` clean
- [x] `cargo check` clean
- [x] `cargo test list_git_repos` — 3/3 pass
- [ ] Manual: add a repo root in Settings and verify New Session quick-pick uses it
- [ ] Manual: toggle exclude-worktrees and confirm filtering
- [ ] Manual: `task dev` from clean clone installs frontend deps and stages CLI binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)