### PR TITLE
fix(panes): propagate PTY name when attaching to an existing pane

### DIFF
--- a/src/lib/commands/panes.ts
+++ b/src/lib/commands/panes.ts
@@ -766,7 +766,7 @@ export function registerPaneCommands() {
           description: description.trim(),
           action: async () => {
             if (!currentPaneId) return;
-            await attachPtyToPane(currentPaneId, pty.id, { profile: pty.profile });
+            await attachPtyToPane(currentPaneId, pty.id, { profile: pty.profile, name: pty.name });
           },
         });
       }
@@ -783,7 +783,7 @@ export function registerPaneCommands() {
           description: `detached ${ago} · ${pty.working_dir || ""}`.trim(),
           action: async () => {
             if (!currentPaneId) return;
-            await attachPtyToPane(currentPaneId, pty.id, { profile: pty.profile });
+            await attachPtyToPane(currentPaneId, pty.id, { profile: pty.profile, name: pty.name });
           },
         });
       }

--- a/src/lib/panes/attach.ts
+++ b/src/lib/panes/attach.ts
@@ -17,6 +17,8 @@ import type { SpawnProfileRef } from "./profiles";
 export interface AttachOptions {
   /** Profile ID from the PTY (e.g. "claude", "codex"). Updates pane's spawnProfileRef. */
   profile?: string | null;
+  /** Display name from the PTY. Applied to the pane so the titlebar reflects the attached PTY. */
+  name?: string | null;
 }
 
 /**
@@ -74,6 +76,10 @@ export async function attachPtyToPane(
   if (options.profile) {
     const profileRef: SpawnProfileRef = { kind: "registered", id: options.profile };
     updates.spawnProfileRef = profileRef;
+  }
+
+  if (options.name !== undefined) {
+    updates.name = options.name ?? undefined;
   }
 
   // Update pane state to reflect the new attached PTY. `replacePty` already


### PR DESCRIPTION
## Summary
- Attaching a PTY to an already-existing pane (via the Attach Terminal palette) left the pane titlebar showing its previous name; the attached PTY's name was ignored.
- Thread `name` through `AttachOptions`, and apply it in the same `updateInstance` that flips `terminalState` to `attached`.
- Palette action now passes `pty.name` alongside `pty.profile`.

## Test plan
- [ ] Start a PTY with a set name, detach it by closing its pane.
- [ ] Focus another shell pane and run `Attach Terminal…`; pick the detached PTY.
- [ ] Verify the target pane's titlebar updates to the PTY's name.
- [ ] Verify scrollback/history renders in the target pane.
- [ ] `npm run check` and `npm run test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)