### PR TITLE
fix(build): disable Vite minify — unbreaks Claude Code in release builds

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,4 +15,16 @@ export default defineConfig({
     port: 1420,
     strictPort: true,
   },
+  build: {
+    // esbuild's minifier mangles a variable reference inside @xterm/xterm's
+    // `requestMode` (DECRQM) handler, leaving it as a free `i` that throws
+    // `ReferenceError: Can't find variable: i` the first time it fires.
+    // That happens on any `CSI ? <n> $ p` query — notably Claude Code's
+    // synchronized-output probe (`CSI ? 2026 $ p`), which Claude emits
+    // before its TUI renders. The exception is raised from inside xterm's
+    // `_innerWrite`, which halts the parser, so no subsequent PTY output
+    // shows up and the pane appears frozen. Dev builds (unminified) and
+    // CLIs that don't use this query (e.g. Codex) aren't affected.
+    minify: false,
+  },
 });


### PR DESCRIPTION
## Summary

- esbuild (Vite's default minifier) mangles a variable inside `@xterm/xterm`'s `requestMode` (DECRQM) handler, leaving a free `i` that throws `ReferenceError: Can't find variable: i` the first time it fires.
- The exception is raised inside xterm's `_innerWrite`, which halts the parser, so no subsequent PTY output renders and the pane appears frozen.
- It's hit on any `CSI ? <n> $ p` query — notably Claude Code's synchronized-output probe (`CSI ? 2026 $ p`), which Claude emits before its TUI renders. Codex and tools that don't use the query are unaffected, which is why the bug only surfaced for Claude.

## Repro (before fix)

1. `task dev:install` to install the release-built app to `/Applications/Roux.app`
2. Open Roux, create or reconnect a Claude Code session
3. Shell output renders (prompt, etc.) but Claude's TUI never appears
4. With devtools enabled, console shows: `ReferenceError: Can't find variable: i` from `requestMode` inside `_innerWrite`

## Fix

Set `build.minify: false` in `vite.config.ts`. Dev builds were already unminified, which is why `task dev` worked and `task dev:install` didn't.

## Tradeoff & followup

Bundle size grows since we're not minifying anymore. For a local desktop app the size isn't load-bearing, but a cleaner followup would be to try `minify: "terser"` (a more conservative minifier that doesn't have this bug) — that keeps minification on without risking the esbuild regression.

## Test plan

- [x] `task dev:install`, reconnect Claude session → TUI renders
- [x] Same for Codex session (regression check) → still works
- [ ] `task dev` still works
- [ ] `npm run check` passes
- [ ] `npm run test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)