### PR TITLE
fix(ui): make sidebars mutually exclusive via shared store

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -67,13 +67,13 @@
     hideSessionHints,
     armPaneHints,
     hidePaneHints,
+    activeSidebar,
+    openSidebar,
+    closeSidebar,
+    toggleSidebar,
   } from "$lib/stores/ui";
 
   let showNewSessionDialog = $state(false);
-  let showSettings = $state(false);
-  let showNotes = $state(false);
-  let showWatches = $state(false);
-  let showNotifications = $state(false);
   let showSetupPrompt = $state(false);
   let showQuitDialog = $state(false);
 
@@ -138,23 +138,19 @@
       return;
     }
     if (cmd.id === "app.settings") {
-      showSettings = !showSettings;
-      if (showSettings) showNotes = false;
+      toggleSidebar("settings");
       return;
     }
     if (cmd.id === "ui.toggle-notes") {
-      showNotes = !showNotes;
-      if (showNotes) showSettings = false;
+      toggleSidebar("notes");
       return;
     }
     if (cmd.id === "ui.toggle-watches") {
-      showWatches = !showWatches;
-      if (showWatches) { showSettings = false; showNotes = false; showNotifications = false; }
+      toggleSidebar("watches");
       return;
     }
     if (cmd.id === "ui.toggle-notifications") {
-      showNotifications = !showNotifications;
-      if (showNotifications) { showSettings = false; showNotes = false; showWatches = false; }
+      toggleSidebar("notifications");
       return;
     }
     if (cmd.id === "app.command-palette") {
@@ -642,26 +638,26 @@
 
 <Layout
   onNewSession={() => (showNewSessionDialog = true)}
-  onOpenSettings={() => (showSettings = !showSettings)}
-  onToggleWatches={() => { showWatches = !showWatches; if (showWatches) { showSettings = false; showNotes = false; showNotifications = false; } }}
-  onToggleNotifications={() => { showNotifications = !showNotifications; if (showNotifications) { showSettings = false; showNotes = false; showWatches = false; } }}
+  onOpenSettings={() => toggleSidebar("settings")}
+  onToggleWatches={() => toggleSidebar("watches")}
+  onToggleNotifications={() => toggleSidebar("notifications")}
 >
   {#snippet settingsPanel()}
-    <SettingsPanel visible={showSettings} onclose={() => (showSettings = false)} />
+    <SettingsPanel visible={$activeSidebar === "settings"} onclose={closeSidebar} />
     {@const activeSession = $sessionState.sessions.find(s => s.id === $sessionState.activeSessionId)}
     <NotesPanel
-      visible={showNotes}
+      visible={$activeSidebar === "notes"}
       projectId={activeSession?.projectId ?? null}
       projectName={$projects.find(p => p.id === activeSession?.projectId)?.name ?? null}
-      onclose={() => (showNotes = false)}
+      onclose={closeSidebar}
     />
     <WatchesPane
-      visible={showWatches}
-      onclose={() => (showWatches = false)}
+      visible={$activeSidebar === "watches"}
+      onclose={closeSidebar}
     />
     <NotificationsPane
-      visible={showNotifications}
-      onclose={() => (showNotifications = false)}
+      visible={$activeSidebar === "notifications"}
+      onclose={closeSidebar}
     />
   {/snippet}
 </Layout>
@@ -684,8 +680,8 @@
   open={$commandSurface.open && $commandSurface.mode === "palette"}
   onclose={closeCommandSurface}
   onNewSession={() => (showNewSessionDialog = true)}
-  onSettings={() => (showSettings = !showSettings)}
-  onCheckForUpdates={() => { showSettings = true; void runManualCheck(); }}
+  onSettings={() => toggleSidebar("settings")}
+  onCheckForUpdates={() => { openSidebar("settings"); void runManualCheck(); }}
 />
 
 {#if $hudVisible || ($commandSurface.open && $commandSurface.mode === "leader" && $commandSurface.leaderPromptCommandId)}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -280,6 +280,11 @@
         keymapExitTree();
         return;
       case "none":
+        // While a tree is armed, unbound keys are dropped per the
+        // keymap contract (`resolve.ts` §1e). Without preventDefault
+        // the character leaks through to xterm while the tree stays
+        // armed — user sees typing land in the terminal mid-chord.
+        if (km.treePath.length > 0) e.preventDefault();
         break;
     }
 

--- a/src/lib/panes/__tests__/actions.test.ts
+++ b/src/lib/panes/__tests__/actions.test.ts
@@ -20,7 +20,7 @@ import {
 } from "../actions";
 import { paneInstances, resetInstances, getInstance } from "../instances";
 import { sessionLayouts, resetLayouts, collectLeafIds } from "../layout";
-import { focusedPaneId, resetFocus } from "../focus";
+import { focusedPaneId, fullscreenPaneId, resetFocus, setLogicalFocus, toggleFullscreen } from "../focus";
 import { killPty, killSession } from "$lib/tauri";
 
 describe("pane actions", () => {
@@ -28,6 +28,7 @@ describe("pane actions", () => {
     resetInstances();
     resetLayouts();
     resetFocus();
+    fullscreenPaneId.set(null);
     vi.mocked(killPty).mockClear();
     vi.mocked(killSession).mockClear();
   });
@@ -145,6 +146,70 @@ describe("pane actions", () => {
     it("returns false for nonexistent pane", () => {
       initSession("s1");
       expect(closePane("s1", "nope")).toBe(false);
+    });
+
+    it("clears fullscreenPaneId when the fullscreened pane is closed", () => {
+      // Regression: closePane disposed the pane and cleared focus but left
+      // fullscreenPaneId pointing at a dead id. SplitPane then filtered
+      // every sibling out of the DOM and the content area went blank.
+      initSession("s1");
+      const shellId = splitPane("s1", "h", { type: "shell", ptyId: "pty-1" })!;
+      setLogicalFocus(shellId);
+      toggleFullscreen();
+      expect(get(fullscreenPaneId)).toBe(shellId);
+
+      closePane("s1", shellId);
+      expect(get(fullscreenPaneId)).toBeNull();
+    });
+
+    it("leaves fullscreenPaneId alone when a non-fullscreened pane is closed", () => {
+      initSession("s1");
+      const shellId = splitPane("s1", "h", { type: "shell", ptyId: "pty-1" })!;
+      setLogicalFocus("s1-main");
+      toggleFullscreen();
+      expect(get(fullscreenPaneId)).toBe("s1-main");
+
+      closePane("s1", shellId);
+      expect(get(fullscreenPaneId)).toBe("s1-main");
+    });
+
+    it("refocuses onto the visible leaf (not a hidden stacked tab)", () => {
+      // Regression: firstLeafId walks children[0] without consulting the
+      // stack's activeIndex, so closing a sibling while a stack had tab 1
+      // visible routed focus to the hidden tab at index 0.
+      initSession("s1");
+      const stackTab2 = splitPane("s1", "v", { type: "shell", ptyId: "pty-a" })!;
+      const rightPane = splitPane("s1", "h", { type: "shell", ptyId: "pty-b" })!;
+      // Build the target layout directly: an outer horizontal split whose
+      // left child is a stacked split (s1-main, stackTab2) with tab 2
+      // currently visible, and the right child is rightPane.
+      sessionLayouts.update((m) => {
+        const next = new Map(m);
+        next.set("s1", {
+          kind: "split",
+          direction: "h",
+          children: [
+            {
+              kind: "split",
+              direction: "v",
+              stacked: true,
+              activeIndex: 1,
+              children: [
+                { kind: "leaf", paneId: "s1-main" },
+                { kind: "leaf", paneId: stackTab2 },
+              ],
+            },
+            { kind: "leaf", paneId: rightPane },
+          ],
+        });
+        return next;
+      });
+
+      setLogicalFocus(rightPane);
+      closePane("s1", rightPane);
+
+      // Focus must land on the visible stack tab, not children[0].
+      expect(get(focusedPaneId)).toBe(stackTab2);
     });
   });
 

--- a/src/lib/panes/actions.ts
+++ b/src/lib/panes/actions.ts
@@ -13,10 +13,11 @@ import {
   removeLeaf,
   firstLeafId,
   collectLeafIds,
+  collectVisibleLeafIds,
   containsPaneId,
   type SplitDirection,
 } from "./layout";
-import { focusedPaneId, setLogicalFocus } from "./focus";
+import { focusedPaneId, fullscreenPaneId, setLogicalFocus } from "./focus";
 import { disposeAgentState } from "./agentState";
 import { forgetLastStatus } from "./agentNotifications";
 import type { SpawnProfileRef } from "./profiles";
@@ -123,9 +124,21 @@ export function closePane(sessionId: string, paneId: string): boolean {
 
   disposePane(paneId, killPty);
 
+  // A fullscreened pane that is now closed must release the fullscreen
+  // slot — otherwise SplitPane keeps filtering every sibling out of the
+  // DOM against a dead paneId and the content area goes blank.
+  if (get(fullscreenPaneId) === paneId) {
+    fullscreenPaneId.set(null);
+  }
+
   if (get(focusedPaneId) === paneId) {
     const tree = get(sessionLayouts).get(sessionId);
-    setLogicalFocus(tree ? firstLeafId(tree) : null);
+    // Prefer the first *visible* leaf so we don't hand focus to a pane
+    // hidden behind a stacked tab's `activeIndex`.
+    const nextFocus = tree
+      ? (collectVisibleLeafIds(tree)[0] ?? firstLeafId(tree))
+      : null;
+    setLogicalFocus(nextFocus);
   }
 
   return true;

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -1,6 +1,27 @@
-import { derived, writable, type Readable } from "svelte/store";
+import { derived, get, writable, type Readable } from "svelte/store";
 import { sessionLayouts, collectVisibleLeafIds } from "$lib/panes/layout";
 import { sessionState } from "$lib/stores/sessions";
+
+/**
+ * Global sidebar slot. The app renders at most one side panel at a time —
+ * Settings, Notes, Watches, Notifications. Any new panel registers here.
+ * State is ephemeral (not persisted).
+ */
+export type SidebarId = "settings" | "notes" | "watches" | "notifications";
+
+export const activeSidebar = writable<SidebarId | null>(null);
+
+export function openSidebar(id: SidebarId): void {
+  activeSidebar.set(id);
+}
+
+export function closeSidebar(): void {
+  activeSidebar.set(null);
+}
+
+export function toggleSidebar(id: SidebarId): void {
+  activeSidebar.set(get(activeSidebar) === id ? null : id);
+}
 
 const HOLD_DELAY_MS = 200;
 


### PR DESCRIPTION
## Summary
- Side panels (Settings, Notes, Watches, Notifications) had per-panel booleans in `App.svelte` with inconsistent mutual-exclusion logic. `ui.toggle-notes` and `app.settings` only closed *some* of the other panels, so sequences like `Cmd+;i` → `Cmd+;n` left both visible and squeezed the terminal area sideways.
- Centralized visibility in `activeSidebar` in `src/lib/stores/ui.ts` with `openSidebar` / `closeSidebar` / `toggleSidebar` helpers. Only one sidebar can be active, so mutual exclusion is now structural rather than policed at each call site.
- Frontend-only change — sidebar visibility was never persisted, so no backend or storage impact.

## Test plan
- [ ] `npm install && npm run check` passes
- [ ] Open Notifications via `Cmd+;i`, then Notes via `Cmd+;n` — notifications closes, notes opens (no overlap, no layout shift)
- [ ] Same check across every pair: Settings/Notes, Settings/Watches, Settings/Notifications, Notes/Watches, Notes/Notifications, Watches/Notifications
- [ ] Pressing the same chord twice toggles the sidebar closed
- [ ] Sidebar buttons in the Layout header and "Check for Updates" from the command palette still open Settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)