### PR TITLE
feat(updater): add user-subscribable pre-release channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3881,7 +3881,7 @@ dependencies = [
 
 [[package]]
 name = "roux"
-version = "0.4.4"
+version = "0.4.5-alpha.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3910,6 +3910,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
+ "url",
  "uuid",
  "vte",
 ]

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -309,60 +309,66 @@ tasks:
           echo "Uploaded $DMG to $TAG"
         done
 
-        # Updater manifest: skip for prereleases so they never become "latest" for everyone.
-        if [ -n "$PRE_FLAG" ]; then
-          echo "Skipping updater manifest for prerelease $TAG"
-        else
-          TARBALL_MATCHES=$(find "${TARGET_ROOT}" -path "*/release/bundle/macos/*.app.tar.gz" -print)
-          TARBALL_COUNT=$(printf '%s\n' "$TARBALL_MATCHES" | grep -c . || true)
-          if [ "$TARBALL_COUNT" -eq 0 ]; then
-            echo "ERROR: no updater tarball (*.app.tar.gz) found under ${TARGET_ROOT}" >&2
-            exit 1
-          fi
-          if [ "$TARBALL_COUNT" -gt 1 ]; then
-            echo "ERROR: multiple updater tarballs found under ${TARGET_ROOT}:" >&2
-            printf '%s\n' "$TARBALL_MATCHES" >&2
-            exit 1
-          fi
-          TARBALL="$TARBALL_MATCHES"
-          SIG_PATH="${TARBALL}.sig"
-          if [ ! -f "$SIG_PATH" ]; then
-            echo "ERROR: updater signature file missing: $SIG_PATH" >&2
-            exit 1
-          fi
-          TARBALL_BASENAME=$(basename "$TARBALL")
-          MANIFEST_DIR=$(dirname "$TARBALL")
-          MANIFEST="${MANIFEST_DIR}/latest.json"
-          PUB_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          URL="https://github.com/phin-tech/roux/releases/download/${TAG}/${TARBALL_BASENAME}"
-
-          ROUX_VERSION="$VERSION" \
-          ROUX_NOTES="$CHANGELOG" \
-          ROUX_PUB_DATE="$PUB_DATE" \
-          ROUX_URL="$URL" \
-          ROUX_SIG_PATH="$SIG_PATH" \
-          ROUX_MANIFEST="$MANIFEST" \
-          python3 -c '
-          import json, os
-          sig = open(os.environ["ROUX_SIG_PATH"]).read()
-          manifest = {
-              "version": os.environ["ROUX_VERSION"],
-              "notes": os.environ["ROUX_NOTES"],
-              "pub_date": os.environ["ROUX_PUB_DATE"],
-              "platforms": {
-                  "darwin-aarch64": {
-                      "signature": sig,
-                      "url": os.environ["ROUX_URL"],
-                  },
-              },
-          }
-          with open(os.environ["ROUX_MANIFEST"], "w") as f:
-              json.dump(manifest, f, indent=2)
-          '
-
-          gh release upload "$TAG" "$TARBALL" "$SIG_PATH" "$MANIFEST" --clobber
-          echo "Uploaded updater artifacts ($TARBALL_BASENAME, .sig, latest.json) to $TAG"
+        # Updater manifest. Stable releases get `latest.json` (the fixed URL
+        # Tauri's `endpoints` config points at). Prereleases get
+        # `latest-prerelease.json`, which the Rust updater resolves by querying
+        # the GitHub API for the newest prerelease tag and then fetching that
+        # tag's manifest — so each prerelease owns its own manifest and the
+        # "latest" stable release is never polluted with alpha artifacts.
+        TARBALL_MATCHES=$(find "${TARGET_ROOT}" -path "*/release/bundle/macos/*.app.tar.gz" -print)
+        TARBALL_COUNT=$(printf '%s\n' "$TARBALL_MATCHES" | grep -c . || true)
+        if [ "$TARBALL_COUNT" -eq 0 ]; then
+          echo "ERROR: no updater tarball (*.app.tar.gz) found under ${TARGET_ROOT}" >&2
+          exit 1
         fi
+        if [ "$TARBALL_COUNT" -gt 1 ]; then
+          echo "ERROR: multiple updater tarballs found under ${TARGET_ROOT}:" >&2
+          printf '%s\n' "$TARBALL_MATCHES" >&2
+          exit 1
+        fi
+        TARBALL="$TARBALL_MATCHES"
+        SIG_PATH="${TARBALL}.sig"
+        if [ ! -f "$SIG_PATH" ]; then
+          echo "ERROR: updater signature file missing: $SIG_PATH" >&2
+          exit 1
+        fi
+        TARBALL_BASENAME=$(basename "$TARBALL")
+        MANIFEST_DIR=$(dirname "$TARBALL")
+        if [ -n "$PRE_FLAG" ]; then
+          MANIFEST_NAME="latest-prerelease.json"
+        else
+          MANIFEST_NAME="latest.json"
+        fi
+        MANIFEST="${MANIFEST_DIR}/${MANIFEST_NAME}"
+        PUB_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+        URL="https://github.com/phin-tech/roux/releases/download/${TAG}/${TARBALL_BASENAME}"
+
+        ROUX_VERSION="$VERSION" \
+        ROUX_NOTES="$CHANGELOG" \
+        ROUX_PUB_DATE="$PUB_DATE" \
+        ROUX_URL="$URL" \
+        ROUX_SIG_PATH="$SIG_PATH" \
+        ROUX_MANIFEST="$MANIFEST" \
+        python3 -c '
+        import json, os
+        sig = open(os.environ["ROUX_SIG_PATH"]).read()
+        manifest = {
+            "version": os.environ["ROUX_VERSION"],
+            "notes": os.environ["ROUX_NOTES"],
+            "pub_date": os.environ["ROUX_PUB_DATE"],
+            "platforms": {
+                "darwin-aarch64": {
+                    "signature": sig,
+                    "url": os.environ["ROUX_URL"],
+                },
+            },
+        }
+        with open(os.environ["ROUX_MANIFEST"], "w") as f:
+            json.dump(manifest, f, indent=2)
+        '
+
+        gh release upload "$TAG" "$TARBALL" "$SIG_PATH" "$MANIFEST" --clobber
+        echo "Uploaded updater artifacts ($TARBALL_BASENAME, .sig, $MANIFEST_NAME) to $TAG"
 
   publish:op:
     desc: "Sign with 1Password-backed secrets, then publish the current version"

--- a/crates/roux-core/src/models/mod.rs
+++ b/crates/roux-core/src/models/mod.rs
@@ -27,7 +27,8 @@ pub use profile::{ProfileSource, Provider, SpawnProfile, StartupBehavior};
 pub use project::Project;
 pub use session::{Session, SessionStatus};
 pub use settings::{
-    CursorStyle, GroupBy, RouxSettings, StatusBarPosition, TabPosition, WorktreeCleanupMode,
+    CursorStyle, GroupBy, RouxSettings, StatusBarPosition, TabPosition, UpdateChannel,
+    WorktreeCleanupMode,
 };
 pub use task::{KeepOpen, TaskDefinition, TaskGroup};
 pub use watch::*;

--- a/crates/roux-core/src/models/settings.rs
+++ b/crates/roux-core/src/models/settings.rs
@@ -61,6 +61,14 @@ pub enum GroupBy {
     Project,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, specta::Type, Default)]
+#[serde(rename_all = "camelCase")]
+pub enum UpdateChannel {
+    #[default]
+    Stable,
+    PreRelease,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
 #[serde(rename_all = "camelCase")]
 pub struct RouxSettings {
@@ -126,6 +134,11 @@ pub struct RouxSettings {
     /// Settings / command palette remain available regardless.
     #[serde(default = "default_true")]
     pub update_check_on_launch: bool,
+    /// Which update channel this user is subscribed to. `Stable` pulls from the
+    /// standard `latest.json` manifest; `PreRelease` resolves the newest
+    /// GitHub prerelease at check time and pulls its `latest-prerelease.json`.
+    #[serde(default)]
+    pub update_channel: UpdateChannel,
     /// User-defined spawn profiles. Edited as raw JSON in the settings file
     /// in v1 — the "Save as user profile" UI is a later addition. The settings
     /// loader force-sets `source: "user"` on each entry regardless of what
@@ -185,6 +198,7 @@ impl Default for RouxSettings {
             notifications_enabled: true,
             auto_clear_attention_state: true,
             update_check_on_launch: true,
+            update_channel: UpdateChannel::default(),
             spawn_profiles: Vec::new(),
             trusted_workspaces: Vec::new(),
             status_bar_position: StatusBarPosition::Bottom,
@@ -243,7 +257,7 @@ fn normalize_theme(theme: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::RouxSettings;
+    use super::{RouxSettings, UpdateChannel};
 
     #[test]
     fn hint_overlay_defaults_preserve_command_drop_option() {
@@ -290,6 +304,32 @@ mod tests {
 
         let normalized = settings.normalized();
         assert_eq!(normalized.repo_roots, vec!["/tmp/src", "/tmp/other"]);
+    }
+
+    #[test]
+    fn settings_without_update_channel_defaults_to_stable() {
+        let legacy = r#"{
+            "tabPosition": "left",
+            "tabWidth": 260,
+            "fontSize": 14,
+            "fontFamily": "monospace",
+            "lineHeight": 1.2,
+            "scrollback": 5000,
+            "cursorStyle": "block",
+            "cursorBlink": true,
+            "defaultProjectPath": null,
+            "confirmOnClose": true,
+            "restoreSessionsOnLaunch": true,
+            "worktreeBasePath": null,
+            "cleanupWorktreesOnClose": false,
+            "theme": "deep-blue",
+            "defaultModel": null,
+            "additionalFlags": [],
+            "taskPanelSplit": 0.5,
+            "taskPanelCollapsed": true
+        }"#;
+        let parsed: RouxSettings = serde_json::from_str(legacy).unwrap();
+        assert_eq!(parsed.update_channel, UpdateChannel::Stable);
     }
 
     #[test]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roux",
-  "version": "0.3.6",
+  "version": "0.4.5-alpha.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roux",
-      "version": "0.3.6",
+      "version": "0.4.5-alpha.3",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -41,6 +41,7 @@ serde_yaml = "0.9"
 tokio = { version = "1", features = ["net", "io-util", "macros", "rt-multi-thread", "process", "time", "sync"] }
 tokio-util = "0.7"
 reqwest = { version = "0.12", features = ["json"] }
+url = "2"
 octocrab = "0.44"
 tauri-plugin-opener = "2.5.3"
 thiserror = "2"

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -8,4 +8,5 @@ pub(crate) mod projects;
 pub(crate) mod sessions;
 pub(crate) mod settings;
 pub(crate) mod setup;
+pub(crate) mod updater;
 pub(crate) mod worktrees;

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -1,0 +1,20 @@
+use crate::updater::{self, UpdateInfo, UpdaterError};
+use roux_core::UpdateChannel;
+
+#[tauri::command]
+#[specta::specta]
+pub(crate) async fn check_for_update(
+    app: tauri::AppHandle,
+    channel: UpdateChannel,
+) -> Result<Option<UpdateInfo>, UpdaterError> {
+    updater::check_for_update(&app, channel).await
+}
+
+#[tauri::command]
+#[specta::specta]
+pub(crate) async fn install_update(
+    app: tauri::AppHandle,
+    channel: UpdateChannel,
+) -> Result<(), UpdaterError> {
+    updater::install_update(&app, channel).await
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -27,6 +27,7 @@ mod skill;
 mod socket;
 mod state;
 mod tasks;
+mod updater;
 mod watches;
 mod worktree;
 
@@ -70,6 +71,8 @@ fn main() {
         commands::misc::frontend_log,
         commands::settings::get_settings,
         commands::settings::update_settings,
+        commands::updater::check_for_update,
+        commands::updater::install_update,
         commands::worktrees::cmd_create_worktree,
         commands::worktrees::cmd_remove_worktree,
         commands::worktrees::cmd_list_worktrees,
@@ -155,6 +158,12 @@ fn main() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_notification::init())
+        // Registers the updater plugin and the `UpdaterExt` trait. The
+        // `endpoints` configured in tauri.conf.json are effectively unused at
+        // runtime — `src/updater.rs` overrides them per-channel via
+        // `app.updater_builder().endpoints(...)`. The static config is kept as
+        // a defensive fallback so checks still work if the Rust command path
+        // ever regresses.
         .plugin(tauri_plugin_updater::Builder::new().build())
         .manage(AppState {
             settings: Mutex::new(initial_settings),
@@ -171,6 +180,8 @@ fn main() {
             commands::misc::frontend_log,
             commands::settings::get_settings,
             commands::settings::update_settings,
+            commands::updater::check_for_update,
+            commands::updater::install_update,
             commands::worktrees::cmd_create_worktree,
             commands::worktrees::cmd_remove_worktree,
             commands::worktrees::cmd_list_worktrees,

--- a/src-tauri/src/updater.rs
+++ b/src-tauri/src/updater.rs
@@ -61,7 +61,7 @@ pub struct UpdateInfo {
 }
 
 #[derive(Debug, Clone, Serialize, specta::Type)]
-#[serde(rename_all = "camelCase", tag = "phase")]
+#[serde(rename_all = "camelCase", rename_all_fields = "camelCase", tag = "phase")]
 pub enum UpdateProgress {
     Started { content_length: Option<u64> },
     Progress { chunk_length: u64 },
@@ -84,8 +84,12 @@ async fn resolve_latest_prerelease_manifest() -> Result<String, UpdaterError> {
         created_at: String,
     }
 
+    // 100 is the GitHub API's max per_page. In practice a repo is unlikely
+    // to go 100 releases without a prerelease, and paginating would add
+    // another network round-trip per check. If the repo ever outgrows this,
+    // bump to full pagination.
     let api_url = format!(
-        "https://api.github.com/repos/{}/{}/releases?per_page=30",
+        "https://api.github.com/repos/{}/{}/releases?per_page=100",
         GITHUB_OWNER, GITHUB_REPO
     );
     let client = reqwest::Client::builder()
@@ -206,6 +210,27 @@ mod tests {
     async fn stable_endpoint_is_static_manifest_url() {
         let url = resolve_endpoint(UpdateChannel::Stable).await.unwrap();
         assert_eq!(url, STABLE_MANIFEST_URL);
+    }
+
+    #[test]
+    fn update_progress_serializes_in_camel_case() {
+        let started = serde_json::to_value(UpdateProgress::Started {
+            content_length: Some(1024),
+        })
+        .unwrap();
+        assert_eq!(started["phase"], "started");
+        assert_eq!(started["contentLength"], 1024);
+        assert!(
+            started.get("content_length").is_none(),
+            "snake_case field would break the frontend progress listener"
+        );
+
+        let progress = serde_json::to_value(UpdateProgress::Progress { chunk_length: 256 }).unwrap();
+        assert_eq!(progress["phase"], "progress");
+        assert_eq!(progress["chunkLength"], 256);
+
+        let finished = serde_json::to_value(UpdateProgress::Finished).unwrap();
+        assert_eq!(finished["phase"], "finished");
     }
 
     #[test]

--- a/src-tauri/src/updater.rs
+++ b/src-tauri/src/updater.rs
@@ -1,0 +1,219 @@
+use roux_core::UpdateChannel;
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter};
+use tauri_plugin_updater::UpdaterExt;
+use thiserror::Error;
+
+const GITHUB_OWNER: &str = "phin-tech";
+const GITHUB_REPO: &str = "roux";
+const STABLE_MANIFEST_URL: &str =
+    "https://github.com/phin-tech/roux/releases/latest/download/latest.json";
+const PRERELEASE_MANIFEST_NAME: &str = "latest-prerelease.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type, Error)]
+#[serde(rename_all = "kebab-case", tag = "kind")]
+pub enum UpdaterError {
+    #[error("network failure while reaching the update server")]
+    Network,
+    #[error("update signature verification failed")]
+    SignatureInvalid,
+    #[error("no release available for the selected channel")]
+    NotFound,
+    #[error("updater internal error: {message}")]
+    Internal { message: String },
+}
+
+impl UpdaterError {
+    fn from_update_error(err: tauri_plugin_updater::Error) -> Self {
+        let message = err.to_string();
+        if message.to_lowercase().contains("signature") {
+            UpdaterError::SignatureInvalid
+        } else if is_network_message(&message) {
+            UpdaterError::Network
+        } else {
+            UpdaterError::Internal { message }
+        }
+    }
+
+    fn from_reqwest(err: reqwest::Error) -> Self {
+        if err.is_connect() || err.is_timeout() || err.is_request() {
+            UpdaterError::Network
+        } else {
+            UpdaterError::Internal {
+                message: err.to_string(),
+            }
+        }
+    }
+}
+
+fn is_network_message(msg: &str) -> bool {
+    let lower = msg.to_lowercase();
+    ["network", "connect", "dns", "timeout", "request", "http"]
+        .iter()
+        .any(|needle| lower.contains(needle))
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateInfo {
+    pub version: String,
+    pub notes: String,
+}
+
+#[derive(Debug, Clone, Serialize, specta::Type)]
+#[serde(rename_all = "camelCase", tag = "phase")]
+pub enum UpdateProgress {
+    Started { content_length: Option<u64> },
+    Progress { chunk_length: u64 },
+    Finished,
+}
+
+pub(crate) async fn resolve_endpoint(channel: UpdateChannel) -> Result<String, UpdaterError> {
+    match channel {
+        UpdateChannel::Stable => Ok(STABLE_MANIFEST_URL.to_string()),
+        UpdateChannel::PreRelease => resolve_latest_prerelease_manifest().await,
+    }
+}
+
+async fn resolve_latest_prerelease_manifest() -> Result<String, UpdaterError> {
+    #[derive(Deserialize)]
+    struct Release {
+        tag_name: String,
+        prerelease: bool,
+        draft: bool,
+        created_at: String,
+    }
+
+    let api_url = format!(
+        "https://api.github.com/repos/{}/{}/releases?per_page=30",
+        GITHUB_OWNER, GITHUB_REPO
+    );
+    let client = reqwest::Client::builder()
+        .user_agent(format!("roux-updater/{}", env!("CARGO_PKG_VERSION")))
+        .build()
+        .map_err(UpdaterError::from_reqwest)?;
+
+    let releases: Vec<Release> = client
+        .get(&api_url)
+        .header("Accept", "application/vnd.github+json")
+        .send()
+        .await
+        .map_err(UpdaterError::from_reqwest)?
+        .error_for_status()
+        .map_err(UpdaterError::from_reqwest)?
+        .json()
+        .await
+        .map_err(UpdaterError::from_reqwest)?;
+
+    let newest = releases
+        .into_iter()
+        .filter(|r| r.prerelease && !r.draft)
+        .max_by(|a, b| a.created_at.cmp(&b.created_at))
+        .ok_or(UpdaterError::NotFound)?;
+
+    Ok(format!(
+        "https://github.com/{}/{}/releases/download/{}/{}",
+        GITHUB_OWNER, GITHUB_REPO, newest.tag_name, PRERELEASE_MANIFEST_NAME
+    ))
+}
+
+pub(crate) async fn check_for_update(
+    app: &AppHandle,
+    channel: UpdateChannel,
+) -> Result<Option<UpdateInfo>, UpdaterError> {
+    let endpoint = resolve_endpoint(channel).await?;
+    let endpoint_url = endpoint
+        .parse::<url::Url>()
+        .map_err(|e| UpdaterError::Internal {
+            message: format!("invalid endpoint url: {e}"),
+        })?;
+
+    let update = app
+        .updater_builder()
+        .endpoints(vec![endpoint_url])
+        .map_err(UpdaterError::from_update_error)?
+        .build()
+        .map_err(UpdaterError::from_update_error)?
+        .check()
+        .await
+        .map_err(UpdaterError::from_update_error)?;
+
+    Ok(update.map(|u| UpdateInfo {
+        version: u.version.clone(),
+        notes: u.body.clone().unwrap_or_default(),
+    }))
+}
+
+pub(crate) async fn install_update(
+    app: &AppHandle,
+    channel: UpdateChannel,
+) -> Result<(), UpdaterError> {
+    let endpoint = resolve_endpoint(channel).await?;
+    let endpoint_url = endpoint
+        .parse::<url::Url>()
+        .map_err(|e| UpdaterError::Internal {
+            message: format!("invalid endpoint url: {e}"),
+        })?;
+
+    let update = app
+        .updater_builder()
+        .endpoints(vec![endpoint_url])
+        .map_err(UpdaterError::from_update_error)?
+        .build()
+        .map_err(UpdaterError::from_update_error)?
+        .check()
+        .await
+        .map_err(UpdaterError::from_update_error)?
+        .ok_or(UpdaterError::NotFound)?;
+
+    let app_for_progress = app.clone();
+    let app_for_finish = app.clone();
+    let mut started = false;
+    update
+        .download_and_install(
+            move |chunk_length, content_length| {
+                // The plugin invokes this callback once per HTTP chunk, starting
+                // with the first real chunk — there is no separate start signal.
+                // Emit a synthetic Started on the first call so the frontend can
+                // initialize its progress state with the total size.
+                if !started {
+                    started = true;
+                    let _ = app_for_progress
+                        .emit("updater://progress", UpdateProgress::Started { content_length });
+                }
+                let _ = app_for_progress.emit(
+                    "updater://progress",
+                    UpdateProgress::Progress {
+                        chunk_length: chunk_length as u64,
+                    },
+                );
+            },
+            move || {
+                let _ = app_for_finish.emit("updater://progress", UpdateProgress::Finished);
+            },
+        )
+        .await
+        .map_err(UpdaterError::from_update_error)?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn stable_endpoint_is_static_manifest_url() {
+        let url = resolve_endpoint(UpdateChannel::Stable).await.unwrap();
+        assert_eq!(url, STABLE_MANIFEST_URL);
+    }
+
+    #[test]
+    fn network_messages_classify_as_network() {
+        assert!(is_network_message("DNS lookup failed"));
+        assert!(is_network_message("connect: connection refused"));
+        assert!(is_network_message("HTTP 500"));
+        assert!(!is_network_message("unexpected end of file"));
+    }
+
+}

--- a/src/lib/__tests__/updater.test.ts
+++ b/src/lib/__tests__/updater.test.ts
@@ -118,6 +118,18 @@ describe("checkForUpdate", () => {
     expect(status).toEqual({ kind: "error", reason: "signature-invalid" });
   });
 
+  it("maps not-found to no-update (empty channel is not an error)", async () => {
+    const { checkForUpdate } = await import("$lib/updater");
+    checkForUpdateMock.mockResolvedValueOnce({
+      status: "error",
+      error: { kind: "not-found" },
+    });
+
+    const status = await checkForUpdate({ silent: false, channel: "preRelease" });
+
+    expect(status).toEqual({ kind: "no-update" });
+  });
+
   it("classifies internal errors as unknown", async () => {
     const { checkForUpdate } = await import("$lib/updater");
     checkForUpdateMock.mockResolvedValueOnce({

--- a/src/lib/__tests__/updater.test.ts
+++ b/src/lib/__tests__/updater.test.ts
@@ -1,10 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const checkMock = vi.fn();
+const checkForUpdateMock = vi.fn();
+const installUpdateMock = vi.fn();
+const listenMock = vi.fn();
 const relaunchMock = vi.fn();
 
-vi.mock("@tauri-apps/plugin-updater", () => ({
-  check: (...args: unknown[]) => checkMock(...args),
+vi.mock("$lib/bindings", () => ({
+  commands: {
+    checkForUpdate: (...args: unknown[]) => checkForUpdateMock(...args),
+    installUpdate: (...args: unknown[]) => installUpdateMock(...args),
+  },
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: (...args: unknown[]) => listenMock(...args),
 }));
 
 vi.mock("@tauri-apps/plugin-process", () => ({
@@ -13,7 +22,9 @@ vi.mock("@tauri-apps/plugin-process", () => ({
 
 describe("checkForUpdate", () => {
   beforeEach(() => {
-    checkMock.mockReset();
+    checkForUpdateMock.mockReset();
+    installUpdateMock.mockReset();
+    listenMock.mockReset();
     relaunchMock.mockReset();
     vi.stubEnv("DEV", false);
   });
@@ -23,24 +34,32 @@ describe("checkForUpdate", () => {
     vi.restoreAllMocks();
   });
 
-  it("returns no-update when the plugin returns null (silent)", async () => {
+  it("passes the channel through to the Rust command", async () => {
     const { checkForUpdate } = await import("$lib/updater");
-    checkMock.mockResolvedValueOnce(null);
+    checkForUpdateMock.mockResolvedValueOnce({ status: "ok", data: null });
 
-    const status = await checkForUpdate({ silent: true });
+    await checkForUpdate({ silent: true, channel: "preRelease" });
 
-    expect(status).toEqual({ kind: "no-update" });
-    expect(checkMock).toHaveBeenCalledTimes(1);
+    expect(checkForUpdateMock).toHaveBeenCalledWith("preRelease");
   });
 
-  it("returns available with version and notes when plugin returns an Update", async () => {
+  it("returns no-update when the command returns null data", async () => {
     const { checkForUpdate } = await import("$lib/updater");
-    checkMock.mockResolvedValueOnce({
-      version: "1.2.3",
-      body: "Release notes here",
+    checkForUpdateMock.mockResolvedValueOnce({ status: "ok", data: null });
+
+    const status = await checkForUpdate({ silent: true, channel: "stable" });
+
+    expect(status).toEqual({ kind: "no-update" });
+  });
+
+  it("returns available with version and notes when an update is found", async () => {
+    const { checkForUpdate } = await import("$lib/updater");
+    checkForUpdateMock.mockResolvedValueOnce({
+      status: "ok",
+      data: { version: "1.2.3", notes: "Release notes here" },
     });
 
-    const status = await checkForUpdate({ silent: false });
+    const status = await checkForUpdate({ silent: false, channel: "stable" });
 
     expect(status).toEqual({
       kind: "available",
@@ -49,58 +68,84 @@ describe("checkForUpdate", () => {
     });
   });
 
-  it("defaults notes to empty string when body is undefined", async () => {
+  it("defaults notes to empty string when the backend omits them", async () => {
     const { checkForUpdate } = await import("$lib/updater");
-    checkMock.mockResolvedValueOnce({
-      version: "2.0.0",
-      body: undefined,
+    checkForUpdateMock.mockResolvedValueOnce({
+      status: "ok",
+      data: { version: "2.0.0", notes: "" },
     });
 
-    const status = await checkForUpdate({ silent: false });
+    const status = await checkForUpdate({ silent: false, channel: "stable" });
 
-    expect(status).toEqual({
-      kind: "available",
-      version: "2.0.0",
-      notes: "",
-    });
+    expect(status).toEqual({ kind: "available", version: "2.0.0", notes: "" });
   });
 
-  it("swallows network errors in silent mode and returns no-update", async () => {
+  it("swallows backend network errors in silent mode", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const { checkForUpdate } = await import("$lib/updater");
-    checkMock.mockRejectedValueOnce(new Error("network connect timeout"));
+    checkForUpdateMock.mockResolvedValueOnce({
+      status: "error",
+      error: { kind: "network" },
+    });
 
-    const status = await checkForUpdate({ silent: true });
+    const status = await checkForUpdate({ silent: true, channel: "stable" });
 
     expect(status).toEqual({ kind: "no-update" });
     expect(warnSpy).toHaveBeenCalled();
   });
 
-  it("surfaces network errors in non-silent mode", async () => {
+  it("surfaces backend network errors in non-silent mode", async () => {
     const { checkForUpdate } = await import("$lib/updater");
-    checkMock.mockRejectedValueOnce(new Error("network connect timeout"));
+    checkForUpdateMock.mockResolvedValueOnce({
+      status: "error",
+      error: { kind: "network" },
+    });
 
-    const status = await checkForUpdate({ silent: false });
+    const status = await checkForUpdate({ silent: false, channel: "stable" });
 
     expect(status).toEqual({ kind: "error", reason: "network" });
   });
 
   it("always surfaces signature errors even in silent mode", async () => {
     const { checkForUpdate } = await import("$lib/updater");
-    checkMock.mockRejectedValueOnce(new Error("signature verification failed"));
+    checkForUpdateMock.mockResolvedValueOnce({
+      status: "error",
+      error: { kind: "signature-invalid" },
+    });
 
-    const status = await checkForUpdate({ silent: true });
+    const status = await checkForUpdate({ silent: true, channel: "stable" });
 
     expect(status).toEqual({ kind: "error", reason: "signature-invalid" });
   });
 
-  it("short-circuits in dev mode without calling the plugin", async () => {
+  it("classifies internal errors as unknown", async () => {
+    const { checkForUpdate } = await import("$lib/updater");
+    checkForUpdateMock.mockResolvedValueOnce({
+      status: "error",
+      error: { kind: "internal", message: "boom" },
+    });
+
+    const status = await checkForUpdate({ silent: false, channel: "stable" });
+
+    expect(status).toEqual({ kind: "error", reason: "unknown" });
+  });
+
+  it("surfaces transport failures as a classified error", async () => {
+    const { checkForUpdate } = await import("$lib/updater");
+    checkForUpdateMock.mockRejectedValueOnce(new Error("network connect timeout"));
+
+    const status = await checkForUpdate({ silent: false, channel: "stable" });
+
+    expect(status).toEqual({ kind: "error", reason: "network" });
+  });
+
+  it("short-circuits in dev mode without calling the command", async () => {
     vi.stubEnv("DEV", true);
     const { checkForUpdate } = await import("$lib/updater");
 
-    const status = await checkForUpdate({ silent: false });
+    const status = await checkForUpdate({ silent: false, channel: "stable" });
 
     expect(status).toEqual({ kind: "no-update" });
-    expect(checkMock).not.toHaveBeenCalled();
+    expect(checkForUpdateMock).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -8,6 +8,11 @@ export const commands = {
 	frontendLog: (message: string) => __TAURI_INVOKE<void>("frontend_log", { message }),
 	getSettings: () => __TAURI_INVOKE<RouxSettings>("get_settings"),
 	updateSettings: (settings: RouxSettings) => typedError<null, string>(__TAURI_INVOKE("update_settings", { settings })),
+	checkForUpdate: (channel: UpdateChannel) => typedError<{
+	version: string,
+	notes: string,
+} | null, UpdaterError>(__TAURI_INVOKE("check_for_update", { channel })),
+	installUpdate: (channel: UpdateChannel) => typedError<null, UpdaterError>(__TAURI_INVOKE("install_update", { channel })),
 	cmdCreateWorktree: (repoPath: string, branch: string) => typedError<string, string>(__TAURI_INVOKE("cmd_create_worktree", { repoPath, branch })),
 	cmdRemoveWorktree: (worktreePath: string) => typedError<null, string>(__TAURI_INVOKE("cmd_remove_worktree", { worktreePath })),
 	cmdListWorktrees: (repoPath: string) => typedError<Worktree[], string>(__TAURI_INVOKE("cmd_list_worktrees", { repoPath })),
@@ -514,6 +519,12 @@ export type RouxSettings = {
 	 */
 	updateCheckOnLaunch?: boolean,
 	/**
+	 *  Which update channel this user is subscribed to. `Stable` pulls from the
+	 *  standard `latest.json` manifest; `PreRelease` resolves the newest
+	 *  GitHub prerelease at check time and pulls its `latest-prerelease.json`.
+	 */
+	updateChannel?: UpdateChannel,
+	/**
 	 *  User-defined spawn profiles. Edited as raw JSON in the settings file
 	 *  in v1 — the "Save as user profile" UI is a later addition. The settings
 	 *  loader force-sets `source: "user"` on each entry regardless of what
@@ -615,6 +626,15 @@ export type TaskGroup = {
 	configFile: string,
 	tasks: TaskDefinition[],
 };
+
+export type UpdateChannel = "stable" | "preRelease";
+
+export type UpdateInfo = {
+	version: string,
+	notes: string,
+};
+
+export type UpdaterError = { kind: "network" } | { kind: "signature-invalid" } | { kind: "not-found" } | { kind: "internal"; message: string };
 
 export type Watch = {
 	id: string,

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -5,7 +5,7 @@
   import { getLogPath, setLoggingEnabled } from "$lib/logging";
   import { notificationsPush } from "$lib/tauri";
   import { commands } from "$lib/bindings";
-  import type { WorktreeCleanupMode } from "$lib/bindings";
+  import type { UpdateChannel, WorktreeCleanupMode } from "$lib/bindings";
   import { updateStatus, runManualCheck, performInstall } from "$lib/stores/updater";
   import { getVersion } from "@tauri-apps/api/app";
   import { quitApp } from "$lib/tauri";
@@ -648,6 +648,21 @@
             {:else if $updateStatus.kind === "error"}
               <div class="mt-2 text-[11px] text-red">{describeError($updateStatus.reason)}</div>
             {/if}
+
+            <div class="mt-4 flex items-center justify-between py-2">
+              <div>
+                <div class="text-[13px]">Update channel</div>
+                <div class="text-[11px] text-text-muted mt-0.5">Switching to Stable takes effect on the next stable release at or above your current version.</div>
+              </div>
+              <select
+                class="bg-bg-deep border border-border rounded px-2 py-1 font-mono text-xs text-text-primary outline-none cursor-pointer appearance-none pr-6"
+                value={$settings.updateChannel ?? "stable"}
+                onchange={(e) => updateSetting("updateChannel", e.currentTarget.value as UpdateChannel)}
+              >
+                <option value="stable">Stable</option>
+                <option value="preRelease">Pre-release (Alpha)</option>
+              </select>
+            </div>
 
             <div class="mt-4 flex items-center justify-between py-2">
               <div>

--- a/src/lib/stores/updater.ts
+++ b/src/lib/stores/updater.ts
@@ -5,11 +5,16 @@ import {
   relaunchApp,
   type UpdateStatus,
 } from "$lib/updater";
+import type { UpdateChannel } from "$lib/bindings";
 import { settings } from "./settings";
 
 export const updateStatus = writable<UpdateStatus>({ kind: "idle" });
 
 let startupCheckStarted = false;
+
+function currentChannel(): UpdateChannel {
+  return get(settings).updateChannel ?? "stable";
+}
 
 export function runStartupCheck(): void {
   if (startupCheckStarted) return;
@@ -18,7 +23,7 @@ export function runStartupCheck(): void {
   if (!(get(settings).updateCheckOnLaunch ?? true)) return;
 
   setTimeout(async () => {
-    const status = await checkForUpdate({ silent: true });
+    const status = await checkForUpdate({ silent: true, channel: currentChannel() });
     if (status.kind === "available" || status.kind === "error") {
       updateStatus.set(status);
     }
@@ -27,7 +32,7 @@ export function runStartupCheck(): void {
 
 export async function runManualCheck(): Promise<void> {
   updateStatus.set({ kind: "checking" });
-  const status = await checkForUpdate({ silent: false });
+  const status = await checkForUpdate({ silent: false, channel: currentChannel() });
   updateStatus.set(status);
 }
 
@@ -35,7 +40,7 @@ export async function performInstall(): Promise<void> {
   updateStatus.set({ kind: "downloading", progress: null });
 
   try {
-    await installUpdate((progress) => {
+    await installUpdate({ channel: currentChannel() }, (progress) => {
       updateStatus.set({ kind: "downloading", progress });
     });
   } catch (e) {

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -54,6 +54,7 @@ export async function checkForUpdate(opts: {
   }
 
   let reason: UpdaterError;
+  let rawError: unknown;
   try {
     const result = await commands.checkForUpdate(opts.channel);
     if (result.status === "ok") {
@@ -64,9 +65,17 @@ export async function checkForUpdate(opts: {
         notes: result.data.notes ?? "",
       };
     }
+    // "not-found" means the selected channel has no published release (e.g.
+    // the pre-release channel before the first alpha ships). From the user's
+    // perspective that's indistinguishable from "no update available".
+    if (result.error.kind === "not-found") {
+      return { kind: "no-update" };
+    }
     reason = classifyBackendError(result.error);
+    rawError = result.error;
   } catch (err) {
     reason = classifyTransportError(err);
+    rawError = err;
   }
 
   // Signature errors are a tamper signal; always surface.
@@ -74,7 +83,7 @@ export async function checkForUpdate(opts: {
     return { kind: "error", reason };
   }
   if (opts.silent) {
-    console.warn("[updater] check failed (silent)");
+    console.warn("[updater] check failed (silent):", reason, rawError);
     return { kind: "no-update" };
   }
   return { kind: "error", reason };

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1,10 +1,11 @@
-import { check } from "@tauri-apps/plugin-updater";
+import { commands, type UpdateChannel, type UpdaterError as BackendError } from "$lib/bindings";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { relaunch } from "@tauri-apps/plugin-process";
 
-type DownloadEvent =
-  | { event: "Started"; data: { contentLength?: number } }
-  | { event: "Progress"; data: { chunkLength: number } }
-  | { event: "Finished" };
+type ProgressPayload =
+  | { phase: "started"; contentLength: number | null }
+  | { phase: "progress"; chunkLength: number }
+  | { phase: "finished" };
 
 export type UpdaterError = "network" | "signature-invalid" | "unknown";
 
@@ -26,86 +27,107 @@ function isDev(): boolean {
   }
 }
 
-function classifyError(err: unknown): UpdaterError {
+function classifyBackendError(err: BackendError): UpdaterError {
+  switch (err.kind) {
+    case "signature-invalid":
+      return "signature-invalid";
+    case "network":
+      return "network";
+    default:
+      return "unknown";
+  }
+}
+
+function classifyTransportError(err: unknown): UpdaterError {
   const message = err instanceof Error ? err.message : String(err ?? "");
-  if (/signature/i.test(message)) {
-    return "signature-invalid";
-  }
-  if (/network|connect|dns|request|http|timeout/i.test(message)) {
-    return "network";
-  }
+  if (/signature/i.test(message)) return "signature-invalid";
+  if (/network|connect|dns|request|http|timeout/i.test(message)) return "network";
   return "unknown";
 }
 
 export async function checkForUpdate(opts: {
   silent: boolean;
+  channel: UpdateChannel;
 }): Promise<UpdateStatus> {
   if (isDev()) {
     return { kind: "no-update" };
   }
 
+  let reason: UpdaterError;
   try {
-    const update = await check();
-    if (!update) {
-      return { kind: "no-update" };
+    const result = await commands.checkForUpdate(opts.channel);
+    if (result.status === "ok") {
+      if (!result.data) return { kind: "no-update" };
+      return {
+        kind: "available",
+        version: result.data.version,
+        notes: result.data.notes ?? "",
+      };
     }
-    return {
-      kind: "available",
-      version: update.version,
-      notes: update.body ?? "",
-    };
+    reason = classifyBackendError(result.error);
   } catch (err) {
-    const reason = classifyError(err);
-    if (reason === "signature-invalid") {
-      // Signature errors are a tamper signal; always surface.
-      return { kind: "error", reason };
-    }
-    if (opts.silent) {
-      console.warn("[updater] check failed (silent):", err);
-      return { kind: "no-update" };
-    }
+    reason = classifyTransportError(err);
+  }
+
+  // Signature errors are a tamper signal; always surface.
+  if (reason === "signature-invalid") {
     return { kind: "error", reason };
   }
+  if (opts.silent) {
+    console.warn("[updater] check failed (silent)");
+    return { kind: "no-update" };
+  }
+  return { kind: "error", reason };
 }
 
 export async function installUpdate(
+  opts: { channel: UpdateChannel },
   onProgress: (progress: number | null) => void,
 ): Promise<void> {
   if (isDev()) {
     throw new Error("installUpdate is not available in dev mode");
   }
 
-  const update = await check();
-  if (!update) {
-    throw new Error("No update available");
-  }
-
-  let contentLength: number | undefined;
+  let contentLength: number | null = null;
   let downloaded = 0;
+  let unlisten: UnlistenFn | null = null;
 
-  await update.downloadAndInstall((event: DownloadEvent) => {
-    switch (event.event) {
-      case "Started": {
-        contentLength = event.data.contentLength;
-        downloaded = 0;
-        onProgress(contentLength ? 0 : null);
-        break;
-      }
-      case "Progress": {
-        downloaded += event.data.chunkLength;
-        if (contentLength && contentLength > 0) {
-          onProgress(downloaded / contentLength);
-        } else {
-          onProgress(null);
+  try {
+    unlisten = await listen<ProgressPayload>("updater://progress", ({ payload }) => {
+      switch (payload.phase) {
+        case "started": {
+          contentLength = payload.contentLength ?? null;
+          downloaded = 0;
+          onProgress(contentLength && contentLength > 0 ? 0 : null);
+          break;
         }
-        break;
+        case "progress": {
+          downloaded += payload.chunkLength;
+          if (contentLength && contentLength > 0) {
+            onProgress(downloaded / contentLength);
+          } else {
+            onProgress(null);
+          }
+          break;
+        }
+        case "finished": {
+          onProgress(1);
+          break;
+        }
       }
-      case "Finished": {
-        onProgress(1);
-        break;
-      }
+    });
+
+    const result = await commands.installUpdate(opts.channel);
+    if (result.status === "error") {
+      const reason = classifyBackendError(result.error);
+      // Mirror the legacy error shape so upstream callers match on .message.
+      const err = new Error(reason);
+      (err as Error & { reason?: UpdaterError }).reason = reason;
+      throw err;
     }
-  });
+  } finally {
+    unlisten?.();
+  }
   // Do NOT call relaunch() here. The install is complete; relaunch is a
   // separate, best-effort step handled by the caller so we can distinguish
   // "install failed" from "install succeeded but restart failed".


### PR DESCRIPTION
## Summary
- Adds a **Stable / Pre-release** dropdown in Settings → Advanced (Updates section) that switches which manifest the auto-updater checks against.
- Moves the check + install flow to a Rust command that uses `app.updater_builder().endpoints(...)` at call time. Pre-release endpoint is resolved via the GitHub API (newest `prerelease: true` release), so the public releases list stays clean and each prerelease owns its own `latest-prerelease.json`.
- `task publish` now emits a manifest for prereleases too (previously skipped); stable keeps emitting `latest.json`, prereleases get `latest-prerelease.json`.
- New settings field `updateChannel: UpdateChannel` with `#[serde(default)]` → existing `settings.json` files parse unchanged and default to `Stable`.

## Notes
- **Downgrade semantics (v1):** switching from Pre-release back to Stable is inert until Stable reaches/surpasses the user's current version (default `version_comparator`). Helper text in the dropdown explains this. Can add a "reinstall stable" path later if users ask.
- Shared signing key — same `TAURI_SIGNING_PRIVATE_KEY` signs both channels' tarballs. `pubkey` in `tauri.conf.json` unchanged.
- The `endpoints` array in `tauri.conf.json` is effectively dead config at runtime; kept as a defensive fallback with a doc comment at the plugin registration site.

## Test plan
- [x] `cargo test -p roux-core` — includes new `settings_without_update_channel_defaults_to_stable`
- [x] `cargo test --bin roux updater` — stable endpoint + network-error classifier
- [x] `npm run test` — full frontend suite (345 passing), updater tests rewritten for the invoke flow
- [x] `npm run check` — 0 errors / 0 warnings
- [ ] **UI smoke test:** `task dev`, flip channel to Pre-release, confirm persists across restart, click Check
- [ ] **End-to-end install:** cut a real alpha via `task release BUMP=patch PRE=alpha`, install an older stable build locally, flip channel, verify prerelease downloads + signature verifies + relaunches
- [ ] **Stable path regression:** confirm a normal stable release still uploads `latest.json` and existing users on Stable see no behavioral change

## Known follow-ups (out of scope)
- GitHub API response is not cached per-session yet (rate limit is fine at realistic check frequency, but noted in the plan).
- First alpha release cut with this code will be the real validation for the prerelease endpoint resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)