### PR TITLE
refactor: host paths in roux_lib, trim dead items

### DIFF
--- a/src-tauri/src/agent_registry.rs
+++ b/src-tauri/src/agent_registry.rs
@@ -26,7 +26,6 @@ use roux_core::agent_fsm::{AgentEffect, AgentEvent, AgentFsm, AgentIdentity, Att
 pub struct EventContext {
     pub cwd: String,
     pub provider: String,
-    pub provider_session_id: Option<String>,
     pub roux_session_id: Option<String>,
     pub roux_pane_id: Option<String>,
     pub tool_name: Option<String>,

--- a/src-tauri/src/agent_sources/file_status.rs
+++ b/src-tauri/src/agent_sources/file_status.rs
@@ -162,10 +162,13 @@ pub fn payload_to_identity(update: &StatusUpdate) -> AgentIdentity {
 }
 
 pub fn payload_to_event_context(update: &StatusUpdate) -> EventContext {
+    // `StatusUpdate::provider_session_id` is intentionally *not* copied:
+    // it rides the `roux-status-update` Tauri event for the frontend,
+    // but nothing downstream of the FSM registry reads it. See the
+    // notes on `EventContext` in `agent_registry.rs`.
     EventContext {
         cwd: update.cwd.clone(),
         provider: update.provider.clone(),
-        provider_session_id: update.provider_session_id.clone(),
         roux_session_id: update.roux_session_id.clone(),
         roux_pane_id: update.roux_pane_id.clone(),
         tool_name: update.tool_name.clone(),

--- a/src-tauri/src/agent_sources/notification_sink.rs
+++ b/src-tauri/src/agent_sources/notification_sink.rs
@@ -53,12 +53,23 @@ impl NotificationSink for NotificationManagerSink {
             let state = app.state::<AppState>();
 
             // Best-effort session match for the notification subtitle /
-            // focus action. Legacy (cwd-only) hooks still work because
-            // we fall back to the cwd label.
+            // focus action. Prefer the explicit `roux_session_id` the
+            // modern hook ships; fall back to cwd matching so legacy
+            // (cwd-only) hooks still produce a meaningful subtitle.
+            // cwd matching is ambiguous when two sessions share a
+            // worktree, so the id path is strictly better when present.
             let matched = match state.session_handle.list().await {
-                Ok(sessions) => sessions.into_iter().find(|s| {
-                    s.worktree_path == context.cwd || s.repo_root == context.cwd
-                }),
+                Ok(sessions) => {
+                    let by_id = context
+                        .roux_session_id
+                        .as_deref()
+                        .and_then(|sid| sessions.iter().find(|s| s.id == sid).cloned());
+                    by_id.or_else(|| {
+                        sessions.into_iter().find(|s| {
+                            s.worktree_path == context.cwd || s.repo_root == context.cwd
+                        })
+                    })
+                }
                 Err(_) => None,
             };
             let session_id = matched.as_ref().map(|s| s.id.clone());

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -5,7 +5,8 @@ use std::io::Read;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-mod paths;
+use roux_lib::paths;
+
 mod platform;
 
 #[derive(Parser)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod paths;
+
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -11,7 +11,6 @@ mod layouts;
 mod notifications;
 mod pane_service;
 mod pane_state;
-mod paths;
 mod platform;
 mod pr;
 mod project_service;
@@ -38,6 +37,13 @@ use tauri_specta::{collect_commands, Builder};
 
 use crate::pty::PtyManager;
 use crate::state::AppState;
+
+// `paths` is defined in the library crate (`roux_lib`) so both the
+// `roux` and `roux-cli` binaries can use it without duplicating
+// compilation — and so library visibility keeps dead-code checks from
+// firing on helpers only one of the binaries calls (e.g. the legacy
+// config migration only runs from `main`).
+use roux_lib::paths;
 
 fn main() {
     // Move any legacy state from the pre-unification config location

--- a/src-tauri/src/services/setup.rs
+++ b/src-tauri/src/services/setup.rs
@@ -77,10 +77,6 @@ pub(crate) fn bundled_cli_version() -> &'static str {
     crate::hooks::bundled_cli_version()
 }
 
-pub(crate) fn is_setup_complete() -> bool {
-    crate::hooks::setup_is_complete()
-}
-
 pub(crate) fn install_hooks() -> anyhow::Result<()> {
     crate::hooks::install_hooks().map_err(anyhow::Error::msg)?;
     Ok(())


### PR DESCRIPTION
Closes #79.

## Summary

Fixes five `cargo build` `dead_code` warnings without introducing any
`#[allow(dead_code)]`. Each warning pointed at something real -- a
shared module hosted in the wrong place, a speculative context field,
and a duplicate wrapper function -- so the changes are surgical.

**Before:** `cargo build` emits

```
warning: function `legacy_config_dir` is never used        [paths.rs  -> roux-cli]
warning: function `migrate_legacy_config_dir` is never used[paths.rs  -> roux-cli]
warning: function `copy_dir_skip_existing` is never used   [paths.rs  -> roux-cli]
warning: fields `provider_session_id` and `roux_session_id`
        are never read                                     [EventContext]
warning: function `is_setup_complete` is never used        [services::setup]
```

**After:** clean build.

## The four changes

### 1. Host `paths` in `roux_lib`

`src-tauri/src/paths.rs` was pulled in via `mod paths;` in both
`main.rs` (the `roux` binary) and `cli.rs` (the `roux-cli` binary).
The migration helpers (`legacy_config_dir`, `migrate_legacy_config_dir`,
`copy_dir_skip_existing`) are only called from `main.rs`. In
`roux-cli`'s compilation unit they're unreachable -- the compiler was
correctly flagging them.

Fix: move `paths` into the existing `roux_lib` library crate by adding
`pub mod paths;` to `src-tauri/src/lib.rs`, then replace
`mod paths;` in each binary with `use roux_lib::paths;`. `use` at the
binary's crate root creates a `paths` alias in crate scope, so the
~15 sibling modules already calling `crate::paths::roux_config_dir()`
continue to resolve unchanged.

Library `pub` items don't trip `dead_code` because the compiler can't
prove no external consumer uses them -- exactly the property we want
for a shared module two binaries dip into asymmetrically.

### 2. Drop `EventContext::provider_session_id`

Two fields share the name and only the internal one is dead:

- `StatusUpdate::provider_session_id` -- emitted to the frontend via
  the `roux-status-update` Tauri event. Consumed by
  `src/lib/panes/statusRouting.ts` and `src/lib/panes/agentState.ts`.
  **Kept.**
- `EventContext::provider_session_id` -- internal context shipped to
  the FSM `NotificationSink`. Populated from `StatusUpdate`, never
  read downstream. **Removed**, along with the matching line in
  `payload_to_event_context`.

Wire contract, parser, and tests are unchanged.

### 3. Use `roux_session_id` in `NotificationSink::push_attention`

`EventContext::roux_session_id` was populated but the sink ignored it
and looked up sessions purely by `cwd`. That's ambiguous when two
sessions share a worktree. Prefer the explicit id, fall back to cwd
for legacy hooks that don't ship one:

```rust
let matched = match state.session_handle.list().await {
    Ok(sessions) => {
        let by_id = context
            .roux_session_id
            .as_deref()
            .and_then(|sid| sessions.iter().find(|s| s.id == sid).cloned());
        by_id.or_else(|| {
            sessions.into_iter().find(|s| {
                s.worktree_path == context.cwd || s.repo_root == context.cwd
            })
        })
    }
    Err(_) => None,
};
```

Strict improvement over cwd-only matching when the hook provides an
id; no regression when it doesn't.

### 4. Delete `services::setup::is_setup_complete`

It's `crate::hooks::setup_is_complete()` wrapped in another name, with
zero callers. `is_hooks_installed()` -- also in `services/setup.rs` --
wraps the same underlying function and *is* called from three places.
Drop the duplicate.

## Why not `#[allow(dead_code)]`?

Each warning pointed at a real shape issue:
- wrong module location (fix: move to `lib`)
- speculative field never wired up (fix: delete)
- load-bearing field ignored by its consumer (fix: use it)
- duplicate wrapper (fix: delete)

`#[allow(dead_code)]` would have silenced the compiler in every case
while leaving the actual problems in place. The diff is 31 additions,
13 deletions across 7 files -- cheaper than the `allow`-per-warning
alternative, and leaves the codebase a bit cleaner.

## Test plan

- [x] `cargo build --manifest-path src-tauri/Cargo.toml` produces **zero** warnings, down from 5.
- [x] `cargo test --manifest-path src-tauri/Cargo.toml agent_registry` -- 11 passed.
- [x] `cargo test --manifest-path src-tauri/Cargo.toml agent_sources` -- 24 passed (includes `payload_to_event_context_copies_all_fields` and all `file_status` parser tests).
- [x] `cargo test --manifest-path src-tauri/Cargo.toml paths` -- 5 passed (migration + symlink guards).
- [x] `cargo test --manifest-path src-tauri/Cargo.toml` -- 253 passed. The 6 remaining failures (`pty::get_user_path_returns_nonempty_string`, `pty::cwd_for_pid_returns_current_process_cwd`, `pty::nono_tests::resolved_allow_dirs_*`, `services::sessions::tests::list_git_repos_in_roots_*`) reproduce identically on `main` -- they're preexisting Windows-only platform quirks unrelated to this refactor.
- [x] No frontend file touched; `StatusUpdate` TS binding is identical.
