### PR TITLE
chore(rust): fix rust-1.95 clippy lints so CI is green

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
 [workspace]
 members = ["src-tauri", "crates/roux-core"]
 resolver = "2"
+
+[workspace.lints.clippy]
+too_many_arguments = "allow"

--- a/crates/roux-core/Cargo.toml
+++ b/crates/roux-core/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 description = "Shared types and models for Roux"
 
+[lints]
+workspace = true
+
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/roux-core/src/models/keymap.rs
+++ b/crates/roux-core/src/models/keymap.rs
@@ -106,7 +106,7 @@ pub struct KeymapWarning {
 /// Fully parsed keymap. `preset_ref` is the raw `preset "<name>"`
 /// reference, if the document declared one; the loader resolves it by
 /// parsing the preset KDL separately and calling [`merge_keymaps`].
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
 #[serde(rename_all = "camelCase")]
 pub struct ParsedKeymap {
     #[serde(default)]
@@ -122,20 +122,6 @@ pub struct ParsedKeymap {
     pub trees: Vec<KeymapTree>,
     pub prefixes: Vec<Prefix>,
     pub warnings: Vec<KeymapWarning>,
-}
-
-impl Default for ParsedKeymap {
-    fn default() -> Self {
-        Self {
-            preset_ref: None,
-            hud_default: None,
-            direct_binds: Vec::new(),
-            unbinds: Vec::new(),
-            trees: Vec::new(),
-            prefixes: Vec::new(),
-            warnings: Vec::new(),
-        }
-    }
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
@@ -886,7 +872,7 @@ fn promote_char_to_code(loc: (u32, u32), c: &str) -> Result<String, KeymapParseE
     Ok(name.to_string())
 }
 
-fn sort_mods(mods: &mut Vec<Modifier>) {
+fn sort_mods(mods: &mut [Modifier]) {
     // Canonical order so equality compares structurally regardless of
     // authoring order: Cmd, Ctrl, Alt, Shift.
     mods.sort_by_key(|m| match m {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,6 +6,9 @@ authors = ["phin-tech"]
 edition = "2021"
 default-run = "roux"
 
+[lints]
+workspace = true
+
 [lib]
 name = "roux_lib"
 crate-type = ["lib", "cdylib", "staticlib"]

--- a/src-tauri/src/agent_registry.rs
+++ b/src-tauri/src/agent_registry.rs
@@ -47,7 +47,7 @@ pub struct AgentInput {
 /// that fan out to every FSM belonging to a given session.
 #[derive(Debug, Clone)]
 pub enum RegistryMessage {
-    Input(AgentInput),
+    Input(Box<AgentInput>),
     /// A session (PTY) has exited. Dispatch `SessionEnded` to every
     /// FSM whose identity records this session id — its notifications
     /// get auto-dismissed without the hook needing to fire any more
@@ -156,7 +156,7 @@ pub fn spawn_worker(
         let mut registry = AgentRegistry::new(sink);
         while let Ok(msg) = rx.recv() {
             match msg {
-                RegistryMessage::Input(input) => registry.dispatch(input),
+                RegistryMessage::Input(input) => registry.dispatch(*input),
                 RegistryMessage::SessionEnded { session_id } => {
                     registry.on_session_ended(&session_id);
                 }
@@ -330,10 +330,12 @@ mod tests {
         let sink = Arc::new(RecordingSink::default());
         let mut registry = AgentRegistry::new(sink.clone());
 
-        let mut context = EventContext::default();
-        context.cwd = "/home/user/repo".into();
-        context.tool_name = Some("Bash".into());
-        context.roux_pane_id = Some("p-1".into());
+        let context = EventContext {
+            cwd: "/home/user/repo".into(),
+            tool_name: Some("Bash".into()),
+            roux_pane_id: Some("p-1".into()),
+            ..EventContext::default()
+        };
 
         registry.dispatch(AgentInput {
             identity: pane_identity("p-1"),
@@ -353,17 +355,17 @@ mod tests {
         let (tx, rx) = mpsc::channel::<RegistryMessage>();
         let handle = spawn_worker(rx, sink.clone());
 
-        tx.send(RegistryMessage::Input(input(
+        tx.send(RegistryMessage::Input(Box::new(input(
             pane_identity("p-1"),
             AgentEvent::HookStatus(MappedStatus::Attention),
             "/repo",
-        )))
+        ))))
         .unwrap();
-        tx.send(RegistryMessage::Input(input(
+        tx.send(RegistryMessage::Input(Box::new(input(
             pane_identity("p-1"),
             AgentEvent::HookStatus(MappedStatus::Idle),
             "/repo",
-        )))
+        ))))
         .unwrap();
         drop(tx);
         handle.join().expect("worker joined");
@@ -433,11 +435,11 @@ mod tests {
             session_id: Some("s-42".into()),
             cwd: None,
         };
-        tx.send(RegistryMessage::Input(AgentInput {
+        tx.send(RegistryMessage::Input(Box::new(AgentInput {
             identity: id,
             event: AgentEvent::HookStatus(MappedStatus::Attention),
             context: EventContext::default(),
-        }))
+        })))
         .unwrap();
         tx.send(RegistryMessage::SessionEnded { session_id: "s-42".into() })
             .unwrap();

--- a/src-tauri/src/agent_sources/file_status.rs
+++ b/src-tauri/src/agent_sources/file_status.rs
@@ -289,7 +289,7 @@ fn process_path_change(
         event: AgentEvent::HookStatus(mapped),
         context,
     };
-    tx.send(RegistryMessage::Input(input)).map_err(|e| e.to_string())?;
+    tx.send(RegistryMessage::Input(Box::new(input))).map_err(|e| e.to_string())?;
     Ok(())
 }
 

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -523,232 +523,6 @@ fn clear_status() {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use clap::Parser;
-
-    // ── resolve_path ────────────────────────────────────────
-
-    #[test]
-    fn resolve_path_keeps_absolute_path_as_is() {
-        // "/" always exists on Unix, canonicalize succeeds.
-        let got = resolve_path("/");
-        assert!(got.starts_with('/'));
-    }
-
-    #[test]
-    fn resolve_path_turns_relative_into_absolute() {
-        let got = resolve_path(".");
-        assert!(std::path::Path::new(&got).is_absolute(), "got {}", got);
-    }
-
-    #[test]
-    fn resolve_path_nonexistent_falls_back_to_uncanonicalized_absolute() {
-        // canonicalize() fails on missing paths; resolve_path must still
-        // return an absolute string rather than panicking or returning "".
-        let got = resolve_path("/definitely/not/a/real/path/roux-test");
-        assert!(std::path::Path::new(&got).is_absolute(), "got {}", got);
-        assert!(got.contains("roux-test"));
-    }
-
-    // ── Cli parsing ─────────────────────────────────────────
-
-    #[test]
-    fn cli_parses_app_with_default_path() {
-        let cli = Cli::try_parse_from(["roux-cli", "app"]).unwrap();
-        match cli.command {
-            Commands::App { path } => assert_eq!(path, "."),
-            other => panic!("expected App, got {:?}", std::mem::discriminant(&other)),
-        }
-    }
-
-    #[test]
-    fn cli_parses_app_with_explicit_path() {
-        let cli = Cli::try_parse_from(["roux-cli", "app", "/tmp/foo"]).unwrap();
-        match cli.command {
-            Commands::App { path } => assert_eq!(path, "/tmp/foo"),
-            _ => panic!("expected App"),
-        }
-    }
-
-    #[test]
-    fn cli_parses_session_list() {
-        let cli = Cli::try_parse_from(["roux-cli", "session", "list"]).unwrap();
-        match cli.command {
-            Commands::Session { action: SessionAction::List } => {}
-            _ => panic!("expected Session::List"),
-        }
-    }
-
-    #[test]
-    fn cli_parses_session_poll_with_session_id() {
-        let cli = Cli::try_parse_from(["roux-cli", "session", "poll", "-s", "sid-1"]).unwrap();
-        match cli.command {
-            Commands::Session { action: SessionAction::Poll { session } } => {
-                assert_eq!(session.as_deref(), Some("sid-1"));
-            }
-            _ => panic!("expected Session::Poll"),
-        }
-    }
-
-    #[test]
-    fn cli_parses_session_send_default_has_enter_true() {
-        let cli = Cli::try_parse_from(["roux-cli", "session", "send", "hello"]).unwrap();
-        match cli.command {
-            Commands::Session { action: SessionAction::Send { text, no_enter, .. } } => {
-                assert_eq!(text, "hello");
-                assert!(!no_enter, "--no-enter not passed, so no_enter must be false");
-            }
-            _ => panic!("expected Session::Send"),
-        }
-    }
-
-    #[test]
-    fn cli_parses_session_send_with_no_enter_flag() {
-        let cli =
-            Cli::try_parse_from(["roux-cli", "session", "send", "hello", "--no-enter"]).unwrap();
-        match cli.command {
-            Commands::Session { action: SessionAction::Send { no_enter, .. } } => assert!(no_enter),
-            _ => panic!("expected Session::Send"),
-        }
-    }
-
-    #[test]
-    fn cli_parses_session_send_with_session_and_pane() {
-        let cli =
-            Cli::try_parse_from(["roux-cli", "session", "send", "hi", "-s", "sid", "-p", "pid"])
-                .unwrap();
-        match cli.command {
-            Commands::Session { action: SessionAction::Send { session, pane, .. } } => {
-                assert_eq!(session.as_deref(), Some("sid"));
-                assert_eq!(pane.as_deref(), Some("pid"));
-            }
-            _ => panic!("expected Session::Send"),
-        }
-    }
-
-    #[test]
-    fn cli_parses_session_create_with_full_options() {
-        let cli = Cli::try_parse_from([
-            "roux-cli",
-            "session",
-            "create",
-            "--name",
-            "feat-x",
-            "--worktree-branch",
-            "feat/x",
-            "--profile",
-            "claude",
-            "-f",
-            "--debug",
-            "-f",
-            "--model=opus",
-            "--nono-profile",
-            "strict",
-            "--nono-allow-dir",
-            "~/work",
-            "--nono-allow-dir",
-            "/tmp",
-        ])
-        .unwrap();
-        match cli.command {
-            Commands::Session {
-                action:
-                    SessionAction::Create {
-                        name,
-                        worktree_branch,
-                        profile,
-                        flags,
-                        nono_profile,
-                        nono_allow_dirs,
-                        working_dir,
-                    },
-            } => {
-                assert_eq!(name.as_deref(), Some("feat-x"));
-                assert_eq!(worktree_branch.as_deref(), Some("feat/x"));
-                assert_eq!(profile.as_deref(), Some("claude"));
-                assert_eq!(flags, vec!["--debug", "--model=opus"]);
-                assert_eq!(nono_profile.as_deref(), Some("strict"));
-                assert_eq!(nono_allow_dirs, vec!["~/work", "/tmp"]);
-                assert!(working_dir.is_none());
-            }
-            _ => panic!("expected Session::Create"),
-        }
-    }
-
-    #[test]
-    fn cli_parses_session_panes_list_with_session() {
-        let cli =
-            Cli::try_parse_from(["roux-cli", "session", "panes", "list", "-s", "sid"]).unwrap();
-        match cli.command {
-            Commands::Session {
-                action: SessionAction::Panes { action: PaneAction::List { session } },
-            } => {
-                assert_eq!(session.as_deref(), Some("sid"));
-            }
-            _ => panic!("expected Session::Panes::List"),
-        }
-    }
-
-    #[test]
-    fn cli_parses_session_panes_create_defaults() {
-        let cli =
-            Cli::try_parse_from(["roux-cli", "session", "panes", "create", "-s", "sid"]).unwrap();
-        match cli.command {
-            Commands::Session {
-                action:
-                    SessionAction::Panes {
-                        action: PaneAction::Create { session, profile, direction, working_dir },
-                    },
-            } => {
-                assert_eq!(session.as_deref(), Some("sid"));
-                assert!(profile.is_none());
-                assert_eq!(direction, "horizontal");
-                assert!(working_dir.is_none());
-            }
-            _ => panic!("expected Session::Panes::Create"),
-        }
-    }
-
-    #[test]
-    fn cli_parses_session_panes_create_with_all_options() {
-        let cli = Cli::try_parse_from([
-            "roux-cli", "session", "panes", "create", "-s", "sid", "-P", "shell", "-d", "vertical",
-            "-w", "/tmp",
-        ])
-        .unwrap();
-        match cli.command {
-            Commands::Session {
-                action:
-                    SessionAction::Panes {
-                        action: PaneAction::Create { profile, direction, working_dir, .. },
-                    },
-            } => {
-                assert_eq!(profile.as_deref(), Some("shell"));
-                assert_eq!(direction, "vertical");
-                assert_eq!(working_dir.as_deref(), Some("/tmp"));
-            }
-            _ => panic!("expected Session::Panes::Create"),
-        }
-    }
-
-    #[test]
-    fn cli_rejects_removed_top_level_send() {
-        // `roux send "x"` used to work; now it must live under `session`.
-        let err = Cli::try_parse_from(["roux-cli", "send", "x"]);
-        assert!(err.is_err(), "top-level `send` must no longer parse");
-    }
-
-    #[test]
-    fn cli_split_still_parses_with_direction() {
-        let cli = Cli::try_parse_from(["roux-cli", "split", "-d", "vertical"]).unwrap();
-        match cli.command {
-            Commands::Split { direction } => assert_eq!(direction, "vertical"),
-            _ => panic!("expected Split"),
-        }
-    }
-}
 
 fn main() {
     let cli = Cli::parse();
@@ -1079,6 +853,232 @@ fn handle_notes_verb(scope: &str, verb: NotesScopeVerb) {
                     "dir": dir,
                 },
             }));
+        }
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    // ── resolve_path ────────────────────────────────────────
+
+    #[test]
+    fn resolve_path_keeps_absolute_path_as_is() {
+        // "/" always exists on Unix, canonicalize succeeds.
+        let got = resolve_path("/");
+        assert!(got.starts_with('/'));
+    }
+
+    #[test]
+    fn resolve_path_turns_relative_into_absolute() {
+        let got = resolve_path(".");
+        assert!(std::path::Path::new(&got).is_absolute(), "got {}", got);
+    }
+
+    #[test]
+    fn resolve_path_nonexistent_falls_back_to_uncanonicalized_absolute() {
+        // canonicalize() fails on missing paths; resolve_path must still
+        // return an absolute string rather than panicking or returning "".
+        let got = resolve_path("/definitely/not/a/real/path/roux-test");
+        assert!(std::path::Path::new(&got).is_absolute(), "got {}", got);
+        assert!(got.contains("roux-test"));
+    }
+
+    // ── Cli parsing ─────────────────────────────────────────
+
+    #[test]
+    fn cli_parses_app_with_default_path() {
+        let cli = Cli::try_parse_from(["roux-cli", "app"]).unwrap();
+        match cli.command {
+            Commands::App { path } => assert_eq!(path, "."),
+            other => panic!("expected App, got {:?}", std::mem::discriminant(&other)),
+        }
+    }
+
+    #[test]
+    fn cli_parses_app_with_explicit_path() {
+        let cli = Cli::try_parse_from(["roux-cli", "app", "/tmp/foo"]).unwrap();
+        match cli.command {
+            Commands::App { path } => assert_eq!(path, "/tmp/foo"),
+            _ => panic!("expected App"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_session_list() {
+        let cli = Cli::try_parse_from(["roux-cli", "session", "list"]).unwrap();
+        match cli.command {
+            Commands::Session { action: SessionAction::List } => {}
+            _ => panic!("expected Session::List"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_session_poll_with_session_id() {
+        let cli = Cli::try_parse_from(["roux-cli", "session", "poll", "-s", "sid-1"]).unwrap();
+        match cli.command {
+            Commands::Session { action: SessionAction::Poll { session } } => {
+                assert_eq!(session.as_deref(), Some("sid-1"));
+            }
+            _ => panic!("expected Session::Poll"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_session_send_default_has_enter_true() {
+        let cli = Cli::try_parse_from(["roux-cli", "session", "send", "hello"]).unwrap();
+        match cli.command {
+            Commands::Session { action: SessionAction::Send { text, no_enter, .. } } => {
+                assert_eq!(text, "hello");
+                assert!(!no_enter, "--no-enter not passed, so no_enter must be false");
+            }
+            _ => panic!("expected Session::Send"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_session_send_with_no_enter_flag() {
+        let cli =
+            Cli::try_parse_from(["roux-cli", "session", "send", "hello", "--no-enter"]).unwrap();
+        match cli.command {
+            Commands::Session { action: SessionAction::Send { no_enter, .. } } => assert!(no_enter),
+            _ => panic!("expected Session::Send"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_session_send_with_session_and_pane() {
+        let cli =
+            Cli::try_parse_from(["roux-cli", "session", "send", "hi", "-s", "sid", "-p", "pid"])
+                .unwrap();
+        match cli.command {
+            Commands::Session { action: SessionAction::Send { session, pane, .. } } => {
+                assert_eq!(session.as_deref(), Some("sid"));
+                assert_eq!(pane.as_deref(), Some("pid"));
+            }
+            _ => panic!("expected Session::Send"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_session_create_with_full_options() {
+        let cli = Cli::try_parse_from([
+            "roux-cli",
+            "session",
+            "create",
+            "--name",
+            "feat-x",
+            "--worktree-branch",
+            "feat/x",
+            "--profile",
+            "claude",
+            "-f",
+            "--debug",
+            "-f",
+            "--model=opus",
+            "--nono-profile",
+            "strict",
+            "--nono-allow-dir",
+            "~/work",
+            "--nono-allow-dir",
+            "/tmp",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Session {
+                action:
+                    SessionAction::Create {
+                        name,
+                        worktree_branch,
+                        profile,
+                        flags,
+                        nono_profile,
+                        nono_allow_dirs,
+                        working_dir,
+                    },
+            } => {
+                assert_eq!(name.as_deref(), Some("feat-x"));
+                assert_eq!(worktree_branch.as_deref(), Some("feat/x"));
+                assert_eq!(profile.as_deref(), Some("claude"));
+                assert_eq!(flags, vec!["--debug", "--model=opus"]);
+                assert_eq!(nono_profile.as_deref(), Some("strict"));
+                assert_eq!(nono_allow_dirs, vec!["~/work", "/tmp"]);
+                assert!(working_dir.is_none());
+            }
+            _ => panic!("expected Session::Create"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_session_panes_list_with_session() {
+        let cli =
+            Cli::try_parse_from(["roux-cli", "session", "panes", "list", "-s", "sid"]).unwrap();
+        match cli.command {
+            Commands::Session {
+                action: SessionAction::Panes { action: PaneAction::List { session } },
+            } => {
+                assert_eq!(session.as_deref(), Some("sid"));
+            }
+            _ => panic!("expected Session::Panes::List"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_session_panes_create_defaults() {
+        let cli =
+            Cli::try_parse_from(["roux-cli", "session", "panes", "create", "-s", "sid"]).unwrap();
+        match cli.command {
+            Commands::Session {
+                action:
+                    SessionAction::Panes {
+                        action: PaneAction::Create { session, profile, direction, working_dir },
+                    },
+            } => {
+                assert_eq!(session.as_deref(), Some("sid"));
+                assert!(profile.is_none());
+                assert_eq!(direction, "horizontal");
+                assert!(working_dir.is_none());
+            }
+            _ => panic!("expected Session::Panes::Create"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_session_panes_create_with_all_options() {
+        let cli = Cli::try_parse_from([
+            "roux-cli", "session", "panes", "create", "-s", "sid", "-P", "shell", "-d", "vertical",
+            "-w", "/tmp",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Session {
+                action:
+                    SessionAction::Panes {
+                        action: PaneAction::Create { profile, direction, working_dir, .. },
+                    },
+            } => {
+                assert_eq!(profile.as_deref(), Some("shell"));
+                assert_eq!(direction, "vertical");
+                assert_eq!(working_dir.as_deref(), Some("/tmp"));
+            }
+            _ => panic!("expected Session::Panes::Create"),
+        }
+    }
+
+    #[test]
+    fn cli_rejects_removed_top_level_send() {
+        // `roux send "x"` used to work; now it must live under `session`.
+        let err = Cli::try_parse_from(["roux-cli", "send", "x"]);
+        assert!(err.is_err(), "top-level `send` must no longer parse");
+    }
+
+    #[test]
+    fn cli_split_still_parses_with_direction() {
+        let cli = Cli::try_parse_from(["roux-cli", "split", "-d", "vertical"]).unwrap();
+        match cli.command {
+            Commands::Split { direction } => assert_eq!(direction, "vertical"),
+            _ => panic!("expected Split"),
         }
     }
 }

--- a/src-tauri/src/notifications/osc_parser.rs
+++ b/src-tauri/src/notifications/osc_parser.rs
@@ -301,9 +301,7 @@ fn parse_osc9_payload(raw: &str) -> Option<ParsedOsc9Payload> {
             let title = first_string(&obj, &["title", "summary", "subject"]);
             let message = first_string(&obj, &["body", "message", "text", "detail", "details"]);
 
-            let Some(final_title) = title.clone().or_else(|| message.clone()) else {
-                return None;
-            };
+            let final_title = title.clone().or_else(|| message.clone())?;
             let body = match (title.is_some(), message) {
                 (true, Some(m)) if m != final_title => Some(m),
                 _ => None,

--- a/src-tauri/src/pane_service.rs
+++ b/src-tauri/src/pane_service.rs
@@ -44,7 +44,7 @@ pub struct PaneRecord {
 #[serde(tag = "kind", rename_all = "camelCase")]
 pub enum PaneSpawnProfileRef {
     Registered { id: String },
-    Inline { profile: SpawnProfile },
+    Inline { profile: Box<SpawnProfile> },
 }
 
 impl PaneRecord {
@@ -68,7 +68,7 @@ impl PaneRecord {
 
 enum PaneMsg {
     Upsert {
-        record: PaneRecord,
+        record: Box<PaneRecord>,
         reply: oneshot::Sender<()>,
     },
     Remove {
@@ -97,7 +97,7 @@ impl PaneHandle {
 
     pub async fn upsert(&self, record: PaneRecord) -> Result<(), ServiceError> {
         let (reply_tx, reply_rx) = oneshot::channel();
-        self.send(PaneMsg::Upsert { record, reply: reply_tx })?;
+        self.send(PaneMsg::Upsert { record: Box::new(record), reply: reply_tx })?;
         reply_rx.await.map_err(|_| ServiceError)
     }
 
@@ -126,7 +126,7 @@ async fn service_loop(mut rx: mpsc::UnboundedReceiver<PaneMsg>) {
     while let Some(msg) = rx.recv().await {
         match msg {
             PaneMsg::Upsert { record, reply } => {
-                panes.insert(record.id.clone(), record);
+                panes.insert(record.id.clone(), *record);
                 let _ = reply.send(());
             }
             PaneMsg::Remove { id, reply } => {

--- a/src-tauri/src/pane_state.rs
+++ b/src-tauri/src/pane_state.rs
@@ -43,7 +43,7 @@ enum SplitDirection {
 #[serde(tag = "kind", rename_all = "lowercase")]
 enum PersistedSpawnProfileRef {
     Registered { id: String },
-    Inline { profile: SpawnProfile },
+    Inline { profile: Box<SpawnProfile> },
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]

--- a/src-tauri/src/providers/claude.rs
+++ b/src-tauri/src/providers/claude.rs
@@ -75,34 +75,42 @@ mod tests {
 
     #[test]
     fn startup_command_uses_custom_binary_and_model() {
-        let mut settings = RouxSettings::default();
-        settings.claude_binary_path = Some("/opt/claude/bin/claude".into());
-        settings.default_model = Some("claude-opus-4-6".into());
+        let settings = RouxSettings {
+            claude_binary_path: Some("/opt/claude/bin/claude".into()),
+            default_model: Some("claude-opus-4-6".into()),
+            ..RouxSettings::default()
+        };
         let cmd = build_startup_command(&settings);
         assert_eq!(cmd, "/opt/claude/bin/claude --model claude-opus-4-6");
     }
 
     #[test]
     fn startup_command_quotes_binary_path_with_spaces() {
-        let mut settings = RouxSettings::default();
-        settings.claude_binary_path = Some("/Applications/Claude Code.app/claude".into());
+        let settings = RouxSettings {
+            claude_binary_path: Some("/Applications/Claude Code.app/claude".into()),
+            ..RouxSettings::default()
+        };
         let cmd = build_startup_command(&settings);
         assert_eq!(cmd, "'/Applications/Claude Code.app/claude'");
     }
 
     #[test]
     fn startup_command_appends_additional_flags() {
-        let mut settings = RouxSettings::default();
-        settings.additional_flags = vec!["--verbose".into(), "--trust-workspace".into()];
+        let settings = RouxSettings {
+            additional_flags: vec!["--verbose".into(), "--trust-workspace".into()],
+            ..RouxSettings::default()
+        };
         let cmd = build_startup_command(&settings);
         assert_eq!(cmd, "claude --verbose --trust-workspace");
     }
 
     #[test]
     fn startup_command_ignores_empty_binary_and_model_strings() {
-        let mut settings = RouxSettings::default();
-        settings.claude_binary_path = Some(String::new());
-        settings.default_model = Some(String::new());
+        let settings = RouxSettings {
+            claude_binary_path: Some(String::new()),
+            default_model: Some(String::new()),
+            ..RouxSettings::default()
+        };
         let cmd = build_startup_command(&settings);
         assert_eq!(cmd, "claude");
     }

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -329,7 +329,7 @@ impl portable_pty::Child for WaitedChild {
         Ok(None)
     }
     fn wait(&mut self) -> std::io::Result<portable_pty::ExitStatus> {
-        Err(std::io::Error::new(std::io::ErrorKind::Other, "child already waited"))
+        Err(std::io::Error::other("child already waited"))
     }
     fn process_id(&self) -> Option<u32> {
         None

--- a/src-tauri/src/services/docs.rs
+++ b/src-tauri/src/services/docs.rs
@@ -70,6 +70,6 @@ pub(crate) fn list_docs(dir: &str) -> anyhow::Result<Vec<DocFile>> {
         }
     }
 
-    docs.sort_by(|a, b| b.modified.cmp(&a.modified));
+    docs.sort_by_key(|d| std::cmp::Reverse(d.modified));
     Ok(docs)
 }

--- a/src-tauri/src/services/notes.rs
+++ b/src-tauri/src/services/notes.rs
@@ -463,16 +463,13 @@ pub(crate) fn search_by_tags(
     exact: bool,
 ) -> Vec<std::path::PathBuf> {
     let search_root = match scope_filter {
-        Some(scope) => {
-            let sub = match scope {
-                "global" => vault_root.join("global"),
-                "project" => vault_root.join("projects"),
-                "repo" => vault_root.join("repos"),
-                "session" => vault_root.join("sessions"),
-                _ => vault_root.to_path_buf(),
-            };
-            sub
-        }
+        Some(scope) => match scope {
+            "global" => vault_root.join("global"),
+            "project" => vault_root.join("projects"),
+            "repo" => vault_root.join("repos"),
+            "session" => vault_root.join("sessions"),
+            _ => vault_root.to_path_buf(),
+        },
         None => vault_root.to_path_buf(),
     };
 

--- a/src-tauri/src/services/sessions.rs
+++ b/src-tauri/src/services/sessions.rs
@@ -326,7 +326,7 @@ pub(crate) fn list_claude_sessions(cwd: &str) -> anyhow::Result<Vec<ClaudeSessio
     let home = dirs::home_dir().ok_or_else(|| anyhow!("Cannot find home directory"))?;
     let projects_dir = home.join(".claude").join("projects");
 
-    let encoded = cwd.replace('/', "-").replace('.', "-");
+    let encoded = cwd.replace(['/', '.'], "-");
     let project_dir = projects_dir.join(&encoded);
 
     if !project_dir.is_dir() {
@@ -389,7 +389,7 @@ pub(crate) fn list_claude_sessions(cwd: &str) -> anyhow::Result<Vec<ClaudeSessio
         sessions.push(ClaudeSession { session_id, summary, modified_at });
     }
 
-    sessions.sort_by(|a, b| b.modified_at.cmp(&a.modified_at));
+    sessions.sort_by_key(|s| std::cmp::Reverse(s.modified_at));
     Ok(sessions)
 }
 

--- a/src-tauri/src/session_service.rs
+++ b/src-tauri/src/session_service.rs
@@ -227,7 +227,7 @@ async fn service_loop(
 }
 
 /// Synchronous disk write — used from `spawn_blocking` and from shutdown (where blocking is fine).
-fn persist_to_disk(sessions: &[Session], path: &PathBuf) {
+fn persist_to_disk(sessions: &[Session], path: &std::path::Path) {
     write_to_path(sessions, path);
 }
 

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -59,8 +59,10 @@ mod tests {
 
     #[test]
     fn claude_binary_path_round_trips_through_json() {
-        let mut settings = RouxSettings::default();
-        settings.claude_binary_path = Some("/usr/local/bin/claude".to_string());
+        let settings = RouxSettings {
+            claude_binary_path: Some("/usr/local/bin/claude".to_string()),
+            ..RouxSettings::default()
+        };
         let json = serde_json::to_string(&settings).unwrap();
         let deserialized: RouxSettings = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.claude_binary_path, Some("/usr/local/bin/claude".to_string()));

--- a/src-tauri/src/socket.rs
+++ b/src-tauri/src/socket.rs
@@ -17,6 +17,7 @@ struct Request {
     command: String,
     session_id: Option<String>,
     pane_id: Option<String>,
+    #[allow(dead_code)]
     auth_token: Option<String>,
     #[serde(default)]
     args: serde_json::Value,

--- a/src-tauri/src/watches/manager.rs
+++ b/src-tauri/src/watches/manager.rs
@@ -186,8 +186,8 @@ impl WatchManager {
                             let mut trackers = flap_trackers.lock().unwrap();
                             let tracker =
                                 trackers.entry(watch_id.clone()).or_insert_with(FlapTracker::new);
-                            if let Some(ref o) = outcome {
-                                tracker.record((*o).clone(), now);
+                            if let Some(o) = outcome {
+                                tracker.record(o.clone(), now);
                             }
                             tracker.is_flapping()
                         };

--- a/src-tauri/src/watches/store.rs
+++ b/src-tauri/src/watches/store.rs
@@ -7,7 +7,7 @@ use roux_core::{RuntimeState, Watch, WatchScope};
 
 enum WatchMsg {
     Add {
-        watch: Watch,
+        watch: Box<Watch>,
         reply: oneshot::Sender<()>,
     },
     Remove {
@@ -52,7 +52,7 @@ impl WatchStoreHandle {
 
     pub async fn add(&self, watch: Watch) -> Result<(), ServiceError> {
         let (reply_tx, reply_rx) = oneshot::channel();
-        self.send(WatchMsg::Add { watch, reply: reply_tx })?;
+        self.send(WatchMsg::Add { watch: Box::new(watch), reply: reply_tx })?;
         reply_rx.await.map_err(|_| ServiceError)
     }
 
@@ -128,7 +128,7 @@ async fn service_loop(
             msg = rx.recv() => {
                 match msg {
                     Some(WatchMsg::Add { watch, reply }) => {
-                        watches.push(watch);
+                        watches.push(*watch);
                         dirty = true;
                         let _ = reply.send(());
                     }


### PR DESCRIPTION
## Summary

CI pinned `-D warnings` against rust-stable, which advanced to 1.95 and surfaced a batch of new default-deny lints. The rust CI job was failing on `roux-core` and would have failed on `src-tauri` as well once the first two lints were fixed.

Now: `cargo clippy --all-targets -- -D warnings`, `cargo check --all-targets`, and `cargo test --all` all pass locally against rust 1.95.

### Fixed

- `derivable_impls` / `ptr_arg` in `roux-core` (the two errors CI reported)
- `field_reassign_with_default` in several tests
- `large_enum_variant`: boxed the bulky variants in `RegistryMessage::Input`, `PaneMsg::Upsert`, `WatchMsg::Add`, `PaneSpawnProfileRef::Inline`, `PersistedSpawnProfileRef::Inline`
- `io_other_error`, `question_mark`, `let_and_return`, `unnecessary_sort_by`, `collapsible_str_replace`, `needless_borrow`
- `items_after_test_module` in `cli.rs`: moved `fn main` + notes helpers above the test module
- `#[allow(dead_code)]` on `socket.rs` `Request.auth_token` (reserved wire-format field)

### Allowed at workspace level

`clippy::too_many_arguments` — the ~8 flagged functions are Tauri command adapters; inflating a struct per command is pure ceremony, not a real signal.

## Test plan

- [x] `CI=1 cargo clippy --all-targets -- -D warnings` → clean
- [x] `CI=1 cargo check --all-targets` → clean
- [x] `CI=1 cargo test --all` → 450 passed, 0 failed
- [ ] Remote CI (`frontend` + `rust` jobs) green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)