### PR TITLE
feat(status-bar): make active session name prominent

### DIFF
--- a/src/lib/components/StatusBar.svelte
+++ b/src/lib/components/StatusBar.svelte
@@ -18,15 +18,15 @@
 </script>
 
 <div
-  class="flex h-6 items-center gap-3 bg-bg-base px-3 text-[11px] text-text-muted"
+  class="flex h-8 items-center gap-3 bg-bg-base px-3 text-[12px] text-text-muted"
   class:border-t={position === "bottom"}
   class:border-b={position === "top"}
   class:border-border-subtle={true}
 >
   {#if $activeSession}
-    <div class="flex items-center gap-1.5">
-      <div class="w-1.5 h-1.5 rounded-full {statusDotClass[$activeSession.status] ?? 'bg-gray'}"></div>
-      <span class="font-medium tracking-tight text-text-secondary">{$activeSession.name}</span>
+    <div class="flex items-center gap-2">
+      <div class="w-2.5 h-2.5 rounded-full {statusDotClass[$activeSession.status] ?? 'bg-gray'}"></div>
+      <span class="text-[14px] font-semibold tracking-tight text-text-primary">{$activeSession.name}</span>
     </div>
     {#if $activeSession.isGitRepo}
       <span class="text-text-secondary">&bull;</span>


### PR DESCRIPTION
## Summary
- With the new dockable sidebar, `SessionTabs` can be hidden — the status bar is sometimes the only place the active session name is shown.
- Bumps the status bar height (`h-6` → `h-8`), the session name to `14px` semibold primary text, and enlarges the status dot so the active session reads as the header of the bar rather than another muted metadata chip.

## Test plan
- [ ] `task dev` — confirm the session name pops as the first element and the overall bar height still feels proportional
- [ ] Toggle between top/bottom status bar positions (settings) to confirm borders still render correctly
- [ ] Switch sessions with different statuses (idle / thinking / generating / disconnected) and verify the dot still reads clearly at the larger size

🤖 Generated with [Claude Code](https://claude.com/claude-code)