### PR TITLE
feat(settings): add Notes category with vault location picker

### DIFF
--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -18,16 +18,18 @@
   import Keyboard from "@lucide/svelte/icons/keyboard";
   import Wrench from "@lucide/svelte/icons/wrench";
   import Plug from "@lucide/svelte/icons/plug";
+  import NotebookPen from "@lucide/svelte/icons/notebook-pen";
   import X from "@lucide/svelte/icons/x";
   import DoctorPanel from "$lib/components/DoctorPanel.svelte";
 
-  type CategoryId = "general" | "sessions" | "terminal" | "claude" | "integrations" | "notifications" | "keyboard" | "advanced";
+  type CategoryId = "general" | "sessions" | "terminal" | "claude" | "notes" | "integrations" | "notifications" | "keyboard" | "advanced";
 
   const CATEGORIES: { id: CategoryId; label: string; icon: typeof Settings }[] = [
     { id: "general", label: "General", icon: Settings },
     { id: "sessions", label: "Sessions", icon: FolderTree },
     { id: "terminal", label: "Terminal", icon: TerminalIcon },
     { id: "claude", label: "Claude", icon: Sparkles },
+    { id: "notes", label: "Notes", icon: NotebookPen },
     { id: "integrations", label: "Integrations", icon: Plug },
     { id: "notifications", label: "Notifications", icon: Bell },
     { id: "keyboard", label: "Keyboard", icon: Keyboard },
@@ -169,6 +171,11 @@
   async function browseAndAddRepoRoot() {
     const selected = await open({ directory: true, title: "Select Repo Root Directory" });
     if (selected) addRepoRoot(selected as string);
+  }
+
+  async function browseNotesVault() {
+    const selected = await open({ directory: true, title: "Select Notes Vault Location" });
+    if (selected) updateSetting("notesVaultRoot", selected as string);
   }
 </script>
 
@@ -491,6 +498,45 @@
                 oninput={(e) => updateSetting("additionalFlags", e.currentTarget.value.split(" ").filter(Boolean))}
                 placeholder="--verbose"
               />
+            </div>
+          {:else if selected === "notes"}
+            <div class="py-2">
+              <div class="flex items-center justify-between">
+                <div>
+                  <div class="text-[13px]">Vault location</div>
+                  <div class="text-[11px] text-text-muted mt-0.5">Where Roux stores notes. Works as a standalone folder or a subdirectory inside an Obsidian vault.</div>
+                </div>
+              </div>
+              <div class="mt-2 flex gap-1">
+                <input
+                  class="bg-bg-deep border border-border rounded px-2 py-1 font-mono text-xs text-text-primary outline-none flex-1 focus:border-accent-dim"
+                  value={$settings.notesVaultRoot ?? ""}
+                  oninput={(e) => updateSetting("notesVaultRoot", e.currentTarget.value || null)}
+                  placeholder="~/Documents/Roux"
+                />
+                <button
+                  class="px-2 py-1 bg-bg-elevated border border-border rounded text-text-secondary text-[10px] cursor-pointer hover:bg-bg-hover"
+                  onclick={browseNotesVault}
+                >...</button>
+              </div>
+              <div class="mt-1.5 text-[11px] text-text-muted">
+                Leave blank to use the default location. Changing this does not move existing notes.
+              </div>
+            </div>
+            <div class="flex items-center justify-between py-2 mt-2">
+              <div>
+                <div class="text-[13px]">Include web anchors</div>
+                <div class="text-[11px] text-text-muted mt-0.5">Add HTML anchor tags for compatibility with static site generators. Disable for cleaner markdown in Obsidian.</div>
+              </div>
+              <button
+                aria-label="Toggle web anchors in notes"
+                class="w-9 h-5 rounded-full relative cursor-pointer transition-all border
+                  {($settings.notesIncludeWebAnchors ?? true) ? 'bg-accent-dim border-accent' : 'bg-bg-deep border-border'}"
+                onclick={() => updateSetting("notesIncludeWebAnchors", !($settings.notesIncludeWebAnchors ?? true))}
+              >
+                <div class="w-3.5 h-3.5 rounded-full absolute top-0.5 transition-all
+                  {($settings.notesIncludeWebAnchors ?? true) ? 'left-[18px] bg-accent' : 'left-0.5 bg-text-secondary'}"></div>
+              </button>
             </div>
           {:else if selected === "integrations"}
             <div class="rounded-xl border border-border-subtle bg-bg-surface/35 p-3">


### PR DESCRIPTION
## Summary
- Adds a **Notes** category to the Settings panel (between Claude and Integrations)
- **Vault location** — text input + folder picker for `notesVaultRoot`, so users can point notes at a standalone folder or a subdirectory inside an existing Obsidian vault
- **Include web anchors** — toggle for `notesIncludeWebAnchors` (disable for cleaner Obsidian markdown)

Both settings already existed in the backend — this just gives them a GUI.

## Test plan
- [ ] Open Settings, confirm "Notes" appears in the sidebar with a notebook icon
- [ ] Verify vault location input shows placeholder `~/Documents/Roux`
- [ ] Use the browse button to pick a folder, confirm it persists after closing/reopening settings
- [ ] Clear the field, confirm it falls back to default
- [ ] Toggle "Include web anchors" on/off, confirm the setting persists
- [ ] Point vault at an Obsidian vault subfolder (e.g. `~/Notes/Roux`), verify notes write there

🤖 Generated with [Claude Code](https://claude.com/claude-code)