### PR TITLE
feat(sidebar): collapse to icon rail instead of hiding completely

### DIFF
--- a/src/lib/commands/ui.ts
+++ b/src/lib/commands/ui.ts
@@ -14,7 +14,6 @@ import {
 } from "$lib/stores/ui";
 import {
   setRailSide,
-  showSidebar,
   toggleRailSide,
   toggleSidebarHidden,
 } from "$lib/stores/sidebarLayout";
@@ -315,7 +314,7 @@ export function registerUiCommands() {
 
   registry.register({
     id: "ui.toggle-sidebar",
-    label: "Toggle Sidebar (Rail + Dock)",
+    label: "Toggle Sidebar Dock",
     category: "App",
     available: () => true,
     execute: () => toggleSidebarHidden(),
@@ -373,9 +372,6 @@ export function registerUiCommands() {
     label: "Roux Documentation",
     category: "Help",
     execute: () => {
-      // Help menu must work even if the user has hidden the whole sidebar —
-      // force it back open before dispatching the Docs panel.
-      showSidebar();
       openSidebar("docs");
     },
   });

--- a/src/lib/components/ActivityRail.svelte
+++ b/src/lib/components/ActivityRail.svelte
@@ -20,6 +20,7 @@
     toggleSidebar,
     type SidebarId,
   } from "$lib/stores/ui";
+  import { sidebarLayout } from "$lib/stores/sidebarLayout";
   import { unreadTotal } from "$lib/stores/notifications";
 
   interface Item {
@@ -41,6 +42,15 @@
 
   function handleClick(event: MouseEvent, id: SidebarId): void {
     event.preventDefault();
+    // When the dock is collapsed to icons, any rail click should bring it
+    // back — there's no visible panel to dismiss, and the pinned-icon
+    // branch below would otherwise make plain-clicks dead. openSidebar()
+    // calls showSidebar() internally and is a no-op on the active slot
+    // when id is already pinned, so the pinned panel re-appears correctly.
+    if ($sidebarLayout.hidden) {
+      openSidebar(id);
+      return;
+    }
     if ($pinnedSidebar === id) {
       if (event.shiftKey) unpinSidebar();
       return;

--- a/src/lib/components/Layout.svelte
+++ b/src/lib/components/Layout.svelte
@@ -41,9 +41,11 @@
 
 <div class="flex h-screen flex-col overflow-hidden bg-bg-deep text-text-primary">
   <div class="flex min-h-0 flex-1 flex-row">
-    {#if !sidebarHidden && railSide === "left"}
+    {#if railSide === "left"}
       {@render rail()}
-      {@render dock()}
+      {#if !sidebarHidden}
+        {@render dock()}
+      {/if}
     {/if}
 
     <div class="relative flex min-w-0 flex-1 flex-col overflow-hidden bg-bg-deep">
@@ -94,8 +96,10 @@
       {/if}
     </div>
 
-    {#if !sidebarHidden && railSide === "right"}
-      {@render dock()}
+    {#if railSide === "right"}
+      {#if !sidebarHidden}
+        {@render dock()}
+      {/if}
       {@render rail()}
     {/if}
   </div>

--- a/src/lib/components/__tests__/ActivityRail.test.ts
+++ b/src/lib/components/__tests__/ActivityRail.test.ts
@@ -4,21 +4,29 @@ import { fireEvent, render, screen } from "@testing-library/svelte";
 import {
   activeSidebar,
   closeSidebar,
+  openSidebar,
   pinnedSidebar,
   pinSidebar,
   unpinSidebar,
 } from "$lib/stores/ui";
+import {
+  sidebarLayout,
+  hideSidebar,
+  showSidebar,
+} from "$lib/stores/sidebarLayout";
 import ActivityRail from "../ActivityRail.svelte";
 
 describe("ActivityRail", () => {
   beforeEach(() => {
     closeSidebar();
     unpinSidebar();
+    showSidebar();
   });
 
   afterEach(() => {
     closeSidebar();
     unpinSidebar();
+    showSidebar();
   });
 
   it("renders an icon button for each sidebar item", () => {
@@ -111,5 +119,33 @@ describe("ActivityRail", () => {
     await fireEvent.click(screen.getByRole("button", { name: /docs/i }));
     expect(get(pinnedSidebar)).toBe("notes");
     expect(get(activeSidebar)).toBe("docs");
+  });
+
+  describe("collapsed-to-icons interactions", () => {
+    it("clicking the active icon while collapsed reopens in one click", async () => {
+      openSidebar("watches");
+      hideSidebar();
+      render(ActivityRail);
+      await fireEvent.click(screen.getByRole("button", { name: /watches/i }));
+      expect(get(sidebarLayout).hidden).toBe(false);
+      expect(get(activeSidebar)).toBe("watches");
+    });
+
+    it("clicking the pinned icon while collapsed reopens in one click", async () => {
+      pinSidebar("notes");
+      hideSidebar();
+      render(ActivityRail);
+      await fireEvent.click(screen.getByRole("button", { name: /notes/i }));
+      expect(get(sidebarLayout).hidden).toBe(false);
+      expect(get(pinnedSidebar)).toBe("notes");
+    });
+
+    it("clicking a non-active icon while collapsed reopens and activates", async () => {
+      hideSidebar();
+      render(ActivityRail);
+      await fireEvent.click(screen.getByRole("button", { name: /tasks/i }));
+      expect(get(sidebarLayout).hidden).toBe(false);
+      expect(get(activeSidebar)).toBe("tasks");
+    });
   });
 });

--- a/src/lib/stores/__tests__/ui.test.ts
+++ b/src/lib/stores/__tests__/ui.test.ts
@@ -218,6 +218,51 @@ describe("sidebar pin-slot state", () => {
       expect(get(activeSidebar)).toBe("docs");
     });
   });
+
+  describe("collapse-to-icons: opening a panel unhides the dock", () => {
+    it("openSidebar unhides the dock when collapsed", async () => {
+      const { sidebarLayout, hideSidebar, showSidebar } = await import(
+        "../sidebarLayout"
+      );
+      showSidebar();
+      hideSidebar();
+      expect(get(sidebarLayout).hidden).toBe(true);
+      openSidebar("watches");
+      expect(get(sidebarLayout).hidden).toBe(false);
+    });
+
+    it("toggleSidebar activating a panel unhides the dock", async () => {
+      const { sidebarLayout, hideSidebar, showSidebar } = await import(
+        "../sidebarLayout"
+      );
+      showSidebar();
+      hideSidebar();
+      expect(get(sidebarLayout).hidden).toBe(true);
+      toggleSidebar("watches");
+      expect(get(sidebarLayout).hidden).toBe(false);
+      expect(get(activeSidebar)).toBe("watches");
+    });
+
+    it("toggleSidebar dismissing the active panel does not touch hidden", async () => {
+      const { sidebarLayout, showSidebar } = await import("../sidebarLayout");
+      showSidebar();
+      openSidebar("watches");
+      toggleSidebar("watches");
+      expect(get(activeSidebar)).toBeNull();
+      expect(get(sidebarLayout).hidden).toBe(false);
+    });
+
+    it("pinSidebar unhides the dock when collapsed", async () => {
+      const { sidebarLayout, hideSidebar, showSidebar } = await import(
+        "../sidebarLayout"
+      );
+      showSidebar();
+      hideSidebar();
+      pinSidebar("notes");
+      expect(get(sidebarLayout).hidden).toBe(false);
+      expect(get(pinnedSidebar)).toBe("notes");
+    });
+  });
 });
 
 describe("showPaneHints", () => {

--- a/src/lib/stores/sidebarLayout.ts
+++ b/src/lib/stores/sidebarLayout.ts
@@ -92,6 +92,12 @@ export function toggleRailSide(): void {
 }
 
 export function showSidebar(): void {
+  // No-op when already visible. Callers invoke this on every open/pin
+  // action; Svelte's writable notifies subscribers on any `update` (even
+  // when returning the same object ref), so we must short-circuit before
+  // touching the store to avoid redundant localStorage writes and
+  // downstream $derived re-evaluations.
+  if (!get(sidebarLayout).hidden) return;
   sidebarLayout.update((s) => ({ ...s, hidden: false }));
 }
 

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -1,6 +1,7 @@
 import { derived, get, writable, type Readable } from "svelte/store";
 import { sessionLayouts, collectVisibleLeafIds } from "$lib/panes/layout";
 import { sessionState } from "$lib/stores/sessions";
+import { showSidebar } from "$lib/stores/sidebarLayout";
 
 /**
  * Global sidebar slots. The docked sidebar has a pin slot (for lightweight,
@@ -87,6 +88,9 @@ function clearNotesOverrideIfLeaving(id: SidebarId | null): void {
 }
 
 export function openSidebar(id: SidebarId): void {
+  // Opening a panel implies the user wants to see it — bring the dock back
+  // if the sidebar is currently collapsed to icons.
+  showSidebar();
   sidebarState.update((s) => {
     if (s.pinned === id) return s;
     return { ...s, active: id };
@@ -110,12 +114,15 @@ export function toggleSidebar(id: SidebarId): void {
     clearNotesOverrideIfLeaving(null);
     return;
   }
+  // Activating a panel implies the user wants to see it.
+  showSidebar();
   sidebarState.set({ ...s, active: id });
   clearNotesOverrideIfLeaving(id);
 }
 
 export function pinSidebar(id: SidebarId): void {
   if (!PINNABLE_SIDEBARS.has(id)) return;
+  showSidebar();
   sidebarState.update((s) => ({
     pinned: id,
     active: s.active === id ? null : s.active,
@@ -157,6 +164,7 @@ export function isPinned(id: SidebarId): boolean {
 }
 
 export function openNotesForSession(sessionId: string): void {
+  showSidebar();
   notesOverrideSessionId.set(sessionId);
   sidebarState.update((s) => ({ ...s, active: "notes" }));
 }


### PR DESCRIPTION
## Summary
- Cmd+\\ now collapses the sidebar to just the activity rail (icons) instead of hiding it completely. The dock panel goes away; the rail stays visible.
- Clicking a rail icon — or any programmatic `openSidebar` / `toggleSidebar` / `pinSidebar` / `openNotesForSession` call — brings the dock back, so the collapsed state isn't a dead end.
- Dismiss actions (`closeSidebar`, `closePinned`, `unpinSidebar`) deliberately leave `hidden` alone, so cmd+\\ stays in sole control of the collapsed state.

## Changes
- `src/lib/components/Layout.svelte` — always render the `ActivityRail`; only gate the `SidebarDock` on `sidebarLayout.hidden`.
- `src/lib/stores/ui.ts` — `openSidebar` / `toggleSidebar` (on activate) / `pinSidebar` / `openNotesForSession` now call `showSidebar()` first.
- `src/lib/commands/ui.ts` — command label updated from "Toggle Sidebar (Rail + Dock)" to "Toggle Sidebar Dock"; removed now-redundant `showSidebar()` from `help.open-docs` (openSidebar guarantees it).
- `src/lib/stores/__tests__/ui.test.ts` — four new tests covering the unhide-on-open invariant and the "dismiss does not unhide" guarantee.

## Test plan
- [x] `npm run test` — 440 passing / 2 skipped
- [x] `npm run check` — 0 errors, 0 warnings
- [ ] Manual: hit Cmd+\\ with a panel open — dock hides, rail stays
- [ ] Manual: click a rail icon while collapsed — dock returns with that panel
- [ ] Manual: Cmd+\\ again with a panel active — dock hides again
- [ ] Manual: verify both `railSide: "left"` and `railSide: "right"` render correctly in both states
- [ ] Manual: verify settings takeover (Cmd+,) while collapsed re-opens the settings modal correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)