### PR TITLE
fix(notifications): clear, dedup, cross-session focus, unread badge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3881,7 +3881,7 @@ dependencies = [
 
 [[package]]
 name = "roux"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -29,8 +29,26 @@ tasks:
           echo "No installed app found at $APP"
         fi
 
+  cli:ensure-placeholder:
+    desc: "Ensure a placeholder binary exists so Tauri build.rs doesn't fail on fresh checkouts"
+    cmds:
+      - cmd: |
+          TARGET="${TAURI_TARGET:-$(rustc -vV | sed -n 's/^host: //p')}"
+          mkdir -p src-tauri/binaries
+          if [ ! -f "src-tauri/binaries/roux-cli-${TARGET}" ]; then
+            touch "src-tauri/binaries/roux-cli-${TARGET}"
+            chmod +x "src-tauri/binaries/roux-cli-${TARGET}"
+            echo "Created placeholder for roux-cli-${TARGET}"
+          fi
+        platforms: [darwin, linux]
+      - cmd: |
+          if not exist src-tauri\binaries mkdir src-tauri\binaries
+          if not exist src-tauri\binaries\roux-cli.exe echo. > src-tauri\binaries\roux-cli.exe
+        platforms: [windows]
+
   cli:install:
     desc: "Build and prepare roux-cli for local development"
+    deps: [cli:ensure-placeholder]
     cmds:
       - cargo build --manifest-path src-tauri/Cargo.toml --bin roux-cli
       - cmd: |

--- a/crates/roux-core/src/models/notification.rs
+++ b/crates/roux-core/src/models/notification.rs
@@ -13,6 +13,11 @@ pub struct Notification {
     pub session_id: Option<String>,
     pub read: bool,
     pub actions: Vec<NotificationAction>,
+    /// When set, a subsequent push with the same `dedup_key` updates this
+    /// notification in place instead of creating a new one. Cleared when the
+    /// user reads or dismisses the notification (tracked via `read`).
+    #[serde(default)]
+    pub dedup_key: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
@@ -98,11 +103,17 @@ pub struct NotificationRequest {
     pub body: Option<String>,
     pub session_id: Option<String>,
     pub actions: Vec<NotificationAction>,
+    /// Optional dedup key. When set, `NotificationManager::push` will update
+    /// an existing unread notification carrying the same key instead of
+    /// creating a new one. Useful for flood-prone sources like permission
+    /// prompts that fire repeatedly for the same pane.
+    #[serde(default)]
+    pub dedup_key: Option<String>,
 }
 
 /// Event emitted to the frontend on store mutations.
 #[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
-#[serde(rename_all = "camelCase", tag = "type")]
+#[serde(rename_all = "camelCase", rename_all_fields = "camelCase", tag = "type")]
 pub enum NotificationEvent {
     Added { notification: Notification },
     Updated { notification: Notification },
@@ -110,4 +121,32 @@ pub enum NotificationEvent {
     ReadAll { session_id: Option<String> },
     Removed { id: String },
     Cleared { session_id: Option<String> },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cleared_event_serializes_session_id_as_camelcase() {
+        // Regression: a missing `rename_all_fields = "camelCase"` once caused
+        // this to emit `session_id`, and the frontend handler (which reads
+        // `event.sessionId`) silently no-op'd — the clear button did nothing.
+        let json =
+            serde_json::to_string(&NotificationEvent::Cleared { session_id: None }).unwrap();
+        assert!(json.contains("\"sessionId\""), "expected camelCase field in: {json}");
+        assert!(!json.contains("\"session_id\""), "snake_case leaked in: {json}");
+        assert!(json.contains("\"type\":\"cleared\""));
+    }
+
+    #[test]
+    fn read_all_event_serializes_session_id_as_camelcase() {
+        let json = serde_json::to_string(&NotificationEvent::ReadAll {
+            session_id: Some("sess-1".into()),
+        })
+        .unwrap();
+        assert!(json.contains("\"sessionId\":\"sess-1\""), "unexpected: {json}");
+        assert!(!json.contains("\"session_id\""));
+        assert!(json.contains("\"type\":\"readAll\""));
+    }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roux",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roux",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/src-tauri/src/notifications/manager.rs
+++ b/src-tauri/src/notifications/manager.rs
@@ -28,6 +28,27 @@ impl NotificationManager {
     /// Also fans out to an OS notification when the policy says so. Returns
     /// the stored notification (with id + created_at filled in).
     pub fn push(&self, req: NotificationRequest, app: Option<&AppHandle>) -> Notification {
+        // Dedup fast path: if the request carries a dedup_key and an unread
+        // entry with that key already exists, update it in place instead of
+        // creating a new notification. Keeps permission-prompt floods from
+        // stacking up dozens of identical cards.
+        if let Some(key) = req.dedup_key.clone() {
+            let updated = {
+                let mut store = self.inner.lock().expect("notification store poisoned");
+                store.update_by_dedup_key(&key, &req)
+            };
+            if let Some(notification) = updated {
+                if let Some(app) = app {
+                    let _ = app.emit(
+                        NOTIFICATION_EVENT,
+                        &NotificationEvent::Updated { notification: notification.clone() },
+                    );
+                    self.maybe_fan_out_to_os(app, &notification);
+                }
+                return notification;
+            }
+        }
+
         let notification = {
             let mut store = self.inner.lock().expect("notification store poisoned");
             store.push(req)
@@ -154,19 +175,19 @@ impl NotificationManager {
         source: &NotificationSource,
         app: Option<&AppHandle>,
     ) -> usize {
-        let removed = {
+        let removed_ids = {
             let mut store = self.inner.lock().expect("notification store poisoned");
             store.remove_by_source_variant(source)
         };
-        if removed > 0 {
-            if let Some(app) = app {
-                // Emit Cleared for now — frontend can re-query if it needs
-                // fine-grained per-id events. Phase 2 may expand this.
-                let _ =
-                    app.emit(NOTIFICATION_EVENT, &NotificationEvent::Cleared { session_id: None });
+        if let Some(app) = app {
+            for id in &removed_ids {
+                let _ = app.emit(
+                    NOTIFICATION_EVENT,
+                    &NotificationEvent::Removed { id: id.clone() },
+                );
             }
         }
-        removed
+        removed_ids.len()
     }
 
     pub fn clear(&self, session_filter: Option<Option<&str>>, app: Option<&AppHandle>) -> usize {
@@ -233,6 +254,7 @@ mod tests {
             body: None,
             session_id: session.map(String::from),
             actions: Vec::new(),
+            dedup_key: None,
         }
     }
 
@@ -260,5 +282,34 @@ mod tests {
         let n = mgr.push(req("hello", None), None);
         assert!(mgr.remove(&n.id, None));
         assert!(mgr.get(&n.id).is_none());
+    }
+
+    #[test]
+    fn manager_push_with_dedup_key_updates_in_place() {
+        let mgr = NotificationManager::new();
+        let mut first_req = req("first", None);
+        first_req.dedup_key = Some("key-1".into());
+        let first = mgr.push(first_req, None);
+
+        let mut second_req = req("second", None);
+        second_req.dedup_key = Some("key-1".into());
+        let second = mgr.push(second_req, None);
+
+        // Same id, refreshed title, store length unchanged.
+        assert_eq!(first.id, second.id);
+        assert_eq!(second.title, "second");
+        assert_eq!(mgr.list().len(), 1);
+    }
+
+    #[test]
+    fn manager_push_with_different_dedup_keys_appends() {
+        let mgr = NotificationManager::new();
+        let mut a = req("a", None);
+        a.dedup_key = Some("ka".into());
+        let mut b = req("b", None);
+        b.dedup_key = Some("kb".into());
+        mgr.push(a, None);
+        mgr.push(b, None);
+        assert_eq!(mgr.list().len(), 2);
     }
 }

--- a/src-tauri/src/notifications/mod.rs
+++ b/src-tauri/src/notifications/mod.rs
@@ -1,9 +1,10 @@
 //! Notification service — in-memory store, event emitter, and Tauri commands.
 //!
-//! Phase 1 scope: service skeleton, specta-bound types, Tauri commands, and
-//! wiring the existing watch desktop-notification path so each fired watch
-//! notification also lands in the store. The frontend pane, OSC parser,
-//! `roux notify` CLI, and focus-gated policy all arrive in later phases.
+//! Ingress paths: watches, status-watcher hook bridge, OSC sniffer, `roux
+//! notify` CLI, and frontend `notificationsPush`. All routes funnel through
+//! `NotificationManager::push`, which applies dedup (via `dedup_key`),
+//! emits an `Added`/`Updated` event to the frontend, and fans out to the
+//! OS notification center when focus policy allows.
 
 pub mod manager;
 pub mod osc_parser;

--- a/src-tauri/src/notifications/osc_parser.rs
+++ b/src-tauri/src/notifications/osc_parser.rs
@@ -26,9 +26,6 @@ struct Osc99Buffer {
     title: Option<String>,
     subtitle: Option<String>,
     body: Option<String>,
-    /// Existing notification id in the store if this buffer has been flushed
-    /// at least once — subsequent packets update in place.
-    notification_id: Option<String>,
 }
 
 pub struct OscSniffer {
@@ -188,30 +185,25 @@ impl OscState {
         }
         let subtitle = buf.subtitle.clone();
         let body = if buf.title.is_some() { buf.body.clone() } else { None };
-        let existing_id = buf.notification_id.clone();
 
-        // If we've already pushed an earlier version of this notification,
-        // remove it so the update appears fresh (Phase 2 pane doesn't yet
-        // support in-place replacement via Updated, but Removed + Added is
-        // semantically correct and already wired).
-        if let Some(ref old_id) = existing_id {
-            let state = self.app.state::<AppState>();
-            state.notification_manager.remove(old_id, Some(&self.app));
-        }
+        // Sender-addressable OSC 99 notifications dedup in place via the
+        // store's dedup_key mechanism — a repeat packet for the same `i=<id>`
+        // updates the existing entry and emits `Updated` rather than
+        // stacking up duplicates. Anonymous packets (no id) fall back to
+        // new-entry-every-time, which matches how plain OSC 9 / 777 behave.
+        let dedup_key = id.as_ref().map(|sender| format!("osc:99:{sender}"));
 
-        let pushed = self.push_returning(
+        self.push_returning(
             NotificationSource::Osc { code: 99, sender_id: id.clone() },
             title,
             subtitle,
             body,
-            id.clone(),
+            dedup_key,
         );
 
-        // Re-fetch the entry (we held a &mut borrow that dropped at self.push).
+        // Clear field accumulators so the next OSC 99 with the same id
+        // starts fresh (the sender always includes the fields it wants).
         if let Some(buf) = self.osc99_buffers.get_mut(&key) {
-            buf.notification_id = Some(pushed);
-            // Clear field accumulators so the next OSC 99 with the same id
-            // starts fresh (the sender always includes the fields it wants).
             buf.title = None;
             buf.subtitle = None;
             buf.body = None;
@@ -224,9 +216,9 @@ impl OscState {
         title: String,
         subtitle: Option<String>,
         body: Option<String>,
-        _sender_id: Option<String>,
+        dedup_key: Option<String>,
     ) {
-        let _ = self.push_returning(source, title, subtitle, body, _sender_id);
+        let _ = self.push_returning(source, title, subtitle, body, dedup_key);
     }
 
     fn push_returning(
@@ -235,7 +227,7 @@ impl OscState {
         title: String,
         subtitle: Option<String>,
         body: Option<String>,
-        _sender_id: Option<String>,
+        dedup_key: Option<String>,
     ) -> String {
         let state = self.app.state::<AppState>();
         let mut actions = Vec::new();
@@ -263,6 +255,7 @@ impl OscState {
                 body,
                 session_id: self.session_id.clone(),
                 actions,
+                dedup_key,
             },
             Some(&self.app),
         );

--- a/src-tauri/src/notifications/store.rs
+++ b/src-tauri/src/notifications/store.rs
@@ -42,6 +42,7 @@ impl NotificationStore {
             session_id: req.session_id,
             read: false,
             actions: req.actions,
+            dedup_key: req.dedup_key,
         };
 
         self.entries.push_back(notification.clone());
@@ -49,6 +50,36 @@ impl NotificationStore {
             self.entries.pop_front();
         }
         notification
+    }
+
+    /// Update an existing unread notification with the given dedup key in-place.
+    /// Returns the updated notification, or `None` if no matching unread entry exists.
+    /// The caller is responsible for emitting the `Updated` event.
+    pub fn update_by_dedup_key(
+        &mut self,
+        key: &str,
+        req: &NotificationRequest,
+    ) -> Option<Notification> {
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+
+        let entry = self
+            .entries
+            .iter_mut()
+            .rev()
+            .find(|n| !n.read && n.dedup_key.as_deref() == Some(key))?;
+
+        entry.level = req.level;
+        entry.source = req.source.clone();
+        entry.title = req.title.clone();
+        entry.subtitle = req.subtitle.clone();
+        entry.body = req.body.clone();
+        entry.session_id = req.session_id.clone();
+        entry.actions = req.actions.clone();
+        entry.created_at = now_ms;
+        Some(entry.clone())
     }
 
     /// Return a snapshot of all notifications, newest first.
@@ -119,11 +150,19 @@ impl NotificationStore {
     /// Remove all notifications with a source that matches the given source variant.
     /// Variant equality only — e.g. removing with `Source::Watch { watch_id: "abc" }`
     /// removes all `Source::Watch` entries, regardless of which watch_id they carry.
-    /// This matches the "dismiss all from source X" UX.
-    pub fn remove_by_source_variant(&mut self, source: &NotificationSource) -> usize {
-        let before = self.entries.len();
-        self.entries.retain(|n| !same_source_variant(&n.source, source));
-        before - self.entries.len()
+    /// This matches the "dismiss all from source X" UX. Returns the ids of the
+    /// removed notifications so the caller can emit per-id `Removed` events.
+    pub fn remove_by_source_variant(&mut self, source: &NotificationSource) -> Vec<String> {
+        let mut removed = Vec::new();
+        self.entries.retain(|n| {
+            if same_source_variant(&n.source, source) {
+                removed.push(n.id.clone());
+                false
+            } else {
+                true
+            }
+        });
+        removed
     }
 
     pub fn clear(&mut self, session_filter: Option<Option<&str>>) -> usize {
@@ -143,8 +182,9 @@ impl NotificationStore {
         self.entries.len()
     }
 
-    /// Get a notification by id. Used by tests today; reserved for Phase 2
-    /// frontend command routing (e.g. focusing by notification id).
+    /// Get a notification by id. Currently used only by tests — kept because
+    /// any future per-id command routing (e.g. focus-by-notification) would
+    /// want a direct lookup rather than scanning `list()`.
     #[allow(dead_code)]
     pub fn get(&self, id: &str) -> Option<Notification> {
         self.entries.iter().find(|n| n.id == id).cloned()
@@ -187,6 +227,7 @@ pub(crate) fn test_request(
         body: None,
         session_id: session_id.map(String::from),
         actions: Vec::new(),
+        dedup_key: None,
     }
 }
 
@@ -228,6 +269,44 @@ mod tests {
         let list = store.list();
         assert_eq!(list[0].title, "second");
         assert_eq!(list[1].title, "first");
+    }
+
+    fn req_with_key(title: &str, key: &str) -> NotificationRequest {
+        let mut r = test_request(L::Info, S::Cli, title, None);
+        r.dedup_key = Some(key.to_string());
+        r
+    }
+
+    #[test]
+    fn update_by_dedup_key_refreshes_existing_unread() {
+        let mut store = NotificationStore::new();
+        let first = store.push(req_with_key("first", "abc"));
+        let next_req = req_with_key("second", "abc");
+        let updated = store.update_by_dedup_key("abc", &next_req).expect("match");
+        assert_eq!(store.len(), 1, "should update in place, not append");
+        assert_eq!(updated.id, first.id, "id preserved");
+        assert_eq!(updated.title, "second", "title refreshed");
+        assert!(updated.created_at >= first.created_at);
+    }
+
+    #[test]
+    fn update_by_dedup_key_does_not_match_read_entries() {
+        let mut store = NotificationStore::new();
+        let first = store.push(req_with_key("first", "abc"));
+        store.mark_read(&first.id);
+        let next_req = req_with_key("second", "abc");
+        assert!(store.update_by_dedup_key("abc", &next_req).is_none());
+        // Caller falls back to push; simulate that here to lock behavior.
+        store.push(next_req);
+        assert_eq!(store.len(), 2);
+    }
+
+    #[test]
+    fn update_by_dedup_key_returns_none_without_match() {
+        let mut store = NotificationStore::new();
+        store.push(req_with_key("first", "abc"));
+        assert!(store.update_by_dedup_key("different", &req_with_key("x", "abc")).is_none());
+        assert_eq!(store.len(), 1);
     }
 
     #[test]
@@ -278,7 +357,7 @@ mod tests {
         store.push(test_request(L::Info, S::Watch { watch_id: "w2".into() }, "watch-2", None));
 
         let removed = store.remove_by_source_variant(&S::Watch { watch_id: "irrelevant".into() });
-        assert_eq!(removed, 2);
+        assert_eq!(removed.len(), 2);
         assert_eq!(store.len(), 2);
         let remaining: Vec<_> = store.list().iter().map(|n| n.title.clone()).collect();
         assert_eq!(remaining, vec!["cli-2", "cli-1"]);

--- a/src-tauri/src/socket.rs
+++ b/src-tauri/src/socket.rs
@@ -848,7 +848,7 @@ async fn handle_notify(req: Request, app: &tauri::AppHandle) -> Response {
     });
 
     let notification = state.notification_manager.push(
-        NReq { level, source: NotificationSource::Cli, title, subtitle, body, session_id, actions },
+        NReq { level, source: NotificationSource::Cli, title, subtitle, body, session_id, actions, dedup_key: None },
         Some(app),
     );
 

--- a/src-tauri/src/status_watcher.rs
+++ b/src-tauri/src/status_watcher.rs
@@ -387,11 +387,11 @@ async fn push_attention_notification(
     // launched inside a Roux-managed PTY). Fall back to session focus for
     // legacy or external installs.
     let mut actions: Vec<NotificationAction> = Vec::new();
-    if let Some(pane_id) = roux_pane_id {
+    if let Some(ref pane_id) = roux_pane_id {
         actions.push(NotificationAction {
             id: "focus".into(),
             label: "Focus pane".into(),
-            kind: ActionKind::FocusPane { pane_id },
+            kind: ActionKind::FocusPane { pane_id: pane_id.clone() },
             primary: true,
         });
     } else if let Some(ref sid) = session_id {
@@ -409,6 +409,21 @@ async fn push_attention_notification(
         primary: actions.is_empty(),
     });
 
+    // Dedup by pane (tier-1) or session (tier-2 fallback). If neither is
+    // available we fall back to the cwd so at least the same project stops
+    // stacking identical cards.
+    let dedup_key = roux_pane_id
+        .as_ref()
+        .map(|p| format!("attention:pane:{}", p))
+        .or_else(|| session_id.as_ref().map(|s| format!("attention:session:{}", s)))
+        .or_else(|| {
+            if cwd.is_empty() {
+                None
+            } else {
+                Some(format!("attention:cwd:{}", cwd))
+            }
+        });
+
     state.notification_manager.push(
         NotificationRequest {
             level: NotificationLevel::Attention,
@@ -418,6 +433,7 @@ async fn push_attention_notification(
             body,
             session_id,
             actions,
+            dedup_key,
         },
         Some(app),
     );

--- a/src-tauri/src/watches/manager.rs
+++ b/src-tauri/src/watches/manager.rs
@@ -301,6 +301,7 @@ impl WatchManager {
                                     body: Some(body),
                                     session_id,
                                     actions,
+                                    dedup_key: None,
                                 },
                                 Some(&app),
                             );

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -704,7 +704,8 @@
 <Layout
   onNewSession={() => (showNewSessionDialog = true)}
   onOpenSettings={() => (showSettings = !showSettings)}
-  onToggleWatches={() => { showWatches = !showWatches; if (showWatches) { showSettings = false; showNotes = false; } }}
+  onToggleWatches={() => { showWatches = !showWatches; if (showWatches) { showSettings = false; showNotes = false; showNotifications = false; } }}
+  onToggleNotifications={() => { showNotifications = !showNotifications; if (showNotifications) { showSettings = false; showNotes = false; showWatches = false; } }}
 >
   {#snippet settingsPanel()}
     <SettingsPanel visible={showSettings} onclose={() => (showSettings = false)} />

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -228,6 +228,12 @@ export type Notification = {
 	sessionId: string | null,
 	read: boolean,
 	actions: NotificationAction[],
+	/**
+	 *  When set, a subsequent push with the same `dedup_key` updates this
+	 *  notification in place instead of creating a new one. Cleared when the
+	 *  user reads or dismisses the notification (tracked via `read`).
+	 */
+	dedupKey?: string | null,
 };
 
 export type NotificationAction = {
@@ -248,6 +254,13 @@ export type NotificationRequest = {
 	body: string | null,
 	sessionId: string | null,
 	actions: NotificationAction[],
+	/**
+	 *  Optional dedup key. When set, `NotificationManager::push` will update
+	 *  an existing unread notification carrying the same key instead of
+	 *  creating a new one. Useful for flood-prone sources like permission
+	 *  prompts that fire repeatedly for the same pane.
+	 */
+	dedupKey?: string | null,
 };
 
 export type NotificationSource = { type: "hook"; provider: string } | { type: "watch"; watchId: string } | { type: "task"; paneId: string } | { type: "cli" } | { type: "osc"; code: number; senderId: string | null } | { type: "internal" };

--- a/src/lib/commands/panes.ts
+++ b/src/lib/commands/panes.ts
@@ -100,6 +100,7 @@ async function spawnShellPaneWithProfile(
           primary: true,
         },
       ],
+      dedupKey: null,
     }).catch((pushErr) =>
       logError("split-with-profile: notificationsPush failed", pushErr),
     );

--- a/src/lib/components/Layout.svelte
+++ b/src/lib/components/Layout.svelte
@@ -11,10 +11,11 @@
     onNewSession: () => void;
     onOpenSettings: () => void;
     onToggleWatches: () => void;
+    onToggleNotifications: () => void;
     settingsPanel?: Snippet;
   }
 
-  let { onNewSession, onOpenSettings, onToggleWatches, settingsPanel }: Props = $props();
+  let { onNewSession, onOpenSettings, onToggleWatches, onToggleNotifications, settingsPanel }: Props = $props();
 
   let dragging = $state(false);
   let sidebarWidth = $derived($settings.tabWidth);
@@ -46,7 +47,7 @@
   >
     {#if !$settings.sidebarCollapsed}
       <div style="width: {sidebarWidth}px" class="shrink-0">
-        <SessionTabs {onNewSession} {onOpenSettings} {onToggleWatches} />
+        <SessionTabs {onNewSession} {onOpenSettings} {onToggleWatches} {onToggleNotifications} />
       </div>
 
       <!-- svelte-ignore a11y_no_static_element_interactions -->

--- a/src/lib/components/PaneShell.svelte
+++ b/src/lib/components/PaneShell.svelte
@@ -111,6 +111,7 @@
             primary: true,
           },
         ],
+        dedupKey: null,
       }).catch((pushErr) =>
         logError("re-run profile: notificationsPush failed", pushErr),
       );

--- a/src/lib/components/SessionTabs.svelte
+++ b/src/lib/components/SessionTabs.svelte
@@ -24,6 +24,7 @@
   import { setSessionProject as tauriSetSessionProject } from "$lib/tauri";
   import { log, logError } from "$lib/logging";
   import { failureCount } from "$lib/stores/watches";
+  import { unreadTotal } from "$lib/stores/notifications";
   import type { Session } from "$lib/types";
   import { getGroupedSessions } from "$lib/sessions/order";
 
@@ -31,9 +32,10 @@
     onNewSession: () => void;
     onOpenSettings: () => void;
     onToggleWatches: () => void;
+    onToggleNotifications: () => void;
   }
 
-  let { onNewSession, onOpenSettings, onToggleWatches }: Props = $props();
+  let { onNewSession, onOpenSettings, onToggleWatches, onToggleNotifications }: Props = $props();
 
   let dragging = $state(false);
   let containerEl: HTMLDivElement | undefined = $state();
@@ -336,6 +338,22 @@
       {#if $failureCount > 0}
         <span class="ml-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-red px-1 text-[10px] font-bold text-white">
           {$failureCount}
+        </span>
+      {/if}
+    </button>
+    <button
+      class="flex items-center justify-center gap-1 bg-bg-active/50 px-3 py-2 text-[13px] font-medium text-text-secondary cursor-pointer transition-all duration-150 hover:bg-bg-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50 focus-visible:ring-offset-1 focus-visible:ring-offset-bg-deep"
+      onclick={onToggleNotifications}
+      title="Toggle notifications (⌘I)"
+      aria-label="Toggle notifications"
+    >
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
+        <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
+      </svg>
+      {#if $unreadTotal > 0}
+        <span class="ml-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-accent px-1 text-[10px] font-bold text-white">
+          {$unreadTotal}
         </span>
       {/if}
     </button>

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -58,6 +58,7 @@
         body: "If you saw a macOS notification, permissions are set up correctly.",
         sessionId: null,
         actions: [],
+        dedupKey: null,
       });
       notifTestStatus = "sent";
     } catch (e) {

--- a/src/lib/notifications/dispatchAction.ts
+++ b/src/lib/notifications/dispatchAction.ts
@@ -1,9 +1,9 @@
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { setActiveSession } from "$lib/stores/sessions";
+import { setActiveSession, sessionState } from "$lib/stores/sessions";
 import { setLogicalFocus } from "$lib/panes/focus";
 import { paneInstances } from "$lib/panes/instances";
+import { sessionLayouts, collectLeafIds } from "$lib/panes/layout";
 import { get } from "svelte/store";
-import { sessionState } from "$lib/stores/sessions";
 import { log } from "$lib/logging";
 import {
   dismissNotificationSource,
@@ -12,6 +12,44 @@ import {
   getNotificationSnapshot,
 } from "$lib/stores/notifications";
 import type { NotificationAction } from "$lib/types";
+
+/** Find which session owns a pane by walking layouts. Returns null if none. */
+function findSessionForPane(paneId: string): string | null {
+  for (const [sessionId, layout] of get(sessionLayouts)) {
+    for (const leafId of collectLeafIds(layout)) {
+      if (leafId === paneId) return sessionId;
+    }
+  }
+  return null;
+}
+
+/**
+ * Wait until a pane instance is registered, then set logical focus on it.
+ * Needed when switching sessions: panes mount asynchronously after
+ * `setActiveSession`, so an immediate `setLogicalFocus` would no-op
+ * because the instance isn't in `paneInstances` yet. Gives up after
+ * `timeoutMs` to avoid hanging if the pane never mounts.
+ */
+function focusPaneWhenMounted(paneId: string, timeoutMs = 2000): void {
+  if (get(paneInstances).has(paneId)) {
+    setLogicalFocus(paneId);
+    return;
+  }
+  let done = false;
+  const unsubscribe = paneInstances.subscribe((instances) => {
+    if (done || !instances.has(paneId)) return;
+    done = true;
+    setLogicalFocus(paneId);
+    // Defer unsubscribe so Svelte's own subscription bookkeeping settles.
+    queueMicrotask(() => unsubscribe());
+  });
+  setTimeout(() => {
+    if (done) return;
+    done = true;
+    unsubscribe();
+    log(`focusPane: pane ${paneId} never mounted within ${timeoutMs}ms`);
+  }, timeoutMs);
+}
 
 /**
  * Execute a notification action. The notification id is needed so that
@@ -32,16 +70,19 @@ export async function dispatchNotificationAction(
       break;
     }
     case "focusPane": {
-      // Find which session owns this pane (by walking paneInstances — the
-      // instance itself doesn't carry a sessionId, so we scan sessions and
-      // match on known pane ids via the layout. For Phase 2 the simpler
-      // approach is to just set logical focus and hope the current session
-      // contains it; if not, the caller should have used focusSession.
-      const instances = get(paneInstances);
-      if (instances.has(kind.paneId)) {
-        setLogicalFocus(kind.paneId);
+      // Walk all session layouts so a notification's Focus-pane action
+      // works even when the target pane lives in a different session than
+      // the one currently active. Without this, cross-session notifications
+      // silently no-op (the pane's instance isn't registered until its
+      // owning session is active).
+      const owningSessionId = findSessionForPane(kind.paneId);
+      if (!owningSessionId) {
+        log(`focusPane: pane ${kind.paneId} not found in any session`);
       } else {
-        log(`focusPane: pane ${kind.paneId} not found in current instances`);
+        if (owningSessionId !== get(sessionState).activeSessionId) {
+          setActiveSession(owningSessionId);
+        }
+        focusPaneWhenMounted(kind.paneId);
       }
       await markNotificationRead(notificationId);
       break;
@@ -61,19 +102,15 @@ export async function dispatchNotificationAction(
       break;
     }
     case "runCommand": {
-      // Frontend command registry wiring. Phase 2 defers this because
-      // there's no current caller; stub + log so it's visible.
-      log(
-        `notification.runCommand: command=${kind.commandId} (not yet wired — Phase 3)`,
-      );
+      // TODO: wire to the frontend command registry once a notification
+      // source actually emits runCommand actions.
+      log(`notification.runCommand: command=${kind.commandId} (not yet wired)`);
       break;
     }
     case "retryWatch": {
-      // RetryWatch backend command lands with the hook-bridge work;
-      // stub + log for Phase 2. The button still appears and records intent.
-      log(
-        `notification.retryWatch: watch=${kind.watchId} (not yet wired — Phase 3)`,
-      );
+      // TODO: call the backend watch-retry command once it exists. The
+      // button currently records intent but is a no-op.
+      log(`notification.retryWatch: watch=${kind.watchId} (not yet wired)`);
       break;
     }
     case "dismiss": {
@@ -91,6 +128,4 @@ export async function dispatchNotificationAction(
       break;
     }
   }
-  // Silence unused-var warning if session is unused in the current branch.
-  void sessionState;
 }

--- a/src/lib/panes/agentNotifications.ts
+++ b/src/lib/panes/agentNotifications.ts
@@ -111,6 +111,7 @@ async function fireCompletionNotification(
           primary: false,
         },
       ],
+      dedupKey: `completion:pane:${paneId}`,
     });
     log(`agentNotifications: fired generating→idle notification for pane ${paneId}`);
   } catch (e) {


### PR DESCRIPTION
## Summary

- **Clear button** now works. Root cause was a serde quirk: `rename_all = "camelCase"` on an enum only renames variant names, not fields inside struct variants, so `Cleared { session_id }` serialized as snake_case and the frontend handler (reading `sessionId`) silently no-op'd. Fixed with `rename_all_fields = "camelCase"` and locked with a regression test.
- **Notification dedup.** New `dedup_key` on `NotificationRequest` — repeat pushes for the same key update the existing unread entry in place and emit `Updated` instead of stacking duplicates. Wired into three sources: attention-prompt flood (status_watcher, dedup per pane/session/cwd), completion notifications (agentNotifications, dedup per pane), and OSC 99 (dedup per sender id, replacing an old remove+add hack).
- **Cross-session Focus-pane** action now walks all session layouts to find the owning session, activates it, and waits for the pane to mount before setting logical focus.
- **Unread bell badge** in the sidebar footer, wired to the existing `ui.toggle-notifications` command — the pane finally has a visible entry point alongside ⌘I.
- Fixed `remove_by_source_variant` emitting a lying `Cleared` event (it was wiping the whole frontend store). Now emits per-id `Removed` events.
- Stripped stale Phase-N scaffolding comments across the notification module.
- Taskfile `cli:ensure-placeholder` step so fresh checkouts can `task dev` without hitting the Tauri build.rs chicken-and-egg with the missing `roux-cli` binary.

## Test plan
- [x] `cargo test --manifest-path src-tauri/Cargo.toml notifications` — 33 pass (5 new dedup tests)
- [x] `cargo test --manifest-path crates/roux-core/Cargo.toml notification` — 2 new camelCase regression tests pass
- [x] `npm run test` — 297 pass
- [x] `npm run check` — 0 errors / 0 warnings
- [ ] Manual: open notifications pane, click Clear → list empties immediately
- [ ] Manual: trigger a flood of permission prompts → single card updates in place instead of stacking
- [ ] Manual: trigger a completion notification while on a different session → clicking "Focus pane" switches sessions and focuses the correct pane
- [ ] Manual: confirm bell icon in sidebar footer shows unread count and toggles the pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)