### PR TITLE
[codex] Add hooks runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3881,7 +3881,7 @@ dependencies = [
 
 [[package]]
 name = "roux"
-version = "0.4.4"
+version = "0.4.5-alpha.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/crates/roux-core/src/models/hooks.rs
+++ b/crates/roux-core/src/models/hooks.rs
@@ -1,0 +1,713 @@
+//! Roux hooks v1 — shared event types and KDL parser.
+//!
+//! The initial goal is intentionally narrow:
+//!
+//! - parse a small `hooks.kdl` file format into plain Rust types
+//! - keep routing declarative and cheap
+//! - leave fine-grained applicability to the spawned hook script
+//!
+//! This module is the only place in `roux-core` that touches `kdl`.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct HookConfig {
+    pub hooks: Vec<HookDefinition>,
+}
+
+impl Default for HookConfig {
+    fn default() -> Self {
+        Self { hooks: Vec::new() }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct HookDefinition {
+    pub id: String,
+    pub on: Vec<HookEventKind>,
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub filters: Vec<HookFilter>,
+    pub run: HookRun,
+    #[serde(default)]
+    pub policy: HookPolicy,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct HookRun {
+    pub command: String,
+    #[serde(default)]
+    pub args: Vec<String>,
+    #[serde(default)]
+    pub cwd: Option<String>,
+    #[serde(default)]
+    pub timeout_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, specta::Type, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct HookPolicy {
+    #[serde(default)]
+    pub concurrency: Option<HookConcurrency>,
+    #[serde(default)]
+    pub dedupe_key: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub enum HookConcurrency {
+    Drop,
+    Queue,
+    Replace,
+    Parallel,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+pub enum HookFilter {
+    Equals { field: String, value: String },
+    In { field: String, values: Vec<String> },
+    Exists { field: String },
+}
+
+impl Default for HookDefinition {
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            on: Vec::new(),
+            enabled: true,
+            filters: Vec::new(),
+            run: HookRun::default(),
+            policy: HookPolicy::default(),
+        }
+    }
+}
+
+impl Default for HookRun {
+    fn default() -> Self {
+        Self { command: String::new(), args: Vec::new(), cwd: None, timeout_ms: None }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct RouxEvent {
+    pub id: String,
+    pub kind: HookEventKind,
+    pub timestamp: String,
+    pub origin: RouxEventOrigin,
+    #[serde(default)]
+    pub session: Option<RouxEventSession>,
+    #[serde(default)]
+    pub workspace: Option<RouxEventWorkspace>,
+    pub payload: serde_json::Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct RouxEventOrigin {
+    pub kind: String,
+    #[serde(default)]
+    pub causation_id: Option<String>,
+    #[serde(default)]
+    pub triggered_by_hook_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct RouxEventSession {
+    #[serde(default)]
+    pub roux_session_id: Option<String>,
+    #[serde(default)]
+    pub pane_id: Option<String>,
+    #[serde(default)]
+    pub profile: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct RouxEventWorkspace {
+    #[serde(default)]
+    pub repo_root: Option<String>,
+    #[serde(default)]
+    pub worktree_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+pub enum HookEventKind {
+    #[serde(rename = "watch.outcome_changed")]
+    WatchOutcomeChanged,
+    #[serde(rename = "watch.completed")]
+    WatchCompleted,
+    #[serde(rename = "agent.attention.entered")]
+    AgentAttentionEntered,
+    #[serde(rename = "agent.attention.exited")]
+    AgentAttentionExited,
+    #[serde(rename = "session.created")]
+    SessionCreated,
+    #[serde(rename = "session.ended")]
+    SessionEnded,
+}
+
+impl HookEventKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::WatchOutcomeChanged => "watch.outcome_changed",
+            Self::WatchCompleted => "watch.completed",
+            Self::AgentAttentionEntered => "agent.attention.entered",
+            Self::AgentAttentionExited => "agent.attention.exited",
+            Self::SessionCreated => "session.created",
+            Self::SessionEnded => "session.ended",
+        }
+    }
+
+    fn parse(value: &str, loc: (usize, usize)) -> Result<Self, HookParseError> {
+        match value {
+            "watch.outcome_changed" => Ok(Self::WatchOutcomeChanged),
+            "watch.completed" => Ok(Self::WatchCompleted),
+            "agent.attention.entered" => Ok(Self::AgentAttentionEntered),
+            "agent.attention.exited" => Ok(Self::AgentAttentionExited),
+            "session.created" => Ok(Self::SessionCreated),
+            "session.ended" => Ok(Self::SessionEnded),
+            other => Err(HookParseError::schema(
+                loc,
+                format!(
+                    "unknown hook event `{other}`; expected one of `watch.outcome_changed`, `watch.completed`, `agent.attention.entered`, `agent.attention.exited`, `session.created`, or `session.ended`"
+                ),
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum HookParseError {
+    #[error("kdl parse error at {line}:{column}: {message}")]
+    Syntax { line: usize, column: usize, message: String },
+    #[error("{message} at {line}:{column}")]
+    Schema { line: usize, column: usize, message: String },
+}
+
+impl HookParseError {
+    fn schema(loc: (usize, usize), message: impl Into<String>) -> Self {
+        Self::Schema { line: loc.0, column: loc.1, message: message.into() }
+    }
+}
+
+pub fn parse_hooks_kdl(src: &str) -> Result<HookConfig, HookParseError> {
+    let doc: kdl::KdlDocument = src.parse().map_err(|e: kdl::KdlError| {
+        let (line, column, message) = e
+            .diagnostics
+            .first()
+            .map(|d| {
+                let (l, c) = offset_to_line_col(src, d.span.offset());
+                (l, c, d.message.clone().unwrap_or_else(|| "invalid KDL syntax".to_string()))
+            })
+            .unwrap_or_else(|| (0, 0, "invalid KDL syntax".to_string()));
+        HookParseError::Syntax { line, column, message }
+    })?;
+
+    let top_nodes: Vec<&kdl::KdlNode> = doc.nodes().iter().collect();
+    let hooks_node = match top_nodes.as_slice() {
+        [single] if single.name().value() == "hooks" => *single,
+        [] => {
+            return Err(HookParseError::schema(
+                (1, 1),
+                "expected a top-level `hooks` node; document is empty",
+            ));
+        }
+        [single] => {
+            return Err(HookParseError::schema(
+                node_loc(src, single),
+                format!(
+                    "unknown top-level node `{}`; expected a top-level `hooks` node",
+                    single.name().value()
+                ),
+            ));
+        }
+        [_, second, ..] => {
+            return Err(HookParseError::schema(
+                node_loc(src, second),
+                "exactly one top-level `hooks` node is permitted",
+            ));
+        }
+    };
+
+    parse_hooks_node(src, hooks_node)
+}
+
+pub fn merge_hook_configs(base: &HookConfig, overlay: &HookConfig) -> HookConfig {
+    let mut hooks = base.hooks.clone();
+    for overlay_hook in &overlay.hooks {
+        if let Some(idx) = hooks.iter().position(|existing| existing.id == overlay_hook.id) {
+            hooks[idx] = overlay_hook.clone();
+        } else {
+            hooks.push(overlay_hook.clone());
+        }
+    }
+    hooks.retain(|hook| hook.enabled);
+    HookConfig { hooks }
+}
+
+fn parse_hooks_node(src: &str, node: &kdl::KdlNode) -> Result<HookConfig, HookParseError> {
+    if let Some(entry) = node.entries().iter().next() {
+        return Err(HookParseError::schema(
+            entry_loc(src, entry),
+            "`hooks` node takes no arguments; define child `hook` nodes inside it",
+        ));
+    }
+    let body = node
+        .children()
+        .ok_or_else(|| HookParseError::schema(node_loc(src, node), "`hooks` must have a body"))?;
+
+    let mut hooks = Vec::new();
+    for child in body.nodes() {
+        match child.name().value() {
+            "hook" => hooks.push(parse_hook_node(src, child)?),
+            other => {
+                return Err(HookParseError::schema(
+                    node_loc(src, child),
+                    format!("unknown child node `{other}` in `hooks`; expected `hook`"),
+                ));
+            }
+        }
+    }
+    Ok(HookConfig { hooks })
+}
+
+fn parse_hook_node(src: &str, node: &kdl::KdlNode) -> Result<HookDefinition, HookParseError> {
+    let id = single_string_arg(src, node, "hook")?;
+    let body = node.children().ok_or_else(|| {
+        HookParseError::schema(node_loc(src, node), "`hook` must have a body `{ ... }`")
+    })?;
+
+    let mut hook = HookDefinition { id, ..HookDefinition::default() };
+
+    for child in body.nodes() {
+        match child.name().value() {
+            "on" => {
+                let raw = single_string_arg(src, child, "on")?;
+                hook.on.push(HookEventKind::parse(&raw, node_loc(src, child))?);
+            }
+            "enabled" => hook.enabled = single_bool_arg(src, child, "enabled")?,
+            "run" => {
+                if hook.run.command.is_empty() {
+                    hook.run = parse_run_node(src, child)?;
+                } else {
+                    return Err(HookParseError::schema(
+                        node_loc(src, child),
+                        "duplicate `run` block",
+                    ));
+                }
+            }
+            "policy" => {
+                if hook.policy == HookPolicy::default() {
+                    hook.policy = parse_policy_node(src, child)?;
+                } else {
+                    return Err(HookParseError::schema(
+                        node_loc(src, child),
+                        "duplicate `policy` block",
+                    ));
+                }
+            }
+            "filter" => hook.filters.push(parse_filter_node(src, child)?),
+            other => {
+                return Err(HookParseError::schema(
+                    node_loc(src, child),
+                    format!(
+                        "unknown child node `{other}` in `hook`; expected `on`, `enabled`, `run`, `policy`, or `filter`"
+                    ),
+                ));
+            }
+        }
+    }
+
+    if hook.on.is_empty() {
+        return Err(HookParseError::schema(
+            node_loc(src, node),
+            "`hook` must contain at least one `on` child node",
+        ));
+    }
+    if hook.run.command.is_empty() {
+        return Err(HookParseError::schema(
+            node_loc(src, node),
+            "`hook` is missing required `run` block",
+        ));
+    }
+
+    Ok(hook)
+}
+
+fn parse_run_node(src: &str, node: &kdl::KdlNode) -> Result<HookRun, HookParseError> {
+    if let Some(entry) = node.entries().iter().next() {
+        return Err(HookParseError::schema(
+            entry_loc(src, entry),
+            "`run` node takes no arguments; configure child nodes inside it",
+        ));
+    }
+    let body = node
+        .children()
+        .ok_or_else(|| HookParseError::schema(node_loc(src, node), "`run` must have a body"))?;
+
+    let mut run = HookRun::default();
+    for child in body.nodes() {
+        match child.name().value() {
+            "command" => {
+                if run.command.is_empty() {
+                    run.command = single_string_arg(src, child, "command")?;
+                } else {
+                    return Err(HookParseError::schema(
+                        node_loc(src, child),
+                        "duplicate `command` in `run` block",
+                    ));
+                }
+            }
+            "arg" => run.args.push(single_string_arg(src, child, "arg")?),
+            "cwd" => run.cwd = Some(single_string_arg(src, child, "cwd")?),
+            "timeout-ms" => run.timeout_ms = Some(single_u64_arg(src, child, "timeout-ms")?),
+            other => {
+                return Err(HookParseError::schema(
+                    node_loc(src, child),
+                    format!(
+                        "unknown child node `{other}` in `run`; expected `command`, `arg`, `cwd`, or `timeout-ms`"
+                    ),
+                ));
+            }
+        }
+    }
+
+    if run.command.is_empty() {
+        return Err(HookParseError::schema(
+            node_loc(src, node),
+            "`run` is missing required `command` child node",
+        ));
+    }
+    Ok(run)
+}
+
+fn parse_policy_node(src: &str, node: &kdl::KdlNode) -> Result<HookPolicy, HookParseError> {
+    if let Some(entry) = node.entries().iter().next() {
+        return Err(HookParseError::schema(
+            entry_loc(src, entry),
+            "`policy` node takes no arguments; configure child nodes inside it",
+        ));
+    }
+    let body = node.children().ok_or_else(|| {
+        HookParseError::schema(node_loc(src, node), "`policy` must have a body")
+    })?;
+
+    let mut policy = HookPolicy::default();
+    for child in body.nodes() {
+        match child.name().value() {
+            "concurrency" => {
+                policy.concurrency = Some(parse_concurrency(src, child)?);
+            }
+            "dedupe-key" => {
+                policy.dedupe_key = Some(single_string_arg(src, child, "dedupe-key")?);
+            }
+            other => {
+                return Err(HookParseError::schema(
+                    node_loc(src, child),
+                    format!(
+                        "unknown child node `{other}` in `policy`; expected `concurrency` or `dedupe-key`"
+                    ),
+                ));
+            }
+        }
+    }
+    Ok(policy)
+}
+
+fn parse_filter_node(src: &str, node: &kdl::KdlNode) -> Result<HookFilter, HookParseError> {
+    let field = string_prop(src, node, "field")?;
+    if let Some(value) = optional_string_prop(src, node, "equals")? {
+        return Ok(HookFilter::Equals { field, value });
+    }
+    if let Some(value) = optional_string_prop(src, node, "in")? {
+        let values = value
+            .split(',')
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+            .map(ToOwned::to_owned)
+            .collect();
+        return Ok(HookFilter::In { field, values });
+    }
+    if optional_bool_prop(src, node, "exists")?.unwrap_or(false) {
+        return Ok(HookFilter::Exists { field });
+    }
+    Err(HookParseError::schema(
+        node_loc(src, node),
+        "`filter` requires one of `equals`, `in`, or `exists=true`",
+    ))
+}
+
+fn parse_concurrency(src: &str, node: &kdl::KdlNode) -> Result<HookConcurrency, HookParseError> {
+    match single_string_arg(src, node, "concurrency")?.as_str() {
+        "drop" => Ok(HookConcurrency::Drop),
+        "queue" => Ok(HookConcurrency::Queue),
+        "replace" => Ok(HookConcurrency::Replace),
+        "parallel" => Ok(HookConcurrency::Parallel),
+        other => Err(HookParseError::schema(
+            node_loc(src, node),
+            format!(
+                "unknown concurrency `{other}`; expected `drop`, `queue`, `replace`, or `parallel`"
+            ),
+        )),
+    }
+}
+
+fn single_string_arg(
+    src: &str,
+    node: &kdl::KdlNode,
+    what: &str,
+) -> Result<String, HookParseError> {
+    let entries: Vec<&kdl::KdlEntry> = node.entries().iter().collect();
+    match entries.as_slice() {
+        [entry] => match entry.value() {
+            kdl::KdlValue::String(value) => Ok(value.clone()),
+            _ => Err(HookParseError::schema(
+                entry_loc(src, entry),
+                format!("`{what}` requires a string argument"),
+            )),
+        },
+        [] => Err(HookParseError::schema(
+            node_loc(src, node),
+            format!("`{what}` requires one string argument"),
+        )),
+        [_, second, ..] => Err(HookParseError::schema(
+            entry_loc(src, second),
+            format!("`{what}` accepts exactly one argument"),
+        )),
+    }
+}
+
+fn single_u64_arg(src: &str, node: &kdl::KdlNode, what: &str) -> Result<u64, HookParseError> {
+    let entries: Vec<&kdl::KdlEntry> = node.entries().iter().collect();
+    match entries.as_slice() {
+        [entry] => match entry.value() {
+            kdl::KdlValue::Integer(value) if *value >= 0 => Ok(*value as u64),
+            _ => Err(HookParseError::schema(
+                entry_loc(src, entry),
+                format!("`{what}` requires a non-negative integer argument"),
+            )),
+        },
+        [] => Err(HookParseError::schema(
+            node_loc(src, node),
+            format!("`{what}` requires one integer argument"),
+        )),
+        [_, second, ..] => Err(HookParseError::schema(
+            entry_loc(src, second),
+            format!("`{what}` accepts exactly one argument"),
+        )),
+    }
+}
+
+fn single_bool_arg(src: &str, node: &kdl::KdlNode, what: &str) -> Result<bool, HookParseError> {
+    let entries: Vec<&kdl::KdlEntry> = node.entries().iter().collect();
+    match entries.as_slice() {
+        [entry] => match entry.value() {
+            kdl::KdlValue::Bool(value) => Ok(*value),
+            _ => Err(HookParseError::schema(
+                entry_loc(src, entry),
+                format!("`{what}` requires a boolean argument"),
+            )),
+        },
+        [] => Err(HookParseError::schema(
+            node_loc(src, node),
+            format!("`{what}` requires one boolean argument"),
+        )),
+        [_, second, ..] => Err(HookParseError::schema(
+            entry_loc(src, second),
+            format!("`{what}` accepts exactly one argument"),
+        )),
+    }
+}
+
+fn string_prop(src: &str, node: &kdl::KdlNode, key: &str) -> Result<String, HookParseError> {
+    optional_string_prop(src, node, key)?.ok_or_else(|| {
+        HookParseError::schema(node_loc(src, node), format!("`filter` requires `{key}` property"))
+    })
+}
+
+fn optional_string_prop(
+    src: &str,
+    node: &kdl::KdlNode,
+    key: &str,
+) -> Result<Option<String>, HookParseError> {
+    let Some(value) = node.get(key) else {
+        return Ok(None);
+    };
+    match value {
+        kdl::KdlValue::String(value) => Ok(Some(value.clone())),
+        _ => Err(HookParseError::schema(
+            node_loc(src, node),
+            format!("property `{key}` requires a string value"),
+        )),
+    }
+}
+
+fn optional_bool_prop(
+    src: &str,
+    node: &kdl::KdlNode,
+    key: &str,
+) -> Result<Option<bool>, HookParseError> {
+    let Some(value) = node.get(key) else {
+        return Ok(None);
+    };
+    match value {
+        kdl::KdlValue::Bool(value) => Ok(Some(*value)),
+        _ => Err(HookParseError::schema(
+            node_loc(src, node),
+            format!("property `{key}` requires a boolean value"),
+        )),
+    }
+}
+
+fn offset_to_line_col(src: &str, offset: usize) -> (usize, usize) {
+    let offset = offset.min(src.len());
+    let prefix = &src[..offset];
+    let line = 1 + prefix.matches('\n').count();
+    let column = match prefix.rfind('\n') {
+        Some(nl) => prefix[nl + 1..].chars().count() + 1,
+        None => prefix.chars().count() + 1,
+    };
+    (line, column)
+}
+
+fn node_loc(src: &str, node: &kdl::KdlNode) -> (usize, usize) {
+    offset_to_line_col(src, node.span().offset())
+}
+
+fn entry_loc(src: &str, entry: &kdl::KdlEntry) -> (usize, usize) {
+    offset_to_line_col(src, entry.span().offset())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_minimal_hook_config() {
+        let src = r#"
+            hooks {
+              hook "pr-watch-auto-fix" {
+                on "watch.completed"
+
+                run {
+                  command "python3"
+                  arg ".roux/scripts/pr_watch.py"
+                  cwd "worktree"
+                  timeout-ms 300000
+                }
+
+                policy {
+                  concurrency "replace"
+                }
+              }
+            }
+        "#;
+
+        let parsed = parse_hooks_kdl(src).expect("parse ok");
+        assert_eq!(parsed.hooks.len(), 1);
+
+        let hook = &parsed.hooks[0];
+        assert_eq!(hook.id, "pr-watch-auto-fix");
+        assert_eq!(hook.on, vec![HookEventKind::WatchCompleted]);
+        assert_eq!(hook.run.command, "python3");
+        assert_eq!(hook.run.args, vec![".roux/scripts/pr_watch.py"]);
+        assert_eq!(hook.run.cwd.as_deref(), Some("worktree"));
+        assert_eq!(hook.run.timeout_ms, Some(300000));
+        assert_eq!(hook.policy.concurrency, Some(HookConcurrency::Replace));
+        assert!(hook.enabled, "hooks default to enabled");
+    }
+
+    #[test]
+    fn rejects_unknown_hook_event_kind() {
+        let err = parse_hooks_kdl(
+            r#"
+                hooks {
+                  hook "bad" {
+                    on "watch.failed_hard"
+                    run { command "python3" }
+                  }
+                }
+            "#,
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("unknown hook event") && msg.contains("watch.failed_hard"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_top_level_node() {
+        let err = parse_hooks_kdl("wat garbage").unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("top-level `hooks` node") || msg.contains("invalid KDL syntax"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn merge_replaces_same_id_and_disabled_overlay_suppresses_base() {
+        let base = parse_hooks_kdl(
+            r#"
+                hooks {
+                  hook "keep-me" {
+                    on "watch.completed"
+                    run { command "python3" }
+                  }
+                  hook "replace-me" {
+                    on "watch.completed"
+                    run {
+                      command "python3"
+                      arg "base.py"
+                    }
+                  }
+                  hook "suppress-me" {
+                    on "watch.completed"
+                    run {
+                      command "python3"
+                      arg "base.py"
+                    }
+                  }
+                }
+            "#,
+        )
+        .expect("base parse ok");
+        let overlay = parse_hooks_kdl(
+            r#"
+                hooks {
+                  hook "replace-me" {
+                    on "watch.completed"
+                    run {
+                      command "python3"
+                      arg "overlay.py"
+                    }
+                  }
+                  hook "suppress-me" {
+                    enabled #false
+                    on "watch.completed"
+                    run {
+                      command "python3"
+                      arg "overlay.py"
+                    }
+                  }
+                }
+            "#,
+        )
+        .expect("overlay parse ok");
+
+        let merged = merge_hook_configs(&base, &overlay);
+        assert_eq!(merged.hooks.len(), 2);
+        assert_eq!(merged.hooks[0].id, "keep-me");
+        assert_eq!(merged.hooks[1].id, "replace-me");
+        assert_eq!(merged.hooks[1].run.args, vec!["overlay.py"]);
+    }
+}

--- a/crates/roux-core/src/models/mod.rs
+++ b/crates/roux-core/src/models/mod.rs
@@ -1,4 +1,5 @@
 mod events;
+mod hooks;
 mod keymap;
 mod layout;
 mod notification;
@@ -11,6 +12,11 @@ mod watch;
 mod worktree;
 
 pub use events::{RouxCommand, SessionExitPayload, SessionExitReason};
+pub use hooks::{
+    merge_hook_configs, parse_hooks_kdl, HookConfig, HookConcurrency, HookDefinition, HookEventKind,
+    HookFilter, HookParseError, HookRun, RouxEvent, RouxEventOrigin, RouxEventSession,
+    RouxEventWorkspace,
+};
 pub use keymap::{
     merge_keymaps, parse_keymap_kdl, Bind, HudMode, KeyRef, KeymapAction, KeymapParseError,
     KeymapTree, KeymapWarning, Modifier, ParsedKeymap, Prefix,

--- a/crates/roux-core/src/models/settings.rs
+++ b/crates/roux-core/src/models/settings.rs
@@ -204,6 +204,7 @@ impl RouxSettings {
             profile.source = ProfileSource::User;
         }
         s.repo_roots = normalize_repo_roots(&s.repo_roots);
+        s.trusted_workspaces = normalize_repo_roots(&s.trusted_workspaces);
         // One-way migration: if an older settings file only has the legacy
         // `cleanupWorktreesOnClose: true` flag, promote the new enum to
         // Always. The `Prompt` default already matches legacy `false`, so
@@ -290,6 +291,22 @@ mod tests {
 
         let normalized = settings.normalized();
         assert_eq!(normalized.repo_roots, vec!["/tmp/src", "/tmp/other"]);
+    }
+
+    #[test]
+    fn normalized_trusted_workspaces_trims_empty_and_duplicates() {
+        let settings = RouxSettings {
+            trusted_workspaces: vec![
+                "  /tmp/src  ".to_string(),
+                "".to_string(),
+                " /tmp/src ".to_string(),
+                "/tmp/other".to_string(),
+            ],
+            ..RouxSettings::default()
+        };
+
+        let normalized = settings.normalized();
+        assert_eq!(normalized.trusted_workspaces, vec!["/tmp/src", "/tmp/other"]);
     }
 
     #[test]

--- a/docs/features/hooks.md
+++ b/docs/features/hooks.md
@@ -1,0 +1,159 @@
+# Hooks
+
+Hooks let you attach local automation to Roux events.
+
+Roux emits normalized events for things it already knows about, and user-defined local scripts can react to those events by calling `roux-cli` to open sessions, create panes, send input, or push notifications.
+
+## What hooks are for
+
+Hooks unify a few kinds of automation under one model:
+
+- provider-driven status updates such as Claude or future agent hooks
+- Roux-native lifecycle events such as session or pane creation
+- watch-driven events such as a PR watch changing outcome
+- local workflow automation that should stay on the user's machine
+
+The value of hooks is not an embedded scripting language. The value is:
+
+- normalized events
+- supervised hook execution with timeouts
+- trust gating for repo-local hooks
+- `roux-cli` primitives that are safe enough for automation
+- useful logs when a hook runs, skips, times out, or fails
+
+## Config locations
+
+Roux supports two hook scopes:
+
+- global hooks in `~/.config/roux/hooks.kdl`
+- repo hooks in `<repo>/.roux/hooks.kdl`
+
+Repo hooks only run for trusted workspaces.
+
+## How hooks work
+
+The model is:
+
+- hook registration lives in `hooks.kdl`
+- Roux normalizes events into one shared event envelope
+- Roux spawns the hook as a supervised child process
+- Roux writes the full event JSON to the hook process on `stdin`
+- the hook script uses `roux-cli` to perform any action inside Roux
+
+This deliberately keeps the control boundary outside the app. Hooks should automate Roux through the same public CLI or socket surface that any other local script would use.
+
+## Example use cases
+
+### PR watch opens a fixer session
+
+When a PR watch reports new review comments or failing CI, a hook can:
+
+1. inspect the event payload
+2. decide whether the event is actionable
+3. use `roux-cli` to ensure a background session exists for that PR
+4. open a shell or command pane to start repair work
+
+### Attention hook
+
+When an agent enters an attention state, a hook can:
+
+- push a richer local notification
+- log the event to another local tool
+- open a notes pane or helper session in the same workspace
+
+### Session bootstrap
+
+When a session is created, a hook can:
+
+- create a companion shell pane
+- start a repo-specific watcher
+- annotate the session through future CLI primitives
+
+## Config shape
+
+The format is KDL, consistent with Roux layouts and keymap configuration.
+
+```kdl
+hooks {
+  hook "pr-watch-auto-fix" {
+    on "watch.completed"
+
+    run {
+      command "python3"
+      arg ".roux/scripts/pr_watch.py"
+      cwd "worktree"
+      timeout-ms 300000
+    }
+
+    policy {
+      concurrency "replace"
+    }
+  }
+}
+```
+
+The config stays intentionally small:
+
+- `on` decides which event kinds can spawn the hook
+- `run` describes how to launch the process
+- `policy` controls timeout and concurrency behavior
+
+Fine-grained applicability lives in the hook script itself. A hook may receive an event and immediately decide "not applicable" and exit successfully.
+
+## Filters
+
+Hooks do not assume a rich matcher language.
+
+Built-in pre-spawn filters stay very small and cheap. The first candidates are:
+
+- `equals`
+- `in`
+- `exists`
+
+Anything more ambitious than that should wait for real examples.
+
+## Event envelope
+
+The hook process receives a normalized event object with fields like:
+
+- event id
+- event kind
+- timestamp
+- origin or causation metadata
+- session and pane identifiers where available
+- repo root and worktree path where available
+- event-specific payload data
+
+The event envelope exists so hook scripts can be boring and deterministic. They should not need to scrape UI state or infer context from filenames.
+
+## Safety model
+
+Hooks run as supervised child processes, not in-process plugins.
+
+The safety rules are:
+
+- every run has a timeout
+- Roux owns process cleanup
+- Roux captures stdout and stderr for logs
+- repo-local hooks only run in trusted workspaces
+- hook-caused events are tracked so Roux can prevent accidental loops
+
+That last point matters. A hook that opens a session in response to an event should not recursively trigger itself forever.
+
+## What hooks are not
+
+Hooks are not:
+
+- an in-app plugin API
+- an embedded language runtime such as Scheme or Rhai
+- a replacement for writing a normal local script
+- a promise that Roux will execute arbitrary repo code without trust gating
+
+If matching logic ever grows more complex, that should happen only after the simple model proves insufficient in practice.
+
+## Related features
+
+- [CLI bridge](cli.md)
+- [Watches](watches.md)
+- [Sessions](sessions.md)
+- [Worktrees](worktrees.md)

--- a/docs/plans/2026-04-16-hooks-system.md
+++ b/docs/plans/2026-04-16-hooks-system.md
@@ -1,0 +1,393 @@
+# Hooks System Plan
+
+## Summary
+
+- Add a generalized Roux hooks system that turns internal app activity and external agent/provider status changes into a single normalized event stream.
+- Let users register locally-running hooks in KDL at both global and repo scope:
+  - `~/.config/roux/hooks.kdl`
+  - `<repo>/.roux/hooks.kdl`
+- Execute hooks as supervised child processes owned by Roux, not as in-process plugins.
+- Send the full event envelope to the hook process as JSON on `stdin`; keep KDL as the human-authored config surface.
+- Require explicit execution policy on every hook run: timeout, concurrency behavior, and loop-prevention metadata.
+- Use `roux-cli` as the automation control plane for hooks. Hook scripts should open sessions, panes, notifications, and future automation primitives through the CLI or socket boundary rather than private in-process APIs.
+
+## Goals
+
+- Unify today's Claude hook bridge with Roux-native events such as watch completion, session lifecycle, pane lifecycle, and agent attention transitions.
+- Make hooks predictable and debuggable enough for real automation, especially background workflows like PR-watch-driven repair sessions.
+- Keep the system safe by default for a desktop app with real filesystem, process, PTY, and worktree side effects.
+- Reuse existing Roux architectural seams where possible:
+  - the current `roux-cli` + socket boundary
+  - existing event producers like watches and agent lifecycle sources
+  - existing trusted-workspace settings
+
+## Non-goals
+
+- In-process plugin APIs for arbitrary user code.
+- A full sandbox or container runtime in v1.
+- A visual hook editor in v1.
+- An arbitrary boolean or scripting expression language in the hook config.
+- Full provider parity on day one. Claude compatibility and Roux-native events are enough for the first pass.
+
+## Decisions Locked In
+
+- Hook registration format is KDL. Do not introduce TOML or YAML for this feature.
+- Hook process input is JSON on `stdin`. This is a wire format, not a second config surface.
+- Hooks run out of process under Roux supervision.
+- Repo hooks are gated by workspace trust. Untrusted repos do not get to execute `.roux/hooks.kdl`.
+- Global and repo hooks both participate in matching. Repo hooks extend or override global hooks according to stable merge rules.
+- Hooks should automate Roux through `roux-cli`, not internal Rust APIs.
+- Hook execution must have timeouts and descendant cleanup from day one.
+- Hook config should stay intentionally small in v1. Applicability logic belongs in the hook script unless real evidence proves otherwise.
+
+## User-Facing Model
+
+### Config locations
+
+- Global hooks: `~/.config/roux/hooks.kdl`
+- Repo hooks: `<repo>/.roux/hooks.kdl`
+
+### Scope model
+
+- Global hooks apply everywhere.
+- Repo hooks apply to any session or event whose `repo_root` matches that repository.
+- Worktrees inherit repo hooks from the owning repo root.
+- The event payload should include both `repo_root` and `worktree_path` so hooks can reason about either.
+
+### Trust model
+
+- Repo hooks only load when the repo root is present in `RouxSettings.trusted_workspaces`.
+- Global hooks are always user-trusted because they live under the user's Roux config directory.
+- If a repo is not trusted, Roux should surface that fact clearly in logs and any future UI, but it should not execute the repo hook file.
+
+## Proposed KDL Shape
+
+Keep the grammar intentionally small in v1. The config should answer "when should Roux spawn this hook process?" not "how should Roux evaluate business logic?"
+
+```kdl
+hooks {
+  hook "pr-watch-auto-fix" {
+    on "watch.completed"
+
+    run {
+      command "python3"
+      arg ".roux/scripts/pr_watch.py"
+      cwd "worktree"
+      timeout-ms 300000
+    }
+
+    policy {
+      concurrency "replace"
+      dedupe-key "pr:${payload.pr_number}"
+    }
+  }
+}
+```
+
+### Minimal v1 grammar
+
+- `hooks { ... }` top-level container
+- `hook "<id>" { ... }`
+- `on "<event-name>"`
+- `run { command "..."; arg "..."; cwd "..."; timeout-ms 30000 }`
+- `policy { concurrency "..."; dedupe-key "..." }`
+- optional `enabled true|false`
+
+### Applicability split
+
+- Roux config should do coarse routing:
+  - event kind
+  - scope
+  - execution policy
+- The hook script should do fine-grained applicability:
+  - draft PR or not
+  - failed checks count
+  - whether the target fixer session already exists
+  - whether review comments are actually actionable
+
+That keeps Roux from growing a second programming environment before it has any evidence that one is needed.
+
+### Keep out of v1
+
+- Arbitrary boolean expressions
+- Nested `and` or `or` trees
+- Reusable predicates or macros
+- Embedded matcher runtimes such as Rhai or Scheme
+- Shell snippets as the primary command model
+
+If shell convenience is needed, make it explicit with `command "sh"` + `arg "-c"` rather than adding a second execution mode.
+
+## Event Model
+
+Introduce a single normalized event envelope in `roux-core` so Rust, TypeScript, and `roux-cli` can all share the same type vocabulary.
+
+```json
+{
+  "id": "evt_123",
+  "kind": "watch.completed",
+  "timestamp": "2026-04-16T20:30:00Z",
+  "origin": {
+    "kind": "watch",
+    "causationId": null,
+    "triggeredByHookId": null
+  },
+  "session": {
+    "rouxSessionId": "sess_1",
+    "paneId": "pane_2",
+    "profile": "codex"
+  },
+  "workspace": {
+    "repoRoot": "/repo",
+    "worktreePath": "/repo/.worktrees/pr-123"
+  },
+  "payload": {
+    "watchId": "watch_1",
+    "outcome": "failure"
+  }
+}
+```
+
+### First event set
+
+- `watch.completed`
+- `session.created`
+- `session.ended`
+- `pane.opened`
+- `agent.attention.entered`
+- `agent.attention.exited`
+
+### Event source mapping
+
+- Claude hook bridge and future provider bridges become event sources, not special cases.
+- Watch manager emits `watch.completed` on meaningful state transitions.
+- Session and pane lifecycle emit normalized events from the Rust backend.
+- Agent lifecycle registry emits attention enter or exit events in addition to its current notification work.
+
+## Backend Architecture
+
+Add a dedicated backend service, likely `HookManager`, and store it in `AppState`.
+
+### Responsibilities
+
+- Load and merge hook config from global and repo scopes
+- Route hook definitions by normalized event kind and scope
+- Enforce trust gating for repo hooks
+- Spawn and supervise hook child processes
+- Track hook runs, outcomes, timeouts, and captured logs
+- Apply concurrency policy and dedupe policy
+- Attach causation metadata to follow-on events
+
+### Non-responsibilities
+
+- Directly performing the automation itself
+- Exposing private app internals to user scripts
+- Owning business logic of watches, sessions, or agent state machines
+
+### Relationship to current systems
+
+- Keep the current provider-specific `hooks.rs` logic as an event source adapter initially.
+- Reuse the existing socket and CLI boundary in `src-tauri/src/socket.rs` and `src-tauri/src/cli.rs`.
+- Reuse trusted workspace settings already present in `RouxSettings`.
+- Do not let watch manager or agent registry spawn user scripts directly. They should emit normalized events into the hook manager instead.
+
+## Hook Execution Model
+
+Hooks should run as supervised child processes. "Container process" here means a Roux-owned execution envelope, not Docker.
+
+### Child process contract
+
+- Full event envelope is written to `stdin` as JSON.
+- Useful env vars are also provided:
+  - `ROUX_HOOK_ID`
+  - `ROUX_EVENT_ID`
+  - `ROUX_EVENT_KIND`
+  - `ROUX_REPO_ROOT`
+  - `ROUX_WORKTREE_PATH`
+  - `ROUX_SESSION_ID`
+  - `ROUX_PANE_ID`
+- Exit code `0` means success.
+- Nonzero exit codes mean failure.
+- `stdout` and `stderr` are captured for logs, not treated as structured protocol output.
+
+### Script applicability semantics
+
+- Hook scripts are expected to exit quickly when an event is not actually actionable.
+- Exit code `0` should be treated as successful completion, including "not applicable" no-op exits.
+- Nonzero exit codes should mean actual failure.
+- If we later need better observability, add an optional reserved skip code or structured log convention only after real examples demand it.
+
+### Mandatory execution controls
+
+- Default timeout: `30000ms`
+- Graceful shutdown window after timeout: `2000ms`
+- Hard kill after grace period
+- Max stdout capture: `64KB`
+- Max stderr capture: `64KB`
+- Default concurrency per hook: `1`
+
+### Concurrency modes
+
+- `drop`: if already running, drop the new invocation
+- `queue`: enqueue and run later
+- `replace`: terminate the old run and start the new one
+- `parallel`: allow concurrent runs
+
+`replace` or deduped latest-wins behavior is likely the correct default for noisy PR or watch-driven automations.
+
+### Descendant cleanup
+
+- On Unix, each hook run should own a fresh process group or session so Roux can terminate the full subprocess tree.
+- On Windows, use the equivalent job-object-style containment.
+- Killing only the direct child PID is not acceptable because hook scripts will often spawn Python, Node, `gh`, or shell subprocesses.
+
+## Loop Prevention
+
+This feature will be dangerous if Roux cannot distinguish user-originated events from hook-originated events.
+
+### Required metadata
+
+- every event gets an `id`
+- every event gets `origin.kind`
+- hook-triggered follow-on actions should carry `causation_id`
+- events caused by hooks should record `triggered_by_hook_id`
+
+### Default policy
+
+- Hooks ignore hook-caused events by default.
+- Opting into hook-caused events should be explicit in config and probably not part of v1 unless a concrete need appears.
+
+Without this, a hook that opens a session in response to a watch failure can recurse indefinitely via `session.created` or `pane.opened`.
+
+## CLI and Automation Surface
+
+The existing CLI already has enough basic primitives to make hooks useful:
+
+- create sessions
+- create panes
+- open shell panes
+- open command panes
+- focus panes or sessions
+- list and inspect sessions
+- send input to sessions
+- push notifications
+
+However, reliable hook automation will need idempotent targeting. A hook should be able to say "ensure exactly one fixer session exists for this PR" rather than creating duplicate sessions.
+
+### Likely follow-on CLI additions
+
+- session or pane tags
+- `ensure`-style commands for sessions or panes
+- richer `session list` metadata to support external reconciliation
+
+These additions are not required to start the hook system, but they are likely required to make hook-driven automation robust.
+
+## Merge and Override Rules
+
+Start simple and deterministic.
+
+- Load global hooks first.
+- Load repo hooks second.
+- Hook ids are unique within the merged view.
+- If a repo hook reuses a global hook id, the repo hook replaces the global hook definition entirely.
+- Disabled hooks stay in the merged set only long enough to suppress inherited hooks with the same id; they do not match events.
+
+Avoid partial field-level inheritance in v1. Full replacement is easier to reason about and easier to debug.
+
+## Logging and Debuggability
+
+Add persistent or session-visible run records early. Without them, a hook system will be opaque and difficult to trust.
+
+### Record per run
+
+- hook id
+- event id
+- event kind
+- start time
+- end time
+- duration
+- exit code
+- timed out or not
+- killed or not
+- stdout truncated or not
+- stderr truncated or not
+- causation id
+
+### Future UI
+
+Not required in v1, but the backend should preserve enough data that Roux can eventually show:
+
+- which hooks were considered for an event
+- which ones ran
+- which ones were skipped due to trust, timeout, dedupe, loop-prevention rules, or disabled state
+
+## Phased Implementation Plan
+
+### Phase 1: Core types and config parsing
+
+- Add `HookDefinition`, `HookRunPolicy`, and `RouxEvent` types in `roux-core`
+- Add a `hooks.kdl` parser with strong validation and good line or column errors
+- Add tests for parsing, merge behavior, and trust gating
+
+### Phase 2: Hook manager and process supervision
+
+- Add `HookManager` to `AppState`
+- Implement event-kind routing, spawning, timeout handling, descendant cleanup, and run logging
+- Keep execution boundary local to the app first; only split into a dedicated `roux-hook-runner` binary if the supervision surface becomes too awkward in-process
+
+### Phase 3: First event producers
+
+- Route watch transitions into the hook manager
+- Route session lifecycle into the hook manager
+- Route pane lifecycle into the hook manager
+- Route agent attention lifecycle into the hook manager
+- Keep current Tauri frontend events intact while adding normalized hook events in parallel
+
+### Phase 4: Provider integration
+
+- Move the existing Claude-specific hook bridge into the generalized event model
+- Define a provider-agnostic path for future Codex or other agent hooks
+
+### Phase 5: CLI hardening for automation
+
+- Add tags or ensure-style commands for idempotent session or pane creation
+- Add any missing list or lookup APIs required by practical hook scripts
+
+### Phase 6: UI and docs
+
+- Show hook config paths in settings or docs
+- Add docs for the hook schema and event envelope
+- Consider a lightweight hook run log viewer once backend records exist
+
+## Test Plan
+
+- Parser tests for valid and invalid `hooks.kdl`
+- Merge tests for global and repo hook replacement by id
+- Trust-gating tests for untrusted repo hook suppression
+- Event-routing tests across first-party event kinds
+- Supervisor tests for timeout, graceful shutdown, and forced kill
+- Loop-prevention tests ensuring hook-caused events do not re-trigger by default
+- CLI integration tests for representative hook scripts where practical
+
+## Open Questions
+
+- Should the first implementation expose any UI for opening or reloading hook files, or should that wait until the backend contract stabilizes?
+- Do we want per-hook cwd tokens beyond `repo` and `worktree`, such as `session` or explicit absolute paths?
+- Should repo hook files be allowed to reference executables outside the repo root in v1, or should that be constrained later by sandbox policy?
+- Do we want a lightweight `roux hook test` or `roux events emit` command for local hook development?
+
+## Recommendation
+
+Proceed with a design-first implementation. The first coding task should be the pure `roux-core` side:
+
+- define normalized event types
+- define hook config types
+- parse `hooks.kdl`
+- merge global and repo hook sets
+
+Then, when the execution layer is added, keep the first implementation intentionally dumb about applicability:
+
+- route by event kind
+- supervise the child process well
+- let the hook script decide whether the event is actionable
+
+That keeps the first step testable and low-risk before touching PTY, watch, or session lifecycles, and it avoids designing an embedded matcher language before it is needed.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
       - Layouts: features/layouts.md
       - Worktrees: features/worktrees.md
       - Watches: features/watches.md
+      - Hooks: features/hooks.md
       - CLI: features/cli.md
       - Notes: features/notes.md
       - Keymap: features/keymap.md

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -208,6 +208,14 @@ fn status_dir() -> PathBuf {
     platform::status_dir()
 }
 
+fn parse_json_input_or_empty(input: &str) -> Result<Value, String> {
+    if input.trim().is_empty() {
+        Ok(serde_json::json!({}))
+    } else {
+        serde_json::from_str::<Value>(input).map_err(|e| format!("invalid JSON: {}", e))
+    }
+}
+
 fn send_socket_command(request: Value) -> Result<Value, String> {
     #[cfg(windows)]
     {
@@ -714,6 +722,12 @@ mod tests {
             _ => panic!("expected Hooks::Emit"),
         }
     }
+
+    #[test]
+    fn parse_json_input_returns_empty_object_for_blank_input() {
+        let parsed = parse_json_input_or_empty("   \n\t").unwrap();
+        assert_eq!(parsed, serde_json::json!({}));
+    }
 }
 
 fn main() {
@@ -944,10 +958,10 @@ fn main() {
                         eprintln!("Error: failed to read JSON from stdin");
                         std::process::exit(1);
                     }
-                    match serde_json::from_str::<Value>(&input) {
+                    match parse_json_input_or_empty(&input) {
                         Ok(v) => v,
-                        Err(e) => {
-                            eprintln!("Error: invalid JSON: {}", e);
+                        Err(message) => {
+                            eprintln!("Error: {}", message);
                             std::process::exit(1);
                         }
                     }

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -96,6 +96,32 @@ enum Commands {
         #[arg(long)]
         json: bool,
     },
+    /// Hook-related commands
+    Hooks {
+        #[command(subcommand)]
+        action: HooksAction,
+    },
+}
+
+#[derive(Subcommand)]
+enum HooksAction {
+    /// Emit a normalized Roux hook event into the running app
+    Emit {
+        /// Event kind, e.g. watch.completed
+        kind: String,
+        /// Repo root for workspace-scoped hook matching. Defaults to cwd.
+        #[arg(long)]
+        repo_root: Option<String>,
+        /// Worktree path. Defaults to --repo-root, then cwd.
+        #[arg(long)]
+        worktree_path: Option<String>,
+        /// Optional session profile hint
+        #[arg(long)]
+        profile: Option<String>,
+        /// Read event payload JSON from stdin. Defaults to {}.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -658,6 +684,36 @@ mod tests {
             _ => panic!("expected Split"),
         }
     }
+
+    #[test]
+    fn cli_parses_hooks_emit() {
+        let cli = Cli::try_parse_from([
+            "roux-cli",
+            "hooks",
+            "emit",
+            "watch.completed",
+            "--repo-root",
+            "/tmp/repo",
+            "--worktree-path",
+            "/tmp/repo/.worktrees/x",
+            "--profile",
+            "codex",
+            "--json",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Hooks {
+                action: HooksAction::Emit { kind, repo_root, worktree_path, profile, json },
+            } => {
+                assert_eq!(kind, "watch.completed");
+                assert_eq!(repo_root.as_deref(), Some("/tmp/repo"));
+                assert_eq!(worktree_path.as_deref(), Some("/tmp/repo/.worktrees/x"));
+                assert_eq!(profile.as_deref(), Some("codex"));
+                assert!(json);
+            }
+            _ => panic!("expected Hooks::Emit"),
+        }
+    }
 }
 
 fn main() {
@@ -875,5 +931,63 @@ fn main() {
                 "args": Value::Object(args),
             }));
         }
+
+        Commands::Hooks { action } => match action {
+            HooksAction::Emit { kind, repo_root, worktree_path, profile, json } => {
+                let cwd = resolve_path(".");
+                let repo_root = repo_root.unwrap_or_else(|| cwd.clone());
+                let worktree_path = worktree_path.unwrap_or_else(|| repo_root.clone());
+
+                let payload = if json {
+                    let mut input = String::new();
+                    if std::io::stdin().read_to_string(&mut input).is_err() {
+                        eprintln!("Error: failed to read JSON from stdin");
+                        std::process::exit(1);
+                    }
+                    match serde_json::from_str::<Value>(&input) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            eprintln!("Error: invalid JSON: {}", e);
+                            std::process::exit(1);
+                        }
+                    }
+                } else {
+                    serde_json::json!({})
+                };
+
+                let mut event = serde_json::json!({
+                    "id": uuid::Uuid::new_v4().to_string(),
+                    "kind": kind,
+                    "timestamp": SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs().to_string(),
+                    "origin": {
+                        "kind": "cli",
+                        "causationId": null,
+                        "triggeredByHookId": null
+                    },
+                    "session": {
+                        "rouxSessionId": get_session_id(),
+                        "paneId": get_pane_id(),
+                        "profile": profile
+                    },
+                    "workspace": {
+                        "repoRoot": repo_root,
+                        "worktreePath": worktree_path
+                    },
+                    "payload": payload
+                });
+
+                if event["session"]["rouxSessionId"].is_null()
+                    && event["session"]["paneId"].is_null()
+                    && event["session"]["profile"].is_null()
+                {
+                    event["session"] = Value::Null;
+                }
+
+                run_socket_command(serde_json::json!({
+                    "command": "hooks-emit",
+                    "args": { "event": event },
+                }));
+            }
+        },
     }
 }

--- a/src-tauri/src/hook_runtime.rs
+++ b/src-tauri/src/hook_runtime.rs
@@ -1,0 +1,831 @@
+use std::path::{Path, PathBuf};
+
+use roux_core::{
+    merge_hook_configs, parse_hooks_kdl, HookConfig, HookDefinition, HookEventKind, HookFilter,
+    RouxEvent, RouxEventOrigin, RouxEventSession, RouxEventWorkspace, Watch, WatchKind,
+    WatchMode, WatchOutcome, WatchResult, WatchScope,
+};
+use tokio::io::AsyncWriteExt;
+
+#[derive(Debug, Default)]
+pub struct LoadedHooks {
+    pub config: HookConfig,
+    pub errors: Vec<HookLoadError>,
+}
+
+#[derive(Debug)]
+pub struct HookLoadError {
+    pub path: PathBuf,
+    pub message: String,
+}
+
+#[derive(Debug)]
+pub struct HookDispatchResult {
+    pub matched_hook_ids: Vec<String>,
+    pub runs: Vec<HookRunResult>,
+}
+
+#[derive(Debug)]
+pub struct HookRunResult {
+    pub hook_id: String,
+    pub exit_code: Option<i32>,
+    pub timed_out: bool,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+pub fn load_hooks_for_event_in(
+    config_dir: &Path,
+    settings: &crate::settings::RouxSettings,
+    event: &RouxEvent,
+) -> LoadedHooks {
+    let mut out = LoadedHooks::default();
+
+    let global = load_optional_hook_file(&config_dir.join("hooks.kdl"));
+    out.errors.extend(global.errors);
+    out.config = global.config;
+
+    if let Some(repo_root) = event.workspace.as_ref().and_then(|w| w.repo_root.as_deref()) {
+        let trusted = settings.trusted_workspaces.iter().any(|root| root == repo_root);
+        if trusted {
+            let repo = load_optional_hook_file(Path::new(repo_root).join(".roux").join("hooks.kdl").as_path());
+            out.errors.extend(repo.errors);
+            out.config = merge_hook_configs(&out.config, &repo.config);
+        }
+    }
+
+    out
+}
+
+pub fn matching_hooks<'a>(config: &'a HookConfig, event: &RouxEvent) -> Vec<&'a HookDefinition> {
+    let event_value = serde_json::to_value(event).unwrap_or(serde_json::Value::Null);
+
+    config
+        .hooks
+        .iter()
+        .filter(|hook| hook.enabled)
+        .filter(|hook| hook.on.iter().any(|kind| *kind == event.kind))
+        .filter(|hook| hook.filters.iter().all(|filter| filter_matches(filter, &event_value)))
+        .collect()
+}
+
+pub async fn dispatch_event_in(
+    config_dir: &Path,
+    settings: &crate::settings::RouxSettings,
+    event: &RouxEvent,
+) -> HookDispatchResult {
+    let loaded = load_hooks_for_event_in(config_dir, settings, event);
+    let matched = matching_hooks(&loaded.config, event);
+    let matched_hook_ids = matched.iter().map(|hook| hook.id.clone()).collect::<Vec<_>>();
+
+    let mut runs = Vec::new();
+    for hook in matched {
+        runs.push(run_hook(hook, event).await);
+    }
+
+    HookDispatchResult { matched_hook_ids, runs }
+}
+
+pub fn session_created_event(session: &crate::session::Session, profile: Option<&str>) -> RouxEvent {
+    RouxEvent {
+        id: uuid::Uuid::new_v4().to_string(),
+        kind: HookEventKind::SessionCreated,
+        timestamp: session.created_at.to_string(),
+        origin: RouxEventOrigin {
+            kind: "roux".into(),
+            causation_id: None,
+            triggered_by_hook_id: None,
+        },
+        session: Some(RouxEventSession {
+            roux_session_id: Some(session.id.clone()),
+            pane_id: Some(format!("{}-main", session.id)),
+            profile: profile.map(str::to_string),
+        }),
+        workspace: Some(RouxEventWorkspace {
+            repo_root: Some(session.repo_root.clone()),
+            worktree_path: Some(session.worktree_path.clone()),
+        }),
+        payload: serde_json::json!({
+            "sessionId": session.id,
+            "name": session.name,
+            "branch": session.branch,
+            "isWorktree": session.is_worktree,
+        }),
+    }
+}
+
+pub fn watch_events(
+    watch: &Watch,
+    previous_outcome: Option<&WatchOutcome>,
+    session: Option<&crate::session::Session>,
+) -> Vec<RouxEvent> {
+    let Some(result) = watch.last_result.as_ref() else {
+        return Vec::new();
+    };
+
+    let outcome = result.outcome().clone();
+    let timestamp =
+        watch.last_checked.unwrap_or_else(|| {
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis() as u64
+        });
+    let session_payload = session.map(|session| RouxEventSession {
+        roux_session_id: Some(session.id.clone()),
+        pane_id: None,
+        profile: None,
+    });
+    let workspace_payload = session.map(|session| RouxEventWorkspace {
+        repo_root: Some(session.repo_root.clone()),
+        worktree_path: Some(session.worktree_path.clone()),
+    });
+
+    let payload = watch_payload(watch, result, previous_outcome);
+
+    let mut events = vec![RouxEvent {
+        id: uuid::Uuid::new_v4().to_string(),
+        kind: HookEventKind::WatchCompleted,
+        timestamp: timestamp.to_string(),
+        origin: RouxEventOrigin {
+            kind: "watch".into(),
+            causation_id: None,
+            triggered_by_hook_id: None,
+        },
+        session: session_payload.clone(),
+        workspace: workspace_payload.clone(),
+        payload: payload.clone(),
+    }];
+
+    if previous_outcome != Some(&outcome) {
+        events.push(RouxEvent {
+            id: uuid::Uuid::new_v4().to_string(),
+            kind: HookEventKind::WatchOutcomeChanged,
+            timestamp: timestamp.to_string(),
+            origin: RouxEventOrigin {
+                kind: "watch".into(),
+                causation_id: None,
+                triggered_by_hook_id: None,
+            },
+            session: session_payload,
+            workspace: workspace_payload,
+            payload,
+        });
+    }
+
+    events
+}
+
+fn load_optional_hook_file(path: &Path) -> LoadedHooks {
+    let mut out = LoadedHooks::default();
+    if !path.exists() {
+        return out;
+    }
+
+    let src = match std::fs::read_to_string(path) {
+        Ok(src) => src,
+        Err(e) => {
+            out.errors.push(HookLoadError {
+                path: path.to_path_buf(),
+                message: format!("failed to read hook file: {e}"),
+            });
+            return out;
+        }
+    };
+
+    match parse_hooks_kdl(&src) {
+        Ok(config) => out.config = config,
+        Err(e) => out.errors.push(HookLoadError { path: path.to_path_buf(), message: e.to_string() }),
+    }
+    out
+}
+
+async fn run_hook(hook: &HookDefinition, event: &RouxEvent) -> HookRunResult {
+    let mut cmd = tokio::process::Command::new(&hook.run.command);
+    cmd.args(&hook.run.args);
+    if let Some(cwd) = &hook.run.cwd {
+        let resolved = resolve_cwd(cwd, event);
+        cmd.current_dir(resolved);
+    }
+    cmd.stdin(std::process::Stdio::piped());
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::piped());
+    cmd.kill_on_drop(true);
+
+    cmd.env("ROUX_HOOK_ID", &hook.id);
+    cmd.env("ROUX_EVENT_KIND", event.kind.as_str());
+    cmd.env("ROUX_EVENT_ID", &event.id);
+    if let Some(workspace) = &event.workspace {
+        if let Some(repo_root) = &workspace.repo_root {
+            cmd.env("ROUX_REPO_ROOT", repo_root);
+        }
+        if let Some(worktree_path) = &workspace.worktree_path {
+            cmd.env("ROUX_WORKTREE_PATH", worktree_path);
+        }
+    }
+    if let Some(session) = &event.session {
+        if let Some(session_id) = &session.roux_session_id {
+            cmd.env("ROUX_SESSION_ID", session_id);
+        }
+        if let Some(pane_id) = &session.pane_id {
+            cmd.env("ROUX_PANE_ID", pane_id);
+        }
+    }
+
+    let mut child = match cmd.spawn() {
+        Ok(child) => child,
+        Err(e) => {
+            return HookRunResult {
+                hook_id: hook.id.clone(),
+                exit_code: None,
+                timed_out: false,
+                stdout: String::new(),
+                stderr: format!("failed to spawn hook: {e}"),
+            };
+        }
+    };
+
+    if let Some(mut stdin) = child.stdin.take() {
+        let payload = serde_json::to_vec(event).unwrap_or_default();
+        if let Err(e) = stdin.write_all(&payload).await {
+            return HookRunResult {
+                hook_id: hook.id.clone(),
+                exit_code: None,
+                timed_out: false,
+                stdout: String::new(),
+                stderr: format!("failed to write hook stdin: {e}"),
+            };
+        }
+    }
+
+    let wait = child.wait_with_output();
+    let output = if let Some(timeout_ms) = hook.run.timeout_ms {
+        match tokio::time::timeout(std::time::Duration::from_millis(timeout_ms), wait).await {
+            Ok(result) => match result {
+                Ok(output) => {
+                    return HookRunResult {
+                        hook_id: hook.id.clone(),
+                        exit_code: output.status.code(),
+                        timed_out: false,
+                        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+                        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+                    };
+                }
+                Err(e) => {
+                    return HookRunResult {
+                        hook_id: hook.id.clone(),
+                        exit_code: None,
+                        timed_out: false,
+                        stdout: String::new(),
+                        stderr: format!("failed to wait on hook: {e}"),
+                    };
+                }
+            },
+            Err(_) => {
+                return HookRunResult {
+                    hook_id: hook.id.clone(),
+                    exit_code: None,
+                    timed_out: true,
+                    stdout: String::new(),
+                    stderr: "hook timed out".into(),
+                };
+            }
+        }
+    } else {
+        match wait.await {
+            Ok(output) => output,
+            Err(e) => {
+                return HookRunResult {
+                    hook_id: hook.id.clone(),
+                    exit_code: None,
+                    timed_out: false,
+                    stdout: String::new(),
+                    stderr: format!("failed to wait on hook: {e}"),
+                };
+            }
+        }
+    };
+
+    HookRunResult {
+        hook_id: hook.id.clone(),
+        exit_code: output.status.code(),
+        timed_out: false,
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+    }
+}
+
+fn resolve_cwd(cwd: &str, event: &RouxEvent) -> PathBuf {
+    match cwd {
+        "worktree" => event
+            .workspace
+            .as_ref()
+            .and_then(|w| w.worktree_path.as_ref())
+            .map(PathBuf::from)
+            .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))),
+        "repo" => event
+            .workspace
+            .as_ref()
+            .and_then(|w| w.repo_root.as_ref())
+            .map(PathBuf::from)
+            .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))),
+        other => PathBuf::from(other),
+    }
+}
+
+fn watch_payload(
+    watch: &Watch,
+    result: &WatchResult,
+    previous_outcome: Option<&WatchOutcome>,
+) -> serde_json::Value {
+    let (scope_type, session_id, project_id) = match &watch.scope {
+        WatchScope::Global => ("global", None, None),
+        WatchScope::Session { session_id } => ("session", Some(session_id.clone()), None),
+        WatchScope::Project { project_id } => ("project", None, Some(project_id.clone())),
+    };
+
+    let mut payload = serde_json::json!({
+        "watchId": watch.id,
+        "watchName": watch.name,
+        "watchType": watch_type_name(&watch.kind),
+        "scopeType": scope_type,
+        "outcome": watch_outcome_name(result.outcome()),
+        "previousOutcome": previous_outcome.map(watch_outcome_name),
+        "result": result,
+        "watch": watch,
+    });
+
+    if let Some(session_id) = session_id {
+        payload["sessionId"] = serde_json::Value::String(session_id);
+    }
+    if let Some(project_id) = project_id {
+        payload["projectId"] = serde_json::Value::String(project_id);
+    }
+
+    match &watch.kind {
+        WatchKind::GithubAction { repo, run_id, workflow, branch } => {
+            payload["repo"] = serde_json::Value::String(repo.clone());
+            if let Some(run_id) = run_id {
+                payload["runId"] = serde_json::json!(run_id);
+            }
+            if let Some(workflow) = workflow {
+                payload["workflow"] = serde_json::Value::String(workflow.clone());
+            }
+            if let Some(branch) = branch {
+                payload["branch"] = serde_json::Value::String(branch.clone());
+            }
+        }
+        WatchKind::HttpHealth { url, expected_status } => {
+            payload["url"] = serde_json::Value::String(url.clone());
+            payload["expectedStatus"] = serde_json::json!(expected_status);
+        }
+        WatchKind::ShellCommand { command, working_dir, success_exit_code } => {
+            payload["command"] = serde_json::Value::String(command.clone());
+            if let Some(working_dir) = working_dir {
+                payload["workingDir"] = serde_json::Value::String(working_dir.clone());
+            }
+            payload["successExitCode"] = serde_json::json!(success_exit_code);
+        }
+        WatchKind::Task { task_id, command, working_dir } => {
+            payload["taskId"] = serde_json::Value::String(task_id.clone());
+            payload["command"] = serde_json::Value::String(command.clone());
+            payload["workingDir"] = serde_json::Value::String(working_dir.clone());
+        }
+        WatchKind::GithubPr { repo, pr_number } => {
+            payload["repo"] = serde_json::Value::String(repo.clone());
+            payload["prNumber"] = serde_json::json!(pr_number);
+        }
+    }
+
+    match result {
+        WatchResult::GithubRun { run_id, status, conclusion, url, jobs, .. } => {
+            payload["runId"] = serde_json::json!(run_id);
+            payload["status"] = serde_json::Value::String(status.clone());
+            payload["url"] = serde_json::Value::String(url.clone());
+            if let Some(conclusion) = conclusion {
+                payload["conclusion"] = serde_json::Value::String(conclusion.clone());
+            }
+            let failing_jobs = jobs
+                .iter()
+                .filter(|job| job.conclusion.as_deref() == Some("failure"))
+                .map(|job| job.name.clone())
+                .collect::<Vec<_>>();
+            payload["hasCiFailures"] = serde_json::Value::Bool(!failing_jobs.is_empty());
+            payload["failingJobs"] = serde_json::json!(failing_jobs);
+        }
+        WatchResult::HttpCheck { status_code, response_time_ms, .. } => {
+            payload["statusCode"] = serde_json::json!(status_code);
+            payload["responseTimeMs"] = serde_json::json!(response_time_ms);
+        }
+        WatchResult::CommandRun { exit_code, .. } => {
+            payload["exitCode"] = serde_json::json!(exit_code);
+        }
+        WatchResult::GithubPr { pr_number, state, title, url, draft, reviews, checks, .. } => {
+            payload["prNumber"] = serde_json::json!(pr_number);
+            payload["state"] = serde_json::Value::String(state.clone());
+            payload["title"] = serde_json::Value::String(title.clone());
+            payload["url"] = serde_json::Value::String(url.clone());
+            payload["draft"] = serde_json::Value::Bool(*draft);
+            let failing_checks = checks
+                .iter()
+                .filter(|check| {
+                    matches!(
+                        check.conclusion.as_deref(),
+                        Some("failure") | Some("timed_out") | Some("cancelled") | Some("action_required")
+                    )
+                })
+                .map(|check| check.name.clone())
+                .collect::<Vec<_>>();
+            let has_review_changes_requested = reviews
+                .iter()
+                .any(|review| review.state.eq_ignore_ascii_case("changes_requested"));
+            payload["hasCiFailures"] = serde_json::Value::Bool(!failing_checks.is_empty());
+            payload["failingChecks"] = serde_json::json!(failing_checks);
+            payload["hasReviewChangesRequested"] =
+                serde_json::Value::Bool(has_review_changes_requested);
+            payload["reviewStates"] = serde_json::json!(
+                reviews.iter().map(|review| review.state.clone()).collect::<Vec<_>>()
+            );
+        }
+    }
+
+    payload
+}
+
+fn watch_type_name(kind: &WatchKind) -> &'static str {
+    match kind {
+        WatchKind::GithubAction { .. } => "github_action",
+        WatchKind::HttpHealth { .. } => "http_health",
+        WatchKind::ShellCommand { .. } => "shell_command",
+        WatchKind::Task { .. } => "task",
+        WatchKind::GithubPr { .. } => "github_pr",
+    }
+}
+
+fn watch_outcome_name(outcome: &WatchOutcome) -> &'static str {
+    match outcome {
+        WatchOutcome::Success => "success",
+        WatchOutcome::Failure => "failure",
+        WatchOutcome::InProgress => "in_progress",
+    }
+}
+
+fn filter_matches(filter: &HookFilter, event: &serde_json::Value) -> bool {
+    match filter {
+        HookFilter::Equals { field, value } => {
+            lookup_field(event, field).and_then(json_scalar_string) == Some(value.clone())
+        }
+        HookFilter::In { field, values } => lookup_field(event, field)
+            .and_then(json_scalar_string)
+            .is_some_and(|actual| values.iter().any(|expected| expected == &actual)),
+        HookFilter::Exists { field } => lookup_field(event, field).is_some_and(|value| !value.is_null()),
+    }
+}
+
+fn lookup_field<'a>(value: &'a serde_json::Value, field: &str) -> Option<&'a serde_json::Value> {
+    let mut current = value;
+    for segment in field.split('.').filter(|segment| !segment.is_empty()) {
+        current = current.get(segment)?;
+    }
+    Some(current)
+}
+
+fn json_scalar_string(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::String(value) => Some(value.clone()),
+        serde_json::Value::Number(value) => Some(value.to_string()),
+        serde_json::Value::Bool(value) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use roux_core::{
+        HookEventKind, HookFilter, HookRun, RouxEvent, RouxEventOrigin, RouxEventSession,
+        RouxEventWorkspace, Session, SessionStatus,
+    };
+
+    fn write(path: &std::path::Path, contents: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, contents).unwrap();
+    }
+
+    fn event_for_repo(repo_root: &std::path::Path) -> RouxEvent {
+        RouxEvent {
+            id: "evt-1".into(),
+            kind: HookEventKind::WatchCompleted,
+            timestamp: "now".into(),
+            origin: RouxEventOrigin {
+                kind: "cli".into(),
+                causation_id: None,
+                triggered_by_hook_id: None,
+            },
+            session: None,
+            workspace: Some(RouxEventWorkspace {
+                repo_root: Some(repo_root.display().to_string()),
+                worktree_path: Some(repo_root.display().to_string()),
+            }),
+            payload: serde_json::json!({}),
+        }
+    }
+
+    #[test]
+    fn watch_events_include_completed_and_changed_payload() {
+        let watch = Watch {
+            id: "watch-1".into(),
+            name: "PR watch".into(),
+            kind: WatchKind::GithubPr { repo: "owner/repo".into(), pr_number: 42 },
+            mode: WatchMode::Recurring { interval_secs: 60 },
+            scope: WatchScope::Session { session_id: "sess-1".into() },
+            runtime_state: roux_core::RuntimeState::Active,
+            last_result: Some(WatchResult::GithubPr {
+                pr_number: 42,
+                state: "open".into(),
+                title: "Fix hooks".into(),
+                url: "https://example.test/pr/42".into(),
+                head_sha: "abc123".into(),
+                draft: false,
+                reviews: vec![
+                    roux_core::PrReview {
+                        reviewer: "sam".into(),
+                        state: "changes_requested".into(),
+                        url: None,
+                    },
+                    roux_core::PrReview {
+                        reviewer: "pat".into(),
+                        state: "approved".into(),
+                        url: None,
+                    },
+                ],
+                checks: vec![
+                    roux_core::PrCheckRun {
+                        name: "ci / test".into(),
+                        conclusion: Some("failure".into()),
+                        url: None,
+                    },
+                    roux_core::PrCheckRun {
+                        name: "ci / lint".into(),
+                        conclusion: Some("success".into()),
+                        url: None,
+                    },
+                ],
+                outcome: WatchOutcome::Failure,
+            }),
+            last_checked: Some(12345),
+            notify: Default::default(),
+            created_at: 12000,
+        };
+        let session = Session {
+            id: "sess-1".into(),
+            name: "repo".into(),
+            repo_root: "/tmp/repo".into(),
+            worktree_path: "/tmp/repo/.worktrees/pr-42".into(),
+            branch: "pr-42".into(),
+            is_worktree: true,
+            status: SessionStatus::Idle,
+            model: None,
+            cost: None,
+            created_at: 999,
+            project_id: None,
+            is_git_repo: true,
+            name_override: None,
+        };
+
+        let events = watch_events(&watch, Some(&WatchOutcome::InProgress), Some(&session));
+
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].kind, HookEventKind::WatchCompleted);
+        assert_eq!(events[1].kind, HookEventKind::WatchOutcomeChanged);
+        assert_eq!(
+            events[0].workspace.as_ref().and_then(|w| w.repo_root.as_deref()),
+            Some("/tmp/repo")
+        );
+        assert_eq!(
+            events[0].session.as_ref().and_then(|s| s.roux_session_id.as_deref()),
+            Some("sess-1")
+        );
+        assert_eq!(events[0].payload["watchId"], "watch-1");
+        assert_eq!(events[0].payload["watchType"], "github_pr");
+        assert_eq!(events[0].payload["scopeType"], "session");
+        assert_eq!(events[0].payload["outcome"], "failure");
+        assert_eq!(events[0].payload["previousOutcome"], "in_progress");
+        assert_eq!(events[0].payload["prNumber"], 42);
+        assert_eq!(events[0].payload["repo"], "owner/repo");
+        assert_eq!(events[0].payload["hasCiFailures"], true);
+        assert_eq!(events[0].payload["hasReviewChangesRequested"], true);
+        assert_eq!(events[0].payload["failingChecks"], serde_json::json!(["ci / test"]));
+    }
+
+    #[test]
+    fn matching_hooks_applies_equals_in_and_exists_filters() {
+        let event = RouxEvent {
+            id: "evt-1".into(),
+            kind: HookEventKind::WatchCompleted,
+            timestamp: "now".into(),
+            origin: RouxEventOrigin {
+                kind: "cli".into(),
+                causation_id: None,
+                triggered_by_hook_id: None,
+            },
+            session: Some(RouxEventSession {
+                roux_session_id: Some("sess-1".into()),
+                pane_id: Some("pane-1".into()),
+                profile: Some("codex".into()),
+            }),
+            workspace: Some(RouxEventWorkspace {
+                repo_root: Some("/tmp/repo".into()),
+                worktree_path: Some("/tmp/repo".into()),
+            }),
+            payload: serde_json::json!({
+                "outcome": "failure",
+                "watchId": "watch-1",
+            }),
+        };
+
+        let config = HookConfig {
+            hooks: vec![
+                HookDefinition {
+                    id: "match".into(),
+                    on: vec![HookEventKind::WatchCompleted],
+                    enabled: true,
+                    filters: vec![
+                        HookFilter::Equals {
+                            field: "payload.outcome".into(),
+                            value: "failure".into(),
+                        },
+                        HookFilter::In {
+                            field: "session.profile".into(),
+                            values: vec!["codex".into(), "claude".into()],
+                        },
+                        HookFilter::Exists { field: "workspace.repoRoot".into() },
+                    ],
+                    run: HookRun { command: "echo".into(), ..HookRun::default() },
+                    policy: Default::default(),
+                },
+                HookDefinition {
+                    id: "wrong-outcome".into(),
+                    on: vec![HookEventKind::WatchCompleted],
+                    enabled: true,
+                    filters: vec![HookFilter::Equals {
+                        field: "payload.outcome".into(),
+                        value: "success".into(),
+                    }],
+                    run: HookRun { command: "echo".into(), ..HookRun::default() },
+                    policy: Default::default(),
+                },
+                HookDefinition {
+                    id: "wrong-profile".into(),
+                    on: vec![HookEventKind::WatchCompleted],
+                    enabled: true,
+                    filters: vec![HookFilter::In {
+                        field: "session.profile".into(),
+                        values: vec!["plain-shell".into()],
+                    }],
+                    run: HookRun { command: "echo".into(), ..HookRun::default() },
+                    policy: Default::default(),
+                },
+                HookDefinition {
+                    id: "missing-field".into(),
+                    on: vec![HookEventKind::WatchCompleted],
+                    enabled: true,
+                    filters: vec![HookFilter::Exists { field: "payload.missing".into() }],
+                    run: HookRun { command: "echo".into(), ..HookRun::default() },
+                    policy: Default::default(),
+                },
+            ],
+        };
+
+        let matched = matching_hooks(&config, &event);
+        let matched_ids = matched.iter().map(|hook| hook.id.as_str()).collect::<Vec<_>>();
+        assert_eq!(matched_ids, vec!["match"]);
+    }
+
+    #[test]
+    fn loads_global_and_trusted_repo_hooks_and_matches_event_kind() {
+        let cfg = tempfile::tempdir().unwrap();
+        let repo = tempfile::tempdir().unwrap();
+
+        write(
+            &cfg.path().join("hooks.kdl"),
+            r#"
+                hooks {
+                  hook "global-watch" {
+                    on "watch.completed"
+                    run { command "python3" }
+                  }
+                }
+            "#,
+        );
+        write(
+            &repo.path().join(".roux/hooks.kdl"),
+            r#"
+                hooks {
+                  hook "repo-watch" {
+                    on "watch.completed"
+                    run { command "python3" }
+                  }
+                }
+            "#,
+        );
+
+        let mut settings = crate::settings::RouxSettings::default();
+        settings.trusted_workspaces = vec![repo.path().display().to_string()];
+        let event = event_for_repo(repo.path());
+
+        let loaded = load_hooks_for_event_in(cfg.path(), &settings, &event);
+        assert!(loaded.errors.is_empty(), "unexpected load errors: {:?}", loaded.errors);
+        assert_eq!(loaded.config.hooks.len(), 2);
+
+        let matched = matching_hooks(&loaded.config, &event);
+        let ids: Vec<&str> = matched.iter().map(|hook| hook.id.as_str()).collect();
+        assert_eq!(ids, vec!["global-watch", "repo-watch"]);
+    }
+
+    #[test]
+    fn builds_session_created_event_with_workspace_and_profile() {
+        let session = crate::session::Session {
+            id: "sess-1".into(),
+            name: "Test Session".into(),
+            repo_root: "/repo".into(),
+            worktree_path: "/repo/.worktrees/test".into(),
+            branch: "feature/x".into(),
+            is_worktree: true,
+            status: roux_core::SessionStatus::Idle,
+            model: None,
+            cost: None,
+            created_at: 123,
+            project_id: None,
+            is_git_repo: true,
+            name_override: None,
+        };
+
+        let event = session_created_event(&session, Some("codex"));
+        assert_eq!(event.kind, HookEventKind::SessionCreated);
+        assert_eq!(
+            event.workspace.as_ref().and_then(|w| w.repo_root.as_deref()),
+            Some("/repo")
+        );
+        assert_eq!(
+            event.session.as_ref().and_then(|s| s.profile.as_deref()),
+            Some("codex")
+        );
+        assert_eq!(event.payload["sessionId"], "sess-1");
+        assert_eq!(event.payload["isWorktree"], true);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn dispatch_runs_matching_hook_and_writes_event_to_stdin() {
+        let cfg = tempfile::tempdir().unwrap();
+        let repo = tempfile::tempdir().unwrap();
+        let out = repo.path().join("event.json");
+        let script = repo.path().join("hook.sh");
+        write(
+            &script,
+            "#!/usr/bin/env sh\ncat > \"$1\"\n",
+        );
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        write(
+            &cfg.path().join("hooks.kdl"),
+            &format!(
+                r#"
+                    hooks {{
+                      hook "global-watch" {{
+                        on "watch.completed"
+                        run {{
+                          command "sh"
+                          arg "{}"
+                          arg "{}"
+                          timeout-ms 5000
+                        }}
+                      }}
+                    }}
+                "#,
+                script.display(),
+                out.display()
+            ),
+        );
+
+        let settings = crate::settings::RouxSettings::default();
+        let event = event_for_repo(repo.path());
+
+        let result = dispatch_event_in(cfg.path(), &settings, &event).await;
+        assert_eq!(result.matched_hook_ids, vec!["global-watch"]);
+        assert_eq!(result.runs.len(), 1);
+        assert_eq!(result.runs[0].exit_code, Some(0));
+        assert!(!result.runs[0].timed_out);
+
+        let written = std::fs::read_to_string(&out).unwrap();
+        assert!(written.contains("\"kind\":\"watch.completed\""), "unexpected event json: {written}");
+        assert!(
+            written.contains(&format!("\"repoRoot\":\"{}\"", repo.path().display())),
+            "repo root missing from event json: {written}"
+        );
+    }
+}

--- a/src-tauri/src/hook_runtime.rs
+++ b/src-tauri/src/hook_runtime.rs
@@ -5,7 +5,10 @@ use roux_core::{
     RouxEvent, RouxEventOrigin, RouxEventSession, RouxEventWorkspace, Watch, WatchKind,
     WatchMode, WatchOutcome, WatchResult, WatchScope,
 };
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+const DEFAULT_HOOK_TIMEOUT_MS: u64 = 30_000;
+const MAX_HOOK_OUTPUT_BYTES: usize = 64 * 1024;
 
 #[derive(Debug, Default)]
 pub struct LoadedHooks {
@@ -13,7 +16,7 @@ pub struct LoadedHooks {
     pub errors: Vec<HookLoadError>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct HookLoadError {
     pub path: PathBuf,
     pub message: String,
@@ -23,6 +26,7 @@ pub struct HookLoadError {
 pub struct HookDispatchResult {
     pub matched_hook_ids: Vec<String>,
     pub runs: Vec<HookRunResult>,
+    pub load_errors: Vec<HookLoadError>,
 }
 
 #[derive(Debug)]
@@ -31,7 +35,9 @@ pub struct HookRunResult {
     pub exit_code: Option<i32>,
     pub timed_out: bool,
     pub stdout: String,
+    pub stdout_truncated: bool,
     pub stderr: String,
+    pub stderr_truncated: bool,
 }
 
 pub fn load_hooks_for_event_in(
@@ -46,7 +52,10 @@ pub fn load_hooks_for_event_in(
     out.config = global.config;
 
     if let Some(repo_root) = event.workspace.as_ref().and_then(|w| w.repo_root.as_deref()) {
-        let trusted = settings.trusted_workspaces.iter().any(|root| root == repo_root);
+        let trusted = settings
+            .trusted_workspaces
+            .iter()
+            .any(|root| normalized_workspace_path(root) == normalized_workspace_path(repo_root));
         if trusted {
             let repo = load_optional_hook_file(Path::new(repo_root).join(".roux").join("hooks.kdl").as_path());
             out.errors.extend(repo.errors);
@@ -74,7 +83,26 @@ pub async fn dispatch_event_in(
     settings: &crate::settings::RouxSettings,
     event: &RouxEvent,
 ) -> HookDispatchResult {
-    let loaded = load_hooks_for_event_in(config_dir, settings, event);
+    let config_dir = config_dir.to_path_buf();
+    let settings = settings.clone();
+    let event_for_load = event.clone();
+    let loaded = match tokio::task::spawn_blocking(move || {
+        load_hooks_for_event_in(&config_dir, &settings, &event_for_load)
+    })
+    .await
+    {
+        Ok(loaded) => loaded,
+        Err(e) => LoadedHooks {
+            config: HookConfig::default(),
+            errors: vec![HookLoadError {
+                path: PathBuf::from("<hook-loader>"),
+                message: format!("failed to join hook loader task: {e}"),
+            }],
+        },
+    };
+    for error in &loaded.errors {
+        eprintln!("Roux hook load error in {}: {}", error.path.display(), error.message);
+    }
     let matched = matching_hooks(&loaded.config, event);
     let matched_hook_ids = matched.iter().map(|hook| hook.id.clone()).collect::<Vec<_>>();
 
@@ -83,7 +111,7 @@ pub async fn dispatch_event_in(
         runs.push(run_hook(hook, event).await);
     }
 
-    HookDispatchResult { matched_hook_ids, runs }
+    HookDispatchResult { matched_hook_ids, runs, load_errors: loaded.errors }
 }
 
 pub fn session_created_event(session: &crate::session::Session, profile: Option<&str>) -> RouxEvent {
@@ -211,6 +239,10 @@ async fn run_hook(hook: &HookDefinition, event: &RouxEvent) -> HookRunResult {
     cmd.stdout(std::process::Stdio::piped());
     cmd.stderr(std::process::Stdio::piped());
     cmd.kill_on_drop(true);
+    #[cfg(unix)]
+    {
+        cmd.process_group(0);
+    }
 
     cmd.env("ROUX_HOOK_ID", &hook.id);
     cmd.env("ROUX_EVENT_KIND", event.kind.as_str());
@@ -240,7 +272,9 @@ async fn run_hook(hook: &HookDefinition, event: &RouxEvent) -> HookRunResult {
                 exit_code: None,
                 timed_out: false,
                 stdout: String::new(),
+                stdout_truncated: false,
                 stderr: format!("failed to spawn hook: {e}"),
+                stderr_truncated: false,
             };
         }
     };
@@ -253,65 +287,47 @@ async fn run_hook(hook: &HookDefinition, event: &RouxEvent) -> HookRunResult {
                 exit_code: None,
                 timed_out: false,
                 stdout: String::new(),
+                stdout_truncated: false,
                 stderr: format!("failed to write hook stdin: {e}"),
+                stderr_truncated: false,
             };
         }
     }
 
-    let wait = child.wait_with_output();
-    let output = if let Some(timeout_ms) = hook.run.timeout_ms {
-        match tokio::time::timeout(std::time::Duration::from_millis(timeout_ms), wait).await {
-            Ok(result) => match result {
-                Ok(output) => {
-                    return HookRunResult {
-                        hook_id: hook.id.clone(),
-                        exit_code: output.status.code(),
-                        timed_out: false,
-                        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-                        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
-                    };
-                }
-                Err(e) => {
-                    return HookRunResult {
-                        hook_id: hook.id.clone(),
-                        exit_code: None,
-                        timed_out: false,
-                        stdout: String::new(),
-                        stderr: format!("failed to wait on hook: {e}"),
-                    };
-                }
-            },
-            Err(_) => {
-                return HookRunResult {
-                    hook_id: hook.id.clone(),
-                    exit_code: None,
-                    timed_out: true,
-                    stdout: String::new(),
-                    stderr: "hook timed out".into(),
-                };
-            }
-        }
-    } else {
-        match wait.await {
-            Ok(output) => output,
-            Err(e) => {
-                return HookRunResult {
-                    hook_id: hook.id.clone(),
-                    exit_code: None,
-                    timed_out: false,
-                    stdout: String::new(),
-                    stderr: format!("failed to wait on hook: {e}"),
-                };
-            }
+    let stdout_task = child.stdout.take().map(|stdout| tokio::spawn(read_stream_with_limit(stdout)));
+    let stderr_task = child.stderr.take().map(|stderr| tokio::spawn(read_stream_with_limit(stderr)));
+
+    let timeout_ms = hook_timeout_ms(hook);
+    let wait_result =
+        tokio::time::timeout(std::time::Duration::from_millis(timeout_ms), child.wait()).await;
+
+    let (exit_code, timed_out, wait_error) = match wait_result {
+        Ok(Ok(status)) => (status.code(), false, None),
+        Ok(Err(e)) => (None, false, Some(format!("failed to wait on hook: {e}"))),
+        Err(_) => {
+            terminate_hook_process(&mut child).await;
+            (None, true, Some("hook timed out".into()))
         }
     };
 
+    let stdout = collect_output(stdout_task, "stdout").await;
+    let stderr = collect_output(stderr_task, "stderr").await;
+    let mut stderr_text = stderr.text;
+    if let Some(wait_error) = wait_error {
+        if !stderr_text.is_empty() {
+            stderr_text.push('\n');
+        }
+        stderr_text.push_str(&wait_error);
+    }
+
     HookRunResult {
         hook_id: hook.id.clone(),
-        exit_code: output.status.code(),
-        timed_out: false,
-        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        exit_code,
+        timed_out,
+        stdout: stdout.text,
+        stdout_truncated: stdout.truncated,
+        stderr: stderr_text,
+        stderr_truncated: stderr.truncated,
     }
 }
 
@@ -331,6 +347,91 @@ fn resolve_cwd(cwd: &str, event: &RouxEvent) -> PathBuf {
             .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))),
         other => PathBuf::from(other),
     }
+}
+
+fn hook_timeout_ms(hook: &HookDefinition) -> u64 {
+    hook.run.timeout_ms.unwrap_or(DEFAULT_HOOK_TIMEOUT_MS)
+}
+
+#[derive(Debug, Default)]
+struct OutputCapture {
+    text: String,
+    truncated: bool,
+}
+
+fn normalized_workspace_path(path: &str) -> String {
+    let path = path.trim();
+    let path = PathBuf::from(path);
+    let normalized = path.canonicalize().unwrap_or(path);
+    let normalized = normalized.to_string_lossy().to_string();
+    #[cfg(windows)]
+    {
+        normalized.to_ascii_lowercase()
+    }
+    #[cfg(not(windows))]
+    {
+        normalized
+    }
+}
+
+async fn read_stream_with_limit<R>(mut reader: R) -> std::io::Result<OutputCapture>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    let mut captured = Vec::new();
+    let mut truncated = false;
+    let mut buf = [0_u8; 4096];
+
+    loop {
+        let read = reader.read(&mut buf).await?;
+        if read == 0 {
+            break;
+        }
+
+        if captured.len() < MAX_HOOK_OUTPUT_BYTES {
+            let remaining = MAX_HOOK_OUTPUT_BYTES - captured.len();
+            let take = remaining.min(read);
+            captured.extend_from_slice(&buf[..take]);
+            if take < read {
+                truncated = true;
+            }
+        } else {
+            truncated = true;
+        }
+    }
+
+    Ok(OutputCapture { text: String::from_utf8_lossy(&captured).into_owned(), truncated })
+}
+
+async fn collect_output(
+    task: Option<tokio::task::JoinHandle<std::io::Result<OutputCapture>>>,
+    stream_name: &str,
+) -> OutputCapture {
+    match task {
+        Some(task) => match task.await {
+            Ok(Ok(output)) => output,
+            Ok(Err(e)) => OutputCapture {
+                text: format!("failed to read hook {stream_name}: {e}"),
+                truncated: false,
+            },
+            Err(e) => OutputCapture {
+                text: format!("failed to join hook {stream_name} reader: {e}"),
+                truncated: false,
+            },
+        },
+        None => OutputCapture::default(),
+    }
+}
+
+async fn terminate_hook_process(child: &mut tokio::process::Child) {
+    #[cfg(unix)]
+    if let Some(pid) = child.id() {
+        unsafe {
+            libc::killpg(pid as i32, libc::SIGKILL);
+        }
+    }
+    let _ = child.kill().await;
+    let _ = child.wait().await;
 }
 
 fn watch_payload(
@@ -746,6 +847,46 @@ mod tests {
     }
 
     #[test]
+    fn hook_timeout_defaults_when_omitted() {
+        let hook = HookDefinition {
+            id: "default-timeout".into(),
+            on: vec![HookEventKind::WatchCompleted],
+            enabled: true,
+            filters: Vec::new(),
+            run: HookRun { command: "echo".into(), timeout_ms: None, ..HookRun::default() },
+            policy: Default::default(),
+        };
+
+        assert_eq!(hook_timeout_ms(&hook), DEFAULT_HOOK_TIMEOUT_MS);
+    }
+
+    #[test]
+    fn trusted_workspace_matching_normalizes_trailing_slashes() {
+        let cfg = tempfile::tempdir().unwrap();
+        let repo = tempfile::tempdir().unwrap();
+
+        write(
+            &repo.path().join(".roux/hooks.kdl"),
+            r#"
+                hooks {
+                  hook "repo-watch" {
+                    on "watch.completed"
+                    run { command "python3" }
+                  }
+                }
+            "#,
+        );
+
+        let mut settings = crate::settings::RouxSettings::default();
+        settings.trusted_workspaces = vec![format!("{}/", repo.path().display())];
+        let event = event_for_repo(repo.path());
+
+        let loaded = load_hooks_for_event_in(cfg.path(), &settings, &event);
+        let ids: Vec<&str> = loaded.config.hooks.iter().map(|hook| hook.id.as_str()).collect();
+        assert_eq!(ids, vec!["repo-watch"]);
+    }
+
+    #[test]
     fn builds_session_created_event_with_workspace_and_profile() {
         let session = crate::session::Session {
             id: "sess-1".into(),
@@ -827,5 +968,117 @@ mod tests {
             written.contains(&format!("\"repoRoot\":\"{}\"", repo.path().display())),
             "repo root missing from event json: {written}"
         );
+    }
+
+    #[tokio::test]
+    async fn dispatch_surfaces_hook_load_errors() {
+        let cfg = tempfile::tempdir().unwrap();
+        write(
+            &cfg.path().join("hooks.kdl"),
+            r#"
+                not-hooks {
+                  nope "x"
+                }
+            "#,
+        );
+
+        let settings = crate::settings::RouxSettings::default();
+        let event = event_for_repo(cfg.path());
+
+        let result = dispatch_event_in(cfg.path(), &settings, &event).await;
+        assert!(result.runs.is_empty());
+        assert_eq!(result.matched_hook_ids, Vec::<String>::new());
+        assert_eq!(result.load_errors.len(), 1);
+        assert!(result.load_errors[0].message.contains("top-level `hooks` node"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn timed_out_hook_is_killed_before_later_side_effects() {
+        let cfg = tempfile::tempdir().unwrap();
+        let repo = tempfile::tempdir().unwrap();
+        let out = repo.path().join("should-not-exist");
+        let script = repo.path().join("slow-hook.sh");
+        write(
+            &script,
+            &format!(
+                "#!/usr/bin/env sh\nsleep 1\nprintf done > \"{}\"\n",
+                out.display()
+            ),
+        );
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        write(
+            &cfg.path().join("hooks.kdl"),
+            &format!(
+                r#"
+                    hooks {{
+                      hook "slow-hook" {{
+                        on "watch.completed"
+                        run {{
+                          command "sh"
+                          arg "{}"
+                          timeout-ms 50
+                        }}
+                      }}
+                    }}
+                "#,
+                script.display()
+            ),
+        );
+
+        let settings = crate::settings::RouxSettings::default();
+        let event = event_for_repo(repo.path());
+
+        let result = dispatch_event_in(cfg.path(), &settings, &event).await;
+        assert_eq!(result.runs.len(), 1);
+        assert!(result.runs[0].timed_out);
+
+        tokio::time::sleep(std::time::Duration::from_millis(1200)).await;
+        assert!(!out.exists(), "timed-out hook still produced a later side effect");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn hook_output_is_truncated_to_capture_limit() {
+        let cfg = tempfile::tempdir().unwrap();
+        let repo = tempfile::tempdir().unwrap();
+        let script = repo.path().join("loud-hook.sh");
+        write(
+            &script,
+            "python3 - <<'PY'\nimport sys\nsys.stdout.write('x' * 70000)\nsys.stderr.write('y' * 70000)\nPY\n",
+        );
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        write(
+            &cfg.path().join("hooks.kdl"),
+            &format!(
+                r#"
+                    hooks {{
+                      hook "loud-hook" {{
+                        on "watch.completed"
+                        run {{
+                          command "sh"
+                          arg "{}"
+                          timeout-ms 5000
+                        }}
+                      }}
+                    }}
+                "#,
+                script.display()
+            ),
+        );
+
+        let settings = crate::settings::RouxSettings::default();
+        let event = event_for_repo(repo.path());
+
+        let result = dispatch_event_in(cfg.path(), &settings, &event).await;
+        assert_eq!(result.runs.len(), 1);
+        assert!(result.runs[0].stdout_truncated);
+        assert!(result.runs[0].stderr_truncated);
+        assert!(result.runs[0].stdout.len() <= MAX_HOOK_OUTPUT_BYTES);
+        assert!(result.runs[0].stderr.len() <= MAX_HOOK_OUTPUT_BYTES);
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,6 +3,7 @@
 mod agent_registry;
 mod agent_sources;
 mod hooks;
+mod hook_runtime;
 #[macro_use]
 mod logging;
 mod commands;

--- a/src-tauri/src/socket.rs
+++ b/src-tauri/src/socket.rs
@@ -200,12 +200,18 @@ async fn handle_hooks_emit(req: Request, app: &tauri::AppHandle) -> Response {
 
     Response::success(serde_json::json!({
         "matchedHookIds": result.matched_hook_ids,
+        "loadErrors": result.load_errors.iter().map(|error| serde_json::json!({
+            "path": error.path.display().to_string(),
+            "message": error.message.clone(),
+        })).collect::<Vec<_>>(),
         "runs": result.runs.iter().map(|run| serde_json::json!({
             "hookId": run.hook_id,
             "exitCode": run.exit_code,
             "timedOut": run.timed_out,
             "stdout": run.stdout,
+            "stdoutTruncated": run.stdout_truncated,
             "stderr": run.stderr,
+            "stderrTruncated": run.stderr_truncated,
         })).collect::<Vec<_>>(),
     }))
 }
@@ -649,12 +655,15 @@ async fn handle_session_create(req: Request, app: &tauri::AppHandle) -> Response
     }
 
     let hook_event = crate::hook_runtime::session_created_event(&session, Some(&profile));
-    let _ = crate::hook_runtime::dispatch_event_in(
-        &crate::paths::roux_config_dir(),
-        &settings,
-        &hook_event,
-    )
-    .await;
+    let hook_settings = settings.clone();
+    tauri::async_runtime::spawn(async move {
+        let _ = crate::hook_runtime::dispatch_event_in(
+            &crate::paths::roux_config_dir(),
+            &hook_settings,
+            &hook_event,
+        )
+        .await;
+    });
 
     Response::success(serde_json::json!({ "session_id": session_id }))
 }

--- a/src-tauri/src/socket.rs
+++ b/src-tauri/src/socket.rs
@@ -178,8 +178,36 @@ async fn handle_request(req: Request, app: &tauri::AppHandle) -> Response {
         "session-panes-list" => handle_session_panes_list(req, app).await,
         "session-panes-create" => handle_session_panes_create(req, app).await,
         "app-open" => handle_app_open(req, app).await,
+        "hooks-emit" => handle_hooks_emit(req, app).await,
         _ => Response::err(format!("unknown command: {}", req.command)),
     }
+}
+
+async fn handle_hooks_emit(req: Request, app: &tauri::AppHandle) -> Response {
+    let event = match req.args.get("event") {
+        Some(v) => match serde_json::from_value::<roux_core::RouxEvent>(v.clone()) {
+            Ok(event) => event,
+            Err(e) => return Response::err(format!("invalid hook event payload: {}", e)),
+        },
+        None => return Response::err("event argument required"),
+    };
+
+    let state: tauri::State<AppState> = app.state();
+    let settings = state.settings.lock().unwrap().clone();
+    let result =
+        crate::hook_runtime::dispatch_event_in(&crate::paths::roux_config_dir(), &settings, &event)
+            .await;
+
+    Response::success(serde_json::json!({
+        "matchedHookIds": result.matched_hook_ids,
+        "runs": result.runs.iter().map(|run| serde_json::json!({
+            "hookId": run.hook_id,
+            "exitCode": run.exit_code,
+            "timedOut": run.timed_out,
+            "stdout": run.stdout,
+            "stderr": run.stderr,
+        })).collect::<Vec<_>>(),
+    }))
 }
 
 async fn handle_session_list(_req: Request, app: &tauri::AppHandle) -> Response {
@@ -619,6 +647,14 @@ async fn handle_session_create(req: Request, app: &tauri::AppHandle) -> Response
     if let Err(e) = app.emit("roux-command", &cmd) {
         rlog!("Warning: failed to emit session-created event: {}", e);
     }
+
+    let hook_event = crate::hook_runtime::session_created_event(&session, Some(&profile));
+    let _ = crate::hook_runtime::dispatch_event_in(
+        &crate::paths::roux_config_dir(),
+        &settings,
+        &hook_event,
+    )
+    .await;
 
     Response::success(serde_json::json!({ "session_id": session_id }))
 }

--- a/src-tauri/src/watches/manager.rs
+++ b/src-tauri/src/watches/manager.rs
@@ -155,6 +155,7 @@ impl WatchManager {
 
                 let new_outcome = result.outcome().clone();
                 let changed = previous_outcome.as_ref() != Some(&new_outcome);
+                let previous_outcome_for_hooks = previous_outcome.clone();
 
                 let now = std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
@@ -174,9 +175,16 @@ impl WatchManager {
                     let event = WatchUpdateEvent {
                         watch: updated_watch.clone(),
                         changed,
-                        previous_outcome,
+                        previous_outcome: previous_outcome.clone(),
                     };
                     let _ = app.emit("watch-update", &event);
+
+                    let hook_watch = updated_watch.clone();
+                    let hook_app = app.clone();
+                    tokio::spawn(async move {
+                        emit_watch_hook_events(hook_app, hook_watch, previous_outcome_for_hooks)
+                            .await;
+                    });
 
                     // Desktop notification with flap debouncing
                     if changed {
@@ -358,4 +366,23 @@ fn rand_jitter() -> u64 {
         .unwrap_or_default()
         .subsec_nanos();
     (nanos % 5000) as u64
+}
+
+async fn emit_watch_hook_events(
+    app: tauri::AppHandle,
+    watch: Watch,
+    previous_outcome: Option<WatchOutcome>,
+) {
+    let state: tauri::State<'_, AppState> = app.state();
+    let settings = state.settings.lock().unwrap().clone();
+    let session = match &watch.scope {
+        WatchScope::Session { session_id } => state.session_handle.get(session_id).await.ok().flatten(),
+        _ => None,
+    };
+
+    for event in crate::hook_runtime::watch_events(&watch, previous_outcome.as_ref(), session.as_ref()) {
+        let _ =
+            crate::hook_runtime::dispatch_event_in(&crate::paths::roux_config_dir(), &settings, &event)
+                .await;
+    }
 }


### PR DESCRIPTION
## Summary

This PR adds the first end-to-end Roux hooks runtime and wires in the first real event producers.

## What Changed

- added a shared hooks model and KDL parser in `roux-core`
- added a backend hook runtime that:
  - loads global hooks from `~/.config/roux/hooks.kdl`
  - loads trusted repo hooks from `<repo>/.roux/hooks.kdl`
  - merges configs with repo overrides
  - matches enabled hooks by event kind and simple filters
  - runs hook scripts out of process with stdin JSON, env vars, and timeouts
- added `roux-cli hooks emit ...` so hooks and local scripts can emit normalized events into a running app
- added socket support for `hooks-emit`
- emit `session.created` automatically when a session is created
- emit `watch.completed` and `watch.outcome_changed` automatically from the watch manager
- added docs for the hooks feature and the implementation plan

## Why

The near-term value here is a normalized event stream plus supervised local automation, not an embedded policy language. This gets Roux to a point where a user can write a hook tonight that reacts to session or watch activity and then drives Roux through the CLI.

## User Impact

Users can now define hooks in KDL, receive a structured event envelope on stdin, and automate Roux actions from local scripts. The initial matching surface is intentionally narrow: `equals`, `in`, and `exists`.

## Validation

- `cargo test -p roux hook_runtime -- --nocapture`
- `cargo test -p roux cli_parses_hooks_emit -- --nocapture`

## Notes

This is intentionally the first slice. Concurrency policy parsing exists, but the runtime behavior is still basic and hook-run observability is still minimal.
