### PR TITLE
ci(release): move macOS+Windows release pipeline to GitHub Actions

### DIFF
--- a/.env.signing.example
+++ b/.env.signing.example
@@ -7,9 +7,11 @@ APPLE_SIGNING_IDENTITY=Developer ID Application: Your Name (TEAMID)
 TAURI_SIGNING_PRIVATE_KEY=op://owkafiordkt5yio7nt6rpjvzma/Roux Updater/private_key
 TAURI_SIGNING_PRIVATE_KEY_PASSWORD=op://owkafiordkt5yio7nt6rpjvzma/Roux Updater/password
 
-# Optional backup for CI or recovery only.
-# APPLE_CERTIFICATE=op://Mac%20Development/Roux%20Signing/apple_certificate_base64
-# APPLE_CERTIFICATE_PASSWORD=op://Mac%20Development/Roux%20Signing/apple_certificate_password
+# Required for CI signing (imported into a temp keychain by
+# scripts/ci-setup-macos-keychain.sh). Keep these uncommented if you use
+# `task ci:sync-secrets` to push secrets to GitHub Actions.
+APPLE_CERTIFICATE=op://Mac%20Development/Roux%20Signing/apple_certificate_base64
+APPLE_CERTIFICATE_PASSWORD=op://Mac%20Development/Roux%20Signing/apple_certificate_password
 
 # Choose one notarization method.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,92 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Tag to build (e.g. v0.4.5-alpha.5)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  release-macos:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.version }}
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri -> target
+      - name: Install Task
+        run: brew install go-task
+      - name: Install frontend deps
+        run: npm ci
+      - name: Import Developer ID cert
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: ./scripts/ci-setup-macos-keychain.sh
+      - name: Sign, notarize, staple
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: task sign
+      - name: Publish release + updater manifest
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: task publish
+
+  build-windows:
+    runs-on: windows-latest
+    needs: release-macos
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.version }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri -> target
+      - name: Install Task
+        run: choco install go-task -y
+      - name: Install frontend deps
+        run: npm ci
+      - name: Build NSIS installer
+        run: task windows:build
+      - name: Upload NSIS to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          artifacts=(src-tauri/target/release/bundle/nsis/*.exe src-tauri/target/release/bundle/nsis/*.nsis.zip)
+          if (( ${#artifacts[@]} == 0 )); then
+            echo "No NSIS artifacts found under src-tauri/target/release/bundle/nsis" >&2
+            exit 1
+          fi
+          for f in "${artifacts[@]}"; do
+            gh release upload "${{ inputs.version }}" "$f" --clobber
+          done

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -449,7 +449,7 @@ tasks:
         echo "Released v${NEW}"
 
   release:
-    desc: "Bump version, build, sign, notarize, and publish in one shot. Usage: task release BUMP=patch|minor|major [PRE=alpha|beta|dev|rc]"
+    desc: "Bump version + tag locally, then trigger the GitHub Actions release workflow. Usage: task release BUMP=patch|minor|major [PRE=alpha|beta|dev|rc]"
     requires:
       vars: [BUMP]
     cmds:
@@ -457,4 +457,49 @@ tasks:
         vars:
           BUMP: "{{.BUMP}}"
           PRE: "{{.PRE}}"
-      - task: publish:op
+      - task: ci:trigger
+
+  ci:sync-secrets:
+    desc: "Push signing/notarization/updater secrets from 1Password into GitHub Actions secrets"
+    preconditions:
+      - sh: "command -v op >/dev/null 2>&1"
+        msg: "1Password CLI 'op' is required"
+      - sh: "command -v gh >/dev/null 2>&1"
+        msg: "GitHub CLI 'gh' is required"
+      - sh: '[ -f ".env.signing" ]'
+        msg: ".env.signing is required"
+    cmds:
+      - ./scripts/sync-gh-secrets.sh
+
+  ci:trigger:
+    desc: "Dispatch the release workflow for the current version in src-tauri/tauri.conf.json"
+    preconditions:
+      - sh: "command -v gh >/dev/null 2>&1"
+        msg: "GitHub CLI 'gh' is required"
+    cmds:
+      - |
+        set -euo pipefail
+        VERSION=$(python3 -c 'import json; print(json.load(open("src-tauri/tauri.conf.json"))["version"])')
+        TAG="v${VERSION}"
+        echo "Dispatching release workflow for ${TAG}..."
+        # Retry briefly because a freshly-pushed tag can take a few seconds
+        # to register on GitHub before workflow_dispatch accepts it.
+        for i in 1 2 3 4 5; do
+          if gh workflow run release.yml -f version="${TAG}"; then
+            break
+          fi
+          if [ "$i" = "5" ]; then
+            echo "gh workflow run failed after 5 attempts" >&2
+            exit 1
+          fi
+          echo "Dispatch attempt ${i} failed; retrying in 3s..."
+          sleep 3
+        done
+        sleep 2
+        RUN_ID=$(gh run list --workflow=release.yml --event=workflow_dispatch --limit=1 --json databaseId --jq '.[0].databaseId')
+        if [ -z "${RUN_ID}" ]; then
+          echo "Dispatched, but could not resolve the run ID. Check https://github.com/phin-tech/roux/actions" >&2
+          exit 0
+        fi
+        echo "Watching run ${RUN_ID}..."
+        gh run watch "${RUN_ID}" --exit-status

--- a/scripts/ci-setup-macos-keychain.sh
+++ b/scripts/ci-setup-macos-keychain.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Create a temporary keychain on a CI runner and import the Developer ID
+# Application certificate from $APPLE_CERTIFICATE (base64-encoded .p12) so
+# `codesign` can run unattended. Only meant for CI; local dev uses the
+# developer's login keychain.
+set -euo pipefail
+
+: "${APPLE_CERTIFICATE:?base64-encoded .p12 required}"
+: "${APPLE_CERTIFICATE_PASSWORD:?.p12 password required}"
+: "${RUNNER_TEMP:?RUNNER_TEMP must be set (GitHub Actions runner var)}"
+
+KEYCHAIN_NAME="roux-build.keychain"
+KEYCHAIN_PASSWORD="$(openssl rand -base64 24)"
+CERT_PATH="${RUNNER_TEMP}/cert.p12"
+
+cleanup() { rm -f "${CERT_PATH}"; }
+trap cleanup EXIT
+
+printf '%s' "${APPLE_CERTIFICATE}" | base64 --decode > "${CERT_PATH}"
+
+security create-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_NAME}"
+security set-keychain-settings -lut 21600 "${KEYCHAIN_NAME}"
+security unlock-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_NAME}"
+
+# Prepend the build keychain to the user search list so codesign finds the identity.
+EXISTING_KEYCHAINS=$(security list-keychains -d user | sed -E 's/^[[:space:]]*"?//; s/"?$//')
+# shellcheck disable=SC2086
+security list-keychains -d user -s "${KEYCHAIN_NAME}" ${EXISTING_KEYCHAINS}
+
+security import "${CERT_PATH}" \
+  -k "${KEYCHAIN_NAME}" \
+  -P "${APPLE_CERTIFICATE_PASSWORD}" \
+  -T /usr/bin/codesign \
+  -T /usr/bin/security \
+  -T /usr/bin/productbuild
+
+security set-key-partition-list \
+  -S apple-tool:,apple: \
+  -s -k "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_NAME}" >/dev/null
+
+echo "Imported signing identities:"
+security find-identity -v -p codesigning "${KEYCHAIN_NAME}"

--- a/scripts/sync-gh-secrets.sh
+++ b/scripts/sync-gh-secrets.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# One-shot bootstrap: read .env.signing via `op run`, then push each value
+# into GitHub Actions secrets via `gh secret set`. Idempotent — rerun after
+# rotating anything in 1Password.
+set -euo pipefail
+
+VARS=(
+  APPLE_SIGNING_IDENTITY
+  APPLE_CERTIFICATE
+  APPLE_CERTIFICATE_PASSWORD
+  APPLE_ID
+  APPLE_PASSWORD
+  APPLE_TEAM_ID
+  TAURI_SIGNING_PRIVATE_KEY
+  TAURI_SIGNING_PRIVATE_KEY_PASSWORD
+)
+
+command -v op >/dev/null || { echo "op CLI required" >&2; exit 1; }
+command -v gh >/dev/null || { echo "gh CLI required" >&2; exit 1; }
+[ -f .env.signing ] || { echo ".env.signing not found in $(pwd)" >&2; exit 1; }
+
+missing=()
+for v in "${VARS[@]}"; do
+  if ! grep -qE "^${v}=" .env.signing; then
+    missing+=("$v")
+  fi
+done
+if (( ${#missing[@]} > 0 )); then
+  echo "Missing from .env.signing (uncomment or add these lines):" >&2
+  printf '  - %s\n' "${missing[@]}" >&2
+  exit 1
+fi
+
+# op run expands op:// refs into real env values for the child process.
+# --no-masking keeps stderr diagnostics readable on failure; the actual
+# secret values are still piped directly to `gh secret set --body -`.
+op run --env-file=.env.signing --no-masking -- bash -c '
+  set -euo pipefail
+  for v in '"${VARS[*]}"'; do
+    val="${!v-}"
+    if [ -z "$val" ]; then
+      echo "Skipping ${v} (empty after op resolution)" >&2
+      continue
+    fi
+    printf "%s" "$val" | gh secret set "$v" --body -
+    echo "Set ${v}"
+  done
+'


### PR DESCRIPTION
## Summary
- `task release` now bumps the version + tag locally, then dispatches a new `workflow_dispatch` GitHub Actions workflow that runs the full signing/notarization/publish flow on a GH runner.
- Release workflow has two jobs:
  - `release-macos` on `macos-14` — imports the Developer ID cert into a temp keychain, then runs the existing `task sign` + `task publish` (updater manifest, changelog, pre-release detection — all unchanged).
  - `build-windows` on `windows-latest` — runs `task windows:build` and attaches the unsigned NSIS installer to the same release.
- Secrets bootstrap: `task ci:sync-secrets` reads `.env.signing` via `op run` and pushes all 8 signing/notarization/updater values to GH Actions via `gh secret set`. Idempotent.
- Local `task publish:op` / `task sign:op` kept as a break-glass fallback — no changes.

## Files
- `.github/workflows/release.yml` — new workflow.
- `scripts/ci-setup-macos-keychain.sh` — temp keychain + p12 import (CI-only).
- `scripts/sync-gh-secrets.sh` — one-shot 1Password → GH secret bootstrap.
- `Taskfile.yml` — adds `ci:sync-secrets` and `ci:trigger`; reshapes `release` to dispatch CI instead of signing locally.
- `.env.signing.example` — uncomments `APPLE_CERTIFICATE` / `_PASSWORD` and notes they're required for CI.

## Notes
- CD does **not** gate on CI tests. `ci.yml` still runs on push/PR; the release workflow trusts the operator.
- Workflow only responds to `workflow_dispatch` (not tag push), so a stray tag doesn't trigger a release.
- `task ci:trigger` retries the dispatch up to 5 times because a freshly-pushed tag can take a few seconds to register server-side.
- Runner is pinned to `macos-14` (arm64) because the updater manifest is hard-coded `darwin-aarch64`.

## Test plan
- [ ] On this branch: `task ci:sync-secrets` succeeds; `gh secret list` shows all 8 vars.
- [ ] Merge to `main` so `release.yml` lives on the default branch (required for `workflow_dispatch`).
- [ ] `task release BUMP=patch PRE=alpha` → watch `gh run watch` succeed.
- [ ] Verify release has: `Roux_*.app.zip`, `Roux_*.dmg`, `Roux.app.tar.gz`, `Roux.app.tar.gz.sig`, `latest-prerelease.json`, and a Windows `.exe`.
- [ ] Download the `.dmg` on a clean Mac — installs without Gatekeeper prompts (notarization stapled).
- [ ] Previous stable `v0.4.4` install stays on stable channel; pre-release channel updates to the new alpha.
- [ ] `task publish:op` still works locally on a throwaway tag (break-glass intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)