### PR TITLE
feat(new-session): paste a PR URL to create a session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3881,7 +3881,7 @@ dependencies = [
 
 [[package]]
 name = "roux"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/docs/superpowers/specs/2026-04-14-session-from-pr-design.md
+++ b/docs/superpowers/specs/2026-04-14-session-from-pr-design.md
@@ -1,0 +1,240 @@
+# Session from PR URL — Design
+
+## Goal
+
+Let the user paste a GitHub pull request URL into the New Session dialog and have
+Roux create a session whose worktree is checked out at the PR's head branch. The
+feature should work for same-repo PRs and fork PRs, fail gracefully when `gh` is
+not installed, and never mutate the main repository's HEAD.
+
+## Non-goals
+
+- No GitHub API / token management in Roux itself. We defer to the `gh` CLI for
+  auth.
+- No PR review UI, no comment surfacing, no CI status. Just branch checkout.
+- No support for GitLab, Bitbucket, or other forges in this iteration.
+
+## UX
+
+A new optional text input titled **"PR URL (optional)"** is added at the top of
+`NewSessionDialog`, above the existing repo/branch section. The input is
+rendered only when the `gh` CLI is detected at dialog-open time (matching the
+existing `checkNonoInstalled` pattern — no blocking modal, no first-run wizard).
+
+The input accepts:
+
+- Full URLs: `https://github.com/owner/repo/pull/142`
+- Shortforms: `owner/repo#142`
+
+On paste or blur, the dialog performs a PR lookup. A status line below the
+input reflects progress:
+
+- `idle` → no status line.
+- `loading` → `Fetching PR…` with a spinner glyph.
+- `ok` → `PR #142: "Fix login redirect"` with a small badge: `same-repo` or
+  `fork: octocat:feature-branch`.
+- `error` → inline red error message (see Error Handling).
+
+When lookup succeeds, the dialog pre-fills:
+
+- `sessionName` with `pr-<NNN>-<slug>` where `<slug>` is the PR title
+  lowercased, non-alphanum characters replaced with `-`, runs of `-` collapsed,
+  trimmed, truncated to ~30 characters. Final session name capped at ~40.
+- `worktreeFilterInput` with the resolved local branch name (see "Branch
+  resolution" below).
+
+The user can still edit either field before clicking Create. The existing
+`resolveGitTarget()` flow takes over from there: if a worktree already exists
+for the branch, it's selected; otherwise the "unknown branch" path creates a
+new worktree on Create.
+
+## Architecture
+
+```
+User pastes URL
+      │
+      ▼
+Frontend: debounce 250ms
+      │
+      ▼
+tauri: lookup_pr(repoPath, url)
+      │
+      ▼
+Rust: shell out to `gh pr view <ref> --json ...`
+      │
+      ▼
+Return PrInfo { number, title, head_ref, head_owner, is_cross_repository }
+      │
+      ├── same-repo? → pre-fill branch = head_ref
+      │
+      └── fork?      → tauri: fetch_pr_branch(repoPath, pr_number)
+                         │
+                         ▼
+                    Rust: `git fetch <fork-url> <head_ref>:pr-<NNN>`
+                         (no HEAD movement)
+                         │
+                         ▼
+                    Pre-fill branch = `pr-<NNN>`
+```
+
+On Create, `create_session_shell` runs with the pre-filled branch. No changes
+to the session-creation path itself.
+
+## Components
+
+### Frontend: `src/lib/components/NewSessionDialog.svelte`
+
+New state:
+
+```ts
+let prUrl = $state("");
+let prLookup = $state<"idle" | "loading" | "ok" | "error">("idle");
+let prInfo = $state<PrInfo | null>(null);
+let prError = $state<string>("");
+let ghInstalled = $state(false);
+```
+
+- `$effect` on dialog visibility: call `checkGhInstalled()` once per open.
+- `$effect` on `prUrl` (debounced ~250ms): if `ghInstalled` and `prUrl` parses
+  as a PR ref, call `lookupPr(repoPath, prUrl)`.
+- On successful lookup with `is_cross_repository === true`, immediately call
+  `fetchPrBranch(repoPath, prInfo.number)` and use the returned branch name.
+- On successful lookup + branch resolution, set `sessionName` and
+  `worktreeFilterInput`. Do not overwrite if the user has already typed into
+  those fields since the last lookup (track a "user has edited" flag per field).
+
+### Frontend: `src/lib/tauri.ts`
+
+New bindings:
+
+```ts
+export async function checkGhInstalled(): Promise<boolean>;
+export async function lookupPr(repoPath: string, url: string): Promise<PrInfo>;
+export async function fetchPrBranch(repoPath: string, prNumber: number): Promise<string>;
+```
+
+Where `PrInfo`:
+
+```ts
+export interface PrInfo {
+  number: number;
+  title: string;
+  headRef: string;
+  headOwner: string;
+  isCrossRepository: boolean;
+}
+```
+
+### Backend: new module `src-tauri/src/pr.rs`
+
+Exposes:
+
+- `parse_pr_ref(input: &str) -> Option<PrRef>` — pure parser, unit tested.
+  Accepts both URL and shortform. Returns `PrRef { owner, repo, number }`.
+- `check_gh_installed() -> bool` — uses `which::which("gh")`.
+- `lookup_pr(repo_path: &str, input: &str) -> anyhow::Result<PrInfo>` — shells
+  out to `gh pr view <ref> --json number,title,headRefName,headRepositoryOwner,isCrossRepository,headRepository`
+  with `--repo owner/repo` when the URL embeds it. Runs in `repo_path` so gh's
+  auth context matches the user's normal workflow.
+- `fetch_pr_branch(repo_path: &str, pr_number: u32) -> anyhow::Result<String>` —
+  runs `gh pr view <N> --json headRepository,headRefName` to discover the fork
+  clone URL, then `git -C <repo_path> fetch <fork-url> <head_ref>:pr-<N>`.
+  Returns the local branch name (`pr-<N>`). Does NOT move HEAD.
+
+### Backend: `src-tauri/src/commands/pr.rs` (new)
+
+Thin Tauri command adapters:
+
+- `#[tauri::command] check_gh_installed() -> bool`
+- `#[tauri::command] lookup_pr(repo_path: String, url: String) -> Result<PrInfo, String>`
+- `#[tauri::command] fetch_pr_branch(repo_path: String, pr_number: u32) -> Result<String, String>`
+
+Registered from `src-tauri/src/main.rs` alongside existing commands.
+
+No changes to `services/sessions.rs` or `worktree.rs` — `create_session_shell`
+already accepts an explicit branch via `SessionTarget::NewWorktree`, and the
+branch exists locally by the time the user clicks Create.
+
+## Data flow
+
+1. Dialog opens → `checkGhInstalled()` → gates PR input visibility.
+2. User pastes URL → debounce → `lookupPr()` → `PrInfo` returned.
+3. Dialog displays PR title + cross-repo badge.
+4. If `isCrossRepository`, `fetchPrBranch()` is called; the local
+   `pr-<NNN>` branch now exists in the main repo's branch list.
+5. Dialog pre-fills `worktreeFilterInput` with the resolved branch name and
+   `sessionName` with the slug.
+6. User clicks Create → existing path:
+   - `resolveGitTarget()` finds either an existing worktree for the branch or
+     returns `branchArg = <branch>`.
+   - `createSessionShell` creates a new worktree off that branch in the
+     configured worktree base dir.
+
+## Error handling
+
+All errors surface inline in the dialog under the PR input. The dialog remains
+usable — the user can clear the URL and proceed without the PR feature.
+
+| Condition                              | Error message                                                        |
+| -------------------------------------- | -------------------------------------------------------------------- |
+| `gh` missing at lookup time            | `gh CLI not found`                                                   |
+| `gh auth` missing / expired            | `gh is not authenticated — run 'gh auth login' and retry`            |
+| PR not found / 404                     | `PR not found`                                                       |
+| URL parse failure                      | `Not a valid GitHub PR URL`                                          |
+| Network failure                        | `Failed to fetch PR: <gh stderr truncated to 200 chars>`             |
+| Fork fetch failure                     | `Failed to fetch fork branch: <git stderr truncated>`                |
+| Branch `pr-<N>` already exists locally | `fetch_pr_branch` force-updates it (`+<head_ref>:pr-<N>` refspec)   |
+
+## Testing
+
+### Rust unit tests (`src-tauri/src/pr.rs`)
+
+- `parse_pr_ref`:
+  - full URL → `Some(PrRef)`
+  - shortform `owner/repo#123` → `Some(PrRef)`
+  - garbage input → `None`
+  - trailing slash / query string variants
+- `lookup_pr` / `fetch_pr_branch`: test via a thin `GhRunner` trait (or
+  `Command` abstraction) so we can stub `gh` output without requiring `gh` on
+  CI. Happy-path + auth-error + 404 cases.
+
+### Frontend unit tests (`src/lib/components/__tests__/NewSessionDialog.test.ts`)
+
+- PR input hidden when `checkGhInstalled()` returns `false`.
+- On valid URL paste + mocked `lookupPr` → session name + branch filter
+  pre-filled.
+- On fork PR → `fetchPrBranch` called; returned branch name populates the
+  filter.
+- On lookup error → error string rendered inline, other dialog fields still
+  usable.
+- User-edit-wins: if the user types into `sessionName` after the lookup, a
+  subsequent lookup does not overwrite it.
+
+### Manual verification
+
+- Paste same-repo PR URL → new worktree created at correct branch.
+- Paste fork PR URL → local `pr-<N>` branch exists after fetch; worktree
+  created off it; main repo HEAD unchanged.
+- Dialog with `gh` uninstalled → no PR input rendered.
+
+## Open considerations
+
+- **Slug locale**: the title slug uses ASCII alphanum only; non-Latin titles
+  will collapse to `pr-<N>-`. Acceptable for v1.
+- **Debounce timing**: 250ms is a starting point; may need tuning if `gh`
+  latency is consistently >1s.
+- **Existing worktree for PR branch**: if the user creates two sessions from
+  the same PR URL, the second one will find the existing worktree and
+  select it. This is correct behavior; no special-case needed.
+
+## Files touched
+
+- `src/lib/components/NewSessionDialog.svelte` — UI + state
+- `src/lib/components/__tests__/NewSessionDialog.test.ts` — new or extended
+- `src/lib/tauri.ts` — three new bindings
+- `src/lib/bindings.ts` — generated types for `PrInfo`
+- `src-tauri/src/pr.rs` — new module
+- `src-tauri/src/commands/pr.rs` — new Tauri commands
+- `src-tauri/src/commands/mod.rs` — register new module
+- `src-tauri/src/main.rs` — register new commands in handler list
+- `src-tauri/Cargo.toml` — `which` likely already present; confirm during plan

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roux",
-  "version": "0.3.4",
+  "version": "0.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roux",
-      "version": "0.3.4",
+      "version": "0.3.6",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod docs;
 pub(crate) mod layouts;
 pub(crate) mod misc;
 pub(crate) mod pane_state;
+pub(crate) mod pr;
 pub(crate) mod projects;
 pub(crate) mod sessions;
 pub(crate) mod settings;

--- a/src-tauri/src/commands/pr.rs
+++ b/src-tauri/src/commands/pr.rs
@@ -1,0 +1,36 @@
+use crate::pr;
+use crate::services::setup as svc;
+
+#[tauri::command]
+#[specta::specta]
+pub(crate) fn check_gh_installed() -> bool {
+    svc::is_command_available("gh")
+}
+
+#[tauri::command]
+#[specta::specta]
+pub(crate) fn lookup_pr(repo_path: Option<String>, url: String) -> Result<pr::PrInfo, String> {
+    pr::lookup_pr(repo_path.as_deref(), &url).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub(crate) fn fetch_pr_branch(
+    repo_path: String,
+    number: u32,
+    head_ref: String,
+    is_cross_repository: bool,
+) -> Result<String, String> {
+    pr::fetch_pr_branch(&repo_path, number, &head_ref, is_cross_repository)
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub(crate) fn clone_repo(
+    owner: String,
+    repo: String,
+    target_dir: String,
+) -> Result<String, String> {
+    pr::clone_repo(&owner, &repo, &target_dir).map_err(|e| e.to_string())
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -9,6 +9,7 @@ mod notifications;
 mod pane_state;
 mod paths;
 mod platform;
+mod pr;
 mod project_service;
 mod projects;
 mod providers;
@@ -100,6 +101,10 @@ fn main() {
         commands::setup::reinstall_hooks,
         commands::setup::reinstall_skill,
         commands::setup::install_all_missing,
+        commands::pr::check_gh_installed,
+        commands::pr::lookup_pr,
+        commands::pr::fetch_pr_branch,
+        commands::pr::clone_repo,
         tasks::cmd_discover_tasks,
         tasks::cmd_load_task_overrides,
         tasks::cmd_save_task_overrides,
@@ -193,6 +198,9 @@ fn main() {
             commands::setup::reinstall_hooks,
             commands::setup::reinstall_skill,
             commands::setup::install_all_missing,
+            commands::pr::check_gh_installed,
+            commands::pr::lookup_pr,
+            commands::pr::fetch_pr_branch,
             tasks::cmd_discover_tasks,
             tasks::cmd_load_task_overrides,
             tasks::cmd_save_task_overrides,

--- a/src-tauri/src/pr.rs
+++ b/src-tauri/src/pr.rs
@@ -1,0 +1,302 @@
+use anyhow::{anyhow, Result};
+use serde::{Deserialize, Serialize};
+use std::process::Command;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PrRef {
+    pub owner: String,
+    pub repo: String,
+    pub number: u32,
+}
+
+#[derive(Debug, Clone, Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PrInfo {
+    pub number: u32,
+    pub title: String,
+    pub head_ref: String,
+    pub head_owner: String,
+    pub is_cross_repository: bool,
+}
+
+/// Parse either a full GitHub PR URL or a shortform `owner/repo#NNN`.
+/// Returns `None` if the input doesn't match a recognizable form.
+pub(crate) fn parse_pr_ref(input: &str) -> Option<PrRef> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if let Some(r) = parse_url_form(trimmed) {
+        return Some(r);
+    }
+    parse_shortform(trimmed)
+}
+
+fn parse_url_form(input: &str) -> Option<PrRef> {
+    let without_scheme = input
+        .strip_prefix("https://")
+        .or_else(|| input.strip_prefix("http://"))?;
+    let host_end = without_scheme.find('/')?;
+    let host = &without_scheme[..host_end];
+    if host != "github.com" && host != "www.github.com" {
+        return None;
+    }
+    let path = &without_scheme[host_end + 1..];
+    let path = path.split(['?', '#']).next().unwrap_or(path);
+    let path = path.trim_end_matches('/');
+    let parts: Vec<&str> = path.split('/').collect();
+    if parts.len() < 4 {
+        return None;
+    }
+    if parts[2] != "pull" && parts[2] != "pulls" {
+        return None;
+    }
+    let number: u32 = parts[3].parse().ok()?;
+    let owner = parts[0];
+    let repo = parts[1];
+    if owner.is_empty() || repo.is_empty() {
+        return None;
+    }
+    Some(PrRef {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        number,
+    })
+}
+
+fn parse_shortform(input: &str) -> Option<PrRef> {
+    // owner/repo#N
+    let (slug, num) = input.split_once('#')?;
+    let number: u32 = num.trim().parse().ok()?;
+    let (owner, repo) = slug.split_once('/')?;
+    if owner.is_empty() || repo.is_empty() {
+        return None;
+    }
+    Some(PrRef {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        number,
+    })
+}
+
+/// Call `gh pr view --json ...` for the given PR and parse the result.
+/// Runs in `repo_path` so gh's auth/config context matches the user's
+/// normal workflow (gh reads `~/.config/gh/hosts.yml` globally, but some
+/// env-based configs are cwd-sensitive).
+pub(crate) fn lookup_pr(repo_path: Option<&str>, input: &str) -> Result<PrInfo> {
+    let pr_ref = parse_pr_ref(input)
+        .ok_or_else(|| anyhow!("Not a valid GitHub PR URL or shortform"))?;
+
+    let repo_slug = format!("{}/{}", pr_ref.owner, pr_ref.repo);
+    let mut cmd = Command::new("gh");
+    cmd.args([
+        "pr",
+        "view",
+        &pr_ref.number.to_string(),
+        "--repo",
+        &repo_slug,
+        "--json",
+        "number,title,headRefName,headRepositoryOwner,isCrossRepository",
+    ]);
+    // cwd only matters for gh's repo auto-detection — irrelevant here since
+    // we pass --repo explicitly. Still, prefer a real dir when available so
+    // gh doesn't barf on a dangling cwd.
+    if let Some(path) = repo_path {
+        if !path.is_empty() {
+            cmd.current_dir(path);
+        }
+    }
+    let output = cmd
+        .output()
+        .map_err(|e| anyhow!("Failed to run gh: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(classify_gh_error(&stderr));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    #[derive(Deserialize)]
+    struct Raw {
+        number: u32,
+        title: String,
+        #[serde(rename = "headRefName")]
+        head_ref_name: String,
+        #[serde(rename = "headRepositoryOwner")]
+        head_repository_owner: RawOwner,
+        #[serde(rename = "isCrossRepository")]
+        is_cross_repository: bool,
+    }
+    #[derive(Deserialize)]
+    struct RawOwner {
+        login: String,
+    }
+
+    let raw: Raw = serde_json::from_str(&stdout)
+        .map_err(|e| anyhow!("Failed to parse gh output: {}", e))?;
+
+    Ok(PrInfo {
+        number: raw.number,
+        title: raw.title,
+        head_ref: raw.head_ref_name,
+        head_owner: raw.head_repository_owner.login,
+        is_cross_repository: raw.is_cross_repository,
+    })
+}
+
+fn classify_gh_error(stderr: &str) -> anyhow::Error {
+    let s = stderr.to_lowercase();
+    if s.contains("authentication") || s.contains("gh auth") || s.contains("not logged in") {
+        anyhow!("gh is not authenticated — run 'gh auth login' and retry")
+    } else if s.contains("could not resolve") || s.contains("not found") || s.contains("404") {
+        anyhow!("PR not found")
+    } else {
+        let trimmed = stderr.trim();
+        let snippet: String = trimmed.chars().take(200).collect();
+        anyhow!("Failed to fetch PR: {}", snippet)
+    }
+}
+
+/// Fetch the PR's head commit into a local branch in `repo_path`, without
+/// moving HEAD. Uses `refs/pull/<N>/head` which GitHub exposes for every PR
+/// (same-repo and fork alike). Returns the local branch name.
+///
+/// For same-repo PRs the target branch name matches the PR's head ref, so
+/// existing worktree detection finds the branch naturally. For cross-repo
+/// PRs the target is `pr-<N>` — the fork's branch name isn't guaranteed to
+/// be a valid or meaningful local ref.
+pub(crate) fn fetch_pr_branch(
+    repo_path: &str,
+    number: u32,
+    head_ref: &str,
+    is_cross_repository: bool,
+) -> Result<String> {
+    let local_branch = if is_cross_repository {
+        format!("pr-{}", number)
+    } else {
+        head_ref.to_string()
+    };
+    let refspec = format!("+refs/pull/{}/head:refs/heads/{}", number, local_branch);
+    let output = Command::new("git")
+        .args(["fetch", "origin", &refspec])
+        .current_dir(repo_path)
+        .output()
+        .map_err(|e| anyhow!("Failed to run git: {}", e))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let trimmed = stderr.trim();
+        let snippet: String = trimmed.chars().take(200).collect();
+        return Err(anyhow!("Failed to fetch PR branch: {}", snippet));
+    }
+    Ok(local_branch)
+}
+
+/// Clone `owner/repo` from GitHub into `target_dir` using `gh repo clone`.
+/// The caller is responsible for ensuring `target_dir`'s parent exists and
+/// `target_dir` itself does not already exist. Returns `target_dir` on
+/// success (the caller already knows the path, but returning it keeps the
+/// command symmetrical with fetch_pr_branch).
+pub(crate) fn clone_repo(owner: &str, repo: &str, target_dir: &str) -> Result<String> {
+    if std::path::Path::new(target_dir).exists() {
+        return Err(anyhow!("Target path already exists: {}", target_dir));
+    }
+    if let Some(parent) = std::path::Path::new(target_dir).parent() {
+        if !parent.exists() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| anyhow!("Failed to create parent dir: {}", e))?;
+        }
+    }
+    let slug = format!("{}/{}", owner, repo);
+    let output = Command::new("gh")
+        .args(["repo", "clone", &slug, target_dir])
+        .output()
+        .map_err(|e| anyhow!("Failed to run gh: {}", e))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(classify_gh_error(&stderr));
+    }
+    Ok(target_dir.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_full_url() {
+        let r = parse_pr_ref("https://github.com/phin-tech/roux/pull/142").unwrap();
+        assert_eq!(r.owner, "phin-tech");
+        assert_eq!(r.repo, "roux");
+        assert_eq!(r.number, 142);
+    }
+
+    #[test]
+    fn parses_url_with_trailing_slash() {
+        let r = parse_pr_ref("https://github.com/phin-tech/roux/pull/142/").unwrap();
+        assert_eq!(r.number, 142);
+    }
+
+    #[test]
+    fn parses_url_with_query_string() {
+        let r = parse_pr_ref("https://github.com/phin-tech/roux/pull/142?foo=bar").unwrap();
+        assert_eq!(r.number, 142);
+    }
+
+    #[test]
+    fn parses_url_with_fragment() {
+        let r =
+            parse_pr_ref("https://github.com/phin-tech/roux/pull/142#issuecomment-123").unwrap();
+        assert_eq!(r.number, 142);
+    }
+
+    #[test]
+    fn parses_url_with_files_tab() {
+        // We deliberately accept any path ending after the PR number; /files
+        // and /commits are common tabs users paste from.
+        let r = parse_pr_ref("https://github.com/phin-tech/roux/pull/142/files").unwrap();
+        assert_eq!(r.number, 142);
+    }
+
+    #[test]
+    fn parses_shortform() {
+        let r = parse_pr_ref("phin-tech/roux#142").unwrap();
+        assert_eq!(r.owner, "phin-tech");
+        assert_eq!(r.repo, "roux");
+        assert_eq!(r.number, 142);
+    }
+
+    #[test]
+    fn parses_shortform_with_whitespace() {
+        let r = parse_pr_ref("  phin-tech/roux#142  ").unwrap();
+        assert_eq!(r.number, 142);
+    }
+
+    #[test]
+    fn rejects_non_github_host() {
+        assert!(parse_pr_ref("https://gitlab.com/foo/bar/pull/1").is_none());
+    }
+
+    #[test]
+    fn rejects_non_pr_path() {
+        assert!(parse_pr_ref("https://github.com/foo/bar/issues/1").is_none());
+    }
+
+    #[test]
+    fn rejects_missing_number() {
+        assert!(parse_pr_ref("https://github.com/foo/bar/pull/").is_none());
+        assert!(parse_pr_ref("https://github.com/foo/bar/pull").is_none());
+    }
+
+    #[test]
+    fn rejects_non_numeric_pr_id() {
+        assert!(parse_pr_ref("https://github.com/foo/bar/pull/abc").is_none());
+    }
+
+    #[test]
+    fn rejects_garbage() {
+        assert!(parse_pr_ref("").is_none());
+        assert!(parse_pr_ref("not a url").is_none());
+        assert!(parse_pr_ref("foo#1").is_none());
+    }
+}

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -11,6 +11,11 @@ export const commands = {
 	cmdCreateWorktree: (repoPath: string, branch: string) => typedError<string, string>(__TAURI_INVOKE("cmd_create_worktree", { repoPath, branch })),
 	cmdRemoveWorktree: (worktreePath: string) => typedError<null, string>(__TAURI_INVOKE("cmd_remove_worktree", { worktreePath })),
 	cmdListWorktrees: (repoPath: string) => typedError<Worktree[], string>(__TAURI_INVOKE("cmd_list_worktrees", { repoPath })),
+	/**
+	 *  Resolve a worktree-base-path template (`{project_dir}`, `{git_root}`,
+	 *  `{project_name}`, `{home}`, leading `~/`) against a sample repo path so
+	 *  Settings can show a live preview.
+	 */
 	cmdPreviewWorktreeBase: (template: string, repoPath: string) => __TAURI_INVOKE<string>("cmd_preview_worktree_base", { template, repoPath }),
 	writeToSession: (id: string, data: string) => typedError<null, string>(__TAURI_INVOKE("write_to_session", { id, data })),
 	resizeSession: (id: string, cols: number, rows: number) => typedError<null, string>(__TAURI_INVOKE("resize_session", { id, cols, rows })),
@@ -92,6 +97,10 @@ export const commands = {
 	reinstallHooks: () => typedError<null, string>(__TAURI_INVOKE("reinstall_hooks")),
 	reinstallSkill: () => typedError<null, string>(__TAURI_INVOKE("reinstall_skill")),
 	installAllMissing: () => typedError<null, string>(__TAURI_INVOKE("install_all_missing")),
+	checkGhInstalled: () => __TAURI_INVOKE<boolean>("check_gh_installed"),
+	lookupPr: (repoPath: string | null, url: string) => typedError<PrInfo, string>(__TAURI_INVOKE("lookup_pr", { repoPath, url })),
+	fetchPrBranch: (repoPath: string, number: number, headRef: string, isCrossRepository: boolean) => typedError<string, string>(__TAURI_INVOKE("fetch_pr_branch", { repoPath, number, headRef, isCrossRepository })),
+	cloneRepo: (owner: string, repo: string, targetDir: string) => typedError<string, string>(__TAURI_INVOKE("clone_repo", { owner, repo, targetDir })),
 	cmdDiscoverTasks: (dir: string) => __TAURI_INVOKE<TaskGroup[]>("cmd_discover_tasks", { dir }),
 	cmdLoadTaskOverrides: () => __TAURI_INVOKE<{ [key in string]: { [key in string]: string } }>("cmd_load_task_overrides"),
 	cmdSaveTaskOverrides: (overrides: { [key in string]: { [key in string]: string } }) => typedError<null, string>(__TAURI_INVOKE("cmd_save_task_overrides", { overrides })),
@@ -301,6 +310,14 @@ export type PrCheckRun = {
 	url: string | null,
 };
 
+export type PrInfo = {
+	number: number,
+	title: string,
+	headRef: string,
+	headOwner: string,
+	isCrossRepository: boolean,
+};
+
 export type PrReview = {
 	reviewer: string,
 	state: string,
@@ -347,7 +364,12 @@ export type RouxSettings = {
 	confirmOnClose: boolean,
 	restoreSessionsOnLaunch: boolean,
 	worktreeBasePath: string | null,
-	/** Legacy boolean; use `worktreeCleanupOnClose` instead. Kept in sync by the Rust migration for backward compat. */
+	/**
+	 *  Legacy boolean kept for backward compatibility with settings files
+	 *  written before `worktree_cleanup_on_close` existed. The frontend no
+	 *  longer reads this directly; `normalized()` migrates it into the new
+	 *  enum and keeps the two in sync for older readers.
+	 */
 	cleanupWorktreesOnClose: boolean,
 	worktreeCleanupOnClose?: WorktreeCleanupMode,
 	theme: string,
@@ -459,8 +481,6 @@ export type StatusBarPosition = "top" | "bottom";
 
 export type TabPosition = "left" | "right";
 
-export type WorktreeCleanupMode = "never" | "prompt" | "always";
-
 export type TaskDefinition = {
 	id: string,
 	name: string,
@@ -504,6 +524,16 @@ export type Worktree = {
 	branch: string,
 	isMain: boolean,
 };
+
+/**
+ *  Behavior when a session that owns a worktree is closed.
+ * 
+ *  - `Never` — leave the worktree on disk
+ *  - `Prompt` — ask the user via a confirm dialog (current default, matches
+ *    the legacy `cleanupWorktreesOnClose: false` behavior)
+ *  - `Always` — remove without asking (matches legacy `true`)
+ */
+export type WorktreeCleanupMode = "never" | "prompt" | "always";
 
 /* Tauri Specta runtime */
 async function typedError<T, E>(result: Promise<T>): Promise<{ status: "ok"; data: T } | { status: "error"; error: E }> {

--- a/src/lib/components/NewSessionDialog.svelte
+++ b/src/lib/components/NewSessionDialog.svelte
@@ -12,6 +12,11 @@
     checkIsGitRepo,
     gitInit,
     killSession,
+    checkGhInstalled,
+    lookupPr,
+    fetchPrBranch,
+    cloneRepo,
+    type PrInfo,
   } from "$lib/tauri";
   import { addSession, removeSession } from "$lib/stores/sessions";
   import { layoutList, type LayoutSpec } from "$lib/panes/layouts";
@@ -141,6 +146,28 @@
   let nonoInstalled = $state(false);
   let nonoProfiles = $state<string[]>([]);
   let selectedNonoProfile = $state<string | null>(null);
+
+  // PR URL integration (gh CLI). The input is hidden unless gh is present.
+  let ghInstalled = $state(false);
+  let prUrl = $state("");
+  // Phase of the PR-driven flow. `needsClone` means we got PR metadata but
+  // no local clone matches owner/repo — the UI offers to clone. `ambiguous`
+  // means multiple local clones match the repo name and the user should
+  // pick one via the repo picker. `cloning` is the clone-in-progress state.
+  let prLookup = $state<
+    "idle" | "loading" | "needsClone" | "ambiguous" | "cloning" | "ok" | "error"
+  >("idle");
+  let prInfo = $state<PrInfo | null>(null);
+  let prError = $state("");
+  let prResolvedBranch = $state("");
+  let prCloneTarget = $state("");
+  // Tracks whether the user has manually edited either prefilled field
+  // since the last successful PR lookup. Prevents a debounce-driven
+  // refetch from clobbering the user's manual edits.
+  let userEditedBranch = $state(false);
+  let userEditedName = $state(false);
+  let prLookupSeq = 0;
+  let prDebounceHandle: ReturnType<typeof setTimeout> | null = null;
   const compatSettings = $derived.by<{
     repoRoots: string[];
     excludeWorktreesFromRepoRoots: boolean;
@@ -169,11 +196,189 @@
           });
         }
       });
+      checkGhInstalled().then((installed) => {
+        ghInstalled = installed;
+      });
       if (repoPath) {
         detectGitRepo(repoPath);
       }
     }
   });
+
+  // Debounced PR URL lookup. Re-fires whenever the URL changes.
+  $effect(() => {
+    const url = prUrl.trim();
+    void url;
+    if (prDebounceHandle) {
+      clearTimeout(prDebounceHandle);
+      prDebounceHandle = null;
+    }
+    if (!ghInstalled || !url) {
+      // Empty URL: reset any prior lookup state but leave the user's
+      // session name / branch field alone.
+      prLookup = "idle";
+      prInfo = null;
+      prError = "";
+      prResolvedBranch = "";
+      prCloneTarget = "";
+      return;
+    }
+    prDebounceHandle = setTimeout(() => {
+      void runPrLookup(url);
+    }, 300);
+  });
+
+  async function runPrLookup(url: string) {
+    const seq = ++prLookupSeq;
+    prLookup = "loading";
+    prError = "";
+    prInfo = null;
+    prResolvedBranch = "";
+    prCloneTarget = "";
+    try {
+      // Use the currently-selected repo as cwd if set, else fall back to
+      // "." — gh doesn't rely on cwd once --repo is passed, but giving it
+      // a real dir keeps the subprocess happy.
+      const cwd = repoPath || null;
+      const info = await lookupPr(cwd, url);
+      if (seq !== prLookupSeq) return;
+      prInfo = info;
+      const resolution = resolveLocalRepoForPr(info);
+      if (resolution.kind === "unique") {
+        repoPath = resolution.path;
+          await detectGitRepo(resolution.path);
+        if (seq !== prLookupSeq) return;
+        await runFetchPrBranch(info, resolution.path, seq);
+      } else if (resolution.kind === "ambiguous") {
+        prLookup = "ambiguous";
+      } else {
+        prCloneTarget = defaultCloneTarget(info);
+        prLookup = "needsClone";
+      }
+    } catch (e) {
+      if (seq !== prLookupSeq) return;
+      prLookup = "error";
+      prError = String(e);
+    }
+  }
+
+  async function runFetchPrBranch(info: PrInfo, path: string, seq: number) {
+    try {
+      const branch = await fetchPrBranch(path, info.number, info.headRef, info.isCrossRepository);
+      if (seq !== prLookupSeq) return;
+      prResolvedBranch = branch;
+      prLookup = "ok";
+      applyPrPrefill(info, branch);
+    } catch (e) {
+      if (seq !== prLookupSeq) return;
+      prLookup = "error";
+      prError = String(e);
+    }
+  }
+
+  function resolveLocalRepoForPr(
+    info: PrInfo,
+  ): { kind: "unique"; path: string } | { kind: "ambiguous" } | { kind: "none" } {
+    const target = info.headRef; // unused here; reference keeps TS happy
+    void target;
+    const needle = repoNameFromPrInfo(info).toLowerCase();
+    const matches = rootRepoPaths.filter((p) => {
+      const last = p.replaceAll("\\", "/").split("/").filter(Boolean).pop();
+      return last?.toLowerCase() === needle;
+    });
+    if (matches.length === 1) return { kind: "unique", path: matches[0] };
+    if (matches.length > 1) return { kind: "ambiguous" };
+    return { kind: "none" };
+  }
+
+  function repoNameFromPrInfo(_info: PrInfo): string {
+    // PrInfo only carries the head-side owner. For matching purposes, the
+    // repo name is shared between upstream and fork, so we fall back to
+    // parsing it out of the pasted URL.
+    const parsed = parsePastedPrUrl(prUrl);
+    return parsed?.repo ?? "";
+  }
+
+  function parsePastedPrUrl(input: string): { owner: string; repo: string; number: number } | null {
+    const t = input.trim();
+    // full URL
+    const m = t.match(/^https?:\/\/(?:www\.)?github\.com\/([^\/]+)\/([^\/]+)\/pull\/(\d+)/);
+    if (m) return { owner: m[1], repo: m[2], number: Number(m[3]) };
+    // shortform
+    const s = t.match(/^([^\/\s]+)\/([^#\s]+)#(\d+)$/);
+    if (s) return { owner: s[1], repo: s[2], number: Number(s[3]) };
+    return null;
+  }
+
+  function defaultCloneTarget(info: PrInfo): string {
+    const parsed = parsePastedPrUrl(prUrl);
+    const repoName = parsed?.repo ?? info.headRef;
+    const roots = compatSettings.repoRoots.map((r) => r.trim()).filter(Boolean);
+    if (roots.length > 0) {
+      return `${roots[0].replace(/\/$/, "")}/${repoName}`;
+    }
+    // Fall back to ~/<repo>. Rust's std::env::home_dir isn't available here;
+    // we let the user pick via Change… if the default looks wrong.
+    return `~/${repoName}`;
+  }
+
+  async function handleClone() {
+    if (!prInfo) return;
+    const parsed = parsePastedPrUrl(prUrl);
+    if (!parsed) return;
+    const target = prCloneTarget.trim();
+    if (!target) return;
+    const seq = prLookupSeq;
+    prLookup = "cloning";
+    prError = "";
+    try {
+      await cloneRepo(parsed.owner, parsed.repo, target);
+      if (seq !== prLookupSeq) return;
+      repoPath = target;
+      await loadRootRepoOptions();
+      await detectGitRepo(target);
+      if (seq !== prLookupSeq) return;
+      await runFetchPrBranch(prInfo, target, seq);
+    } catch (e) {
+      if (seq !== prLookupSeq) return;
+      prLookup = "error";
+      prError = String(e);
+    }
+  }
+
+  async function pickCloneTarget() {
+    const selected = await open({ directory: true, title: "Select Parent Directory" });
+    if (!selected || !prInfo) return;
+    const parsed = parsePastedPrUrl(prUrl);
+    const repoName = parsed?.repo ?? prInfo.headRef;
+    prCloneTarget = `${(selected as string).replace(/\/$/, "")}/${repoName}`;
+  }
+
+  function applyPrPrefill(info: PrInfo, branch: string) {
+    if (!userEditedBranch) {
+      worktreeFilterInput = branch;
+      // Drive the worktree picker's active selection to match if a
+      // worktree already exists for this branch.
+      const existing = worktrees.find((wt) => wt.branch === branch);
+      if (existing) {
+        selectedWorktree = existing;
+      }
+    }
+    if (!userEditedName) {
+      sessionName = buildPrSessionName(info);
+    }
+  }
+
+  function buildPrSessionName(info: PrInfo): string {
+    const slug = info.title
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 30)
+      .replace(/-+$/g, "");
+    const base = slug ? `pr-${info.number}-${slug}` : `pr-${info.number}`;
+    return base.slice(0, 40).replace(/-+$/g, "");
+  }
 
   $effect(() => {
     const rootsKey = compatSettings.repoRoots.join("\n");
@@ -278,6 +483,13 @@
     if (!path) return;
     repoPath = path;
     await detectGitRepo(path);
+    // If we were waiting on the user to disambiguate which local clone
+    // matches the PR's repo, continue the PR flow now.
+    if (prLookup === "ambiguous" && prInfo) {
+      const seq = prLookupSeq;
+      prLookup = "loading";
+      await runFetchPrBranch(prInfo, path, seq);
+    }
   }
 
   function findQuickPickMatch(queryRaw: string): { label: string; path: string } | null {
@@ -596,6 +808,18 @@
     showCustomEditor = false;
     rootReposError = "";
     repoPickerOpen = true;
+    prUrl = "";
+    prLookup = "idle";
+    prInfo = null;
+    prError = "";
+    prResolvedBranch = "";
+    prCloneTarget = "";
+    userEditedBranch = false;
+    userEditedName = false;
+    if (prDebounceHandle) {
+      clearTimeout(prDebounceHandle);
+      prDebounceHandle = null;
+    }
     layoutPickInput = "";
     layoutPickOpen = false;
     profilePickInput = "";
@@ -631,6 +855,73 @@
 
       <!-- Body -->
       <div class="px-6 py-5 flex flex-col gap-4">
+        {#if ghInstalled}
+          <div class="flex flex-col gap-1.5">
+            <label
+              for="new-session-pr-url"
+              class="text-[11px] font-semibold uppercase tracking-wider text-text-muted"
+            >
+              PR URL <span class="font-normal normal-case text-text-muted">(optional)</span>
+            </label>
+            <input
+              id="new-session-pr-url"
+              class="rounded-md border border-border-subtle bg-bg-deep px-3 py-2 font-mono text-[12px] text-text-primary outline-none focus:border-accent-dim"
+              bind:value={prUrl}
+              placeholder="https://github.com/owner/repo/pull/142"
+              autocomplete="off"
+              spellcheck="false"
+            />
+            {#if prLookup === "loading"}
+              <p class="text-[11px] text-text-muted">Fetching PR…</p>
+            {:else if prLookup === "ok" && prInfo}
+              <p class="text-[11px] text-text-muted truncate">
+                <span class="text-accent">PR #{prInfo.number}</span>
+                <span class="text-text-secondary">"{prInfo.title}"</span>
+                {#if prInfo.isCrossRepository}
+                  <span class="ml-1 text-[10px] text-orange">(fork: {prInfo.headOwner}:{prInfo.headRef} → {prResolvedBranch})</span>
+                {:else}
+                  <span class="ml-1 text-[10px] text-text-muted">(same-repo: {prResolvedBranch})</span>
+                {/if}
+              </p>
+            {:else if prLookup === "ambiguous" && prInfo}
+              <p class="text-[11px] text-text-muted">
+                Multiple local clones of <span class="text-accent">{repoNameFromPrInfo(prInfo)}</span> found. Pick one in Repository below.
+              </p>
+            {:else if prLookup === "needsClone" && prInfo}
+              <div class="flex flex-col gap-1.5 rounded-md border border-border-subtle bg-bg-deep/60 px-2.5 py-2">
+                <p class="text-[11px] text-text-muted">
+                  No local clone of <span class="text-accent">{parsePastedPrUrl(prUrl)?.owner}/{parsePastedPrUrl(prUrl)?.repo}</span>.
+                </p>
+                <div class="flex items-center gap-1.5">
+                  <input
+                    class="min-w-0 flex-1 rounded-md border border-border-subtle bg-bg-deep px-2 py-1 font-mono text-[11px] text-text-primary outline-none focus:border-accent-dim"
+                    bind:value={prCloneTarget}
+                  />
+                  <button
+                    type="button"
+                    class="cursor-pointer rounded-md border border-border-subtle bg-bg-surface px-2 py-1 text-[11px] text-text-secondary hover:bg-bg-hover hover:text-text-primary"
+                    onclick={pickCloneTarget}
+                  >
+                    Change…
+                  </button>
+                  <button
+                    type="button"
+                    class="cursor-pointer rounded-md border border-accent-dim/20 bg-accent-dim/15 px-2.5 py-1 text-[11px] font-medium text-accent hover:bg-accent-dim/24"
+                    onclick={handleClone}
+                    disabled={!prCloneTarget.trim()}
+                  >
+                    Clone
+                  </button>
+                </div>
+              </div>
+            {:else if prLookup === "cloning"}
+              <p class="text-[11px] text-text-muted">Cloning {parsePastedPrUrl(prUrl)?.owner}/{parsePastedPrUrl(prUrl)?.repo}…</p>
+            {:else if prLookup === "error"}
+              <p class="text-[11px] text-red">{prError}</p>
+            {/if}
+          </div>
+        {/if}
+
         <!-- Repo picker -->
         <div class="flex flex-col gap-1.5">
           <label
@@ -740,7 +1031,7 @@
                   placeholder="e.g. feat/my-branch"
                   class={pickerInputClass}
                   onfocus={() => { worktreePickOpen = true; }}
-                  oninput={() => { worktreePickOpen = true; }}
+                  oninput={() => { worktreePickOpen = true; userEditedBranch = true; }}
                   onkeydown={(e) => {
                     if (e.key === "ArrowDown") {
                       e.preventDefault();
@@ -988,6 +1279,7 @@
             class="rounded-md border border-border-subtle bg-bg-deep px-3 py-2 font-mono text-[13px] text-text-primary outline-none focus:border-accent-dim"
             bind:value={sessionName}
             placeholder="roux-my-feature"
+            oninput={() => { userEditedName = true; }}
           />
         </div>
 

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -272,6 +272,40 @@ export async function listNonoProfiles(): Promise<string[]> {
   return invoke("list_nono_profiles");
 }
 
+// GitHub PR integration
+export interface PrInfo {
+  number: number;
+  title: string;
+  headRef: string;
+  headOwner: string;
+  isCrossRepository: boolean;
+}
+
+export async function checkGhInstalled(): Promise<boolean> {
+  return invoke("check_gh_installed");
+}
+
+export async function lookupPr(repoPath: string | null, url: string): Promise<PrInfo> {
+  return invoke("lookup_pr", { repoPath, url });
+}
+
+export async function cloneRepo(
+  owner: string,
+  repo: string,
+  targetDir: string,
+): Promise<string> {
+  return invoke("clone_repo", { owner, repo, targetDir });
+}
+
+export async function fetchPrBranch(
+  repoPath: string,
+  number: number,
+  headRef: string,
+  isCrossRepository: boolean,
+): Promise<string> {
+  return invoke("fetch_pr_branch", { repoPath, number, headRef, isCrossRepository });
+}
+
 // Projects
 export async function listProjects(): Promise<Project[]> {
   return invoke("list_projects");


### PR DESCRIPTION
## Summary

Adds a **PR URL** input at the top of the New Session dialog. Pasting a GitHub PR URL auto-wires the whole session setup:

- **Repo auto-select** — matches `owner/repo` against local clones in configured repo roots.
  - Unique match → auto-selected.
  - Multiple matches → user picks in Repository; the PR flow resumes automatically.
  - No match → offers to `gh repo clone` into `<repoRoots[0]>/<repo>` (or `~/<repo>`), with a Change… dir picker.
- **Branch fetch** — uses `refs/pull/<N>/head:<local>`, so no HEAD movement in the main repo. Same-repo PRs target the PR's head ref; fork PRs target `pr-<N>`.
- **Prefill** — worktree filter gets the resolved branch; session name becomes `pr-<N>-<slug>` (capped ~40 chars). Manual edits win on debounced re-lookup.
- **Hidden when `gh` is not installed.**

### Backend

New `src-tauri/src/pr.rs` with a pure URL/shortform parser (`phin-tech/roux#142` and full URLs), `lookup_pr`, `fetch_pr_branch`, `clone_repo`. Unit tests cover URL parsing. Tauri commands are thin adapters in `src-tauri/src/commands/pr.rs`.

### Design doc

Spec committed first as `docs/superpowers/specs/2026-04-14-session-from-pr-design.md`.

## Test plan

- [ ] Paste a same-repo PR URL for a repo that's in your configured roots → session created off a new worktree at the PR's head branch
- [ ] Paste a fork PR URL → local `pr-<N>` branch appears, worktree created off it, main repo HEAD unchanged
- [ ] Paste a PR URL for a repo you haven't cloned → Clone button appears; clicking it clones to the shown target and continues the flow
- [ ] Paste a PR URL where two local clones share the repo name → dialog asks you to pick; picking resumes the flow
- [ ] `gh` uninstalled → PR URL input hidden entirely
- [ ] `gh pr view` auth error → inline error "gh is not authenticated — run 'gh auth login' and retry"
- [ ] `npm run check`, `npm run test`, `cargo test --bin roux pr::` all green (currently: 0 errors, 297/297, 12/12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)