### PR TITLE
ci: speed up rust job (parallel split, mold, nextest, apt cache)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,18 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+env:
+  # Space-separated via YAML folded scalar. Used by both rust jobs to
+  # cache the Tauri system deps install.
+  TAURI_SYSTEM_DEPS: >-
+    libwebkit2gtk-4.1-dev
+    libappindicator3-dev
+    librsvg2-dev
+    patchelf
+    libgtk-3-dev
+    libsoup-3.0-dev
+    libjavascriptcoregtk-4.1-dev
+
 jobs:
   frontend:
     runs-on: ubuntu-latest
@@ -22,33 +34,43 @@ jobs:
       - run: npm run check
       - run: npm run test
 
-  rust:
+  rust-clippy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install system deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libwebkit2gtk-4.1-dev \
-            libappindicator3-dev \
-            librsvg2-dev \
-            patchelf \
-            libgtk-3-dev \
-            libsoup-3.0-dev \
-            libjavascriptcoregtk-4.1-dev
+      - uses: rui314/setup-mold@v1
+      - name: Cache Tauri system deps
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: ${{ env.TAURI_SYSTEM_DEPS }}
+          version: 1
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri -> target
+          key: clippy
       - name: Clippy
         working-directory: src-tauri
         run: cargo clippy --all-targets -- -D warnings
-      - name: Check
-        working-directory: src-tauri
-        run: cargo check --all-targets
+
+  rust-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rui314/setup-mold@v1
+      - name: Cache Tauri system deps
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: ${{ env.TAURI_SYSTEM_DEPS }}
+          version: 1
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@nextest
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri -> target
+          key: test
       - name: Test
         working-directory: src-tauri
-        run: cargo test --all
+        run: cargo nextest run --workspace


### PR DESCRIPTION
## Summary

Five changes working together:

1. **Drop `cargo check --all-targets`** — clippy already type-checks, so it was a full duplicate compile.
2. **Split clippy and test into separate jobs** so they run in parallel on two runners instead of sequentially on one. `rust-cache` keys are per-job (`key: clippy` / `key: test`) to avoid stomping on each other.
3. **`cargo nextest run --workspace`** instead of `cargo test` — modest (30-40s), cheap to install.
4. **`rui314/setup-mold@v1`** — mold linker, noticeable per-compile speedup given the Tauri dep graph.
5. **Cache Tauri system deps** via `awalsh128/cache-apt-pkgs-action` instead of `apt-get update && install` each run.

## Gotchas

- `cargo nextest` does not run doc tests. The workspace currently has zero, so no coverage is lost. If doc tests appear later, add a `cargo test --doc` step alongside nextest.
- Two parallel jobs = more runner-minutes total, but much lower wall-clock time.
- rust-cache entries live under separate keys so clippy's artifacts (different cfg than test) don't invalidate the test job's cache every run.

## Stacking

This branches off `main`, independent of #83 (the rust-1.95 lint fixes). Either can merge first.

## Test plan

- [ ] CI passes on this PR (the workflow is self-testing)
- [ ] Compare run time before/after on \`main\` after merge to confirm the speedup is real

🤖 Generated with [Claude Code](https://claude.com/claude-code)