### PR TITLE
feat(worktrees): choose base branch when creating new worktree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3924,6 +3924,7 @@ dependencies = [
  "serde",
  "serde_json",
  "specta",
+ "tempfile",
  "thiserror 2.0.18",
 ]
 

--- a/crates/roux-core/Cargo.toml
+++ b/crates/roux-core/Cargo.toml
@@ -14,3 +14,6 @@ specta = { version = "=2.0.0-rc.24", features = ["derive", "serde_json"] }
 thiserror = "2"
 dirs = "6"
 kdl = "6.5"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/roux-core/src/lib.rs
+++ b/crates/roux-core/src/lib.rs
@@ -10,6 +10,6 @@ pub mod worktree;
 
 pub use models::*;
 pub use worktree::{
-    create_worktree, expand_base_template, list_worktrees, preview_worktree_base, remove_worktree,
-    WorktreeError,
+    create_worktree, expand_base_template, fetch_origin, list_worktrees, preview_worktree_base,
+    remove_worktree, WorktreeError,
 };

--- a/crates/roux-core/src/models/mod.rs
+++ b/crates/roux-core/src/models/mod.rs
@@ -28,7 +28,7 @@ pub use project::Project;
 pub use session::{Session, SessionStatus};
 pub use settings::{
     CursorStyle, GroupBy, RouxSettings, StatusBarPosition, TabPosition, UpdateChannel,
-    WorktreeCleanupMode,
+    WorktreeCleanupMode, WorktreeDefaultBase,
 };
 pub use task::{KeepOpen, TaskDefinition, TaskGroup};
 pub use watch::*;

--- a/crates/roux-core/src/models/settings.rs
+++ b/crates/roux-core/src/models/settings.rs
@@ -53,6 +53,23 @@ pub enum WorktreeCleanupMode {
     Always,
 }
 
+/// Which starting point the "New Worktree" affordance uses when the user
+/// clicks the primary action directly (as opposed to hovering to pick a
+/// specific base from the flyout). Only affects the default — the three
+/// options remain available via the submenu / command palette either way.
+///
+/// - `CurrentBranch` — the session's current branch (matches legacy behavior)
+/// - `Main` — the local `main` branch
+/// - `OriginMain` — the remote `origin/main`, with a `git fetch origin` first
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, specta::Type, Default)]
+#[serde(rename_all = "camelCase")]
+pub enum WorktreeDefaultBase {
+    #[default]
+    CurrentBranch,
+    Main,
+    OriginMain,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, specta::Type, Default)]
 #[serde(rename_all = "camelCase")]
 pub enum GroupBy {
@@ -110,6 +127,10 @@ pub struct RouxSettings {
     pub cleanup_worktrees_on_close: bool,
     #[serde(default)]
     pub worktree_cleanup_on_close: WorktreeCleanupMode,
+    /// Default starting point when the user clicks "New Worktree" directly.
+    /// The flyout / command palette still let them override per-invocation.
+    #[serde(default)]
+    pub worktree_default_base: WorktreeDefaultBase,
     pub theme: String,
     pub default_model: Option<String>,
     #[serde(default)]
@@ -218,6 +239,7 @@ impl Default for RouxSettings {
             worktree_base_path: None,
             cleanup_worktrees_on_close: false,
             worktree_cleanup_on_close: WorktreeCleanupMode::Prompt,
+            worktree_default_base: WorktreeDefaultBase::CurrentBranch,
             theme: DEFAULT_THEME.to_string(),
             default_model: None,
             claude_binary_path: None,

--- a/crates/roux-core/src/worktree.rs
+++ b/crates/roux-core/src/worktree.rs
@@ -17,6 +17,10 @@ pub enum WorktreeError {
     RemoveFailed { stderr: String },
     #[error("git worktree list failed: {stderr}")]
     ListFailed { stderr: String },
+    #[error("git fetch origin failed: {stderr}")]
+    FetchFailed { stderr: String },
+    #[error("Invalid start point: '{start_point}' does not resolve to a commit")]
+    InvalidStartPoint { start_point: String },
 }
 
 fn sanitize_branch_for_path(branch: &str) -> String {
@@ -125,10 +129,48 @@ fn branch_exists(repo_path: &str, branch: &str) -> bool {
         .unwrap_or(false)
 }
 
+fn rev_exists(repo_path: &str, rev: &str) -> bool {
+    Command::new("git")
+        .args(["rev-parse", "--verify", rev])
+        .current_dir(repo_path)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Runs `git fetch origin` in `repo_path`. Used before creating a worktree
+/// off a remote ref (e.g. `origin/main`) so the ref exists locally.
+pub fn fetch_origin(repo_path: &str) -> Result<(), WorktreeError> {
+    let output = Command::new("git")
+        .args(["fetch", "origin"])
+        .current_dir(repo_path)
+        .output()
+        .map_err(|source| WorktreeError::RunGit { source })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(WorktreeError::FetchFailed { stderr: stderr.to_string() });
+    }
+    Ok(())
+}
+
+/// Create a new worktree for `branch` under a base path derived from
+/// `base_path` (filesystem location — see `resolve_worktree_path`).
+///
+/// Semantics:
+/// - If `branch` is already checked out in an existing worktree, return that
+///   path (no-op).
+/// - If `branch` exists in the repo, run `git worktree add <path> <branch>`.
+///   `start_point` is ignored because git checks out the existing branch.
+/// - If `branch` does not exist and `start_point` is `Some(sp)`, run
+///   `git worktree add -b <branch> <path> <sp>` (new branch from `sp`).
+/// - If `branch` does not exist and `start_point` is `None`, run
+///   `git worktree add -b <branch> <path>` (new branch from HEAD).
 pub fn create_worktree(
     repo_path: &str,
     branch: &str,
     base_path: Option<&str>,
+    start_point: Option<&str>,
 ) -> Result<String, WorktreeError> {
     // Check if the branch is already checked out in an existing worktree
     if let Ok(worktrees) = list_worktrees(repo_path) {
@@ -143,6 +185,17 @@ pub fn create_worktree(
     let output = if branch_exists(repo_path, branch) {
         Command::new("git")
             .args(["worktree", "add", &target_str, branch])
+            .current_dir(repo_path)
+            .output()
+            .map_err(|source| WorktreeError::RunGit { source })?
+    } else if let Some(sp) = start_point {
+        if !rev_exists(repo_path, sp) {
+            return Err(WorktreeError::InvalidStartPoint {
+                start_point: sp.to_string(),
+            });
+        }
+        Command::new("git")
+            .args(["worktree", "add", "-b", branch, &target_str, sp])
             .current_dir(repo_path)
             .output()
             .map_err(|source| WorktreeError::RunGit { source })?
@@ -389,5 +442,120 @@ mod tests {
         let error = WorktreeError::RunGit { source: io::Error::other("boom") };
 
         assert_eq!(error.to_string(), "Failed to run git: boom");
+    }
+
+    // ---- Integration-style tests against a real temp git repo ----
+
+    fn git(repo: &Path, args: &[&str]) {
+        let out = Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .output()
+            .expect("failed to invoke git");
+        assert!(
+            out.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    fn git_stdout(repo: &Path, args: &[&str]) -> String {
+        let out = Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .output()
+            .expect("failed to invoke git");
+        assert!(out.status.success());
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    }
+
+    /// Initialise a temp git repo with a `main` branch and one commit.
+    fn init_repo(dir: &Path) {
+        git(dir, &["init", "-q", "-b", "main"]);
+        git(dir, &["config", "user.email", "t@t.test"]);
+        git(dir, &["config", "user.name", "Test"]);
+        git(dir, &["commit", "--allow-empty", "-m", "init"]);
+    }
+
+    #[test]
+    fn create_worktree_with_start_point_branches_from_it() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        init_repo(&repo);
+
+        // Create a second branch with an extra commit; leave HEAD on it so
+        // HEAD != main. If start_point worked, the new worktree should point
+        // at main's tip, not HEAD.
+        git(&repo, &["checkout", "-q", "-b", "other"]);
+        git(&repo, &["commit", "--allow-empty", "-m", "other-c1"]);
+        let main_tip = git_stdout(&repo, &["rev-parse", "main"]);
+
+        let base = tmp.path().join("wts");
+        std::fs::create_dir_all(&base).unwrap();
+        let repo_str = repo.to_string_lossy().to_string();
+        let base_str = base.to_string_lossy().to_string();
+
+        let wt_path =
+            create_worktree(&repo_str, "feature-from-main", Some(&base_str), Some("main"))
+                .expect("create_worktree should succeed");
+
+        let wt_head = git_stdout(Path::new(&wt_path), &["rev-parse", "HEAD"]);
+        assert_eq!(wt_head, main_tip, "worktree HEAD should match main's tip");
+    }
+
+    #[test]
+    fn create_worktree_ignores_start_point_when_branch_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        init_repo(&repo);
+
+        git(&repo, &["checkout", "-q", "-b", "feature"]);
+        git(&repo, &["commit", "--allow-empty", "-m", "feature-c1"]);
+        let feature_tip = git_stdout(&repo, &["rev-parse", "feature"]);
+        git(&repo, &["checkout", "-q", "main"]);
+
+        let base = tmp.path().join("wts");
+        std::fs::create_dir_all(&base).unwrap();
+        let repo_str = repo.to_string_lossy().to_string();
+        let base_str = base.to_string_lossy().to_string();
+
+        // Even though start_point=main, since `feature` exists, we check it
+        // out and land on feature's tip.
+        let wt_path = create_worktree(&repo_str, "feature", Some(&base_str), Some("main"))
+            .expect("create_worktree should succeed");
+
+        let wt_head = git_stdout(Path::new(&wt_path), &["rev-parse", "HEAD"]);
+        assert_eq!(wt_head, feature_tip);
+    }
+
+    #[test]
+    fn create_worktree_invalid_start_point_returns_typed_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        init_repo(&repo);
+
+        let base = tmp.path().join("wts");
+        std::fs::create_dir_all(&base).unwrap();
+        let repo_str = repo.to_string_lossy().to_string();
+        let base_str = base.to_string_lossy().to_string();
+
+        let err = create_worktree(
+            &repo_str,
+            "will-not-create",
+            Some(&base_str),
+            Some("definitely-not-a-ref"),
+        )
+        .expect_err("should fail with InvalidStartPoint");
+
+        match err {
+            WorktreeError::InvalidStartPoint { start_point } => {
+                assert_eq!(start_point, "definitely-not-a-ref");
+            }
+            other => panic!("expected InvalidStartPoint, got {:?}", other),
+        }
     }
 }

--- a/crates/roux-core/src/worktree.rs
+++ b/crates/roux-core/src/worktree.rs
@@ -129,9 +129,15 @@ fn branch_exists(repo_path: &str, branch: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// `true` iff `rev` resolves to a commit in `repo_path`. The `^{commit}`
+/// peel rejects refs that exist but don't point at a commit (e.g. annotated
+/// tag objects pointing at trees/blobs, or `HEAD` in an unborn repo). This
+/// keeps our `InvalidStartPoint` error text truthful ("does not resolve to
+/// a commit") and avoids handing git a non-commit start point for
+/// `worktree add -b`.
 fn rev_exists(repo_path: &str, rev: &str) -> bool {
     Command::new("git")
-        .args(["rev-parse", "--verify", rev])
+        .args(["rev-parse", "--verify", &format!("{}^{{commit}}", rev)])
         .current_dir(repo_path)
         .output()
         .map(|o| o.status.success())
@@ -557,5 +563,28 @@ mod tests {
             }
             other => panic!("expected InvalidStartPoint, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn create_worktree_start_point_accepts_annotated_tag() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        init_repo(&repo);
+        // Annotated tags are a separate object type but peel to a commit via
+        // `^{commit}`, so they should be accepted as a start point.
+        git(&repo, &["tag", "-a", "v1", "-m", "first tag"]);
+        let tag_commit = git_stdout(&repo, &["rev-parse", "v1^{commit}"]);
+
+        let base = tmp.path().join("wts");
+        std::fs::create_dir_all(&base).unwrap();
+        let repo_str = repo.to_string_lossy().to_string();
+        let base_str = base.to_string_lossy().to_string();
+
+        let wt_path = create_worktree(&repo_str, "feature-from-tag", Some(&base_str), Some("v1"))
+            .expect("create_worktree should accept annotated tag as start point");
+
+        let wt_head = git_stdout(Path::new(&wt_path), &["rev-parse", "HEAD"]);
+        assert_eq!(wt_head, tag_commit);
     }
 }

--- a/docs/features/worktrees.md
+++ b/docs/features/worktrees.md
@@ -44,13 +44,20 @@ Open the palette with ++cmd+k++ and run **New Worktree**. The palette drills int
 
 ### Default starting point
 
-In **Settings → Sessions**, the **New Worktree default** control picks which of the three starting points is used when you click **New Worktree** directly (as opposed to hovering to expose the flyout):
+In **Settings → Sessions**, the **New Worktree default** control picks which starting point is used whenever Roux creates a worktree without an explicit per-invocation base. This covers both:
 
-- **Current** (default) — the session's current branch. Matches the original click behavior before the base picker existed, so no muscle-memory breakage.
+- Clicking **New Worktree** directly in the session context menu (no hover), and
+- Creating a **new worktree session** from the **New Session** dialog (pasting a PR URL or typing a new branch name).
+
+Options:
+
+- **Current branch** (default) — the session's current branch. Matches the original click behavior before the base picker existed, so no muscle-memory breakage.
 - **main** — always branch from local `main`. Good if your personal workflow always spins new branches off `main`.
 - **origin/main** — always fetch origin and branch from `origin/main`. Good for teams that expect every new feature branch to start from an up-to-date remote.
 
-The flyout and command palette always expose all three options regardless of this setting — it only controls the click-without-hover default.
+The context-menu flyout and the command palette always expose all three options regardless of this setting — it only controls the default used when you don't pick explicitly.
+
+> Existing branches (whether local or a PR head ref that's already been fetched) ignore this setting. Git only lets a branch point at one commit, so Roux checks out the existing branch and leaves its history alone.
 
 ## Worktree base path templates
 

--- a/docs/features/worktrees.md
+++ b/docs/features/worktrees.md
@@ -16,6 +16,42 @@ When creating a new session you can choose:
 
 The New Session dialog also supports pasting a GitHub PR URL. Roux can resolve the PR refs and create (or reuse) an appropriate local worktree for review.
 
+## Spawning a worktree from an existing session
+
+Any git-backed session can spawn a sibling worktree that branches from a chosen starting point. This is the fastest way to start a new feature branch without leaving the app.
+
+### From the session context menu
+
+Right-click a session in the sidebar and hover **New Worktree**. A flyout appears with three starting points:
+
+- **Current branch** — branch from the session's current `HEAD`.
+- **main** — branch from the local `main` branch.
+- **origin/main** — Roux runs `git fetch origin` first, then branches from the remote `origin/main` (useful when your local `main` may be stale).
+
+Pick one, type the new branch name, and hit ++enter++. Roux creates the worktree, spins up a Claude Code session in it, and attaches the sidebar.
+
+Clicking **New Worktree** directly (without hovering) uses your configured default — see [Default starting point](#default-starting-point) below.
+
+### From the command palette
+
+Open the palette with ++cmd+k++ and run **New Worktree**. The palette drills into the same three starting points, then prompts for a new branch name.
+
+### Starting-point resolution
+
+- Roux passes the starting point literally to `git worktree add -b <branch> <path> <start_point>`. That means **main**-named repos work out of the box; repos where the default is `master` (or anything else) will surface a clean `Invalid start point` error rather than a raw git stderr.
+- If you type a branch name that already exists, Roux ignores the chosen starting point and checks out the existing branch into the worktree instead (git's own semantics — a branch can only point at one commit).
+- **origin/main** fetches `origin` first. If the fetch fails (network, auth, etc.), the session is not created and the error is surfaced in the context menu.
+
+### Default starting point
+
+In **Settings → Sessions**, the **New Worktree default** control picks which of the three starting points is used when you click **New Worktree** directly (as opposed to hovering to expose the flyout):
+
+- **Current** (default) — the session's current branch. Matches the original click behavior before the base picker existed, so no muscle-memory breakage.
+- **main** — always branch from local `main`. Good if your personal workflow always spins new branches off `main`.
+- **origin/main** — always fetch origin and branch from `origin/main`. Good for teams that expect every new feature branch to start from an up-to-date remote.
+
+The flyout and command palette always expose all three options regardless of this setting — it only controls the click-without-hover default.
+
 ## Worktree base path templates
 
 In **Settings → Sessions**, `Worktree base path` supports template variables:

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -9,7 +9,7 @@ Settings are grouped into categories in a sidebar modal. Changes are persisted a
 ## Sections
 
 - **General** — theme, tab position, status bar position.
-- **Sessions** — close/reconnect behavior, default project path, repo roots quick-pick sources, worktree base template, and worktree cleanup mode.
+- **Sessions** — close/reconnect behavior, default project path, repo roots quick-pick sources, worktree base template, worktree cleanup mode, and the New Worktree default starting point.
 - **Terminal** — font, scrollback, and cursor settings.
 - **Claude** — binary path override, default model, additional flags.
 - **Integrations** — GitHub CLI (`gh`) path override for PR/session integrations.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roux",
-  "version": "0.4.5-alpha.10",
+  "version": "0.4.5-alpha.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roux",
-      "version": "0.4.5-alpha.10",
+      "version": "0.4.5-alpha.12",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/src-tauri/src/commands/sessions.rs
+++ b/src-tauri/src/commands/sessions.rs
@@ -1,6 +1,33 @@
 use crate::services::sessions as svc;
 use crate::session::Session;
 use crate::state::AppState;
+use serde::{Deserialize, Serialize};
+
+/// Options bag for `create_session_shell`. Bundled because Specta caps command
+/// signatures at 10 params, and the Claude/Codex/worktree spawn paths all
+/// share the same set of optional configuration.
+#[derive(Debug, Default, Deserialize, Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CreateShellOpts {
+    #[serde(default)]
+    pub nono_profile: Option<String>,
+    #[serde(default)]
+    pub nono_allow_dirs: Option<Vec<String>>,
+    /// Spawn-profile id (`claude`, `codex`, user-profile id, …). Passed to
+    /// the PTY env so agents wake up under the right profile.
+    #[serde(default)]
+    pub profile: Option<String>,
+    #[serde(default)]
+    pub initial_size: Option<(u16, u16)>,
+    /// Git starting point for a new worktree's branch (e.g. "main",
+    /// "origin/main"). Ignored unless `branch` is set and new.
+    #[serde(default)]
+    pub base: Option<String>,
+    /// Run `git fetch origin` before resolving `base`. Used for
+    /// `origin/*`-style bases that may be stale locally.
+    #[serde(default)]
+    pub fetch_first: Option<bool>,
+}
 
 #[tauri::command]
 #[specta::specta]
@@ -204,23 +231,28 @@ pub(crate) async fn create_session_shell(
     name: String,
     worktree_path: Option<String>,
     branch: Option<String>,
-    nono_profile: Option<String>,
-    nono_allow_dirs: Option<Vec<String>>,
-    profile: Option<String>,
-    initial_size: Option<(u16, u16)>,
+    opts: Option<CreateShellOpts>,
     state: tauri::State<'_, AppState>,
     app: tauri::AppHandle,
 ) -> Result<Session, String> {
     use crate::pty::NonoConfig;
+    let opts = opts.unwrap_or_default();
     // Clone before await — the MutexGuard is not Send.
     let settings = state.settings.lock().unwrap().clone();
-    let nono = nono_profile
-        .map(|profile| NonoConfig { profile, allow_dirs: nono_allow_dirs.unwrap_or_default() });
+    let nono = opts.nono_profile.map(|profile| NonoConfig {
+        profile,
+        allow_dirs: opts.nono_allow_dirs.unwrap_or_default(),
+    });
+    let initial_size = opts.initial_size;
 
     let target = if let Some(ref wt_path) = worktree_path {
         svc::SessionTarget::ExistingWorktree { path: wt_path }
     } else if let Some(ref br) = branch {
-        svc::SessionTarget::NewWorktree { branch: br }
+        svc::SessionTarget::NewWorktree {
+            branch: br,
+            start_point: opts.base.as_deref(),
+            fetch_first: opts.fetch_first.unwrap_or(false),
+        }
     } else {
         svc::SessionTarget::Repo
     };
@@ -233,7 +265,7 @@ pub(crate) async fn create_session_shell(
         &name,
         target,
         nono.as_ref(),
-        profile.as_deref(),
+        opts.profile.as_deref(),
         initial_size,
         &app,
     )

--- a/src-tauri/src/commands/worktrees.rs
+++ b/src-tauri/src/commands/worktrees.rs
@@ -10,7 +10,8 @@ pub(crate) fn cmd_create_worktree(
 ) -> Result<String, String> {
     let settings = state.settings.lock().unwrap();
     let base_path = settings.worktree_base_path.as_deref();
-    crate::worktree::create_worktree(&repo_path, &branch, base_path).map_err(|e| e.to_string())
+    crate::worktree::create_worktree(&repo_path, &branch, base_path, None)
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]

--- a/src-tauri/src/services/sessions.rs
+++ b/src-tauri/src/services/sessions.rs
@@ -114,7 +114,15 @@ pub(crate) enum SessionTarget<'a> {
     /// Use an existing worktree path. The session does NOT own this worktree.
     ExistingWorktree { path: &'a str },
     /// Create a new worktree from a branch. The session owns this worktree.
-    NewWorktree { branch: &'a str },
+    /// When `start_point` is `Some(sp)` and the branch is new, the branch is
+    /// created from `sp` instead of HEAD. When `fetch_first` is true, we
+    /// `git fetch origin` before resolving the start point (used for
+    /// `origin/main`-style bases that may be stale).
+    NewWorktree {
+        branch: &'a str,
+        start_point: Option<&'a str>,
+        fetch_first: bool,
+    },
 }
 
 /// Create a session with a plain shell in its primary PTY. The shell is
@@ -145,9 +153,13 @@ pub(crate) async fn create_session_shell(
             let br = get_current_branch(path).unwrap_or_else(|| "main".to_string());
             (path.to_string(), br, false)
         }
-        SessionTarget::NewWorktree { branch } => {
+        SessionTarget::NewWorktree { branch, start_point, fetch_first } => {
+            if fetch_first {
+                crate::worktree::fetch_origin(repo_path)?;
+            }
             let base = settings.worktree_base_path.as_deref();
-            let wt_path = crate::worktree::create_worktree(repo_path, branch, base)?;
+            let wt_path =
+                crate::worktree::create_worktree(repo_path, branch, base, start_point)?;
             (wt_path, branch.to_string(), true)
         }
         SessionTarget::Repo => {

--- a/src-tauri/src/socket.rs
+++ b/src-tauri/src/socket.rs
@@ -683,7 +683,7 @@ async fn handle_session_create(req: Request, app: &tauri::AppHandle) -> Response
     // Build the session target. worktree_branch wins; else treat a distinct
     // working_dir as an existing worktree; else use the repo directly.
     let target = if let Some(branch) = worktree_branch.as_deref() {
-        SessionTarget::NewWorktree { branch }
+        SessionTarget::NewWorktree { branch, start_point: None, fetch_first: false }
     } else {
         match &working_dir {
             Some(dir) if dir != &repo_path => SessionTarget::ExistingWorktree { path: dir },

--- a/src-tauri/src/worktree.rs
+++ b/src-tauri/src/worktree.rs
@@ -1,2 +1,2 @@
 // Worktree operations are now in roux-core. Re-export everything.
-pub use roux_core::{create_worktree, list_worktrees, remove_worktree, Worktree};
+pub use roux_core::{create_worktree, fetch_origin, list_worktrees, remove_worktree, Worktree};

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -57,7 +57,26 @@ export const commands = {
 	 *  shell is ready. Used for every non-claude profile in the new-session
 	 *  picker (Codex, Plain shell, user profiles, inline Custom…).
 	 */
-	createSessionShell: (repoPath: string, name: string, worktreePath: string | null, branch: string | null, nonoProfile: string | null, nonoAllowDirs: string[] | null, profile: string | null, initialSize: [number, number] | null) => typedError<Session, string>(__TAURI_INVOKE("create_session_shell", { repoPath, name, worktreePath, branch, nonoProfile, nonoAllowDirs, profile, initialSize })),
+	createSessionShell: (repoPath: string, name: string, worktreePath: string | null, branch: string | null, opts: {
+	nonoProfile?: string | null,
+	nonoAllowDirs?: string[] | null,
+	/**
+	 *  Spawn-profile id (`claude`, `codex`, user-profile id, …). Passed to
+	 *  the PTY env so agents wake up under the right profile.
+	 */
+	profile?: string | null,
+	initialSize?: [number, number] | null,
+	/**
+	 *  Git starting point for a new worktree's branch (e.g. "main",
+	 *  "origin/main"). Ignored unless `branch` is set and new.
+	 */
+	base?: string | null,
+	/**
+	 *  Run `git fetch origin` before resolving `base`. Used for
+	 *  `origin/*`-style bases that may be stale locally.
+	 */
+	fetchFirst?: boolean | null,
+} | null) => typedError<Session, string>(__TAURI_INVOKE("create_session_shell", { repoPath, name, worktreePath, branch, opts })),
 	/**
 	 *  Respawns a plain shell in the session's primary PTY. The frontend
 	 *  replays the pane's spawn profile commands into the fresh shell after
@@ -195,6 +214,28 @@ export type ClaudeSession = {
 	sessionId: string,
 	summary: string,
 	modifiedAt: number,
+};
+
+/**
+ *  Options bag for `create_session_shell`. Bundled because Specta caps command
+ *  signatures at 10 params, and the Claude/Codex/worktree spawn paths all
+ *  share the same set of optional configuration.
+ */
+export type CreateShellOpts = {
+	nonoProfile?: string | null,
+	nonoAllowDirs?: string[] | null,
+	initialCols?: number | null,
+	initialRows?: number | null,
+	/**
+	 *  Git starting point for a new worktree's branch (e.g. "main",
+	 *  "origin/main"). Ignored unless `branch` is set and new.
+	 */
+	base?: string | null,
+	/**
+	 *  Run `git fetch origin` before resolving `base`. Used for
+	 *  `origin/*`-style bases that may be stale locally.
+	 */
+	fetchFirst?: boolean | null,
 };
 
 export type CreateWatchConfig = {
@@ -572,6 +613,11 @@ export type RouxSettings = {
 	 */
 	cleanupWorktreesOnClose: boolean,
 	worktreeCleanupOnClose?: WorktreeCleanupMode,
+	/**
+	 *  Default starting point when the user clicks "New Worktree" directly.
+	 *  The flyout / command palette still let them override per-invocation.
+	 */
+	worktreeDefaultBase?: WorktreeDefaultBase,
 	theme: string,
 	defaultModel: string | null,
 	claudeBinaryPath?: string | null,
@@ -794,6 +840,18 @@ export type Worktree = {
  *  - `Always` — remove without asking (matches legacy `true`)
  */
 export type WorktreeCleanupMode = "never" | "prompt" | "always";
+
+/**
+ *  Which starting point the "New Worktree" affordance uses when the user
+ *  clicks the primary action directly (as opposed to hovering to pick a
+ *  specific base from the flyout). Only affects the default — the three
+ *  options remain available via the submenu / command palette either way.
+ * 
+ *  - `CurrentBranch` — the session's current branch (matches legacy behavior)
+ *  - `Main` — the local `main` branch
+ *  - `OriginMain` — the remote `origin/main`, with a `git fetch origin` first
+ */
+export type WorktreeDefaultBase = "currentBranch" | "main" | "originMain";
 
 /* Tauri Specta runtime */
 async function typedError<T, E>(result: Promise<T>): Promise<{ status: "ok"; data: T } | { status: "error"; error: E }> {

--- a/src/lib/commands/sessions.ts
+++ b/src/lib/commands/sessions.ts
@@ -208,7 +208,12 @@ export function registerSessionCommands() {
   registerWorktreeChild({
     id: "session.new-worktree-from-current",
     label: "New Worktree (from current branch)",
-    resolveBase: () => queries.activeSession()?.branch ?? null,
+    // Detached-HEAD sessions report `branch` as "" — normalize to null so
+    // backend falls back to HEAD instead of failing start-point validation.
+    resolveBase: () => {
+      const branch = queries.activeSession()?.branch?.trim();
+      return branch ? branch : null;
+    },
     fetchFirst: false,
   });
   registerWorktreeChild({

--- a/src/lib/commands/sessions.ts
+++ b/src/lib/commands/sessions.ts
@@ -6,7 +6,7 @@ import { projects } from "$lib/stores/projects";
 import { settings } from "$lib/stores/settings";
 import { getVisualSessionOrder } from "$lib/sessions/order";
 import { initSessionWithProfile } from "$lib/panes/actions";
-import { createSessionShell, openInEditor, listBranches, listProjects, setSessionProject as tauriSetSessionProject } from "$lib/tauri";
+import { createSessionShell, openInEditor, listProjects, setSessionProject as tauriSetSessionProject } from "$lib/tauri";
 import type { SpawnProfileRef } from "$lib/panes/profiles";
 import { closeSession } from "$lib/sessions/close";
 import { reconnectSession } from "$lib/sessions/reconnect";
@@ -15,8 +15,18 @@ import { reconnectSession } from "$lib/sessions/reconnect";
  * Create a worktree-backed session that launches the built-in Claude profile.
  * Resolves the profile's nono config up-front so the primary shell is
  * nono-wrapped from the start, matching the layout/dialog paths.
+ *
+ * `base` is the git starting point for the new branch ("main", "origin/main",
+ * or the session's current branch). When `fetchFirst` is true, the backend
+ * runs `git fetch origin` before branching — used for `origin/*` bases.
  */
-async function createWorktreeClaudeSession(repo: string, name: string, branch: string) {
+async function createWorktreeClaudeSession(
+  repo: string,
+  name: string,
+  branch: string,
+  base: string | null,
+  fetchFirst: boolean,
+) {
   const { resolveProfileRef } = await import("$lib/panes/profiles");
   const { runProfileInPane } = await import("$lib/panes/profileRunner");
   const profileRef: SpawnProfileRef = { kind: "registered", id: "claude" };
@@ -26,9 +36,7 @@ async function createWorktreeClaudeSession(repo: string, name: string, branch: s
 
   const newSession = await createSessionShell(
     repo, name, null, branch,
-    nonoProfile, nonoAllowDirs,
-    null, // initialSize
-    "claude", // profile
+    { nonoProfile, nonoAllowDirs, profile: "claude", base, fetchFirst },
   );
   addSession(newSession);
   const mainPaneId = initSessionWithProfile(newSession.id, profileRef, {
@@ -38,6 +46,30 @@ async function createWorktreeClaudeSession(repo: string, name: string, branch: s
   const { connectPaneTerminal } = await import("$lib/panes/terminals");
   await connectPaneTerminal(mainPaneId);
   if (profile) await runProfileInPane(newSession.id, profile);
+}
+
+function registerWorktreeChild(opts: {
+  id: string;
+  label: string;
+  resolveBase: () => string | null;
+  fetchFirst: boolean;
+}) {
+  registry.register({
+    id: opts.id,
+    label: opts.label,
+    category: "Sessions",
+    available: () => !!queries.activeSession(),
+    inputPlaceholder: "New branch name (e.g. feature/my-thing)...",
+    getItems: () => [],
+    onInput: async (branch: string) => {
+      const session = queries.activeSession();
+      if (!session || !branch.trim()) return;
+      const repo = session.repoRoot;
+      const name = repo.split("/").pop() + "-" + branch;
+      const base = opts.resolveBase();
+      await createWorktreeClaudeSession(repo, name, branch.trim(), base, opts.fetchFirst);
+    },
+  });
 }
 
 export function registerSessionCommands() {
@@ -144,33 +176,52 @@ export function registerSessionCommands() {
   });
 
   // -- Worktree --
+  // Parent: drill into base picker. Matches the pattern used by `watch.add`
+  // in commands/watches.ts.
   registry.register({
     id: "session.new-worktree",
     label: "New Worktree",
     category: "Sessions",
     available: () => !!queries.activeSession(),
-    inputPlaceholder: "Branch name (pick existing or type new)...",
-    getItems: async () => {
-      const session = queries.activeSession();
-      if (!session) return [];
-      const branches = await listBranches(session.repoRoot).catch(() => [] as string[]);
-      return branches.map((branch) => ({
-        id: branch,
-        label: branch,
-        action: async () => {
-          const repo = session.repoRoot;
-          const name = repo.split("/").pop() + "-" + branch;
-          await createWorktreeClaudeSession(repo, name, branch);
-        },
-      }));
-    },
-    onInput: async (branch: string) => {
-      const session = queries.activeSession();
-      if (!session) return;
-      const repo = session.repoRoot;
-      const name = repo.split("/").pop() + "-" + branch;
-      await createWorktreeClaudeSession(repo, name, branch);
-    },
+    getItems: () => [
+      {
+        id: "current",
+        label: "From current branch",
+        description: "Branch from this session's current branch",
+        drillCommand: "session.new-worktree-from-current",
+      },
+      {
+        id: "main",
+        label: "From main",
+        description: "Branch from local main",
+        drillCommand: "session.new-worktree-from-main",
+      },
+      {
+        id: "origin-main",
+        label: "From origin/main",
+        description: "Fetches origin, then branches from origin/main",
+        drillCommand: "session.new-worktree-from-origin-main",
+      },
+    ],
+  });
+
+  registerWorktreeChild({
+    id: "session.new-worktree-from-current",
+    label: "New Worktree (from current branch)",
+    resolveBase: () => queries.activeSession()?.branch ?? null,
+    fetchFirst: false,
+  });
+  registerWorktreeChild({
+    id: "session.new-worktree-from-main",
+    label: "New Worktree (from main)",
+    resolveBase: () => "main",
+    fetchFirst: false,
+  });
+  registerWorktreeChild({
+    id: "session.new-worktree-from-origin-main",
+    label: "New Worktree (from origin/main)",
+    resolveBase: () => "origin/main",
+    fetchFirst: true,
   });
 
   // -- Simple commands (handled externally via callbacks) --

--- a/src/lib/components/NewSessionDialog.svelte
+++ b/src/lib/components/NewSessionDialog.svelte
@@ -761,10 +761,12 @@
           name,
           worktreePathArg,
           branchArg,
-          firstLeafInfo.nonoProfile ?? undefined,
-          firstLeafInfo.nonoAllowDirs ?? undefined,
-          initialSize,
-          firstLeafInfo.profileId ?? undefined,
+          {
+            nonoProfile: firstLeafInfo.nonoProfile ?? undefined,
+            nonoAllowDirs: firstLeafInfo.nonoAllowDirs ?? undefined,
+            initialSize,
+            profile: firstLeafInfo.profileId ?? undefined,
+          },
         );
         log(`Session created via layout: ${session.id}`);
         addSession(session);
@@ -804,10 +806,12 @@
         name,
         worktreePathArg,
         branchArg,
-        effectiveNono.nonoProfile,
-        effectiveNono.nonoAllowDirs,
-        initialSize,
-        profile.id,
+        {
+          nonoProfile: effectiveNono.nonoProfile,
+          nonoAllowDirs: effectiveNono.nonoAllowDirs,
+          initialSize,
+          profile: profile.id,
+        },
       );
 
       log(`Session created: ${session.id}`);

--- a/src/lib/components/NewSessionDialog.svelte
+++ b/src/lib/components/NewSessionDialog.svelte
@@ -695,6 +695,24 @@
     return { worktreePathArg: null, branchArg: query, label: query };
   }
 
+  /**
+   * Resolve the default starting point for a newly created worktree based on
+   * the `worktreeDefaultBase` setting. Only meaningful when a new branch is
+   * being created (backend ignores `base`/`fetchFirst` for existing branches
+   * and existing-worktree paths, so passing these unconditionally is safe).
+   */
+  function resolveDefaultBase(): { base: string | null; fetchFirst: boolean } {
+    switch ($settings.worktreeDefaultBase ?? "currentBranch") {
+      case "main":
+        return { base: "main", fetchFirst: false };
+      case "originMain":
+        return { base: "origin/main", fetchFirst: true };
+      case "currentBranch":
+      default:
+        return { base: null, fetchFirst: false };
+    }
+  }
+
   function formatRepoShortLabel(path: string, depth: number = 2): string {
     const normalized = path.replaceAll("\\", "/");
     const segments = normalized.split("/").filter(Boolean);
@@ -756,6 +774,7 @@
         // primary PTY is spawned now by createSessionShell, not by the
         // layout walker (which only spawns PTYs for leaves 2..N).
         const firstLeafInfo = resolveFirstLeafNono(selectedLayout);
+        const defaultBase = resolveDefaultBase();
         const session = await createSessionShell(
           repoPath,
           name,
@@ -766,6 +785,8 @@
             nonoAllowDirs: firstLeafInfo.nonoAllowDirs ?? undefined,
             initialSize,
             profile: firstLeafInfo.profileId ?? undefined,
+            base: defaultBase.base,
+            fetchFirst: defaultBase.fetchFirst,
           },
         );
         log(`Session created via layout: ${session.id}`);
@@ -798,6 +819,7 @@
       // allow_dirs — they describe what that profile needs to work, and
       // aren't tied to a specific sandbox profile name.
       const effectiveNono = resolveNonoForProfile(profile, selectedNonoProfile);
+      const defaultBase = resolveDefaultBase();
 
       // Spawn a shell (optionally nono-wrapped), then type the profile's
       // setup / startup commands into it after the PTY is attached.
@@ -811,6 +833,8 @@
           nonoAllowDirs: effectiveNono.nonoAllowDirs,
           initialSize,
           profile: profile.id,
+          base: defaultBase.base,
+          fetchFirst: defaultBase.fetchFirst,
         },
       );
 

--- a/src/lib/components/SessionTabs.svelte
+++ b/src/lib/components/SessionTabs.svelte
@@ -79,6 +79,9 @@
 
   let contextMenu = $state<{ x: number; y: number; session: Session } | null>(null);
   let worktreeInput = $state(false);
+  let worktreeBase = $state<string | null>(null);
+  let worktreeBaseLabel = $state("");
+  let worktreeFetchFirst = $state(false);
   let branchName = $state("");
   let creatingWorktree = $state(false);
   let worktreeError = $state("");
@@ -90,6 +93,9 @@
   function handleContextMenu(e: MouseEvent, session: Session) {
     contextMenu = { x: e.clientX, y: e.clientY, session };
     worktreeInput = false;
+    worktreeBase = null;
+    worktreeBaseLabel = "";
+    worktreeFetchFirst = false;
     branchName = "";
     worktreeError = "";
   }
@@ -97,6 +103,9 @@
   function closeContextMenu() {
     contextMenu = null;
     worktreeInput = false;
+    worktreeBase = null;
+    worktreeBaseLabel = "";
+    worktreeFetchFirst = false;
     branchName = "";
     worktreeError = "";
     projectMenu = false;
@@ -104,8 +113,28 @@
     newProjectName = "";
   }
 
-  function showWorktreeInput() {
+  function pickWorktreeBase(base: string | null, label: string, fetchFirst: boolean) {
+    worktreeBase = base;
+    worktreeBaseLabel = label;
+    worktreeFetchFirst = fetchFirst;
     worktreeInput = true;
+  }
+
+  function pickDefaultWorktreeBase() {
+    const session = contextMenu?.session;
+    if (!session) return;
+    switch ($settings.worktreeDefaultBase ?? "currentBranch") {
+      case "main":
+        pickWorktreeBase("main", "main", false);
+        break;
+      case "originMain":
+        pickWorktreeBase("origin/main", "origin/main", true);
+        break;
+      case "currentBranch":
+      default:
+        pickWorktreeBase(session.branch, "current branch", false);
+        break;
+    }
   }
 
   function showProjectMenu() {
@@ -148,9 +177,13 @@
 
       const session = await createSessionShell(
         repo, name, null, branch,
-        nonoProfile, nonoAllowDirs,
-        null, // initialSize
-        "claude", // profile
+        {
+          nonoProfile,
+          nonoAllowDirs,
+          profile: "claude",
+          base: worktreeBase,
+          fetchFirst: worktreeFetchFirst,
+        },
       );
       log(`Worktree session created: ${session.id}`);
       addSession(session);
@@ -448,13 +481,42 @@
         Set Project
       </button>
       {#if contextMenu.session.isGitRepo}
-        <button
-          class="flex w-full cursor-pointer items-center gap-2 bg-transparent px-3 py-2 text-left text-xs text-text-secondary hover:bg-bg-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50 focus-visible:ring-offset-1 focus-visible:ring-offset-bg-base"
-          onclick={showWorktreeInput}
-        >
-          <span class="text-[11px] text-text-secondary">&#9095;</span>
-          New Worktree
-        </button>
+        <!-- svelte-ignore a11y_no_static_element_interactions -->
+        <!-- svelte-ignore a11y_mouse_events_have_key_events -->
+        <div class="group relative">
+          <button
+            class="flex w-full cursor-pointer items-center gap-2 bg-transparent px-3 py-2 text-left text-xs text-text-secondary hover:bg-bg-hover hover:text-text-primary group-hover:bg-bg-hover group-hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50 focus-visible:ring-offset-1 focus-visible:ring-offset-bg-base"
+            onclick={pickDefaultWorktreeBase}
+          >
+            <span class="text-[11px] text-text-secondary">&#9095;</span>
+            New Worktree
+            <span class="ml-auto text-[10px] text-text-muted">&#9654;</span>
+          </button>
+          <!-- Hover-flyout submenu: appears to the right, aligned to the button's top. -->
+          <div
+            class="ui-dialog invisible absolute left-full top-0 z-50 ml-0.5 min-w-48 py-1 opacity-0 transition-opacity duration-75 group-hover:visible group-hover:opacity-100"
+          >
+            <div class="px-2 py-1 text-[10px] font-medium uppercase tracking-wider text-text-muted">Branch from</div>
+            <button
+              class="flex w-full cursor-pointer items-center gap-2 bg-transparent px-3 py-1.5 text-left text-xs text-text-secondary hover:bg-bg-hover hover:text-text-primary"
+              onclick={() => pickWorktreeBase(contextMenu?.session.branch ?? null, "current branch", false)}
+            >
+              Current branch
+            </button>
+            <button
+              class="flex w-full cursor-pointer items-center gap-2 bg-transparent px-3 py-1.5 text-left text-xs text-text-secondary hover:bg-bg-hover hover:text-text-primary"
+              onclick={() => pickWorktreeBase("main", "main", false)}
+            >
+              main
+            </button>
+            <button
+              class="flex w-full cursor-pointer items-center gap-2 bg-transparent px-3 py-1.5 text-left text-xs text-text-secondary hover:bg-bg-hover hover:text-text-primary"
+              onclick={() => pickWorktreeBase("origin/main", "origin/main", true)}
+            >
+              origin/main
+            </button>
+          </div>
+        </div>
       {/if}
       <button
         class="flex w-full cursor-pointer items-center gap-2 bg-transparent px-3 py-2 text-left text-xs text-text-secondary hover:bg-bg-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50 focus-visible:ring-offset-1 focus-visible:ring-offset-bg-base"
@@ -465,7 +527,9 @@
       </button>
     {:else}
       <div class="px-3 py-2">
-        <div class="mb-1.5 text-[11px] text-text-muted">Branch name</div>
+        <div class="mb-1.5 text-[11px] text-text-muted">
+          New branch from {worktreeBaseLabel}
+        </div>
         <form
           onsubmit={(e) => {
             e.preventDefault();

--- a/src/lib/components/SessionTabs.svelte
+++ b/src/lib/components/SessionTabs.svelte
@@ -120,6 +120,73 @@
     worktreeInput = true;
   }
 
+  // Detached-HEAD sessions report `branch` as "" — treat that as "branch
+  // from HEAD" (null) rather than passing an empty start point through to
+  // backend `rev-parse --verify`.
+  function currentBranchBase(session: Session): string | null {
+    const trimmed = session.branch.trim();
+    return trimmed ? trimmed : null;
+  }
+
+  // Keyboard handler for the "New Worktree" trigger button: ArrowRight /
+  // ArrowDown opens the hover flyout by focusing its first menuitem.
+  // Enter/Space keep their native button behavior (activate onclick =
+  // pickDefaultWorktreeBase), so keyboard users get the same click-default
+  // semantics as mouse users.
+  function handleWorktreeTriggerKeydown(e: KeyboardEvent) {
+    if (e.key !== "ArrowRight" && e.key !== "ArrowDown") return;
+    e.preventDefault();
+    const trigger = e.currentTarget as HTMLElement;
+    const submenu = trigger.nextElementSibling;
+    const first = submenu?.querySelector<HTMLButtonElement>('button[role="menuitem"]');
+    first?.focus();
+  }
+
+  // Keyboard handler for items inside the "Branch from" flyout:
+  // Arrow up/down cycle through items, Home/End jump to endpoints, and
+  // Escape returns focus to the trigger (which collapses the flyout via
+  // `group-focus-within`).
+  function handleWorktreeMenuItemKeydown(e: KeyboardEvent) {
+    const current = e.currentTarget as HTMLButtonElement;
+    const parent = current.parentElement;
+    if (!parent) return;
+    const items = Array.from(
+      parent.querySelectorAll<HTMLButtonElement>('button[role="menuitem"]'),
+    );
+    const i = items.indexOf(current);
+    if (i < 0) return;
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        items[(i + 1) % items.length]?.focus();
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        items[(i - 1 + items.length) % items.length]?.focus();
+        break;
+      case "Home":
+        e.preventDefault();
+        items[0]?.focus();
+        break;
+      case "End":
+        e.preventDefault();
+        items[items.length - 1]?.focus();
+        break;
+      case "Escape": {
+        e.preventDefault();
+        // Escape returns focus to the trigger, which collapses the flyout
+        // (the outer .group loses :focus-within). A second Escape would
+        // then need to be handled by the context-menu level — currently
+        // the context menu closes on outside click, not Escape.
+        const trigger = parent.parentElement?.querySelector<HTMLButtonElement>(
+          ":scope > button",
+        );
+        trigger?.focus();
+        break;
+      }
+    }
+  }
+
   function pickDefaultWorktreeBase() {
     const session = contextMenu?.session;
     if (!session) return;
@@ -132,7 +199,7 @@
         break;
       case "currentBranch":
       default:
-        pickWorktreeBase(session.branch, "current branch", false);
+        pickWorktreeBase(currentBranchBase(session), "current branch", false);
         break;
     }
   }
@@ -481,37 +548,50 @@
         Set Project
       </button>
       {#if contextMenu.session.isGitRepo}
-        <!-- svelte-ignore a11y_no_static_element_interactions -->
-        <!-- svelte-ignore a11y_mouse_events_have_key_events -->
         <div class="group relative">
           <button
-            class="flex w-full cursor-pointer items-center gap-2 bg-transparent px-3 py-2 text-left text-xs text-text-secondary hover:bg-bg-hover hover:text-text-primary group-hover:bg-bg-hover group-hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50 focus-visible:ring-offset-1 focus-visible:ring-offset-bg-base"
+            class="flex w-full cursor-pointer items-center gap-2 bg-transparent px-3 py-2 text-left text-xs text-text-secondary hover:bg-bg-hover hover:text-text-primary group-hover:bg-bg-hover group-hover:text-text-primary group-focus-within:bg-bg-hover group-focus-within:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50 focus-visible:ring-offset-1 focus-visible:ring-offset-bg-base"
             onclick={pickDefaultWorktreeBase}
+            onkeydown={handleWorktreeTriggerKeydown}
+            aria-haspopup="menu"
           >
             <span class="text-[11px] text-text-secondary">&#9095;</span>
             New Worktree
             <span class="ml-auto text-[10px] text-text-muted">&#9654;</span>
           </button>
-          <!-- Hover-flyout submenu: appears to the right, aligned to the button's top. -->
+          <!--
+            Flyout submenu: appears to the right, aligned to the button's top.
+            Visible on hover (mouse) OR on focus-within (keyboard tabbing into
+            any menuitem) — so keyboard-only users can reach the three base
+            options without the pointer.
+          -->
           <div
-            class="ui-dialog invisible absolute left-full top-0 z-50 ml-0.5 min-w-48 py-1 opacity-0 transition-opacity duration-75 group-hover:visible group-hover:opacity-100"
+            class="ui-dialog invisible absolute left-full top-0 z-50 ml-0.5 min-w-48 py-1 opacity-0 transition-opacity duration-75 group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100"
+            role="menu"
+            aria-label="Branch from"
           >
             <div class="px-2 py-1 text-[10px] font-medium uppercase tracking-wider text-text-muted">Branch from</div>
             <button
-              class="flex w-full cursor-pointer items-center gap-2 bg-transparent px-3 py-1.5 text-left text-xs text-text-secondary hover:bg-bg-hover hover:text-text-primary"
-              onclick={() => pickWorktreeBase(contextMenu?.session.branch ?? null, "current branch", false)}
+              class="flex w-full cursor-pointer items-center gap-2 bg-transparent px-3 py-1.5 text-left text-xs text-text-secondary hover:bg-bg-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50"
+              role="menuitem"
+              onclick={() => contextMenu && pickWorktreeBase(currentBranchBase(contextMenu.session), "current branch", false)}
+              onkeydown={handleWorktreeMenuItemKeydown}
             >
               Current branch
             </button>
             <button
-              class="flex w-full cursor-pointer items-center gap-2 bg-transparent px-3 py-1.5 text-left text-xs text-text-secondary hover:bg-bg-hover hover:text-text-primary"
+              class="flex w-full cursor-pointer items-center gap-2 bg-transparent px-3 py-1.5 text-left text-xs text-text-secondary hover:bg-bg-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50"
+              role="menuitem"
               onclick={() => pickWorktreeBase("main", "main", false)}
+              onkeydown={handleWorktreeMenuItemKeydown}
             >
               main
             </button>
             <button
-              class="flex w-full cursor-pointer items-center gap-2 bg-transparent px-3 py-1.5 text-left text-xs text-text-secondary hover:bg-bg-hover hover:text-text-primary"
+              class="flex w-full cursor-pointer items-center gap-2 bg-transparent px-3 py-1.5 text-left text-xs text-text-secondary hover:bg-bg-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50"
+              role="menuitem"
               onclick={() => pickWorktreeBase("origin/main", "origin/main", true)}
+              onkeydown={handleWorktreeMenuItemKeydown}
             >
               origin/main
             </button>

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -434,7 +434,7 @@
             <div class="flex items-center justify-between py-2">
               <div>
                 <div class="text-[13px]">New Worktree default</div>
-                <div class="text-[11px] text-text-muted mt-0.5">Starting point when you click "New Worktree" directly (hover still exposes all three)</div>
+                <div class="text-[11px] text-text-muted mt-0.5">Default starting point for new worktree branches — applies to the New Session dialog and the "New Worktree" context-menu click. Hover / command palette always expose all three.</div>
               </div>
               <select
                 class="bg-bg-deep border border-border rounded px-2 py-1 font-mono text-xs text-text-primary outline-none cursor-pointer appearance-none pr-6"

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -5,7 +5,7 @@
   import { getLogPath, setLoggingEnabled } from "$lib/logging";
   import { notificationsPush } from "$lib/tauri";
   import { commands } from "$lib/bindings";
-  import type { UpdateChannel, WorktreeCleanupMode } from "$lib/bindings";
+  import type { UpdateChannel, WorktreeCleanupMode, WorktreeDefaultBase } from "$lib/bindings";
   import { updateStatus, runManualCheck, performInstall } from "$lib/stores/updater";
   import { getVersion } from "@tauri-apps/api/app";
   import { quitApp } from "$lib/tauri";
@@ -166,6 +166,10 @@
     // Keep the legacy boolean in sync so any older readers (settings files,
     // pre-migration code) still agree with the frontend.
     updateSetting("cleanupWorktreesOnClose", mode === "always");
+  }
+
+  function setDefaultBase(mode: WorktreeDefaultBase) {
+    updateSetting("worktreeDefaultBase", mode);
   }
 
   async function browseAndAddRepoRoot() {
@@ -426,6 +430,21 @@
                   >{opt.label}</button>
                 {/each}
               </div>
+            </div>
+            <div class="flex items-center justify-between py-2">
+              <div>
+                <div class="text-[13px]">New Worktree default</div>
+                <div class="text-[11px] text-text-muted mt-0.5">Starting point when you click "New Worktree" directly (hover still exposes all three)</div>
+              </div>
+              <select
+                class="bg-bg-deep border border-border rounded px-2 py-1 font-mono text-xs text-text-primary outline-none cursor-pointer appearance-none pr-6"
+                value={$settings.worktreeDefaultBase ?? "currentBranch"}
+                onchange={(e) => setDefaultBase(e.currentTarget.value as WorktreeDefaultBase)}
+              >
+                <option value="currentBranch">Current branch</option>
+                <option value="main">main</option>
+                <option value="originMain">origin/main</option>
+              </select>
             </div>
           {:else if selected === "terminal"}
             <div class="flex items-center justify-between py-2">

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -23,6 +23,25 @@ export interface InitialPtySize {
   rows: number;
 }
 
+export interface CreateSessionShellOpts {
+  nonoProfile?: string | null;
+  nonoAllowDirs?: string[] | null;
+  initialSize?: InitialPtySize | null;
+  /**
+   * Spawn-profile id (`claude`, `codex`, user-profile id). Threaded into the
+   * PTY env so agents wake up under the right profile.
+   */
+  profile?: string | null;
+  /**
+   * Git starting point for a newly-created worktree branch (e.g. "main",
+   * "origin/main"). Only used when `branch` is a new branch; ignored for
+   * existing branches.
+   */
+  base?: string | null;
+  /** Run `git fetch origin` before resolving `base`. */
+  fetchFirst?: boolean;
+}
+
 /**
  * Spawns a plain shell in the session's primary PTY. Caller then attaches
  * a spawn profile and types its setup / startup commands into the shell.
@@ -37,20 +56,22 @@ export async function createSessionShell(
   name: string,
   worktreePath: string | null,
   branch: string | null,
-  nonoProfile?: string | null,
-  nonoAllowDirs?: string[] | null,
-  initialSize?: InitialPtySize | null,
-  profile?: string | null,
+  opts: CreateSessionShellOpts = {},
 ): Promise<Session> {
+  const { nonoProfile, nonoAllowDirs, initialSize, profile, base, fetchFirst } = opts;
   return invoke("create_session_shell", {
     repoPath,
     name,
     worktreePath,
     branch,
-    nonoProfile: nonoProfile ?? null,
-    nonoAllowDirs: nonoAllowDirs ?? null,
-    initialSize: initialSize ? [initialSize.cols, initialSize.rows] : null,
-    profile: profile ?? null,
+    opts: {
+      nonoProfile: nonoProfile ?? null,
+      nonoAllowDirs: nonoAllowDirs ?? null,
+      profile: profile ?? null,
+      initialSize: initialSize ? [initialSize.cols, initialSize.rows] : null,
+      base: base ?? null,
+      fetchFirst: fetchFirst ?? null,
+    },
   });
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -86,6 +86,7 @@ export const DEFAULT_SETTINGS: RouxSettings = {
   worktreeBasePath: null,
   cleanupWorktreesOnClose: false,
   worktreeCleanupOnClose: "prompt",
+  worktreeDefaultBase: "currentBranch",
   theme: "deep-blue",
   defaultModel: null,
   claudeBinaryPath: null,


### PR DESCRIPTION
## Summary

- Adds a base-branch picker to **New Worktree** in both entry points: the session context menu (hover flyout) and the command palette (drill-down). Pick from **current branch**, local **main**, or **origin/main** (fetches first).
- Adds **Settings → Sessions → New Worktree default** (native `<select>`) so a direct click on **New Worktree** uses the user's preferred base without requiring a hover. Hover/palette always expose all three.
- Backend: `create_worktree` now accepts an optional `start_point`, pre-validated with `git rev-parse`. New `WorktreeError::InvalidStartPoint` and `WorktreeError::FetchFailed` variants surface clean errors in the UI. `SessionTarget::NewWorktree` gained additive `start_point` + `fetch_first` fields; the `create_session_shell` Tauri command switched to a trailing `CreateShellOpts` struct (specta 10-arg cap) — frontend mirrors with a `CreateSessionShellOpts` bag.
- Docs: updated `docs/settings.md` and `docs/features/worktrees.md` with the new picker UX, starting-point resolution rules, and the default-base setting.

## Test plan

- [x] `cargo test -p roux-core` — 105 tests pass (3 new integration tests against real temp git repos: start-point branches from the right ref, existing branches ignore start-point, invalid start-point returns typed error)
- [x] `npm run check` — 0 errors / 0 warnings
- [x] `npm run test` — 355 tests pass
- [ ] Manual: right-click session → hover **New Worktree** → flyout shows the three options; picking each creates a worktree branched from the expected ref (verified via `git log -1` in the new worktree).
- [ ] Manual: command palette → `New Worktree` → drills into the three children; each accepts a new branch name.
- [ ] Manual: set **Settings → Sessions → New Worktree default** to `main` / `origin/main` → click **New Worktree** directly (no hover) → input opens pre-filled with that base.
- [ ] Manual: on a `master`-only repo, pick **From main** → clean "Invalid start point" error appears in the context menu (not raw git stderr).

🤖 Generated with [Claude Code](https://claude.com/claude-code)