### PR TITLE
fix(build): stage target-suffixed roux-cli; split per-OS Taskfiles

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,5 +1,18 @@
 version: "3"
 
+# Per-OS task files. Included so that their tasks are reachable as
+# `macos:*` / `windows:*` from the root Taskfile — existing callers keep
+# working unchanged. `optional: true` means running on a different OS
+# doesn't error on missing files, and each task inside carries a
+# `platforms:` guard so cross-OS invocations are no-ops.
+includes:
+  macos:
+    taskfile: ./taskfiles/Taskfile_darwin.yml
+    optional: true
+  windows:
+    taskfile: ./taskfiles/Taskfile_windows.yml
+    optional: true
+
 tasks:
   dev:
     desc: "Run Tauri in development mode (also rebuilds roux-cli)"
@@ -203,135 +216,18 @@ tasks:
       - cargo run --manifest-path src-tauri/Cargo.toml --target-dir src-tauri/target-task --bin roux-cli -- clear
 
   bundle:prepare-cli:
-    desc: "Build roux-cli and stage it for bundling"
+    desc: "Build roux-cli and stage it for bundling (darwin/linux). For Windows, use `task windows:prepare-cli`."
     cmds:
-      - cargo build --manifest-path src-tauri/Cargo.toml --release --bin roux-cli
       - cmd: |
-          cmd /c "if not exist src-tauri\binaries mkdir src-tauri\binaries && copy /Y target\release\roux-cli.exe src-tauri\binaries\roux-cli.exe >nul && echo Prepared bundled roux-cli.exe"
-        platforms: [windows]
-      - cmd: |
+          set -euo pipefail
+          TARGET="${TAURI_TARGET:-$(rustc -vV | sed -n 's/^host: //p')}"
+          cargo build --manifest-path src-tauri/Cargo.toml --release --bin roux-cli
           mkdir -p src-tauri/binaries
           cp target/release/roux-cli src-tauri/binaries/roux-cli
-          chmod +x src-tauri/binaries/roux-cli
-          echo "Prepared bundled roux-cli"
+          cp target/release/roux-cli "src-tauri/binaries/roux-cli-${TARGET}"
+          chmod +x src-tauri/binaries/roux-cli "src-tauri/binaries/roux-cli-${TARGET}"
+          echo "Prepared bundled roux-cli for ${TARGET}"
         platforms: [darwin, linux]
-
-  windows:build:
-    desc: "Build the Windows NSIS installer"
-    cmds:
-      - task: bundle:prepare-cli
-      - npm run tauri build -- --bundles nsis
-
-  macos:prepare-cli:
-    desc: "Build roux-cli and stage it for macOS bundling"
-    cmds:
-      - |
-        set -euo pipefail
-        if [ -n "${TAURI_TARGET:-}" ]; then
-          cargo build --manifest-path src-tauri/Cargo.toml --release --bin roux-cli --target "${TAURI_TARGET}"
-          SOURCE="target/${TAURI_TARGET}/release/roux-cli"
-        else
-          cargo build --manifest-path src-tauri/Cargo.toml --release --bin roux-cli
-          SOURCE="target/release/roux-cli"
-        fi
-        mkdir -p src-tauri/binaries
-        cp "${SOURCE}" src-tauri/binaries/roux-cli
-        chmod +x src-tauri/binaries/roux-cli
-        echo "Prepared bundled roux-cli from ${SOURCE}"
-
-  macos:verify:
-    desc: "Verify the latest signed macOS artifacts"
-    cmds:
-      - |
-        set -euo pipefail
-        TARGET_ROOT="target"
-        if [ -n "${TAURI_TARGET:-}" ]; then
-          TARGET_ROOT="${TARGET_ROOT}/${TAURI_TARGET}"
-        fi
-
-        APP="${TARGET_ROOT}/release/bundle/macos/Roux.app"
-        DMG_DIR="${TARGET_ROOT}/release/bundle/dmg"
-        DMG="$(find "${DMG_DIR}" -maxdepth 1 -name 'Roux_*.dmg' | sort | tail -n 1)"
-
-        codesign --verify --deep --strict --verbose=2 "${APP}"
-        spctl --assess --type execute --verbose=4 "${APP}"
-
-        if [ -n "${DMG}" ]; then
-          xcrun stapler validate "${DMG}"
-        fi
-
-  macos:staple-dmg:
-    desc: "Staple the latest signed macOS DMG"
-    cmds:
-      - |
-        set -euo pipefail
-        TARGET_ROOT="target"
-        if [ -n "${TAURI_TARGET:-}" ]; then
-          TARGET_ROOT="${TARGET_ROOT}/${TAURI_TARGET}"
-        fi
-
-        DMG_DIR="${TARGET_ROOT}/release/bundle/dmg"
-        DMG="$(find "${DMG_DIR}" -maxdepth 1 -name 'Roux_*.dmg' | sort | tail -n 1)"
-
-        if [ -n "${DMG}" ]; then
-          xcrun stapler staple "${DMG}"
-        fi
-
-  macos:zip-app:
-    desc: "Zip the latest signed macOS app bundle"
-    cmds:
-      - |
-        set -euo pipefail
-        TARGET_ROOT="target"
-        if [ -n "${TAURI_TARGET:-}" ]; then
-          TARGET_ROOT="${TARGET_ROOT}/${TAURI_TARGET}"
-        fi
-
-        VERSION=$(python3 -c 'import json; print(json.load(open("src-tauri/tauri.conf.json"))["version"])')
-        APP="${TARGET_ROOT}/release/bundle/macos/Roux.app"
-        APP_ZIP="${TARGET_ROOT}/release/bundle/macos/Roux_${VERSION}.app.zip"
-
-        rm -f "${APP_ZIP}"
-        ditto -c -k --sequesterRsrc --keepParent "${APP}" "${APP_ZIP}"
-        echo "Prepared ${APP_ZIP}"
-
-  macos:notarize-dmg:
-    desc: "Notarize the latest signed macOS DMG"
-    cmds:
-      - |
-        set -euo pipefail
-        TARGET_ROOT="target"
-        if [ -n "${TAURI_TARGET:-}" ]; then
-          TARGET_ROOT="${TARGET_ROOT}/${TAURI_TARGET}"
-        fi
-
-        DMG_DIR="${TARGET_ROOT}/release/bundle/dmg"
-        DMG="$(find "${DMG_DIR}" -maxdepth 1 -name 'Roux_*.dmg' | sort | tail -n 1)"
-
-        if [ -z "${DMG}" ]; then
-          echo "No DMG found to notarize"
-          exit 0
-        fi
-
-        export DMG
-        ./scripts/run-macos-signing.sh sh -c '
-          if [ -n "${APPLE_ID:-}" ] && [ -n "${APPLE_PASSWORD:-}" ] && [ -n "${APPLE_TEAM_ID:-}" ]; then
-            xcrun notarytool submit "$DMG" \
-              --apple-id "$APPLE_ID" \
-              --password "$APPLE_PASSWORD" \
-              --team-id "$APPLE_TEAM_ID" \
-              --wait
-          elif [ -n "${APPLE_API_KEY:-}" ] && [ -n "${APPLE_API_ISSUER:-}" ] && [ -n "${APPLE_API_KEY_PATH:-}" ]; then
-            xcrun notarytool submit "$DMG" \
-              --key "$APPLE_API_KEY" \
-              --issuer "$APPLE_API_ISSUER" \
-              --key-path "$APPLE_API_KEY_PATH" \
-              --wait
-          else
-            echo "Missing notarization credentials for DMG submission" >&2
-            exit 1
-          fi
-        '
 
   sign:
     desc: "Build, sign, notarize, and staple the macOS app"

--- a/taskfiles/Taskfile_darwin.yml
+++ b/taskfiles/Taskfile_darwin.yml
@@ -1,0 +1,125 @@
+version: "3"
+
+# macOS-specific tasks. Included from the root Taskfile under the `macos:`
+# namespace, so external callers still use e.g. `task macos:prepare-cli`.
+# Every task carries `platforms: [darwin]` as a guard — no-op rather than
+# failing obscurely if invoked on another OS.
+
+tasks:
+  prepare-cli:
+    desc: "Build roux-cli and stage it for macOS bundling"
+    cmds:
+      - cmd: |
+          set -euo pipefail
+          TARGET="${TAURI_TARGET:-$(rustc -vV | sed -n 's/^host: //p')}"
+          if [ -n "${TAURI_TARGET:-}" ]; then
+            cargo build --manifest-path src-tauri/Cargo.toml --release --bin roux-cli --target "${TAURI_TARGET}"
+            SOURCE="target/${TAURI_TARGET}/release/roux-cli"
+          else
+            cargo build --manifest-path src-tauri/Cargo.toml --release --bin roux-cli
+            SOURCE="target/release/roux-cli"
+          fi
+          mkdir -p src-tauri/binaries
+          cp "${SOURCE}" src-tauri/binaries/roux-cli
+          cp "${SOURCE}" "src-tauri/binaries/roux-cli-${TARGET}"
+          chmod +x src-tauri/binaries/roux-cli "src-tauri/binaries/roux-cli-${TARGET}"
+          echo "Prepared bundled roux-cli from ${SOURCE}"
+        platforms: [darwin]
+
+  verify:
+    desc: "Verify the latest signed macOS artifacts"
+    cmds:
+      - cmd: |
+          set -euo pipefail
+          TARGET_ROOT="target"
+          if [ -n "${TAURI_TARGET:-}" ]; then
+            TARGET_ROOT="${TARGET_ROOT}/${TAURI_TARGET}"
+          fi
+
+          APP="${TARGET_ROOT}/release/bundle/macos/Roux.app"
+          DMG_DIR="${TARGET_ROOT}/release/bundle/dmg"
+          DMG="$(find "${DMG_DIR}" -maxdepth 1 -name 'Roux_*.dmg' | sort | tail -n 1)"
+
+          codesign --verify --deep --strict --verbose=2 "${APP}"
+          spctl --assess --type execute --verbose=4 "${APP}"
+
+          if [ -n "${DMG}" ]; then
+            xcrun stapler validate "${DMG}"
+          fi
+        platforms: [darwin]
+
+  staple-dmg:
+    desc: "Staple the latest signed macOS DMG"
+    cmds:
+      - cmd: |
+          set -euo pipefail
+          TARGET_ROOT="target"
+          if [ -n "${TAURI_TARGET:-}" ]; then
+            TARGET_ROOT="${TARGET_ROOT}/${TAURI_TARGET}"
+          fi
+
+          DMG_DIR="${TARGET_ROOT}/release/bundle/dmg"
+          DMG="$(find "${DMG_DIR}" -maxdepth 1 -name 'Roux_*.dmg' | sort | tail -n 1)"
+
+          if [ -n "${DMG}" ]; then
+            xcrun stapler staple "${DMG}"
+          fi
+        platforms: [darwin]
+
+  zip-app:
+    desc: "Zip the latest signed macOS app bundle"
+    cmds:
+      - cmd: |
+          set -euo pipefail
+          TARGET_ROOT="target"
+          if [ -n "${TAURI_TARGET:-}" ]; then
+            TARGET_ROOT="${TARGET_ROOT}/${TAURI_TARGET}"
+          fi
+
+          VERSION=$(python3 -c 'import json; print(json.load(open("src-tauri/tauri.conf.json"))["version"])')
+          APP="${TARGET_ROOT}/release/bundle/macos/Roux.app"
+          APP_ZIP="${TARGET_ROOT}/release/bundle/macos/Roux_${VERSION}.app.zip"
+
+          rm -f "${APP_ZIP}"
+          ditto -c -k --sequesterRsrc --keepParent "${APP}" "${APP_ZIP}"
+          echo "Prepared ${APP_ZIP}"
+        platforms: [darwin]
+
+  notarize-dmg:
+    desc: "Notarize the latest signed macOS DMG"
+    cmds:
+      - cmd: |
+          set -euo pipefail
+          TARGET_ROOT="target"
+          if [ -n "${TAURI_TARGET:-}" ]; then
+            TARGET_ROOT="${TARGET_ROOT}/${TAURI_TARGET}"
+          fi
+
+          DMG_DIR="${TARGET_ROOT}/release/bundle/dmg"
+          DMG="$(find "${DMG_DIR}" -maxdepth 1 -name 'Roux_*.dmg' | sort | tail -n 1)"
+
+          if [ -z "${DMG}" ]; then
+            echo "No DMG found to notarize"
+            exit 0
+          fi
+
+          export DMG
+          ./scripts/run-macos-signing.sh sh -c '
+            if [ -n "${APPLE_ID:-}" ] && [ -n "${APPLE_PASSWORD:-}" ] && [ -n "${APPLE_TEAM_ID:-}" ]; then
+              xcrun notarytool submit "$DMG" \
+                --apple-id "$APPLE_ID" \
+                --password "$APPLE_PASSWORD" \
+                --team-id "$APPLE_TEAM_ID" \
+                --wait
+            elif [ -n "${APPLE_API_KEY:-}" ] && [ -n "${APPLE_API_ISSUER:-}" ] && [ -n "${APPLE_API_KEY_PATH:-}" ]; then
+              xcrun notarytool submit "$DMG" \
+                --key "$APPLE_API_KEY" \
+                --issuer "$APPLE_API_ISSUER" \
+                --key-path "$APPLE_API_KEY_PATH" \
+                --wait
+            else
+              echo "Missing notarization credentials for DMG submission" >&2
+              exit 1
+            fi
+          '
+        platforms: [darwin]

--- a/taskfiles/Taskfile_windows.yml
+++ b/taskfiles/Taskfile_windows.yml
@@ -1,0 +1,28 @@
+version: "3"
+
+# Windows-specific tasks. Included from the root Taskfile under the
+# `windows:` namespace, so external callers still use e.g.
+# `task windows:build`. Every task carries `platforms: [windows]` as a
+# guard — no-op rather than failing obscurely if invoked on another OS.
+
+tasks:
+  prepare-cli:
+    desc: "Build roux-cli and stage it for Windows bundling"
+    cmds:
+      - cargo build --manifest-path src-tauri/Cargo.toml --release --bin roux-cli
+      - cmd: |
+          for /f "tokens=2 delims=: " %%a in ('rustc -vV ^| findstr /b "host:"') do set HOST=%%a
+          if not defined HOST set HOST=%TAURI_TARGET%
+          if not defined HOST set HOST=x86_64-pc-windows-msvc
+          if not exist src-tauri\binaries mkdir src-tauri\binaries
+          copy /Y target\release\roux-cli.exe src-tauri\binaries\roux-cli.exe >nul
+          copy /Y target\release\roux-cli.exe src-tauri\binaries\roux-cli-%HOST%.exe >nul
+          echo Prepared bundled roux-cli.exe for %HOST%
+        platforms: [windows]
+
+  build:
+    desc: "Build the Windows NSIS installer"
+    cmds:
+      - task: prepare-cli
+      - cmd: npm run tauri build -- --bundles nsis
+        platforms: [windows]


### PR DESCRIPTION
## Summary

- **Fix:** \`task dev:install\` (and \`task sign\`, \`task build\`) fail on fresh checkouts with \`resource path \`binaries/roux-cli-aarch64-apple-darwin\` doesn't exist\`. Tauri's \`externalBin\` resolves \`binaries/roux-cli\` to \`binaries/roux-cli-\${TARGET}\`, but \`macos:prepare-cli\` and \`bundle:prepare-cli\` only staged the bare \`binaries/roux-cli\`. Both now stage both paths, matching the existing \`cli:stage-dev-binary\` pattern.
- **Cleanup:** Moved pure OS-specific tasks into \`taskfiles/Taskfile_darwin.yml\` and \`taskfiles/Taskfile_windows.yml\`, included from the root Taskfile via \`includes:\` so existing callers (\`macos:prepare-cli\`, \`windows:build\`, \`sign\`, etc.) keep working unchanged. Each moved task carries a \`platforms:\` guard.
- Windows staging lives in \`windows:prepare-cli\`, so \`bundle:prepare-cli\` simplifies to darwin/linux only.

## Test plan

- [ ] \`task dev:install\` on macOS succeeds end-to-end (builds CLI, stages both binary paths, builds Tauri bundle, installs \`/Applications/Roux.app\`)
- [x] \`task -l\` lists all tasks, including \`macos:*\` and \`windows:*\` via includes
- [x] \`task --dry dev:install\` resolves \`macos:prepare-cli\` with both \`cp\` steps (bare + \`-\${TARGET}\`)
- [x] \`task --dry sign\` resolves \`macos:prepare-cli\`, \`macos:notarize-dmg\`, \`macos:staple-dmg\`, \`macos:verify\`
- [x] \`task --dry build\` resolves \`bundle:prepare-cli\` with target-suffix staging
- [x] \`task --dry windows:build\` resolves \`windows:prepare-cli\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)