### PR TITLE
UX/visual polish pass

### DIFF
--- a/crates/roux-core/src/models/settings.rs
+++ b/crates/roux-core/src/models/settings.rs
@@ -93,14 +93,14 @@ pub enum UpdateChannel {
 
 /// What happens to a PTY when its pane is closed.
 ///
+/// - `Kill` — the PTY process is killed immediately.
 /// - `Detach` — the PTY keeps running in the background; it can be
 ///   re-attached to another pane later.
-/// - `Kill` — the PTY process is killed immediately (legacy behaviour).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, specta::Type, Default)]
 #[serde(rename_all = "camelCase")]
 pub enum OnPaneCloseMode {
-    #[default]
     Detach,
+    #[default]
     Kill,
 }
 
@@ -225,8 +225,8 @@ pub struct RouxSettings {
     #[serde(default = "default_true")]
     pub show_session_hints_on_command: bool,
     /// What happens to a PTY when its pane is closed.
-    /// `Detach` (default): the process keeps running and can be re-attached.
-    /// `Kill`: the process is killed immediately (legacy behaviour).
+    /// `Kill` (default): the process is killed immediately.
+    /// `Detach`: the process keeps running and can be re-attached.
     #[serde(default)]
     pub on_pane_close: OnPaneCloseMode,
 }
@@ -276,7 +276,7 @@ impl Default for RouxSettings {
             status_bar_position: StatusBarPosition::Bottom,
             show_pane_hints_on_option: false,
             show_session_hints_on_command: true,
-            on_pane_close: OnPaneCloseMode::Detach,
+            on_pane_close: OnPaneCloseMode::Kill,
         }
     }
 }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -673,9 +673,6 @@
 
 <Layout
   onNewSession={() => (showNewSessionDialog = true)}
-  onOpenSettings={() => toggleSidebar("settings")}
-  onToggleWatches={() => toggleSidebar("watches")}
-  onToggleNotifications={() => toggleSidebar("notifications")}
 >
   {#snippet settingsPanel()}
     <SettingsPanel visible={$activeSidebar === "settings"} onclose={closeSidebar} />

--- a/src/app.css
+++ b/src/app.css
@@ -54,6 +54,8 @@
     overflow: hidden;
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
+    user-select: none;
+    -webkit-user-select: none;
   }
 
   body,
@@ -67,6 +69,41 @@
   select,
   textarea {
     font: inherit;
+  }
+
+  button,
+  [role="button"],
+  [role="tab"],
+  [role="switch"],
+  [role="checkbox"],
+  [role="radio"],
+  [role="menuitem"],
+  [role="option"],
+  summary,
+  select,
+  option,
+  label,
+  [aria-pressed],
+  [aria-selected],
+  [aria-expanded],
+  .select-none {
+    user-select: none;
+    -webkit-user-select: none;
+  }
+
+  input,
+  textarea,
+  [contenteditable="true"],
+  [role="textbox"],
+  .cm-editor,
+  .cm-content,
+  .xterm,
+  .xterm *,
+  .markdown-body,
+  .prose,
+  [data-selectable="true"] {
+    user-select: text;
+    -webkit-user-select: text;
   }
 
   ::selection {

--- a/src/lib/components/ActivityRail.svelte
+++ b/src/lib/components/ActivityRail.svelte
@@ -78,32 +78,36 @@
   }
 
   function buttonTitle(item: Item): string {
-    const suffix = PINNABLE_SIDEBARS.has(item.id)
-      ? isPinned(item.id)
-        ? " (right-click or shift-click to unpin)"
-        : " (right-click to pin)"
-      : "";
-    return `${item.label}${suffix}`;
+    return item.label;
+  }
+
+  const tooltipBaseClass =
+    "pointer-events-none absolute top-1/2 z-50 -translate-y-1/2 whitespace-nowrap rounded border border-border-subtle bg-bg-elevated px-2 py-1 text-[11px] font-medium text-text-primary opacity-0 shadow-lg shadow-black/30 transition-opacity duration-75 group-hover:opacity-100 group-focus-visible:opacity-100";
+
+  function tooltipClass(): string {
+    return $sidebarLayout.railSide === "right"
+      ? `${tooltipBaseClass} right-full mr-1`
+      : `${tooltipBaseClass} left-full ml-1`;
   }
 </script>
 
-<div class="flex h-full flex-col items-center gap-0.5 p-1">
+<div class="flex h-full flex-col items-center p-1">
   {#each dockItems as item (item.id)}
     {@const active = $activeSidebar === item.id}
     {@const pinned = $pinnedSidebar === item.id}
     {@const showBadge = item.id === "notifications" && $unreadTotal > 0}
     <button
       type="button"
-      title={buttonTitle(item)}
       aria-label={item.label}
       aria-pressed={active || pinned}
-      class="relative flex h-7 w-7 shrink-0 items-center justify-center rounded text-text-secondary transition-colors hover:bg-white/5 hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50 {active
+      class="group relative flex h-7 w-7 shrink-0 items-center justify-center rounded text-text-secondary transition-colors hover:bg-white/5 hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50 {active
         ? 'bg-white/10 text-text-primary'
         : ''} {pinned ? 'text-accent' : ''}"
       onclick={(e) => handleClick(e, item.id)}
       oncontextmenu={(e) => handleContextMenu(e, item.id)}
     >
       <item.icon size={16} />
+      <span class={tooltipClass()} aria-hidden="true">{buttonTitle(item)}</span>
       {#if pinned}
         <span class="absolute -top-0.5 -right-0.5 flex h-3 w-3 items-center justify-center rounded-full bg-accent text-[8px] text-bg-deep">
           <Pin size={8} />
@@ -121,12 +125,12 @@
 
   <button
     type="button"
-    title={settingsItem.label}
     aria-label={settingsItem.label}
     aria-pressed={$activeSidebar === "settings"}
-    class="flex h-7 w-7 shrink-0 items-center justify-center rounded text-text-secondary transition-colors hover:bg-white/5 hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50 {$activeSidebar === 'settings' ? 'bg-white/10 text-text-primary' : ''}"
+    class="group relative flex h-7 w-7 shrink-0 items-center justify-center rounded text-text-secondary transition-colors hover:bg-white/5 hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50 {$activeSidebar === 'settings' ? 'bg-white/10 text-text-primary' : ''}"
     onclick={handleSettingsClick}
   >
     <settingsItem.icon size={16} />
+    <span class={tooltipClass()} aria-hidden="true">{settingsItem.label}</span>
   </button>
 </div>

--- a/src/lib/components/ArchivedSessionsList.svelte
+++ b/src/lib/components/ArchivedSessionsList.svelte
@@ -12,7 +12,19 @@
   import type { Session } from "$lib/types";
   import ChevronRight from "@lucide/svelte/icons/chevron-right";
 
-  let collapsed = $state(true);
+  interface Props {
+    collapsed?: boolean;
+    oncollapsedchange?: (collapsed: boolean) => void;
+    onresizestart?: (event: MouseEvent) => void;
+    resizing?: boolean;
+  }
+
+  let {
+    collapsed = true,
+    oncollapsedchange,
+    onresizestart,
+    resizing = false,
+  }: Props = $props();
   let loadError = $state<string | null>(null);
 
   $effect(() => {
@@ -92,12 +104,29 @@
       loadError = `Failed to remove worktree: ${err}`;
     }
   }
+
+  function toggleCollapsed() {
+    collapsed = !collapsed;
+    oncollapsedchange?.(collapsed);
+  }
 </script>
 
-<div class="mt-3 border-t border-hairline pt-2">
+<div class="flex h-full min-h-0 flex-col">
+  {#if collapsed}
+    <div class="border-t border-hairline pt-2"></div>
+  {:else}
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div
+      class="group flex h-2 shrink-0 cursor-row-resize items-center"
+      onmousedown={onresizestart}
+      title="Resize archived sessions"
+    >
+      <div class="h-px w-full transition-colors duration-150 {resizing ? 'bg-white/30' : 'bg-white/15 group-hover:bg-white/35'}"></div>
+    </div>
+  {/if}
   <button
-    class="flex w-full cursor-pointer items-center gap-1.5 bg-transparent px-2 py-1.5 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50"
-    onclick={() => (collapsed = !collapsed)}
+    class="flex w-full shrink-0 cursor-pointer items-center gap-1.5 bg-transparent px-2 py-1.5 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50"
+    onclick={toggleCollapsed}
     title="Archived sessions"
   >
     <ChevronRight size={12} class="text-text-secondary transition-transform duration-150 {collapsed ? '' : 'rotate-90'}" />
@@ -106,7 +135,7 @@
   </button>
 
   {#if !collapsed}
-    <div class="px-1 pb-2">
+    <div class="app-scrollbar min-h-0 flex-1 overflow-y-auto px-1 pb-2">
       {#if loadError}
         <div class="mb-2 rounded border border-red/40 bg-red/10 px-2 py-1 text-[11px] text-red">
           {loadError}

--- a/src/lib/components/CloseButton.svelte
+++ b/src/lib/components/CloseButton.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import X from "@lucide/svelte/icons/x";
+
+  interface Props {
+    label?: string;
+    title?: string;
+    onclick: (event: MouseEvent) => void;
+    size?: number;
+    class?: string;
+    tabindex?: number;
+  }
+
+  let {
+    label = "Close",
+    title = label,
+    onclick,
+    size = 14,
+    class: className = "",
+    tabindex,
+  }: Props = $props();
+</script>
+
+<button
+  type="button"
+  class="cursor-pointer rounded border border-transparent bg-transparent p-1 text-text-muted transition-colors hover:border-border-subtle hover:bg-bg-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50 {className}"
+  {title}
+  aria-label={label}
+  {tabindex}
+  onclick={onclick}
+>
+  <X {size} />
+</button>

--- a/src/lib/components/CollapseSidebarButton.svelte
+++ b/src/lib/components/CollapseSidebarButton.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import ChevronsLeft from "@lucide/svelte/icons/chevrons-left";
+  import ChevronsRight from "@lucide/svelte/icons/chevrons-right";
+  import { sidebarLayout } from "$lib/stores/sidebarLayout";
+
+  interface Props {
+    label?: string;
+    title?: string;
+    onclick: (event: MouseEvent) => void;
+    class?: string;
+  }
+
+  let {
+    label = "Collapse sidebar",
+    title = label,
+    onclick,
+    class: className = "",
+  }: Props = $props();
+</script>
+
+<button
+  type="button"
+  class="cursor-pointer rounded border border-transparent bg-transparent p-1 text-text-muted transition-colors hover:border-border-subtle hover:bg-bg-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50 {className}"
+  {title}
+  aria-label={label}
+  onclick={onclick}
+>
+  {#if $sidebarLayout.railSide === "right"}
+    <ChevronsRight size={14} />
+  {:else}
+    <ChevronsLeft size={14} />
+  {/if}
+</button>

--- a/src/lib/components/DocPanel.svelte
+++ b/src/lib/components/DocPanel.svelte
@@ -3,6 +3,7 @@
   import { marked } from "marked";
   import { listDocs, readFile, type DocFile } from "$lib/tauri";
   import { activeSession } from "$lib/stores/sessions";
+  import CollapseSidebarButton from "./CollapseSidebarButton.svelte";
 
   interface Props {
     visible: boolean;
@@ -107,10 +108,11 @@
         onclick={refreshDocs}
         title="Refresh"
       >&#8635;</button>
-      <button
-        class="cursor-pointer rounded-lg border border-transparent bg-transparent p-1.5 text-base text-text-muted hover:bg-bg-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50 focus-visible:ring-offset-1 focus-visible:ring-offset-bg-deep"
+      <CollapseSidebarButton
         onclick={onclose}
-      >&times;</button>
+        label="Collapse documentation sidebar"
+        title="Collapse documentation sidebar"
+      />
     </div>
   </div>
 

--- a/src/lib/components/DocPanel.svelte
+++ b/src/lib/components/DocPanel.svelte
@@ -4,6 +4,7 @@
   import { listDocs, readFile, type DocFile } from "$lib/tauri";
   import { activeSession } from "$lib/stores/sessions";
   import CollapseSidebarButton from "./CollapseSidebarButton.svelte";
+  import SidebarPanelHeader from "./SidebarPanelHeader.svelte";
 
   interface Props {
     visible: boolean;
@@ -92,17 +93,11 @@
   class="flex h-full w-full min-h-0 flex-col bg-bg-deep"
   class:hidden={!visible}
 >
-  <div class="flex h-9 shrink-0 items-center justify-between border-b border-hairline bg-bg-surface/30 px-3">
-    <div class="space-y-0.5">
-      <div class="flex items-center gap-2">
-        <span class="text-[10px] font-bold uppercase tracking-widest text-text-muted">Documentation</span>
-        <span class="rounded-full border border-border-subtle bg-bg-surface px-2 py-0.5 text-[10px] font-medium text-text-muted">
-          {docs.length}
-        </span>
-      </div>
-      <p class="text-[11px] text-text-muted">Session markdown, notes, and specs</p>
-    </div>
-    <div class="flex items-center gap-2">
+  <SidebarPanelHeader title="Docs">
+    {#snippet actions()}
+      <span class="border border-border-subtle bg-bg-surface px-2 py-1 font-mono text-[12px] text-text-secondary">
+        {docs.length}
+      </span>
       <button
         class="cursor-pointer rounded-lg border border-transparent bg-transparent p-1.5 text-xs text-text-muted hover:bg-bg-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50 focus-visible:ring-offset-1 focus-visible:ring-offset-bg-deep"
         onclick={refreshDocs}
@@ -113,8 +108,8 @@
         label="Collapse documentation sidebar"
         title="Collapse documentation sidebar"
       />
-    </div>
-  </div>
+    {/snippet}
+  </SidebarPanelHeader>
 
   {#if !$activeSession}
     <div class="flex flex-1 items-center justify-center text-sm text-text-muted">

--- a/src/lib/components/Layout.svelte
+++ b/src/lib/components/Layout.svelte
@@ -11,13 +11,10 @@
 
   interface Props {
     onNewSession: () => void;
-    onOpenSettings: () => void;
-    onToggleWatches: () => void;
-    onToggleNotifications: () => void;
     settingsPanel?: Snippet;
   }
 
-  let { onNewSession, onOpenSettings, onToggleWatches, onToggleNotifications, settingsPanel }: Props = $props();
+  let { onNewSession, settingsPanel }: Props = $props();
 
   let statusBarPosition = $derived($settings.statusBarPosition ?? "bottom");
   let railSide = $derived($sidebarLayout.railSide);
@@ -33,9 +30,6 @@
 {#snippet dock()}
   <SidebarDock
     {onNewSession}
-    {onOpenSettings}
-    {onToggleWatches}
-    {onToggleNotifications}
   />
 {/snippet}
 

--- a/src/lib/components/MarkdownPane.svelte
+++ b/src/lib/components/MarkdownPane.svelte
@@ -11,6 +11,7 @@
   import { readFile, writeFile } from "$lib/tauri";
   import { hasPrimaryModifier } from "$lib/platform";
   import { settings } from "$lib/stores/settings";
+  import CloseButton from "./CloseButton.svelte";
 
   interface Props {
     docPath?: string;
@@ -253,11 +254,14 @@
           <span class="max-w-[120px] truncate">
             {#if tab.dirty}<span class="text-accent">&#8226; </span>{/if}{tabName(tab)}
           </span>
-          <button
-            class="ml-0.5 cursor-pointer rounded border-none bg-transparent p-0 text-[10px] leading-none opacity-0 transition-opacity hover:text-text-primary group-hover:opacity-100"
+          <CloseButton
+            class="ml-0.5 p-0 opacity-0 transition-opacity hover:border-transparent group-hover:opacity-100"
             onclick={(e: MouseEvent) => { e.stopPropagation(); closeTab(tab.id); }}
+            label="Close tab"
+            title="Close tab"
+            size={11}
             tabindex={-1}
-          >&times;</button>
+          />
         </div>
       {/each}
     </div>

--- a/src/lib/components/NotesPanel.svelte
+++ b/src/lib/components/NotesPanel.svelte
@@ -10,6 +10,7 @@
 
   import PinButton from "./PinButton.svelte";
   import CollapseSidebarButton from "./CollapseSidebarButton.svelte";
+  import SidebarPanelHeader from "./SidebarPanelHeader.svelte";
 
   interface Props {
     visible: boolean;
@@ -70,17 +71,18 @@
   class="flex h-full w-full min-h-0 flex-col bg-bg-deep"
   class:hidden={!visible}
 >
-  <!-- Sidebar-specific close button row -->
-  <div class="flex h-9 shrink-0 items-center justify-end gap-1 border-b border-hairline bg-bg-surface/30 px-3">
-    {#if onTogglePin}
-      <PinButton {pinned} ontoggle={onTogglePin} />
-    {/if}
-    <CollapseSidebarButton
-      onclick={onclose}
-      label="Collapse notes sidebar"
-      title="Collapse notes sidebar"
-    />
-  </div>
+  <SidebarPanelHeader title="Notes">
+    {#snippet actions()}
+      {#if onTogglePin}
+        <PinButton {pinned} ontoggle={onTogglePin} />
+      {/if}
+      <CollapseSidebarButton
+        onclick={onclose}
+        label="Collapse notes sidebar"
+        title="Collapse notes sidebar"
+      />
+    {/snippet}
+  </SidebarPanelHeader>
 
   {#if sessionId}
     <div class="flex flex-1 min-h-0 flex-col overflow-hidden">

--- a/src/lib/components/NotesPanel.svelte
+++ b/src/lib/components/NotesPanel.svelte
@@ -9,6 +9,7 @@
   import NotesContent from "./NotesContent.svelte";
 
   import PinButton from "./PinButton.svelte";
+  import CollapseSidebarButton from "./CollapseSidebarButton.svelte";
 
   interface Props {
     visible: boolean;
@@ -74,11 +75,11 @@
     {#if onTogglePin}
       <PinButton {pinned} ontoggle={onTogglePin} />
     {/if}
-    <button
-      class="cursor-pointer rounded-lg border border-transparent bg-transparent p-1.5 text-base text-text-muted hover:border-border-subtle hover:bg-bg-hover hover:text-text-primary"
+    <CollapseSidebarButton
       onclick={onclose}
-      aria-label="Close notes"
-    >&times;</button>
+      label="Collapse notes sidebar"
+      title="Collapse notes sidebar"
+    />
   </div>
 
   {#if sessionId}

--- a/src/lib/components/NotificationsPane.svelte
+++ b/src/lib/components/NotificationsPane.svelte
@@ -12,6 +12,7 @@
   import PinButton from "./PinButton.svelte";
   import CloseButton from "./CloseButton.svelte";
   import CollapseSidebarButton from "./CollapseSidebarButton.svelte";
+  import SidebarPanelHeader from "./SidebarPanelHeader.svelte";
 
   interface Props {
     visible: boolean;
@@ -113,9 +114,8 @@
   class="flex h-full w-full min-h-0 flex-col bg-bg-deep"
   class:hidden={!visible}
 >
-  <div class="flex h-9 shrink-0 items-center justify-between border-b border-hairline bg-bg-surface/30 px-3">
-    <span class="text-sm font-semibold tracking-tight">Notifications</span>
-    <div class="flex items-center gap-1">
+  <SidebarPanelHeader title="Notifications">
+    {#snippet actions()}
       {#if $notifications.length > 0}
         <button
           class="cursor-pointer rounded border border-transparent bg-transparent px-2 py-0.5 text-[10px] text-text-muted hover:border-border-subtle hover:bg-bg-hover hover:text-text-primary"
@@ -136,8 +136,8 @@
         label="Collapse notifications sidebar"
         title="Collapse notifications sidebar"
       />
-    </div>
-  </div>
+    {/snippet}
+  </SidebarPanelHeader>
 
   <div class="flex-1 overflow-y-auto p-2">
     {#if $notifications.length === 0}

--- a/src/lib/components/NotificationsPane.svelte
+++ b/src/lib/components/NotificationsPane.svelte
@@ -10,6 +10,8 @@
   import type { Notification, NotificationAction, NotificationLevel, NotificationSource } from "$lib/types";
 
   import PinButton from "./PinButton.svelte";
+  import CloseButton from "./CloseButton.svelte";
+  import CollapseSidebarButton from "./CollapseSidebarButton.svelte";
 
   interface Props {
     visible: boolean;
@@ -129,10 +131,11 @@
       {#if onTogglePin}
         <PinButton {pinned} ontoggle={onTogglePin} />
       {/if}
-      <button
-        class="cursor-pointer rounded-lg border border-transparent bg-transparent p-1.5 text-base text-text-muted hover:border-border-subtle hover:bg-bg-hover hover:text-text-primary"
+      <CollapseSidebarButton
         onclick={onclose}
-      >&times;</button>
+        label="Collapse notifications sidebar"
+        title="Collapse notifications sidebar"
+      />
     </div>
   </div>
 
@@ -163,11 +166,13 @@
                 <span class="min-w-0 flex-1 truncate {n.read ? 'text-text-muted' : 'text-text-primary'}">{n.title}</span>
                 <span class="shrink-0 text-[9px] uppercase tracking-wider text-text-muted/60">{sourceLabel(n.source)}</span>
                 <span class="shrink-0 text-[10px] text-text-muted">{formatRelative(n.createdAt)}</span>
-                <button
-                  class="cursor-pointer border-none bg-transparent px-1 text-[11px] leading-none text-text-muted hover:text-red"
+                <CloseButton
+                  class="shrink-0 p-0.5 hover:border-transparent hover:text-red"
                   onclick={(e) => handleDismiss(e, n)}
+                  label="Dismiss notification"
                   title="Dismiss"
-                >&times;</button>
+                  size={12}
+                />
               </div>
 
               {#if n.subtitle}

--- a/src/lib/components/PaneShell.svelte
+++ b/src/lib/components/PaneShell.svelte
@@ -26,6 +26,7 @@
   import LazyMarkdownPane from "./LazyMarkdownPane.svelte";
   import DeadPaneView from "./DeadPaneView.svelte";
   import NotesPane from "./NotesPane.svelte";
+  import CloseButton from "./CloseButton.svelte";
   import { projects } from "$lib/stores/projects";
 
   interface Props {
@@ -369,16 +370,16 @@
           </button>
         {/if}
         {#if canClose()}
-          <button
-            class="flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center rounded text-[12px] leading-none text-text-secondary transition-colors hover:bg-bg-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50"
+          <CloseButton
+            class="h-5 w-5 shrink-0 p-0"
             onclick={(e) => {
               e.stopPropagation();
               void closePane(sessionId, paneId);
             }}
+            label="Close pane"
             title="Close pane"
-          >
-            &times;
-          </button>
+            size={13}
+          />
         {/if}
       </div>
     </div>

--- a/src/lib/components/SessionCard.svelte
+++ b/src/lib/components/SessionCard.svelte
@@ -40,16 +40,25 @@
     slotNumber == null ? null : slotNumber === 10 ? "0" : String(slotNumber),
   );
 
-  // Detached PTY inventory — polled periodically.
-  // No backend event stream for PTY status changes yet, so polling is the
-  // stopgap. 5s matches the git-status poll interval in SessionTabs.
+  // Poll PTY inventory so the sidebar can show how many panes are active and
+  // whether a session is carrying detached terminals in the background.
+  let attachedCount = $state(0);
   let detachedCount = $state(0);
   let detachedHasUnread = $state(false);
+  let showPaneInventory = $derived(attachedCount > 1 || detachedCount > 0);
+  let activePaneTitle = $derived(
+    `${attachedCount} active pane${attachedCount === 1 ? "" : "s"}`
+  );
+  let detachedPaneTitle = $derived(
+    `${detachedCount} detached terminal${detachedCount === 1 ? "" : "s"}${detachedHasUnread ? " (unread output)" : ""}`
+  );
 
   async function refreshDetachedState() {
     try {
       const ptys = await listSessionPtys(session.id);
+      const attached = ptys.filter((p) => p.status.type === "RunningAttached");
       const detached = ptys.filter((p) => p.status.type === "RunningDetached");
+      attachedCount = attached.length;
       detachedCount = detached.length;
       detachedHasUnread = detached.some((p) => p.unread_output);
     } catch {
@@ -184,13 +193,19 @@
         </span>
       {/if}
 
+      {#if showPaneInventory}
+        <span
+          class="inline-flex h-4 min-w-[16px] shrink-0 items-center justify-center rounded px-1 text-[9px] font-semibold tabular-nums bg-bg-surface text-text-muted"
+          title={activePaneTitle}
+        >{attachedCount}</span>
+      {/if}
       {#if detachedCount > 0}
         <span
           class="inline-flex h-4 min-w-[16px] shrink-0 items-center justify-center rounded px-1 text-[9px] font-semibold tabular-nums
             {detachedHasUnread
               ? 'bg-accent text-white'
               : 'bg-bg-surface text-text-muted'}"
-          title="{detachedCount} detached terminal{detachedCount === 1 ? '' : 's'}{detachedHasUnread ? ' (unread output)' : ''}"
+          title={detachedPaneTitle}
         >{detachedCount}</span>
       {/if}
       {#if unreadCount > 0}

--- a/src/lib/components/SessionCard.svelte
+++ b/src/lib/components/SessionCard.svelte
@@ -12,6 +12,7 @@
   } from "$lib/panes/agentState";
   import { listSessionPtys } from "$lib/tauri";
   import CloseButton from "./CloseButton.svelte";
+  import Pencil from "@lucide/svelte/icons/pencil";
 
   interface Props {
     session: Session;
@@ -176,7 +177,7 @@
     <div class="flex items-center gap-2">
       {#if editing}
         <input
-          class="flex-1 border border-accent-dim/30 bg-bg-deep px-2 py-1 text-[13px] font-semibold tracking-tight text-text-primary outline-none"
+          class="h-5 min-w-0 flex-1 border border-accent-dim/30 bg-bg-deep px-1.5 py-0 text-[13px] font-semibold leading-none tracking-tight text-text-primary outline-none"
           bind:value={editName}
           onblur={commitRename}
           onkeydown={(e) => {
@@ -192,6 +193,15 @@
         >
           {displayName}
         </span>
+        <button
+          type="button"
+          class="flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center border border-transparent bg-transparent p-0 text-text-muted opacity-0 transition-colors duration-150 hover:border-border-subtle hover:bg-bg-hover hover:text-text-primary focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50 group-hover:opacity-100"
+          onclick={startEditing}
+          aria-label="Rename session"
+          title="Rename session"
+        >
+          <Pencil size={12} />
+        </button>
       {/if}
 
       {#if showPaneInventory}
@@ -224,7 +234,7 @@
         </button>
       {/if}
       <CloseButton
-        class="h-5 w-5 p-0 opacity-70 duration-150 group-hover:opacity-100 hover:border-transparent hover:text-red"
+        class="flex h-5 w-5 items-center justify-center p-0 opacity-70 duration-150 group-hover:opacity-100 hover:border-transparent hover:text-red"
         onclick={(e) => { e.stopPropagation(); onclose(); }}
         label="Close session"
         title="Close session"

--- a/src/lib/components/SessionCard.svelte
+++ b/src/lib/components/SessionCard.svelte
@@ -162,7 +162,7 @@
   title={tooltip}
 >
   <!-- Left gutter: persistent status dot -->
-  <div class="flex w-5 shrink-0 items-center justify-center pt-[10px] self-start">
+  <div class="flex h-9 w-5 shrink-0 items-center justify-center self-start">
     <span class="relative inline-flex h-2 w-2 items-center justify-center">
       {#if effectiveStatus === "attention"}
         <span class="absolute inline-flex h-2 w-2 rounded-full {statusDotClasses[effectiveStatus]} animate-ping opacity-60"></span>

--- a/src/lib/components/SessionCard.svelte
+++ b/src/lib/components/SessionCard.svelte
@@ -11,6 +11,7 @@
     computeEffectiveSessionStatus,
   } from "$lib/panes/agentState";
   import { listSessionPtys } from "$lib/tauri";
+  import CloseButton from "./CloseButton.svelte";
 
   interface Props {
     session: Session;
@@ -222,13 +223,13 @@
           reconnect
         </button>
       {/if}
-      <button
-        class="flex h-5 w-5 cursor-pointer items-center justify-center bg-transparent text-[11px] leading-none text-text-secondary opacity-70 transition-all duration-150 group-hover:opacity-100 hover:bg-bg-hover hover:text-red"
+      <CloseButton
+        class="h-5 w-5 p-0 opacity-70 duration-150 group-hover:opacity-100 hover:border-transparent hover:text-red"
         onclick={(e) => { e.stopPropagation(); onclose(); }}
-        aria-label="Close session"
-      >
-        &times;
-      </button>
+        label="Close session"
+        title="Close session"
+        size={13}
+      />
     </div>
 
     {#if showRow2}

--- a/src/lib/components/SessionTabs.svelte
+++ b/src/lib/components/SessionTabs.svelte
@@ -29,6 +29,7 @@
 
   import PinButton from "./PinButton.svelte";
   import CollapseSidebarButton from "./CollapseSidebarButton.svelte";
+  import SidebarPanelHeader from "./SidebarPanelHeader.svelte";
 
   interface Props {
     onclose?: () => void;
@@ -385,11 +386,8 @@
   bind:this={rootEl}
   class="flex h-full flex-col overflow-hidden bg-bg-base/96 shadow-[0_0_0_1px_rgba(255,255,255,0.03)]"
 >
-  <div class="flex h-9 shrink-0 items-center justify-between px-3">
-    <div class="flex items-center gap-2">
-      <span class="text-sm font-semibold tracking-tight text-text-primary">Sessions</span>
-    </div>
-    <div class="flex items-center gap-1.5">
+  <SidebarPanelHeader title="Sessions">
+    {#snippet actions()}
       {#if onTogglePin}
         <PinButton {pinned} ontoggle={onTogglePin} />
       {/if}
@@ -400,8 +398,8 @@
           title="Collapse sessions sidebar"
         />
       {/if}
-    </div>
-  </div>
+    {/snippet}
+  </SidebarPanelHeader>
 
   <div class="flex shrink-0 items-center gap-1.5 border-b border-hairline p-2">
     <button

--- a/src/lib/components/SessionTabs.svelte
+++ b/src/lib/components/SessionTabs.svelte
@@ -17,7 +17,6 @@
   } from "$lib/tauri";
   import type { SpawnProfileRef } from "$lib/panes/profiles";
   import { settings, updateSetting } from "$lib/stores/settings";
-  import { sidebarLayout } from "$lib/stores/sidebarLayout";
   import { reconnectSession } from "$lib/sessions/reconnect";
   import { closeSession } from "$lib/sessions/close";
   import { refreshTasks, initTaskOverrides } from "$lib/stores/tasks";
@@ -25,19 +24,15 @@
   import { setSessionProject } from "$lib/stores/sessions";
   import { setSessionProject as tauriSetSessionProject } from "$lib/tauri";
   import { log, logError } from "$lib/logging";
-  import { failureCount } from "$lib/stores/watches";
-  import { unreadTotal } from "$lib/stores/notifications";
   import type { Session } from "$lib/types";
   import { getGroupedSessions } from "$lib/sessions/order";
 
   import PinButton from "./PinButton.svelte";
+  import CollapseSidebarButton from "./CollapseSidebarButton.svelte";
 
   interface Props {
     onclose?: () => void;
     onNewSession: () => void;
-    onOpenSettings: () => void;
-    onToggleWatches: () => void;
-    onToggleNotifications: () => void;
     pinned?: boolean;
     onTogglePin?: () => void;
   }
@@ -45,9 +40,6 @@
   let {
     onclose,
     onNewSession,
-    onOpenSettings,
-    onToggleWatches,
-    onToggleNotifications,
     pinned = false,
     onTogglePin,
   }: Props = $props();
@@ -395,75 +387,37 @@
 >
   <div class="flex h-9 shrink-0 items-center justify-between px-3">
     <div class="flex items-center gap-2">
+      <span class="text-sm font-semibold tracking-tight text-text-primary">Sessions</span>
+    </div>
+    <div class="flex items-center gap-1.5">
       {#if onTogglePin}
         <PinButton {pinned} ontoggle={onTogglePin} />
       {/if}
       {#if onclose}
-      <button
-        class="flex h-5 w-5 items-center justify-center text-text-secondary cursor-pointer transition-colors hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50"
-        onclick={onclose}
-        title="Hide sessions list"
-        aria-label="Hide sessions list"
-      >
-        <span class="text-[11px]">{$sidebarLayout.railSide === "right" ? "\u25B6" : "\u25C0"}</span>
-      </button>
+        <CollapseSidebarButton
+          onclick={onclose}
+          label="Collapse sessions sidebar"
+          title="Collapse sessions sidebar"
+        />
       {/if}
-      <span class="text-[11px] font-semibold uppercase tracking-[0.18em] text-text-secondary">Sessions</span>
-      <button
-        class="relative flex items-center justify-center text-text-secondary cursor-pointer transition-colors hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50"
-        onclick={onToggleNotifications}
-        title="Toggle notifications (⌘I)"
-        aria-label="Toggle notifications"
-      >
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
-          <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
-        </svg>
-        {#if $unreadTotal > 0}
-          <span class="absolute -right-1.5 -top-1 inline-flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-accent px-1 text-[9px] font-bold text-white">
-            {$unreadTotal}
-          </span>
-        {/if}
-      </button>
-    </div>
-    <div class="flex items-center gap-1.5">
-      <button
-        class="border border-border-subtle bg-bg-surface px-2 py-1 text-[13px] font-medium text-text-secondary cursor-pointer transition-colors hover:bg-bg-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50"
-        onclick={toggleGroupBy}
-        title="Group by {$settings.groupBy === 'project' ? 'repo' : 'project'}"
-      >
-        {$settings.groupBy === "project" ? "project" : "repo"}
-      </button>
-      <span class="border border-border-subtle bg-bg-surface px-2 py-1 font-mono text-[12px] text-text-secondary">
-        {$sessionState.sessions.length}
-      </span>
     </div>
   </div>
 
-  <div class="flex shrink-0 gap-1 border-b border-hairline p-2">
+  <div class="flex shrink-0 items-center gap-1.5 border-b border-hairline p-2">
     <button
-      class="flex flex-1 items-center justify-center gap-1.5 bg-bg-active/50 py-2 text-[13px] font-medium text-text-secondary cursor-pointer transition-all duration-150 hover:bg-bg-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50 focus-visible:ring-offset-1 focus-visible:ring-offset-bg-deep"
+      class="flex h-8 min-w-0 flex-1 cursor-pointer items-center justify-center gap-1.5 border border-accent-dim/20 bg-accent-dim/15 px-3 text-[13px] font-semibold text-accent transition-all duration-150 hover:bg-accent-dim/24 hover:text-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50 focus-visible:ring-offset-1 focus-visible:ring-offset-bg-deep"
       onclick={onNewSession}
     >
-      <span class="text-sm">+</span> New
+      <span class="relative -top-px text-sm leading-none">+</span>
+      <span>New</span>
     </button>
     <button
-      class="flex items-center justify-center gap-1 bg-bg-active/50 px-3 py-2 text-[13px] font-medium text-text-secondary cursor-pointer transition-all duration-150 hover:bg-bg-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50 focus-visible:ring-offset-1 focus-visible:ring-offset-bg-deep"
-      onclick={onToggleWatches}
-      title="Toggle watches"
+      class="flex h-8 shrink-0 cursor-pointer items-center gap-1.5 border border-border-subtle bg-bg-surface px-3 text-[11px] font-medium text-text-secondary transition-colors hover:bg-bg-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-accent-dim/50"
+      onclick={toggleGroupBy}
+      title="Group by {$settings.groupBy === 'project' ? 'repo' : 'project'}"
     >
-      Watches
-      {#if $failureCount > 0}
-        <span class="ml-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-red px-1 text-[10px] font-bold text-white">
-          {$failureCount}
-        </span>
-      {/if}
-    </button>
-    <button
-      class="flex items-center justify-center bg-bg-active/50 px-3 py-2 text-[13px] font-medium text-text-secondary cursor-pointer transition-all duration-150 hover:bg-bg-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50 focus-visible:ring-offset-1 focus-visible:ring-offset-bg-deep"
-      onclick={onOpenSettings}
-    >
-      &#9881;
+      <span class="text-text-muted/70">Group</span>
+      <span class="text-text-primary">{$settings.groupBy === "project" ? "project" : "repo"}</span>
     </button>
   </div>
 

--- a/src/lib/components/SessionTabs.svelte
+++ b/src/lib/components/SessionTabs.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onDestroy } from "svelte";
   import SessionCard from "./SessionCard.svelte";
   import ArchivedSessionsList from "./ArchivedSessionsList.svelte";
   import {
@@ -101,6 +102,11 @@
   let newProjectInput = $state(false);
   let newProjectName = $state("");
   let lastTaskWorktreePath = $state<string | null>(null);
+  let rootEl = $state<HTMLDivElement | null>(null);
+  let archivedCollapsed = $state(true);
+  let archivedHeight = $state(180);
+  let archivedDragging = $state(false);
+  let archivedDragTeardown: (() => void) | null = null;
 
   function handleContextMenu(e: MouseEvent, session: Session) {
     contextMenu = { x: e.clientX, y: e.clientY, session };
@@ -331,11 +337,60 @@
     await reconnectSession(session);
   }
 
+  function archivedMaxHeight(): number {
+    if (!rootEl) return 420;
+    const rect = rootEl.getBoundingClientRect();
+    return Math.max(140, Math.min(520, rect.height * 0.65));
+  }
+
+  function clampArchivedHeight(height: number): number {
+    return Math.max(96, Math.min(archivedMaxHeight(), height));
+  }
+
+  function archivedSectionStyle(): string {
+    return archivedCollapsed ? "" : `height: ${archivedHeight}px;`;
+  }
+
+  function endArchivedDrag(): void {
+    archivedDragTeardown?.();
+    archivedDragTeardown = null;
+    archivedDragging = false;
+  }
+
+  function onArchivedResizeStart(e: MouseEvent): void {
+    if (archivedCollapsed) return;
+    e.preventDefault();
+    endArchivedDrag();
+    archivedDragging = true;
+    const startY = e.clientY;
+    const startHeight = archivedHeight;
+    const onMove = (ev: MouseEvent) => {
+      archivedHeight = clampArchivedHeight(startHeight - (ev.clientY - startY));
+    };
+    const onUp = () => endArchivedDrag();
+    const onKey = (ev: KeyboardEvent) => {
+      if (ev.key === "Escape") endArchivedDrag();
+    };
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+    window.addEventListener("blur", endArchivedDrag);
+    window.addEventListener("keydown", onKey);
+    archivedDragTeardown = () => {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+      window.removeEventListener("blur", endArchivedDrag);
+      window.removeEventListener("keydown", onKey);
+    };
+  }
+
+  onDestroy(() => endArchivedDrag());
+
 </script>
 
 <svelte:window onclick={closeContextMenu} />
 
 <div
+  bind:this={rootEl}
   class="flex h-full flex-col overflow-hidden bg-bg-base/96 shadow-[0_0_0_1px_rgba(255,255,255,0.03)]"
 >
   <div class="flex h-9 shrink-0 items-center justify-between px-3">
@@ -412,7 +467,7 @@
     </button>
   </div>
 
-  <div class="app-scrollbar flex-1 overflow-y-auto px-2">
+  <div class="app-scrollbar min-h-0 flex-1 overflow-y-auto px-2">
     {#each grouped as group (group.key)}
       {#if showGroupHeaders}
         <button
@@ -442,7 +497,15 @@
         </div>
       {/if}
     {/each}
-    <ArchivedSessionsList />
+  </div>
+
+  <div class="min-h-0 shrink-0 px-2 pb-2" style={archivedSectionStyle()}>
+    <ArchivedSessionsList
+      collapsed={archivedCollapsed}
+      oncollapsedchange={(next) => (archivedCollapsed = next)}
+      onresizestart={onArchivedResizeStart}
+      resizing={archivedDragging}
+    />
   </div>
 
 </div>

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -12,7 +12,7 @@
   import { getLogPath, setLoggingEnabled } from "$lib/logging";
   import { notificationsPush } from "$lib/tauri";
   import { commands } from "$lib/bindings";
-  import type { UpdateChannel, WorktreeCleanupMode, WorktreeDefaultBase } from "$lib/bindings";
+  import type { OnPaneCloseMode, UpdateChannel, WorktreeCleanupMode, WorktreeDefaultBase } from "$lib/bindings";
   import { updateStatus, runManualCheck, performInstall } from "$lib/stores/updater";
   import { getVersion } from "@tauri-apps/api/app";
   import { quitApp } from "$lib/tauri";
@@ -179,6 +179,10 @@
     updateSetting("worktreeDefaultBase", mode);
   }
 
+  function setPaneCloseMode(mode: OnPaneCloseMode) {
+    updateSetting("onPaneClose", mode);
+  }
+
   async function browseAndAddRepoRoot() {
     const selected = await open({ directory: true, title: "Select Repo Root Directory" });
     if (selected) addRepoRoot(selected as string);
@@ -317,6 +321,26 @@
                 <div class="w-3.5 h-3.5 rounded-full absolute top-0.5 transition-all
                   {$settings.restoreSessionsOnLaunch ? 'left-[18px] bg-accent' : 'left-0.5 bg-text-secondary'}"></div>
               </button>
+            </div>
+            <div class="flex items-center justify-between py-2">
+              <div>
+                <div class="text-[13px]">On pane close</div>
+                <div class="text-[11px] text-text-muted mt-0.5">Kill the terminal by default, or keep it running detached for later reconnect.</div>
+              </div>
+              <div class="flex overflow-hidden rounded border border-border bg-bg-deep">
+                {#each [
+                  { id: "kill", label: "Kill" },
+                  { id: "detach", label: "Detach" },
+                ] as const as opt}
+                  {@const active = ($settings.onPaneClose ?? "kill") === opt.id}
+                  <button
+                    class="px-2.5 py-1 text-[11px] cursor-pointer transition-colors
+                      {active ? 'bg-accent-dim text-text-primary' : 'text-text-secondary hover:bg-bg-hover'}"
+                    aria-pressed={active}
+                    onclick={() => setPaneCloseMode(opt.id)}
+                  >{opt.label}</button>
+                {/each}
+              </div>
             </div>
             <div class="flex items-center justify-between py-2">
               <span class="text-[13px]">Default project path</span>

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -327,11 +327,12 @@
                 <div class="text-[13px]">On pane close</div>
                 <div class="text-[11px] text-text-muted mt-0.5">Kill the terminal by default, or keep it running detached for later reconnect.</div>
               </div>
+              {@const paneCloseOptions = [
+                { id: "kill", label: "Kill" },
+                { id: "detach", label: "Detach" },
+              ] as const}
               <div class="flex overflow-hidden rounded border border-border bg-bg-deep">
-                {#each [
-                  { id: "kill", label: "Kill" },
-                  { id: "detach", label: "Detach" },
-                ] as const as opt}
+                {#each paneCloseOptions as opt}
                   {@const active = ($settings.onPaneClose ?? "kill") === opt.id}
                   <button
                     class="px-2.5 py-1 text-[11px] cursor-pointer transition-colors

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -43,6 +43,11 @@
     { id: "advanced", label: "Advanced", icon: Wrench },
   ];
 
+  const PANE_CLOSE_OPTIONS = [
+    { id: "kill", label: "Kill" },
+    { id: "detach", label: "Detach" },
+  ] as const;
+
   let selected = $state<CategoryId>("general");
 
   let appVersion = $state<string>("…");
@@ -327,12 +332,8 @@
                 <div class="text-[13px]">On pane close</div>
                 <div class="text-[11px] text-text-muted mt-0.5">Kill the terminal by default, or keep it running detached for later reconnect.</div>
               </div>
-              {@const paneCloseOptions = [
-                { id: "kill", label: "Kill" },
-                { id: "detach", label: "Detach" },
-              ] as const}
               <div class="flex overflow-hidden rounded border border-border bg-bg-deep">
-                {#each paneCloseOptions as opt}
+                {#each PANE_CLOSE_OPTIONS as opt}
                   {@const active = ($settings.onPaneClose ?? "kill") === opt.id}
                   <button
                     class="px-2.5 py-1 text-[11px] cursor-pointer transition-colors

--- a/src/lib/components/SidebarDock.svelte
+++ b/src/lib/components/SidebarDock.svelte
@@ -30,16 +30,10 @@
 
   interface Props {
     onNewSession: () => void;
-    onOpenSettings: () => void;
-    onToggleWatches: () => void;
-    onToggleNotifications: () => void;
   }
 
   let {
     onNewSession,
-    onOpenSettings,
-    onToggleWatches,
-    onToggleNotifications,
   }: Props = $props();
 
   type Slot = "hidden" | "solo" | "pinned-half" | "active-half";
@@ -235,9 +229,6 @@
           {#if id === "sessions"}
             <SessionTabs
               {onNewSession}
-              {onOpenSettings}
-              {onToggleWatches}
-              {onToggleNotifications}
               onclose={onCloseFor(id)}
               pinned={$pinnedSidebar === id}
               onTogglePin={onTogglePinFor(id)}

--- a/src/lib/components/SidebarDock.svelte
+++ b/src/lib/components/SidebarDock.svelte
@@ -219,7 +219,7 @@
     {/if}
     <div
       bind:this={dockEl}
-      class="relative h-full shrink-0 bg-bg-deep {railSide === 'left' ? 'border-r border-hairline' : 'border-l border-hairline'}"
+      class="relative h-full shrink-0 bg-bg-deep"
       style="width: {dockWidth}px"
     >
       {#each DOCK_PANEL_IDS as id (id)}

--- a/src/lib/components/SidebarPanelHeader.svelte
+++ b/src/lib/components/SidebarPanelHeader.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+
+  interface Props {
+    title: string;
+    actions?: Snippet;
+  }
+
+  let { title, actions }: Props = $props();
+</script>
+
+<div class="flex h-9 shrink-0 items-center justify-between border-b border-hairline bg-bg-surface/30 px-3">
+  <span class="text-sm font-semibold tracking-tight text-text-primary">{title}</span>
+  {#if actions}
+    <div class="flex items-center gap-1">
+      {@render actions()}
+    </div>
+  {/if}
+</div>

--- a/src/lib/components/TaskPanel.svelte
+++ b/src/lib/components/TaskPanel.svelte
@@ -12,6 +12,7 @@
   import type { CreateWatchConfig } from "$lib/types";
 
   import PinButton from "./PinButton.svelte";
+  import CollapseSidebarButton from "./CollapseSidebarButton.svelte";
 
   interface Props {
     onCollapse?: () => void;
@@ -134,11 +135,11 @@
         <PinButton {pinned} ontoggle={onTogglePin} />
       {/if}
       {#if onCollapse}
-        <button
-          class="cursor-pointer bg-transparent p-1 text-[12px] font-medium text-text-secondary hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50 focus-visible:ring-offset-1 focus-visible:ring-offset-bg-deep"
+        <CollapseSidebarButton
           onclick={onCollapse}
-          title="Close tasks panel"
-        >&times;</button>
+          label="Collapse tasks sidebar"
+          title="Collapse tasks sidebar"
+        />
       {/if}
     </div>
   </div>

--- a/src/lib/components/TaskPanel.svelte
+++ b/src/lib/components/TaskPanel.svelte
@@ -13,6 +13,7 @@
 
   import PinButton from "./PinButton.svelte";
   import CollapseSidebarButton from "./CollapseSidebarButton.svelte";
+  import SidebarPanelHeader from "./SidebarPanelHeader.svelte";
 
   interface Props {
     onCollapse?: () => void;
@@ -125,9 +126,8 @@
 <svelte:window onclick={handleClickOutside} />
 
 <div class="flex h-full flex-col bg-transparent">
-  <div class="flex h-9 shrink-0 items-center justify-between px-3">
-    <span class="text-[11px] font-semibold uppercase tracking-[0.18em] text-text-secondary">Tasks</span>
-    <div class="flex items-center gap-1.5">
+  <SidebarPanelHeader title="Tasks">
+    {#snippet actions()}
       <span class="border border-border-subtle bg-bg-surface px-2 py-1 font-mono text-[12px] text-text-secondary">
         {filteredGroups.reduce((n, g) => n + g.tasks.length, 0)}
       </span>
@@ -141,8 +141,8 @@
           title="Collapse tasks sidebar"
         />
       {/if}
-    </div>
-  </div>
+    {/snippet}
+  </SidebarPanelHeader>
 
   {#if $taskGroups.length > 0}
     <div class="px-3 pb-2">

--- a/src/lib/components/WatchesPane.svelte
+++ b/src/lib/components/WatchesPane.svelte
@@ -6,6 +6,7 @@
   import { openUrl } from "@tauri-apps/plugin-opener";
 
   import PinButton from "./PinButton.svelte";
+  import CollapseSidebarButton from "./CollapseSidebarButton.svelte";
 
   interface Props {
     visible: boolean;
@@ -109,10 +110,11 @@
       {#if onTogglePin}
         <PinButton {pinned} ontoggle={onTogglePin} />
       {/if}
-      <button
-        class="cursor-pointer rounded-lg border border-transparent bg-transparent p-1.5 text-base text-text-muted hover:border-border-subtle hover:bg-bg-hover hover:text-text-primary"
+      <CollapseSidebarButton
         onclick={onclose}
-      >&times;</button>
+        label="Collapse watches sidebar"
+        title="Collapse watches sidebar"
+      />
     </div>
   </div>
 

--- a/src/lib/components/WatchesPane.svelte
+++ b/src/lib/components/WatchesPane.svelte
@@ -7,6 +7,7 @@
 
   import PinButton from "./PinButton.svelte";
   import CollapseSidebarButton from "./CollapseSidebarButton.svelte";
+  import SidebarPanelHeader from "./SidebarPanelHeader.svelte";
 
   interface Props {
     visible: boolean;
@@ -104,9 +105,8 @@
   class="flex h-full w-full min-h-0 flex-col bg-bg-deep"
   class:hidden={!visible}
 >
-  <div class="flex h-9 shrink-0 items-center justify-between border-b border-hairline bg-bg-surface/30 px-3">
-    <span class="text-sm font-semibold tracking-tight">Watches</span>
-    <div class="flex items-center gap-1">
+  <SidebarPanelHeader title="Watches">
+    {#snippet actions()}
       {#if onTogglePin}
         <PinButton {pinned} ontoggle={onTogglePin} />
       {/if}
@@ -115,8 +115,8 @@
         label="Collapse watches sidebar"
         title="Collapse watches sidebar"
       />
-    </div>
-  </div>
+    {/snippet}
+  </SidebarPanelHeader>
 
   <div class="flex-1 overflow-y-auto p-2">
     {#if $watchState.length === 0}

--- a/src/lib/components/__tests__/ActivityRail.test.ts
+++ b/src/lib/components/__tests__/ActivityRail.test.ts
@@ -44,6 +44,14 @@ describe("ActivityRail", () => {
     }
   });
 
+  it("uses custom rail tooltips instead of native title tooltips", () => {
+    render(ActivityRail);
+
+    const notes = screen.getByRole("button", { name: /notes/i });
+    expect(notes.getAttribute("title")).toBeNull();
+    expect(notes.textContent).toContain("Notes");
+  });
+
   it("clicking the Notes icon activates the notes sidebar", async () => {
     render(ActivityRail);
     await fireEvent.click(screen.getByRole("button", { name: /notes/i }));

--- a/src/lib/components/__tests__/SessionCard.test.ts
+++ b/src/lib/components/__tests__/SessionCard.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/svelte";
+import type { PtyInfo, Session } from "$lib/types";
+import { notifications } from "$lib/stores/notifications";
+import { projects } from "$lib/stores/projects";
+import { flashingSessions } from "$lib/stores/watches";
+import { sessionLayouts } from "$lib/panes/layout";
+import { agentStates } from "$lib/panes/agentState";
+import SessionCard from "../SessionCard.svelte";
+import { listSessionPtys } from "$lib/tauri";
+
+vi.mock("$lib/tauri", () => ({
+  listSessionPtys: vi.fn(),
+}));
+
+const mockListSessionPtys = vi.mocked(listSessionPtys);
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "session-1",
+    name: "main",
+    repoRoot: "/repo",
+    worktreePath: "/repo",
+    branch: "main",
+    isWorktree: false,
+    status: "idle",
+    model: null,
+    cost: null,
+    createdAt: 1,
+    projectId: null,
+    isGitRepo: true,
+    nameOverride: null,
+    primaryPtyId: "pty-1",
+    archived: false,
+    endedAt: null,
+    ...overrides,
+  };
+}
+
+function makePty(overrides: Partial<PtyInfo> = {}): PtyInfo {
+  return {
+    id: "pty-1",
+    session_id: "session-1",
+    role: "sessionPrimary",
+    status: { type: "RunningAttached", pane_id: "pane-1" },
+    name: null,
+    working_dir: "/repo",
+    profile: "claude",
+    unread_output: false,
+    bell_pending: false,
+    ...overrides,
+  };
+}
+
+describe("SessionCard", () => {
+  beforeEach(() => {
+    notifications.set([]);
+    projects.set([]);
+    flashingSessions.set(new Set());
+    sessionLayouts.set(new Map());
+    agentStates.set(new Map());
+    mockListSessionPtys.mockReset();
+  });
+
+  afterEach(() => {
+    notifications.set([]);
+    projects.set([]);
+    flashingSessions.set(new Set());
+    sessionLayouts.set(new Map());
+    agentStates.set(new Map());
+    mockListSessionPtys.mockReset();
+  });
+
+  it("shows active and detached inventory separately when a session has detached terminals", async () => {
+    mockListSessionPtys.mockResolvedValue([
+      makePty({ id: "pty-1", status: { type: "RunningAttached", pane_id: "pane-1" } }),
+      makePty({ id: "pty-2", role: "secondary", status: { type: "RunningAttached", pane_id: "pane-2" } }),
+      makePty({
+        id: "pty-3",
+        role: "secondary",
+        status: { type: "RunningDetached", since_ms: 123 },
+        unread_output: true,
+      }),
+    ]);
+
+    render(SessionCard, {
+      session: makeSession(),
+      active: false,
+      onselect: () => {},
+      onclose: () => {},
+      onrename: () => {},
+      onreconnect: () => {},
+    });
+
+    const activeBadge = await screen.findByTitle("2 active panes");
+    expect(activeBadge.textContent).toBe("2");
+
+    const detachedBadge = await screen.findByTitle("1 detached terminal (unread output)");
+    expect(detachedBadge.textContent).toBe("1");
+  });
+
+  it("hides the pane inventory badge for an ordinary single-pane session", async () => {
+    mockListSessionPtys.mockResolvedValue([
+      makePty({ id: "pty-1", status: { type: "RunningAttached", pane_id: "pane-1" } }),
+    ]);
+
+    render(SessionCard, {
+      session: makeSession(),
+      active: false,
+      onselect: () => {},
+      onclose: () => {},
+      onrename: () => {},
+      onreconnect: () => {},
+    });
+
+    await waitFor(() => expect(mockListSessionPtys).toHaveBeenCalledWith("session-1"));
+    expect(screen.queryByTitle("1 active pane")).toBeNull();
+    expect(screen.queryByTitle(/detached terminal/)).toBeNull();
+  });
+});

--- a/src/lib/panes/__tests__/actions.test.ts
+++ b/src/lib/panes/__tests__/actions.test.ts
@@ -32,7 +32,7 @@ describe("pane actions", () => {
     resetLayouts();
     resetFocus();
     fullscreenPaneId.set(null);
-    settings.set(DEFAULT_SETTINGS); // resets to onPaneClose: "detach"
+    settings.set(DEFAULT_SETTINGS); // resets to onPaneClose: "kill"
     vi.mocked(killPty).mockClear();
     vi.mocked(killSession).mockClear();
     vi.mocked(detachPty).mockClear();
@@ -119,9 +119,18 @@ describe("pane actions", () => {
       expect(get(sessionLayouts).has("s1")).toBe(false);
     });
 
-    it("detaches PTY (not kills) when onPaneClose is 'detach' (the default)", () => {
-      // Default behaviour: closing a pane detaches the PTY so it keeps
-      // running in the background. killPty must not be called.
+    it("uses killPty (not killSession) by default", () => {
+      // Default behaviour: closing a pane kills its PTY. This makes "close"
+      // behave like close rather than hide.
+      initSession("s1");
+      closePane("s1", "s1-main");
+      expect(killPty).toHaveBeenCalledWith("s1");
+      expect(detachPty).not.toHaveBeenCalled();
+      expect(killSession).not.toHaveBeenCalled();
+    });
+
+    it("detaches PTY (not kills) when onPaneClose is explicitly 'detach'", () => {
+      settings.set({ ...DEFAULT_SETTINGS, onPaneClose: "detach" });
       initSession("s1");
       closePane("s1", "s1-main");
       expect(detachPty).toHaveBeenCalledWith("s1");

--- a/src/lib/panes/actions.ts
+++ b/src/lib/panes/actions.ts
@@ -124,7 +124,7 @@ export function closePane(sessionId: string, paneId: string): boolean {
     return new Map(m);
   });
 
-  const onPaneClose = get(settings).onPaneClose ?? "detach";
+  const onPaneClose = get(settings).onPaneClose ?? "kill";
   const ptyId = getAttachedPtyId(instance);
   if (onPaneClose === "detach" && ptyId) {
     // Detach the PTY so it keeps running in the background. Fire-and-forget:

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -104,7 +104,7 @@ export const DEFAULT_SETTINGS: RouxSettings = {
   spawnProfiles: [],
   trustedWorkspaces: [],
   statusBarPosition: "bottom",
-  onPaneClose: "detach",
+  onPaneClose: "kill",
 };
 
 // Re-export frontend-only task types


### PR DESCRIPTION
Closes #99.

## Summary

This PR implements the UX/visual polish pass from issue #99 and includes the follow-up visual refinements made during review.

- Updates session cards to show active pane and detached terminal inventory separately, including unread detached state.
- Changes pane close behavior to default to killing the PTY instead of detaching it, while keeping explicit detach available in Settings.
- Adds a Settings > Sessions control for choosing `Kill` vs `Detach` on pane close.
- Replaces slow native Activity Rail title tooltips with immediate custom tooltips and removes gaps/tooltip shift.
- Pins Archived sessions to the bottom of the Sessions sidebar and makes the expanded archived area resizable from its top separator.
- Standardizes sidebar header controls and title treatment across Sessions, Notes, Watches, Tasks, Docs, and Notifications.
- Uses chevron collapse controls for sidebar panels and `X` icons only for real close/dismiss actions.
- Removes redundant Notifications, Watches, and Settings controls from the Sessions sidebar since they already exist in the Activity Rail.
- Reorganizes the Sessions toolbar so `New` and `Group` sit together in one action row.
- Prevents text selection across app chrome and interactive UI while preserving selection in inputs, editors, terminals, markdown, and prose content.
- Aligns session-card status dots with the title row.
- Removes the duplicate vertical sidebar separator while preserving the draggable resize handle.

## Verification

- `npm run test -- SessionCard`
- `npm run test -- actions.test.ts`
- `npm run test -- ActivityRail`
- `npm run check`

## Visual Review Checklist

- [ ] Session cards show active pane count and detached terminal count separately.
- [ ] A normal single-pane session does not show unnecessary pane inventory badges.
- [ ] Session-card status dots align vertically with the session title text.
- [ ] Closing a pane with default settings kills the pane PTY instead of leaving a detached terminal.
- [ ] Settings > Sessions exposes the On pane close control with Kill and Detach options.
- [ ] Activity Rail tooltips appear immediately, sit close to the icon, and do not shift/inset when hover ends.
- [ ] Activity Rail buttons have no visible vertical gaps between them.
- [ ] Archived sessions stay pinned at the bottom of the Sessions sidebar when active sessions scroll.
- [ ] Expanded Archived section can be resized by dragging its top separator.
- [ ] Sidebar panel headers have consistent height, title typography, padding, background, and right-side control placement.
- [ ] Sidebar panels use chevrons for collapse instead of `X`.
- [ ] Real close/dismiss actions still use `X` icons, such as pane close, session close, notification dismiss, and markdown tab close.
- [ ] Sessions sidebar no longer shows duplicate Notifications, Watches, or Settings controls.
- [ ] Sessions toolbar shows `New` and `Group` together with matching control heights.
- [ ] Dragging over sidebar titles, session cards, buttons, badges, and other app chrome does not select text.
- [ ] Inputs, textareas, terminal text, CodeMirror content, markdown, and prose remain selectable.
- [ ] Sidebar/main boundary shows a single vertical draggable separator, not a duplicated border.
