### PR TITLE
fix(taskfile): unbreak task dev on Windows

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -54,9 +54,13 @@ tasks:
             echo "Created placeholder for roux-cli-${TARGET}"
           fi
         platforms: [darwin, linux]
+      # Task v3 runs `cmd:` blocks through bundled mvdan/sh on every
+      # platform — including Windows — not through `cmd.exe`. Use POSIX
+      # sh, mirroring `taskfiles/Taskfile_windows.yml::prepare-cli`.
       - cmd: |
-          if not exist src-tauri\binaries mkdir src-tauri\binaries
-          if not exist src-tauri\binaries\roux-cli.exe echo. > src-tauri\binaries\roux-cli.exe
+          set -eu
+          mkdir -p src-tauri/binaries
+          [ -f src-tauri/binaries/roux-cli.exe ] || : > src-tauri/binaries/roux-cli.exe
         platforms: [windows]
 
   cli:install:
@@ -64,8 +68,7 @@ tasks:
     deps: [cli:ensure-placeholder]
     cmds:
       - cargo build --manifest-path src-tauri/Cargo.toml --bin roux-cli
-      - cmd: |
-          cmd /c echo Built src-tauri\target\debug\roux-cli.exe for Windows dev use
+      - cmd: echo "Built src-tauri/target/debug/roux-cli.exe for Windows dev use"
         platforms: [windows]
       - cmd: |
           mkdir -p ~/.local/bin
@@ -98,14 +101,17 @@ tasks:
           chmod +x src-tauri/binaries/roux-cli "src-tauri/binaries/roux-cli-${TARGET}"
           echo "Prepared dev roux-cli binaries for ${TARGET}"
         platforms: [darwin, linux]
+      # POSIX sh via bundled mvdan/sh — see comment on cli:ensure-placeholder.
+      # `rustc --print host-tuple` avoids depending on `sed`, which isn't on
+      # PATH on a clean Windows install (unlike CI runners with git-bash).
       - cmd: |
-          for /f "tokens=2 delims=: " %%a in ('rustc -vV ^| findstr /b "host:"') do set HOST=%%a
-          if not defined HOST set HOST=%TAURI_TARGET%
-          if not defined HOST set HOST=x86_64-pc-windows-msvc
-          if not exist src-tauri\binaries mkdir src-tauri\binaries
-          copy /Y target\debug\roux-cli.exe src-tauri\binaries\roux-cli.exe >nul
-          copy /Y target\debug\roux-cli.exe src-tauri\binaries\roux-cli-%HOST%.exe >nul
-          echo Prepared dev roux-cli binaries for %HOST%
+          set -eu
+          TARGET="${TAURI_TARGET:-$(rustc --print host-tuple)}"
+          : "${TARGET:=x86_64-pc-windows-msvc}"
+          mkdir -p src-tauri/binaries
+          cp -f target/debug/roux-cli.exe src-tauri/binaries/roux-cli.exe
+          cp -f target/debug/roux-cli.exe "src-tauri/binaries/roux-cli-${TARGET}.exe"
+          echo "Prepared dev roux-cli binaries for ${TARGET}"
         platforms: [windows]
 
   dev:install:


### PR DESCRIPTION
## Summary

`task dev` was failing on a fresh Windows checkout at `cli:ensure-placeholder`, then `cli:stage-dev-binary`. Root cause: Task v3 runs `cmd:` blocks through bundled **mvdan/sh** on every platform — including Windows — not through `cmd.exe`. The Windows variants of these two dev-mode tasks were written in `cmd.exe` batch (`if not exist`, `for /f`, `copy /Y`), which mvdan/sh fails to parse (the error `2:1: \`if <cond>\` must be followed by \`then\`` is mvdan/sh's POSIX `if` parser complaining).

This PR rewrites the Windows branches in POSIX sh, mirroring the existing `taskfiles/Taskfile_windows.yml::prepare-cli` pattern that landed in commit `8af24fa fix(ci): rewrite windows:prepare-cli staging in POSIX sh`. The two dev-mode tasks here are equivalents that never got the same treatment.

## Changes

- **`cli:ensure-placeholder` (windows)** — POSIX sh: `mkdir -p` and `[ -f x ] || : > x` to create the placeholder.
- **`cli:install` (windows)** — drops the `cmd /c echo` (which mangled backslashes on cmd.exe anyway); plain `echo` via mvdan/sh.
- **`cli:stage-dev-binary` (windows)** — POSIX sh that resolves the host triple, makes the binaries dir, and copies `roux-cli.exe` into both the un-suffixed and host-suffixed paths.

## One small departure from `windows:prepare-cli`

`prepare-cli` extracts the host triple via `rustc -vV | sed -n 's/^host: //p'`. That works on CI (Windows runner ships git-bash, which provides `sed`), but breaks on a clean dev Windows install where `sed` isn't on PATH — mvdan/sh has POSIX built-ins but doesn't ship external tools. I substituted `rustc --print host-tuple`, which is in stable Rust since 1.85 and has zero external deps. Same outcome, no PATH assumption.

(`prepare-cli` itself probably has the same latent bug for any maintainer who tries `task windows:build` on a clean Windows machine; worth a follow-up to swap that one too. Not in scope here.)

## Test plan

- [x] `task cli:ensure-placeholder` runs cleanly on Windows
- [x] `task cli:install` builds and stages `roux-cli.exe`
- [x] `task cli:stage-dev-binary` produces both `src-tauri/binaries/roux-cli.exe` and the host-tripled variant
- [x] `task dev` proceeds to `tauri dev`; Vite reaches `ready`
- [ ] On macOS / Linux, the `darwin/linux` branches are unchanged (no review concern, but worth a sanity check)

Closes #77
