### PR TITLE
feat(ui): UX pass 1 — session dialog, panes, sidebar

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -386,6 +386,10 @@
   .pane-shell[data-focused="true"] {
     opacity: 1;
     filter: saturate(1.02) brightness(var(--pane-active-brightness));
+    box-shadow: inset 0 0 0 1px transparent;
+  }
+
+  .pane-shell[data-focused="true"][data-focus-chrome="true"] {
     box-shadow: inset 0 0 0 1px var(--color-border-subtle);
   }
 

--- a/src/lib/components/Layout.svelte
+++ b/src/lib/components/Layout.svelte
@@ -52,11 +52,11 @@
 
       <!-- svelte-ignore a11y_no_static_element_interactions -->
       <div
-        class="group relative flex w-1 shrink-0 cursor-col-resize items-stretch justify-center"
+        class="group relative flex min-h-0 w-1 shrink-0 cursor-col-resize self-stretch flex-col items-center"
         onmousedown={onDragStart}
       >
         <div
-          class="my-2 w-px rounded-full transition-all duration-150 {dragging ? 'bg-white/30' : 'bg-white/20 group-hover:bg-white/40'}"
+          class="min-h-0 max-w-[0.5px] min-w-[0.5px] flex-1 transition-all duration-150 {dragging ? 'bg-white/30' : 'bg-white/20 group-hover:bg-white/40'}"
         ></div>
       </div>
     {/if}

--- a/src/lib/components/NewSessionDialog.svelte
+++ b/src/lib/components/NewSessionDialog.svelte
@@ -55,19 +55,111 @@
   let rootReposLoading = $state(false);
   let rootReposError = $state("");
   let repoPickerOpen = $state(true);
-  let layoutPickInput = $state("");
   let layoutPickOpen = $state(false);
   let profilePickInput = $state("");
   let profilePickOpen = $state(false);
   let nonoPickInput = $state("");
   let nonoPickOpen = $state(false);
-  const pickerShellClass = "min-w-0 overflow-hidden rounded-md border border-border bg-bg-deep";
+  const pickerShellClass = "relative min-w-0 rounded-md border border-border bg-bg-deep";
   const pickerInputRowClass = "flex min-w-0 items-center gap-2 border-b border-border px-2 py-1.5";
   const pickerInputClass =
     "min-w-0 flex-1 bg-transparent px-1 py-1 font-mono text-[12px] text-text-primary outline-none placeholder:text-text-muted";
-  const pickerListClass = "app-scrollbar overflow-y-auto p-1";
+  const pickerListClass = "app-scrollbar absolute left-0 right-0 z-50 overflow-y-auto border border-border bg-bg-surface p-1 shadow-lg";
   const pickerItemClass =
     "flex cursor-pointer items-center rounded-md border border-border-subtle bg-bg-surface/50 px-2.5 py-2 text-left transition-colors hover:bg-bg-hover";
+
+  /** True when focus is moving to something outside `el` (or focus is lost with no next target). */
+  function focusLeavingElement(el: HTMLElement, related: EventTarget | null): boolean {
+    if (related == null) return true;
+    if (!(related instanceof Node)) return true;
+    return !el.contains(related);
+  }
+
+  let repoPickerCloseT: ReturnType<typeof setTimeout> | null = null;
+  let worktreePickerCloseT: ReturnType<typeof setTimeout> | null = null;
+  let layoutPickerCloseT: ReturnType<typeof setTimeout> | null = null;
+  let profilePickerCloseT: ReturnType<typeof setTimeout> | null = null;
+  let nonoPickerCloseT: ReturnType<typeof setTimeout> | null = null;
+
+  function cancelRepoPickerDeferredClose() {
+    if (repoPickerCloseT != null) {
+      clearTimeout(repoPickerCloseT);
+      repoPickerCloseT = null;
+    }
+  }
+  function armRepoPickerDeferredClose() {
+    cancelRepoPickerDeferredClose();
+    repoPickerCloseT = setTimeout(() => {
+      repoPickerCloseT = null;
+      repoPickerOpen = false;
+    }, 150);
+  }
+
+  function cancelWorktreePickerDeferredClose() {
+    if (worktreePickerCloseT != null) {
+      clearTimeout(worktreePickerCloseT);
+      worktreePickerCloseT = null;
+    }
+  }
+  function armWorktreePickerDeferredClose() {
+    cancelWorktreePickerDeferredClose();
+    worktreePickerCloseT = setTimeout(() => {
+      worktreePickerCloseT = null;
+      worktreePickOpen = false;
+    }, 150);
+  }
+
+  function cancelLayoutPickerDeferredClose() {
+    if (layoutPickerCloseT != null) {
+      clearTimeout(layoutPickerCloseT);
+      layoutPickerCloseT = null;
+    }
+  }
+  function armLayoutPickerDeferredClose() {
+    cancelLayoutPickerDeferredClose();
+    layoutPickerCloseT = setTimeout(() => {
+      layoutPickerCloseT = null;
+      layoutPickOpen = false;
+    }, 150);
+  }
+
+  function cancelProfilePickerDeferredClose() {
+    if (profilePickerCloseT != null) {
+      clearTimeout(profilePickerCloseT);
+      profilePickerCloseT = null;
+    }
+  }
+  function armProfilePickerDeferredClose() {
+    cancelProfilePickerDeferredClose();
+    profilePickerCloseT = setTimeout(() => {
+      profilePickerCloseT = null;
+      profilePickOpen = false;
+    }, 150);
+  }
+
+  function cancelNonoPickerDeferredClose() {
+    if (nonoPickerCloseT != null) {
+      clearTimeout(nonoPickerCloseT);
+      nonoPickerCloseT = null;
+    }
+  }
+  function armNonoPickerDeferredClose() {
+    cancelNonoPickerDeferredClose();
+    nonoPickerCloseT = setTimeout(() => {
+      nonoPickerCloseT = null;
+      nonoPickOpen = false;
+    }, 150);
+  }
+
+  $effect(() => {
+    if (visible) return;
+    cancelRepoPickerDeferredClose();
+    cancelWorktreePickerDeferredClose();
+    cancelLayoutPickerDeferredClose();
+    cancelProfilePickerDeferredClose();
+    cancelNonoPickerDeferredClose();
+  });
+
   let quickPickOptions = $derived.by<{ label: string; path: string }[]>(() =>
     buildQuickPickOptions(rootRepoPaths),
   );
@@ -95,6 +187,11 @@
     options.push({ value: "__custom__", label: "Custom…" });
     return options;
   });
+  let profileListClass = $derived.by<string>(() =>
+    profileOptions.length > 4
+      ? `${pickerListClass} max-h-40 overflow-y-scroll`
+      : `${pickerListClass} overflow-y-visible`,
+  );
   let nonoOptions = $derived.by<{ value: string; label: string }[]>(() => [
     { value: "", label: "None (bare claude)" },
     ...nonoProfiles.map((profile) => ({ value: profile, label: profile })),
@@ -396,9 +493,6 @@
 
   $effect(() => {
     if (!visible) return;
-    if (!layoutPickOpen) {
-      layoutPickInput = selectedLayout?.name ?? "None (single pane)";
-    }
     if (!profilePickOpen) {
       if (selectedProfileId === "__inline__" && inlineProfile) {
         profilePickInput = `${inlineProfile.name} (custom)`;
@@ -534,9 +628,8 @@
     return options.find((o) => o.label.toLowerCase().includes(lower)) ?? null;
   }
 
-  function selectLayoutOption(value: string, label: string) {
+  function selectLayoutOption(value: string) {
     selectedLayoutId = value;
-    layoutPickInput = label;
     layoutPickOpen = false;
   }
 
@@ -544,6 +637,11 @@
     handleProfileSelect(value);
     profilePickInput = label;
     profilePickOpen = false;
+  }
+
+  function openProfilePicker(clearQuery: boolean = false) {
+    if (clearQuery) profilePickInput = "";
+    profilePickOpen = true;
   }
 
   function selectNonoOption(value: string, label: string) {
@@ -819,7 +917,6 @@
       clearTimeout(prDebounceHandle);
       prDebounceHandle = null;
     }
-    layoutPickInput = "";
     layoutPickOpen = false;
     profilePickInput = "";
     profilePickOpen = false;
@@ -929,7 +1026,15 @@
           >
             Repository
           </label>
-          <div class={pickerShellClass}>
+          <div
+            class={pickerShellClass}
+            onfocusin={cancelRepoPickerDeferredClose}
+            onfocusout={(e) => {
+              const shell = e.currentTarget as HTMLElement;
+              if (!focusLeavingElement(shell, e.relatedTarget)) return;
+              armRepoPickerDeferredClose();
+            }}
+          >
             <Command.Root shouldFilter={true} loop={true} vimBindings={true}>
               <div class={pickerInputRowClass}>
                 <Command.Input
@@ -1022,7 +1127,15 @@
           <fieldset class="flex flex-col gap-1.5">
             <legend class="text-[11px] font-semibold uppercase tracking-wider text-text-muted">Worktree / Branch</legend>
             <p class="text-[11px] text-text-muted">Pick an existing worktree, or type a new branch name to create one.</p>
-            <div class={pickerShellClass}>
+            <div
+              class={pickerShellClass}
+              onfocusin={cancelWorktreePickerDeferredClose}
+              onfocusout={(e) => {
+                const shell = e.currentTarget as HTMLElement;
+                if (!focusLeavingElement(shell, e.relatedTarget)) return;
+                armWorktreePickerDeferredClose();
+              }}
+            >
               <div class={pickerInputRowClass}>
                 <input
                   id="new-session-worktree-picker"
@@ -1094,50 +1207,46 @@
           >
             Layout
           </label>
-          <div class={pickerShellClass}>
-            <Command.Root shouldFilter={true} loop={true} vimBindings={true}>
-              <div class={pickerInputRowClass}>
-                <Command.Input
-                  id="new-session-layout"
-                  bind:value={layoutPickInput}
-                  placeholder="Pick layout"
-                  class={pickerInputClass}
-                  onfocus={() => { layoutPickOpen = true; }}
-                  oninput={() => { layoutPickOpen = true; }}
-                  onkeydown={(e) => {
-                    if (e.key !== "Enter") return;
-                    const match = findOptionMatch(layoutPickInput, layoutOptions);
-                    if (!match) return;
-                    e.preventDefault();
-                    selectLayoutOption(match.value, match.label);
-                  }}
-                />
+          <div
+            class={pickerShellClass}
+            onfocusin={cancelLayoutPickerDeferredClose}
+            onfocusout={(e) => {
+              const shell = e.currentTarget as HTMLElement;
+              if (!focusLeavingElement(shell, e.relatedTarget)) return;
+              armLayoutPickerDeferredClose();
+            }}
+          >
+            <div class={pickerInputRowClass}>
+              <button
+                id="new-session-layout"
+                type="button"
+                class="flex w-full items-center justify-between bg-transparent px-1 py-1 text-left font-mono text-[12px] text-text-primary outline-none"
+                onclick={() => { layoutPickOpen = !layoutPickOpen; }}
+                aria-expanded={layoutPickOpen}
+                aria-haspopup="listbox"
+              >
+                <span class="truncate">{selectedLayout?.name ?? "None (single pane)"}</span>
+                <span class="ml-2 text-[10px] text-text-muted">{layoutPickOpen ? "▲" : "▼"}</span>
+              </button>
+            </div>
+            {#if layoutPickOpen}
+              <div class={`${pickerListClass} max-h-32`} role="listbox" aria-labelledby="new-session-layout">
+                {#each layoutOptions as option (option.value)}
+                  <button
+                    type="button"
+                    role="option"
+                    aria-selected={selectedLayoutId === option.value}
+                    class={`${pickerItemClass} w-full justify-between py-1.5 ${selectedLayoutId === option.value ? "bg-bg-active" : ""}`}
+                    onclick={() => selectLayoutOption(option.value)}
+                  >
+                    <span class="truncate font-mono text-[12px] text-text-primary">{option.label}</span>
+                    {#if selectedLayoutId === option.value}
+                      <span class="ml-2 text-[10px] text-accent">selected</span>
+                    {/if}
+                  </button>
+                {/each}
               </div>
-              {#if layoutPickOpen}
-                <Command.List class={`${pickerListClass} max-h-32`}>
-                  <Command.Empty class="px-3 py-2 text-[11px] text-text-muted">
-                    No matching layouts
-                  </Command.Empty>
-                  <Command.Group>
-                    <Command.GroupItems>
-                      {#each layoutOptions as option (option.value)}
-                        <Command.Item
-                          value={option.label}
-                          keywords={[option.value]}
-                          onSelect={() => selectLayoutOption(option.value, option.label)}
-                          class={`${pickerItemClass} justify-between py-1.5 data-[selected]:bg-bg-active`}
-                        >
-                          <span class="truncate font-mono text-[12px] text-text-primary">{option.label}</span>
-                          {#if selectedLayoutId === option.value}
-                            <span class="ml-2 text-[10px] text-accent">selected</span>
-                          {/if}
-                        </Command.Item>
-                      {/each}
-                    </Command.GroupItems>
-                  </Command.Group>
-                </Command.List>
-              {/if}
-            </Command.Root>
+            {/if}
           </div>
           {#if selectedLayout?.description}
             <p class="text-[11px] text-text-muted">{selectedLayout.description}</p>
@@ -1153,7 +1262,15 @@
             >
               Spawn profile
             </label>
-            <div class={pickerShellClass}>
+            <div
+              class={pickerShellClass}
+              onfocusin={cancelProfilePickerDeferredClose}
+              onfocusout={(e) => {
+                const shell = e.currentTarget as HTMLElement;
+                if (!focusLeavingElement(shell, e.relatedTarget)) return;
+                armProfilePickerDeferredClose();
+              }}
+            >
               <Command.Root shouldFilter={true} loop={true} vimBindings={true}>
                 <div class={pickerInputRowClass}>
                   <Command.Input
@@ -1161,7 +1278,10 @@
                     bind:value={profilePickInput}
                     placeholder="Pick spawn profile"
                     class={pickerInputClass}
-                    onfocus={() => { profilePickOpen = true; }}
+                    onfocus={(e) => {
+                      openProfilePicker(true);
+                      (e.currentTarget as HTMLInputElement).select();
+                    }}
                     oninput={() => { profilePickOpen = true; }}
                     onkeydown={(e) => {
                       if (e.key !== "Enter") return;
@@ -1171,9 +1291,17 @@
                       selectProfileOption(match.value, match.label);
                     }}
                   />
+                  <button
+                    type="button"
+                    class="bg-transparent px-1 py-1 leading-none font-mono text-[12px]"
+                    onclick={() => openProfilePicker(true)}
+                    aria-label="Open spawn profile options"
+                  >
+                    <span class="text-[10px] text-text-muted">{profilePickOpen ? "▲" : "▼"}</span>
+                  </button>
                 </div>
                 {#if profilePickOpen}
-                  <Command.List class={`${pickerListClass} max-h-36`}>
+                  <Command.List class={profileListClass}>
                     <Command.Empty class="px-3 py-2 text-[11px] text-text-muted">
                       No matching profiles
                     </Command.Empty>
@@ -1215,7 +1343,15 @@
                 Sandbox Profile
                 <span class="font-normal normal-case tracking-normal">(nono.sh)</span>
               </label>
-              <div class={pickerShellClass}>
+              <div
+                class={pickerShellClass}
+                onfocusin={cancelNonoPickerDeferredClose}
+                onfocusout={(e) => {
+                  const shell = e.currentTarget as HTMLElement;
+                  if (!focusLeavingElement(shell, e.relatedTarget)) return;
+                  armNonoPickerDeferredClose();
+                }}
+              >
                 <Command.Root shouldFilter={true} loop={true} vimBindings={true}>
                   <div class={pickerInputRowClass}>
                     <Command.Input
@@ -1223,7 +1359,7 @@
                       bind:value={nonoPickInput}
                       placeholder="Pick sandbox profile"
                       class={pickerInputClass}
-                      onfocus={() => { nonoPickOpen = true; }}
+                      onfocus={() => { nonoPickInput = ""; nonoPickOpen = true; }}
                       oninput={() => { nonoPickOpen = true; }}
                       onkeydown={(e) => {
                         if (e.key !== "Enter") return;

--- a/src/lib/components/PaneShell.svelte
+++ b/src/lib/components/PaneShell.svelte
@@ -3,6 +3,7 @@
   import "@xterm/xterm/css/xterm.css";
   import { paneInstances, updateInstance } from "$lib/panes/instances";
   import { focusedPaneId, requestDomFocus, setLogicalFocus } from "$lib/panes/focus";
+  import { collectVisibleLeafIds, sessionLayouts } from "$lib/panes/layout";
   import { closePane } from "$lib/panes/actions";
   import { resolveProfileRef } from "$lib/panes/profiles";
   import { runProfileInPane } from "$lib/panes/profileRunner";
@@ -43,6 +44,11 @@
 
   const instance = $derived($paneInstances.get(paneId));
   const isFocused = $derived($focusedPaneId === paneId);
+  const hasMultipleVisiblePanes = $derived.by<boolean>(() => {
+    const layout = $sessionLayouts.get(sessionId);
+    if (!layout) return false;
+    return collectVisibleLeafIds(layout).length > 1;
+  });
   const session = $derived($sessionState.sessions.find((s) => s.id === sessionId));
   const paneSlot = $derived($paneSlotById.get(paneId) ?? null);
   const paneSlotLabel = $derived(
@@ -290,14 +296,15 @@
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <div
-    class="pane-shell relative flex flex-col flex-1 min-h-0 min-w-0 overflow-hidden bg-bg-deep"
+    class="pane-shell group relative flex flex-col flex-1 min-h-0 min-w-0 overflow-hidden bg-bg-deep"
     data-focused={isFocused}
+    data-focus-chrome={(isFocused && hasMultipleVisiblePanes) ? "true" : undefined}
     onmousedown={handleMouseDown}
   >
     <!-- Mini title bar -->
     <div
       class="pane-shell__titlebar flex h-6 shrink-0 select-none items-center border-b border-hairline px-2 gap-1.5"
-      class:shadow-[inset_0_2px_0_var(--color-accent-dim)]={isFocused && !suppressTitleAccent}
+      class:shadow-[inset_0_2px_0_var(--color-accent-dim)]={isFocused && hasMultipleVisiblePanes && !suppressTitleAccent}
       ondblclick={() => startRenaming(instance.name ?? "")}
     >
       <span class="text-[10px] uppercase tracking-wider text-text-muted/60 shrink-0">{paneTypeLabel(instance.type)}</span>
@@ -320,30 +327,34 @@
       {:else}
         <span class="flex-1"></span>
       {/if}
-      {#if canReRunProfile}
-        <button
-          class="flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center rounded text-[11px] leading-none text-text-secondary transition-colors hover:bg-bg-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50"
-          onclick={(e) => {
-            e.stopPropagation();
-            void reRunProfile();
-          }}
-          title={activeProfile ? `Re-run profile: ${activeProfile.name}` : "Re-run profile"}
-        >
-          &#8635;
-        </button>
-      {/if}
-      {#if canClose()}
-        <button
-          class="flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center rounded text-[12px] leading-none text-text-secondary transition-colors hover:bg-bg-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50"
-          onclick={(e) => {
-            e.stopPropagation();
-            void closePane(sessionId, paneId);
-          }}
-          title="Close pane"
-        >
-          &times;
-        </button>
-      {/if}
+      <div
+        class="flex shrink-0 items-center gap-0.5 opacity-0 pointer-events-none transition-opacity duration-150 group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto"
+      >
+        {#if canReRunProfile}
+          <button
+            class="flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center rounded text-[11px] leading-none text-text-secondary transition-colors hover:bg-bg-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50"
+            onclick={(e) => {
+              e.stopPropagation();
+              void reRunProfile();
+            }}
+            title={activeProfile ? `Re-run profile: ${activeProfile.name}` : "Re-run profile"}
+          >
+            &#8635;
+          </button>
+        {/if}
+        {#if canClose()}
+          <button
+            class="flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center rounded text-[12px] leading-none text-text-secondary transition-colors hover:bg-bg-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50"
+            onclick={(e) => {
+              e.stopPropagation();
+              void closePane(sessionId, paneId);
+            }}
+            title="Close pane"
+          >
+            &times;
+          </button>
+        {/if}
+      </div>
     </div>
 
     <div class="flex-1 min-h-0 min-w-0">

--- a/src/lib/components/SessionTabs.svelte
+++ b/src/lib/components/SessionTabs.svelte
@@ -243,9 +243,7 @@
 <svelte:window onclick={closeContextMenu} />
 
 <div
-  class="flex h-full flex-col overflow-hidden border-border-subtle bg-bg-base/96 shadow-[0_0_0_1px_rgba(255,255,255,0.03)]"
-  class:border-r={$settings.tabPosition === "left"}
-  class:border-l={$settings.tabPosition === "right"}
+  class="flex h-full flex-col overflow-hidden bg-bg-base/96 shadow-[0_0_0_1px_rgba(255,255,255,0.03)]"
   bind:this={containerEl}
 >
   <div class="flex h-9 shrink-0 items-center justify-between px-3">


### PR DESCRIPTION
Tracks [Discussion #59](https://github.com/phin-tech/roux/discussions/59) / [#68](https://github.com/phin-tech/roux/issues/68) UX pass 1 scope (launcher/dialog polish, pane chrome, sidebar).

## Summary

Polish for new-session pickers, pane focus chrome, sidebar divider, and pane title actions—mostly small interaction and visual noise fixes.

## Changes

### New Session dialog (`4936dd8`)

- **Layout**: true option selector (button + list), not a type-to-filter text field.
- **Spawn profile**: searchable combo kept, but opening clears stale filter text; click and chevron open the list; list shows all options when there are few, scroll when many; blur/close behavior aligned with other pickers; arrow alignment with layout control.

### Pane focus (`3062e53`)

- **Single-pane highlight**: `data-focused` and title bar accent only when more than one visible pane exists, so a lone terminal does not look “selected” for no reason.

### Sidebar divider (`ba6e99a`)

- **Layout + SessionTabs**: resize strip uses full row height with a finer hairline; removed `SessionTabs` `border-r` / `border-l` so it no longer stacks with the divider (double line).

### Pane title bar (`068ee5a`)

- **Re-run / Close**: hidden until hover anywhere on the pane or focus-within (e.g. terminal focused), with a short opacity transition.

## Out of scope (later / other PRs)

- Task panel collapsed filter (#59 item 2).
- Global `user-select` and other uncommitted local edits (locks, `Taskfile`, etc.) are **not** part of this branch.

## Test plan

- [ ] New Session: layout selector and spawn profile dropdowns behave as expected.
- [ ] Single-pane session: no strong active-pane frame on the only terminal.
- [ ] Sidebar expanded: one clean vertical divider; resize still works.
- [ ] Multi-pane: hover each pane to see re-run/close; focus terminal and confirm actions can still be reached.
