### PR TITLE
fix(ui): hide sidebars via visibility, clip app overflow

### DIFF
--- a/src/lib/components/Layout.svelte
+++ b/src/lib/components/Layout.svelte
@@ -39,7 +39,7 @@
   }
 </script>
 
-<div class="flex h-screen flex-col bg-bg-deep text-text-primary">
+<div class="flex h-screen flex-col overflow-hidden bg-bg-deep text-text-primary">
   <div
     class="flex min-h-0 flex-1"
     class:flex-row={$settings.tabPosition === "left"}
@@ -61,7 +61,7 @@
       </div>
     {/if}
 
-    <div class="relative flex min-w-0 flex-1 flex-col bg-bg-deep">
+    <div class="relative flex min-w-0 flex-1 flex-col overflow-hidden bg-bg-deep">
       {#if statusBarPosition === "top"}
         <StatusBar position="top" />
       {/if}

--- a/src/lib/components/NotesPanel.svelte
+++ b/src/lib/components/NotesPanel.svelte
@@ -40,8 +40,8 @@
 </script>
 
 <div
-  class="absolute top-2 right-2 bottom-2 z-50 flex w-[380px] flex-col rounded-2xl border border-hairline bg-bg-deep shadow-[-8px_8px_48px_rgba(2,6,23,0.55),0_0_0_1px_rgba(255,255,255,0.04)] transition-transform duration-250
-    {visible ? 'translate-x-0' : 'translate-x-[calc(100%+8px)]'}"
+  style="right: {visible ? '0.5rem' : '-400px'}; visibility: {visible ? 'visible' : 'hidden'};"
+  class="absolute top-2 bottom-2 z-50 flex w-[380px] flex-col rounded-2xl border border-hairline bg-bg-deep shadow-[-8px_8px_48px_rgba(2,6,23,0.55),0_0_0_1px_rgba(255,255,255,0.04)] transition-[right] duration-250"
 >
   <div class="flex h-9 shrink-0 items-center justify-between border-b border-hairline bg-bg-surface/30 px-3 rounded-t-2xl">
     <span class="text-sm font-semibold tracking-tight">{projectName ? `${projectName} — Notes` : 'Notes'}</span>

--- a/src/lib/components/NotificationsPane.svelte
+++ b/src/lib/components/NotificationsPane.svelte
@@ -104,8 +104,8 @@
 </script>
 
 <div
-  class="absolute top-2 right-2 bottom-2 z-50 flex w-[400px] flex-col border border-hairline bg-bg-deep shadow-[-8px_8px_48px_rgba(2,6,23,0.55),0_0_0_1px_rgba(255,255,255,0.04)] transition-transform duration-250
-  {visible ? 'translate-x-0' : 'translate-x-[calc(100%+8px)]'}"
+  style="right: {visible ? '0.5rem' : '-420px'}; visibility: {visible ? 'visible' : 'hidden'};"
+  class="absolute top-2 bottom-2 z-50 flex w-[400px] flex-col border border-hairline bg-bg-deep shadow-[-8px_8px_48px_rgba(2,6,23,0.55),0_0_0_1px_rgba(255,255,255,0.04)] transition-[right] duration-250"
 >
   <div class="flex h-9 shrink-0 items-center justify-between border-b border-hairline bg-bg-surface/30 px-3">
     <span class="text-sm font-semibold tracking-tight">Notifications</span>

--- a/src/lib/components/WatchesPane.svelte
+++ b/src/lib/components/WatchesPane.svelte
@@ -96,8 +96,8 @@
 </script>
 
 <div
-  class="absolute top-2 right-2 bottom-2 z-50 flex w-[380px] flex-col border border-hairline bg-bg-deep shadow-[-8px_8px_48px_rgba(2,6,23,0.55),0_0_0_1px_rgba(255,255,255,0.04)] transition-transform duration-250
-  {visible ? 'translate-x-0' : 'translate-x-[calc(100%+8px)]'}"
+  style="right: {visible ? '0.5rem' : '-400px'}; visibility: {visible ? 'visible' : 'hidden'};"
+  class="absolute top-2 bottom-2 z-50 flex w-[380px] flex-col border border-hairline bg-bg-deep shadow-[-8px_8px_48px_rgba(2,6,23,0.55),0_0_0_1px_rgba(255,255,255,0.04)] transition-[right] duration-250"
 >
   <div class="flex h-9 shrink-0 items-center justify-between border-b border-hairline bg-bg-surface/30 px-3">
     <span class="text-sm font-semibold tracking-tight">Watches</span>


### PR DESCRIPTION
## Summary
Follow-up to #71. The mutual-exclusion store was correct, but the side panels still showed up when they shouldn't:

- The Tailwind class `translate-x-[calc(100%+8px)]` never compiled to the intended CSS (the `calc()` parse + parent-width race on first paint meant the "hidden" panel rendered on-screen). A later xterm resize (triggered by typing into Claude) would finally apply the correct layout — that's what the "panel resets after ~10 characters" symptom was.
- Negative `right:` offsets on absolute panels let the app root's scroll width grow past the viewport, pushing the left sidebar off-screen whenever a panel opened from the leader tree.

### Fix
- Replace the Tailwind `translate-x-[calc(...)]` classes with inline `style="right: ...; visibility: ..."`. `visibility: hidden` is layout-independent, so the panel cannot be shown when the store says it shouldn't — regardless of any parent-width race.
- Add `overflow-hidden` on the Layout root and content area so a panel positioned offscreen cannot bleed past the viewport and shift the sidebar.

No backend changes; sidebar visibility is still ephemeral frontend state.

## Test plan
- [x] `npm run test` — 342 pass
- [x] `npm run check` — 0 errors, 0 warnings
- [ ] Fresh launch: no panels visible
- [ ] `Cmd+I`, `Cmd+B`, `Cmd+Shift+W` each toggle their panel cleanly
- [ ] `Cmd+;` → `i` / `n` / `t` toggles the correct panel without flash, misposition, or sidebar shift
- [ ] Type into Claude pane — layout is stable, no "reset" after a few characters
- [ ] Toggle between panels (e.g. `Cmd+;` → `i`, then `Cmd+;` → `n`) and confirm only one is visible at a time

🤖 Generated with [Claude Code](https://claude.com/claude-code)