### PR TITLE
[codex] add pane attach and detach docs

### DIFF
--- a/.github/workflows/docs-republish.yml
+++ b/.github/workflows/docs-republish.yml
@@ -1,0 +1,114 @@
+name: Republish docs version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Docs version to overwrite (e.g. 0.5.0 or v0.5.0)"
+        required: true
+        type: string
+      source_ref:
+        description: "Git ref to build docs from"
+        required: false
+        default: main
+        type: string
+      update_latest:
+        description: "Also move the latest alias and default version"
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Checkout selected ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_ref }}
+          fetch-depth: 0
+
+      - name: Normalize version
+        id: version
+        run: |
+          set -euo pipefail
+          VERSION="${{ inputs.version }}"
+          VERSION="${VERSION#v}"
+          if [[ -z "$VERSION" ]]; then
+            echo "Version cannot be empty." >&2
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: docs/requirements.txt
+
+      - name: Install dependencies
+        run: pip install -r docs/requirements.txt
+
+      - name: Configure Git author
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
+      - name: Fetch existing versioned docs
+        run: |
+          if git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
+            git fetch origin gh-pages --depth=1
+          fi
+
+      - name: Republish versioned docs
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          UPDATE_LATEST: ${{ inputs.update_latest }}
+        run: |
+          set -euo pipefail
+          if [[ "$UPDATE_LATEST" == "true" ]]; then
+            mike deploy --update-aliases "$VERSION" latest
+            mike set-default latest
+          else
+            mike deploy "$VERSION"
+          fi
+
+      - name: Archive versioned site
+        run: |
+          rm -rf site
+          mkdir -p site
+          git archive gh-pages | tar -x -C site
+
+      - name: Push gh-pages history
+        run: git push origin gh-pages
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -11,18 +11,22 @@ Roux lets you run multiple Claude Code sessions side-by-side with split panes, s
 - **Multi-session** -- Run independent Claude Code sessions, each with its own git worktree
 - **Split panes** -- Horizontal and vertical splits with same-direction flattening
 - **Stacked panes** -- Zellij-style tab stacking where collapsed title bars show inactive panes
+- **Collapsible session rail** -- Collapse the sidebar to a slim strip of session dots without losing quick session switching
 - **Session restore on reconnect** -- Restore full split/shell layouts when reconnecting a saved session
+- **Session history** -- Closing a session archives it into a restorable history pane instead of immediately hard-deleting the record
 - **Shell terminals** -- Open shell panes alongside Claude for running commands
 - **Command palette** -- Quick access to all actions via the primary shortcut (`cmd+k` on macOS, `ctrl+k` on Windows/Linux)
 - **Leader mode** -- Vimish pane/session commands via `cmd+;`
+- **Configurable keymap** -- Edit `~/.config/roux/keymap.kdl`, switch between `default` and `tmux`, and reload shortcuts without restarting
 - **Layout persistence** -- Pane layouts survive app restarts; shell panes respawn automatically
-- **Themes** -- Multiple built-in color schemes
+- **Themes** -- Separate GUI and terminal themes, including imported user `.itermcolors` terminal themes
 - **Projects** -- Tag sessions with projects to organize related work across repos and worktrees
 - **Multi-scoped notes vault** (experimental) -- Plain-text notes sidebar (`cmd+b`) with four scopes (global / project / repo / session), backed by an Obsidian-compatible markdown vault at `~/Documents/Roux`. Scriptable from `roux notes <scope> <verb>` and surfaced to agents via per-PTY `ROUX_*_NOTES_*` env vars.
 - **Command panes** -- Run shell commands in dedicated panes with rerun support
 - **Task runner** -- Run predefined commands from configuration files
 - **Document viewer** -- Open markdown files in dedicated panes
 - **Session from PR URL** -- Paste a GitHub PR URL in New Session and auto-prepare a local review worktree
+- **Native menu bar** -- File/Edit/View/Session/Pane/Tools/Window/Help menus wired to the same command registry and keymap as the palette
 - **Doctor panel + setup automation** -- Verify/reinstall CLI, hooks, and Claude skill from Settings
 - **Worktree templates + close policy** -- Use path templates and choose keep/ask/remove behavior on close
 - **Notification center** -- In-app notifications, unread badges, and OS notification fan-out
@@ -41,9 +45,12 @@ Roux lets you run multiple Claude Code sessions side-by-side with split panes, s
 | Focus up | `alt+k` |
 | Focus right | `alt+l` |
 | Toggle notes | `cmd+b` |
+| Toggle sessions history | `cmd+; t s` |
 | Command palette | `cmd+k` |
 | New session | `cmd+n` |
 | Settings | `cmd+,` |
+
+These are the defaults from the bundled `default` keymap. Roux also ships a `tmux` preset, and every shortcut is editable in `~/.config/roux/keymap.kdl`.
 
 ## Tech Stack
 
@@ -75,7 +82,7 @@ Native Windows x64 builds are supported with a per-user NSIS installer:
 task windows:build
 ```
 
-See [docs/windows-build.md](docs/windows-build.md) for prerequisites and runtime notes.
+See [docs/windows-build.md](docs/windows-build.md) for prerequisites, installer output, and current platform limitations.
 
 ## Release
 

--- a/docs/features/cli.md
+++ b/docs/features/cli.md
@@ -2,9 +2,6 @@
 
 Roux ships with a command-line tool, `roux-cli`, that talks to the running app over a Unix socket. It lets you script Roux from the terminal — open sessions, split panes, send text, and focus panes.
 
-!!! note "Stub page"
-    The full command reference is still being written. This page covers the basics.
-
 ## Installing
 
 `roux-cli` is bundled inside `Roux.app`. The easiest way to put it on your `PATH` is to symlink it:
@@ -17,18 +14,258 @@ Then `roux --help` should work from any terminal.
 
 Inside Roux-managed panes, both `roux` and `roux-cli` are injected automatically, so you can call them without adding your own PATH shim.
 
-## What it can do
+## How it talks to Roux
+
+`roux-cli` is a thin client for the running desktop app:
+
+- on macOS/Linux it talks to Roux over a Unix socket
+- on Windows it talks to the app over a local TCP endpoint plus an auth token
+- most commands print JSON payloads from the app, so they compose well with `jq`, shell scripts, and other agents
+
+If the Roux app is not running, socket-backed commands fail with a direct `Roux is not running` error.
+
+## Command groups
+
+`roux-cli` currently exposes these top-level commands:
 
 - Open / focus a session for a directory and raise the app window (`roux app .`)
+- Show or clear legacy hook status files (`roux status`, `roux clear`)
+- Split the current pane (`roux split`)
 - Create, list, and poll sessions (`roux session create|list|poll`)
 - Send keystrokes to a specific session's PTY (`roux session send`)
 - List and create panes inside a session (`roux session panes list|create`)
-- Split the active pane horizontally or vertically (`roux split`)
+- Open a plain shell (`roux shell`)
 - Focus a pane by id (`roux focus`)
 - Run a shell command in a new pane (`roux run`)
 - Push notifications (`roux notify`)
 - Emit hook status transitions (`roux hook`)
 - Read, append, write, or search the multi-scoped notes vault (`roux notes <scope> <verb>` — experimental; see [Notes](notes.md))
+
+## Context-aware defaults
+
+Inside a Roux-managed PTY, the app injects `ROUX_*` environment variables, including:
+
+- `ROUX_SESSION_ID`
+- `ROUX_PANE_ID`
+
+That means many commands can omit explicit `--session` / `--pane` flags when run from inside an existing Roux pane.
+
+Examples:
+
+- `roux session send "continue"`
+- `roux session panes list`
+- `roux notes session show`
+
+When you run the same commands outside Roux, pass explicit ids as needed.
+
+## Command reference
+
+### `roux app`
+
+Open or focus a Roux session for a directory, then bring the app to the foreground.
+
+```sh
+roux app .
+roux app ~/src/my-repo
+```
+
+If no path is given, it defaults to the current working directory.
+
+### `roux split`
+
+Split the current pane.
+
+```sh
+roux split
+roux split --direction vertical
+```
+
+Defaults to `horizontal`.
+
+### `roux shell`
+
+Open a plain shell pane in the current Roux session.
+
+```sh
+roux shell
+roux shell --working-dir ~/src/my-repo
+```
+
+This is primarily useful from inside an existing Roux pane, where session context is already available.
+
+### `roux focus`
+
+Focus a pane or a session by id.
+
+```sh
+roux focus --pane "$ROUX_PANE_ID"
+roux focus --session "$OTHER_SESSION_ID"
+```
+
+### `roux run`
+
+Run a shell command in a new command pane.
+
+```sh
+roux run "npm run test"
+roux run "cargo test" --working-dir ~/src/my-repo
+```
+
+### `roux session`
+
+Session lifecycle and introspection commands.
+
+#### `roux session create`
+
+Create a new session.
+
+```sh
+roux session create
+roux session create --name "review"
+roux session create --working-dir ~/src/my-repo
+roux session create --worktree-branch feat/review
+roux session create --profile codex
+```
+
+Useful flags:
+
+- `--name` — session name
+- `--working-dir` — existing repo/worktree path; defaults to the current directory unless you are already inside a Roux session
+- `--worktree-branch` — create a new worktree session from that branch name
+- `--profile` / `-P` — spawn profile id, defaulting to `claude`
+- `--flag` / `-f` — repeatable extra flags passed to the agent profile
+- `--nono-profile` and `--nono-allow-dir` — sandbox controls
+
+#### `roux session send`
+
+Send text to a session or pane PTY.
+
+```sh
+roux session send "continue"
+roux session send "review this diff" --session "$SID"
+roux session send $'\x03' --session "$SID" --no-enter
+```
+
+By default, Roux appends Enter. Use `--no-enter` for raw bytes or partial input.
+
+#### `roux session poll`
+
+Get the current state of one session as JSON.
+
+```sh
+roux session poll --session "$SID"
+```
+
+#### `roux session list`
+
+List every session as JSON.
+
+```sh
+roux session list
+```
+
+#### `roux session panes list`
+
+List panes for a session as JSON.
+
+```sh
+roux session panes list --session "$SID"
+```
+
+#### `roux session panes create`
+
+Create a new pane inside a session.
+
+```sh
+roux session panes create --session "$SID"
+roux session panes create --session "$SID" --profile plain-shell
+roux session panes create --session "$SID" --profile codex --direction vertical
+roux session panes create --session "$SID" --working-dir ~/src/other-repo
+```
+
+Defaults:
+
+- profile: `plain-shell`
+- direction: `horizontal`
+- working directory: the session worktree path
+
+### `roux notify`
+
+Push a notification into Roux's in-app notification service.
+
+```sh
+roux notify --title "Build finished" --body "All checks passed" --level success
+roux notify --title "Needs attention" --level attention --session "$SID"
+```
+
+You can also send a full JSON payload via stdin:
+
+```sh
+cat payload.json | roux notify --json
+```
+
+Session resolution order is:
+
+1. explicit `--session`
+2. `sessionId` already present in the JSON payload
+3. `ROUX_SESSION_ID`
+4. global notification with no session binding
+
+### `roux hook`
+
+Handle a Claude Code hook event. This is intended for automation/hooks, not normal interactive use.
+
+```sh
+roux hook working
+roux hook idle
+roux hook attention
+roux hook error
+roux hook disconnected
+```
+
+It reads a JSON payload from stdin and writes provider/session status state for Roux to consume.
+
+### `roux status` and `roux clear`
+
+Legacy status-file helpers for hook debugging:
+
+```sh
+roux status
+roux clear
+```
+
+`status` prints the known hook status files, and `clear` removes them.
+
+### `roux notes`
+
+The notes commands are documented in more detail on [Notes](notes.md), but the CLI surface is:
+
+```sh
+roux notes root
+roux notes session show
+roux notes repo append "remember to update the fixture"
+roux notes project write --topic rollout-plan --content "..."
+roux notes search --tag api --scope repo
+```
+
+Supported scopes:
+
+- `global`
+- `project`
+- `repo`
+- `session`
+
+Supported verbs per scope:
+
+- `show`
+- `append`
+- `write`
+- `path`
+
+Global commands:
+
+- `root`
+- `search`
 
 ## Scripting & agent-to-agent examples
 
@@ -83,6 +320,23 @@ Open a new shell pane alongside the main agent:
 
 ```sh
 roux session panes create -s "$SID" --profile plain-shell --direction vertical
+```
+
+Create a new Codex session from inside an existing Roux pane without repeating the working directory:
+
+```sh
+roux session create --name "codex pass" --profile codex
+```
+
+Push a scoped in-app notification from a script:
+
+```sh
+roux notify \
+  --title "Review finished" \
+  --subtitle "docs PR" \
+  --body "Ready for another pass" \
+  --level success \
+  --session "$SID"
 ```
 
 Inside a Roux-managed PTY, `ROUX_*` variables are set (including `$ROUX_SESSION_ID` and `$ROUX_PANE_ID`), so most `-s` / `-p` flags are optional and scripting context is preserved.

--- a/docs/features/notes.md
+++ b/docs/features/notes.md
@@ -26,6 +26,49 @@ Click a pill to switch scope. The Project pill is greyed out when the current se
 
 The panel is deliberately a plain-text editor. For rich viewing — wikilinks, backlinks, graph view, search — open the vault in Obsidian (see below).
 
+## Notes panes
+
+Roux also supports notes as a real pane type, not just the sidebar panel.
+
+Open one from the command palette:
+
+- **Open Notes Pane (Horizontal)**
+- **Open Notes Pane (Vertical)**
+
+A notes pane can live beside terminals, markdown docs, and other notes panes inside the normal split tree.
+
+This is useful when you want notes visible next to a live shell, command pane, or agent session without replacing the sidebar.
+
+### Pane-local scope and mode
+
+Each notes pane keeps its own:
+
+- scope (`session` / `repo` / `project` / `global`)
+- view mode (`edit` / `read`)
+
+That means two notes panes in the same session can show different scopes at the same time.
+
+The available pane commands are:
+
+- **Notes: Session Scope**
+- **Notes: Repo Scope**
+- **Notes: Project Scope**
+- **Notes: Global Scope**
+- **Notes: Toggle Edit/Read**
+
+The **Project** scope is only available when the current session has a project assigned.
+
+### Sidebar notes vs notes panes
+
+The sidebar notes panel and notes panes use the same underlying notes files, but they behave differently:
+
+- the sidebar is a global side panel for the active session
+- a notes pane is part of the split layout and can remain visible beside terminals
+- sidebar scope selection is remembered per session
+- notes panes remember scope and mode per pane
+
+If you just need a quick scratchpad, use ++cmd+b++. If you want notes to stay onscreen as part of the layout, open a notes pane.
+
 ## Where notes live
 
 Notes are stored as regular markdown files in an Obsidian-compatible vault:
@@ -68,7 +111,7 @@ roux notes session show
 roux notes session append "just shipped the TLS fix"
 roux notes session append --timestamp "retried, still failing"
 roux notes repo path
-roux notes global open
+roux notes global show
 
 # Target a specific topic file instead of the scope's notes.md anchor:
 roux notes repo append --topic api-gotchas "handshake fails when SNI is missing"

--- a/docs/features/panes.md
+++ b/docs/features/panes.md
@@ -9,6 +9,21 @@ Panes are the basic building block of a Roux window. Every Claude Code session, 
 
 Consecutive splits in the same direction are flattened into a single row or column, so your layout never accumulates redundant nesting.
 
+## Split with profile
+
+Roux can also split the current pane and seed the new shell with a specific spawn profile.
+
+Available command-palette actions include:
+
+- **Split Right with Profile…**
+- **Split Down with Profile…**
+- **Split Right → Claude**
+- **Split Right → Codex**
+
+The profile-driven path is what lets a new pane start as more than a plain shell. A profile can attach setup commands, startup commands, environment variables, and optional sandbox settings before you start using the pane.
+
+This is the fastest way to drop a second agent or a specialized shell next to the current pane without opening the New Session dialog.
+
 ## Stacking
 
 Toggle stacking with ++cmd+shift+s++. Stacked panes behave like Zellij tabs: the active pane fills the space while inactive panes collapse into a title bar strip. Click a title bar to activate that pane.
@@ -82,6 +97,34 @@ Use **Kill Terminal** when you want to stop the underlying PTY immediately.
 - **Kill Terminal** stops the PTY process itself
 
 This distinction is especially useful for long-running shells or command panes that you want to keep alive while reorganizing the layout.
+
+## Command panes
+
+Roux can run an ad-hoc shell command in its own dedicated pane.
+
+Open one from the command palette with **Run Command**.
+
+Command panes:
+
+- start as a split next to the active pane
+- stream terminal output like any other terminal-backed pane
+- show elapsed time while running
+- show success/error status when the process exits
+- support rerun from the pane header after completion
+
+This is useful for one-off test runs, build commands, or long-running scripts you want visible in the layout without manually opening a shell first.
+
+## Other pane types
+
+Not every pane is an interactive shell.
+
+Roux also supports:
+
+- **Markdown document panes** via **Open Document**
+- **Notes panes** via **Open Notes Pane (Horizontal/Vertical)**
+- **Command panes** via **Run Command**
+
+All of these participate in the same split/stack/focus system as shell and agent panes.
 
 ## Persistence
 

--- a/docs/features/panes.md
+++ b/docs/features/panes.md
@@ -33,7 +33,55 @@ Examples:
 
 ## Closing
 
-++cmd+w++ closes the focused pane. If a pane hosts a Claude session, the session is stopped. If it hosts a shell, the shell is terminated.
+++cmd+w++ closes the focused pane.
+
+- If the pane hosts a Claude session, the session is stopped.
+- If the pane hosts a shell or command PTY, Roux **detaches** that terminal by default instead of killing it. The process keeps running in the background and can be re-attached later.
+
+This matters because closing a pane and killing the underlying terminal are not the same operation in Roux.
+
+## Attaching and detaching terminals
+
+Shell and command panes can own a PTY independently of the pane that is currently displaying it.
+
+### What detach means
+
+When a PTY is **detached**:
+
+- the process keeps running
+- its output continues to accumulate in the background
+- it is no longer bound to a visible pane
+- you can attach it to another shell or command pane later
+
+Detaching is the default behavior when you close a pane that has an attached PTY.
+
+### How to re-attach
+
+Roux currently exposes terminal re-attachment in three places:
+
+- **Empty shell/command pane UI** — when a pane has no terminal attached, it shows **Attach Terminal...**
+- **Command palette** — run **Attach Terminal...**
+- **Native menu bar** — **Pane** → **Attach Terminal...**
+
+The picker shows terminals from the **current session** only. It can include:
+
+- terminals already attached to another pane
+- terminals currently detached and running in the background
+
+Choosing one moves that PTY into the focused pane. If the terminal was already attached somewhere else, Roux clears the old pane’s binding and reattaches the PTY to the new pane.
+
+### Detached terminal badges
+
+Session cards show a small detached-terminal count when a session has background PTYs that are no longer attached to a pane. If unread output arrived while detached, the badge is highlighted.
+
+### Kill vs close
+
+Use **Kill Terminal** when you want to stop the underlying PTY immediately.
+
+- **Close pane** removes the pane and, by default, detaches the PTY
+- **Kill Terminal** stops the PTY process itself
+
+This distinction is especially useful for long-running shells or command panes that you want to keep alive while reorganizing the layout.
 
 ## Persistence
 

--- a/docs/features/sessions.md
+++ b/docs/features/sessions.md
@@ -13,6 +13,14 @@ A **session** is a running agent/shell workflow attached to a specific project d
 
 Sessions can be tagged with a **project**. Projects group related sessions across repos and worktrees so notes, documents, and defaults are shared between them.
 
+## Sidebar and grouping
+
+The session sidebar has a couple of useful modes:
+
+- Sessions can be grouped by **repository** or **project**.
+- ++cmd+"\\"++ collapses the full sidebar into a slim rail of session dots instead of hiding session switching entirely.
+- The native **View** menu exposes the same sidebar toggle and session-grouping controls as the command palette.
+
 ## Session persistence
 
 Session metadata (project, worktree, working directory) is persisted. When you relaunch Roux:
@@ -25,6 +33,25 @@ This is intentional: active agent processes are not silently resumed on launch.
 
 ## Closing a session
 
-Closing the pane (++cmd+w++) terminates the Claude process. Roux takes care not to kill unrelated `node` processes — only the session it owns.
+Closing the session terminates the Claude process and archives the session record instead of immediately hard-deleting it. Roux takes care not to kill unrelated `node` processes — only the session it owns.
+
+## Sessions History
+
+Closed sessions move into **Sessions History**. Open it from the command palette with **Toggle Sessions History**, or use the default leader chord ++cmd+; t s++.
+
+The history pane shows two sections:
+
+- **Active** — your currently live sessions, with their current status.
+- **History** — archived sessions, sorted by most recently closed.
+
+For an archived session you can:
+
+- **Restore** it to the active list if its worktree still exists on disk.
+- Open that session's **Notes**.
+- **Show worktree** in your file manager.
+- **Clean worktree** to remove the checkout but keep the history row.
+- **Delete forever** to remove the archived record itself.
+
+If you clean or manually remove a worktree, Restore is disabled for that archived row because Roux no longer has a checkout to reconnect.
 
 See [Worktrees](worktrees.md) for how sessions interact with git worktrees.

--- a/docs/features/worktrees.md
+++ b/docs/features/worktrees.md
@@ -84,6 +84,12 @@ Use **Settings → Sessions → On session close** to choose worktree cleanup be
 - **Ask** — prompt each time a worktree-backed session closes
 - **Remove** — always remove the worktree on close
 
+Session closure and worktree cleanup are now separate concepts:
+
+- Closing a session archives the session into **Sessions History**.
+- If the worktree is kept on disk, that history row can be restored later.
+- If you later choose **Clean worktree** from Sessions History, the history row stays but Restore becomes unavailable because the checkout is gone.
+
 ## Caveats
 
 - Worktrees share hooks and git config with the main repo. Be aware of any `post-checkout` or `post-commit` hooks that assume a single working copy.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,7 +10,7 @@ Projects can be any directory on disk. A git repository is only required if you 
 
 ## First launch
 
-When you open Roux for the first time you'll see an empty window with a top bar and a single empty pane.
+On first launch, Roux opens to a single empty pane with the session sidebar on the left and the native menu bar available on supported platforms.
 
 ## Creating your first session
 
@@ -28,6 +28,12 @@ When you open Roux for the first time you'll see an empty window with a top bar 
 - ++cmd+w++ closes the current pane.
 
 Roux automatically flattens consecutive splits in the same direction, so your layout stays clean.
+
+## Sidebar and session history
+
+- ++cmd+"\\"++ collapses the session sidebar into a slim rail of session dots; press it again to expand.
+- Closing a session archives it into **Sessions History** instead of immediately deleting the record.
+- Open **Toggle Sessions History** from the command palette, or use the default leader chord ++cmd+; t s++, to restore closed sessions, open their notes, or permanently delete the history entry.
 
 ## Opening a shell
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,14 +15,18 @@ Roux lets you run multiple Claude Code sessions side-by-side with split panes, s
 - **Multi-session** — run independent Claude Code sessions, each with its own git worktree
 - **Split panes** — horizontal and vertical splits with same-direction flattening
 - **Stacked panes** — Zellij-style tab stacking
+- **Collapsible session rail** — shrink the sidebar to a slim strip of session dots without giving up quick session switching
 - **Layouts** — KDL-based session templates that define multi-pane setups with spawn profiles
 - **Session restore on reconnect** — restores full split/shell layouts from saved pane state
+- **Session history** — closed sessions move into a history pane where you can restore them, open their notes, or delete them forever
 - **Shell terminals** — open shell panes alongside Claude for running commands
 - **Command palette** — quick access to every action via ++cmd+k++
 - **Leader mode** — Vimish pane and session actions via ++cmd+;++ with inline pane rename
 - **Configurable keymap** — every shortcut lives in a KDL file you can edit; ships with `default` and `tmux` presets, supports sticky/passthrough modes and per-tree HUD timing
 - **Layout persistence** — pane layouts survive app restarts; shell panes respawn automatically
 - **Session from PR URL** — paste a GitHub PR URL in New Session and Roux prepares the review branch/worktree
+- **Independent terminal themes** — keep the terminal palette separate from the app chrome, including user-imported `.itermcolors` themes
+- **Native menu bar** — File/Edit/View/Session/Pane/Tools/Window/Help menus on macOS, Windows, and Linux
 - **Doctor panel** — inspect and reinstall CLI/hooks/skill integrations from Settings
 - **Projects** — tag sessions with projects to organize related work across repos and worktrees
 - **Multi-scoped notes vault** — plain-text notes sidebar (++cmd+b++) with four scopes (global / project / repo / session), backed by an Obsidian-compatible markdown vault. Scriptable from `roux notes <scope> <verb>` and exposed to agents through per-PTY env vars. Experimental.

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,6 +1,6 @@
 # Install
 
-Roux ships signed and notarized macOS builds. Windows and Linux are not yet supported.
+Roux ships signed and notarized macOS builds. Native Windows x64 builds are also supported from source with an unsigned NSIS installer. Linux is not yet supported.
 
 ## macOS
 
@@ -10,12 +10,25 @@ Roux ships signed and notarized macOS builds. Windows and Linux are not yet supp
 
 The app is code-signed and notarized, so Gatekeeper should not block the first launch.
 
+## Windows
+
+Roux also supports native Windows x64 local builds. For now, Windows is a source-first install path rather than a signed public installer flow:
+
+1. Set up a Windows x64 machine with Claude Code, Git, Node.js, Rust MSVC, and Go Task.
+2. Follow [Windows build](windows-build.md).
+3. Run `task windows:build` to produce `src-tauri\target\release\bundle\nsis\Roux_<version>_x64-setup.exe`.
+
+Current Windows limitations are documented on [Windows build](windows-build.md). In particular, the first Windows milestone does not include auto-update.
+
 ## Updating
 
 Roux has a built-in auto-updater. When a new version is published, Roux checks for it silently on launch and shows a small banner offering to install it. You can also check manually at any time:
 
-- **Settings** (++cmd+","++) → **Updates** → **Check for updates**
-- Or **Command palette** (++cmd+k++) → **Check for Updates**
+- **Settings** (++cmd+","++) → **Advanced** → **Check for updates**
+- **Command palette** (++cmd+k++) → **Check for Updates**
+- Native app menu (**Roux/File** → **Check for Updates…**, depending on platform)
+
+You can also switch between **Stable** and **Pre-release (Alpha)** in **Settings** → **Advanced**. The prerelease channel follows the newest published prerelease build; switching back to Stable takes effect on the next stable release at or above your current version.
 
 Updates are signed and verified on device before they're installed.
 

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -49,6 +49,14 @@ Roux also has a Vimish leader-mode surface for pane and session commands. The le
 - ++r++ — reconnect session
 - ++e++ — open the session worktree in your editor
 
+### Toggle leader keys
+
+- ++cmd+; t++ — UI toggles
+- ++n++ — toggle notes
+- ++s++ — toggle sessions history
+- ++w++ — toggle watches
+- ++i++ — toggle notifications
+
 ## Sessions and windows
 
 | Action | Shortcut |
@@ -67,10 +75,13 @@ You can disable this overlay in **Settings → Keyboard** while keeping ++cmd+di
 |---|---|
 | Command palette | ++cmd+k++ |
 | Toggle notes | ++cmd+b++ |
+| Toggle sessions history | ++cmd+; t s++ |
 | Toggle notifications | ++cmd+i++ |
 | Toggle watches | ++cmd+shift+w++ |
 | Toggle sidebar | ++cmd+"\\"++ |
 | Reload keymap | *(from palette)* |
+
+The native menu bar uses the same active keymap, so menu accelerators follow your current preset and any custom overrides after you reload the keymap.
 
 ## Customizing shortcuts
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -10,13 +10,21 @@ Settings are grouped into categories in a sidebar modal. Changes are persisted a
 
 - **General** — theme, tab position, status bar position.
 - **Sessions** — close/reconnect behavior, default project path, repo roots quick-pick sources, worktree base template, worktree cleanup mode, and the New Worktree default starting point.
-- **Terminal** — font, scrollback, and cursor settings.
+- **Terminal** — independent terminal theme selection, user-imported `.itermcolors` themes, font, scrollback, and cursor settings.
 - **Claude** — binary path override, default model, additional flags.
 - **Integrations** — GitHub CLI (`gh`) path override for PR/session integrations.
 - **Notifications** — OS notification master switch and test notification trigger.
 - **Keyboard** — toggles for Option-pane and Command-session hint overlays.
 - **Notes** — experimental multi-scoped vault settings. See below.
-- **Advanced** — app version and updater controls.
+- **Advanced** — app version, updater controls, update channel, logging, and the Doctor panel.
+
+## Terminal themes
+
+The **Terminal** section controls xterm's palette separately from the rest of the app.
+
+- **Terminal theme** (`terminalTheme`) — choose between auto-follow, built-in app-matched palettes, built-in editor-style palettes, or user themes.
+- **User themes** — drop iTerm2 `.itermcolors` files into `~/.config/roux/themes/`, then use **Reload** to rescan them or **Reveal** to open the folder in your file manager.
+- Missing user themes are preserved as setting values until you restore the file or pick a different theme, so Roux does not silently overwrite a temporarily unavailable palette.
 
 ## Notes (experimental)
 
@@ -40,9 +48,10 @@ Use **Install / Update / Reinstall** actions per item if anything is missing or 
 
 ## Updates
 
-The Updates section shows the currently running Roux version and lets you manage the built-in auto-updater.
+The **Advanced** section shows the currently running Roux version and exposes the built-in auto-updater controls.
 
 - **Check for updates** — runs a manual check against the release server. If a new version is available, release notes appear inline along with an **Install and restart** button.
+- **Update channel** (`updateChannel`) — choose **Stable** or **Pre-release (Alpha)**. Stable follows `latest.json`; Pre-release follows the newest published prerelease manifest. Switching back to Stable only takes effect once a stable release exists at or above the version you're currently running.
 - **Check for updates on launch** — when enabled (the default), Roux silently checks for a new version a few seconds after startup. If one is available, a small banner appears at the top of the window with **Install and restart** and **Later** buttons. Disabling this means you'll only see updates when you click **Check for updates** manually.
 
 Updates are signed by Roux's release key and verified on your machine before they're installed. A signature failure always surfaces visibly — Roux will never silently ignore one.

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -50,6 +50,26 @@ This page tracks major shipped features across Roux's full history.
 - **GitHub CLI resolution improvements**: login-shell PATH lookup plus explicit `gh` binary override.
 - **Configurable keymap**: every keyboard shortcut — including the leader prefix and chord trees — moved out of hardcoded handlers into a KDL file at `~/.config/roux/keymap.kdl`. Switch to a built-in `tmux` preset with a single line, layer your own overrides on top, declare sticky/passthrough modes, and pick per-tree HUD visibility (`always` / `delayed <ms>` / `never`). Reload from the palette without a restart. See [Keymap](features/keymap.md).
 
+## April 17, 2026
+
+- **Collapsible session rail**: ++cmd+"\\"++ now collapses the full sidebar into a narrow rail of session dots, so you can reclaim horizontal space without giving up fast session switching.
+- **Updater channels**: Settings gained a user-selectable **Stable / Pre-release (Alpha)** channel, letting alpha users follow prerelease builds without changing the default stable path for everyone else.
+
 ## April 18, 2026
 
-- **Multi-scoped notes vault (experimental)**: the project-only notes scratchpad expanded into a four-scope Obsidian-compatible vault. The ++cmd+b++ panel now ships a pill row for **Session / Repo / Project / Global** notes with sticky per-session selection. Under the hood, each session writes to `~/Documents/Roux/<scope>/...`, a clean Obsidian vault you can point Obsidian / Quartz / Hugo / any markdown tool at. Every PTY picks up ten new `ROUX_*_NOTES_*` env vars so agents can locate the right file without guessing. A new `roux notes <scope> <verb>` CLI exposes show / append (optionally timestamped, with stable entry ids) / write / path / search-by-tag, plus `--topic` and `--tag` flags for the "many files per scope, tagged" workflow. Existing project notes migrate to `projects/<slug>/notes.md` on first launch; originals are kept as backup. Subject to change until the banner is removed. See [Notes](features/notes.md).
+- **Multi-scoped notes vault (experimental)**: the project-only scratchpad expanded into a four-scope, Obsidian-compatible vault. The ++cmd+b++ panel now supports **Session / Repo / Project / Global** notes with sticky per-session selection. Under the hood, each session writes to `~/Documents/Roux/<scope>/...`, giving you a plain markdown vault you can open in Obsidian, Quartz, Hugo, or other markdown tooling. PTYs now expose `ROUX_*_NOTES_*` env vars so agents can locate the right file without guessing, and `roux notes <scope> <verb>` adds CLI support for show / append / write / path / search-by-tag, plus `--topic` and `--tag` for more structured note sets. Existing project notes migrate to `projects/<slug>/notes.md` on first launch, with the originals kept as backup. Subject to change until the experimental banner is removed. See [Notes](features/notes.md).
+
+## April 20, 2026
+
+- **Worktree base selection**: new worktrees can now start from **current branch**, **main**, or **origin/main**. The same choices are exposed in the New Worktree flows, and Settings now lets you pick the default starting point.
+
+## April 21, 2026
+
+- **Native menu bar**: Roux now ships File/Edit/View/Session/Pane/Tools/Window/Help menus on macOS, Windows, and Linux, wired to the same command registry and active keymap as the palette.
+- **Sessions History**: closing a session now soft-archives it into a history pane instead of immediately deleting the record. Archived rows can be restored, opened in Notes, cleaned up on disk, or permanently deleted later.
+
+## April 22, 2026
+
+- **Independent terminal themes**: terminal colors are now selected separately from the GUI theme, so you can keep a light UI with a dark shell, or the reverse.
+- **User-imported terminal themes**: drop iTerm2 `.itermcolors` files into `~/.config/roux/themes/` and Roux will surface them in Settings alongside the built-in palettes.
+- **v0.5.0**: the late-April UI and workflow polish shipped as the `v0.5.0` release.


### PR DESCRIPTION
## What changed

Adds dedicated user-facing docs for pane terminal attach/detach behavior.

## Why

The current docs covered splits, stacks, focus, and persistence, but they were missing the most important PTY lifecycle behavior for shell and command panes:

- closing a pane detaches the PTY by default instead of killing it
- detached terminals keep running in the background
- users can re-attach them later from the empty-pane UI, command palette, or native menu
- `Close pane` and `Kill Terminal` are different operations

The previous docs were also inaccurate because they implied closing a shell pane always terminated the shell.

## Coverage added

- default detach-on-close behavior
- what a detached terminal means in practice
- where re-attach is exposed in the UI
- detached terminal badges in session cards
- close vs kill semantics

## Validation

- `git diff --check` ✅
