### PR TITLE
Add Roux automation hooks with MiniJinja templating

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2471,6 +2471,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memo-map"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2494,6 +2500,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minijinja"
+version = "2.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "805bfd7352166bae857ee569628b52bcd85a1cecf7810861ebceb1686b72b75d"
+dependencies = [
+ "memo-map",
+ "serde",
+]
 
 [[package]]
 name = "minisign-verify"
@@ -3881,13 +3897,14 @@ dependencies = [
 
 [[package]]
 name = "roux"
-version = "0.5.1-pre.2"
+version = "0.5.1-pre.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
  "clap",
  "dirs",
  "libc",
+ "minijinja",
  "notify",
  "octocrab",
  "portable-pty",
@@ -3897,6 +3914,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "specta",
  "specta-typescript",
  "tauri",
@@ -3911,6 +3929,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
+ "toml 0.8.2",
  "url",
  "uuid",
  "vte",

--- a/docs/features/cli.md
+++ b/docs/features/cli.md
@@ -38,7 +38,7 @@ If the Roux app is not running, socket-backed commands fail with a direct `Roux 
 - Focus a pane by id (`roux focus`)
 - Run a shell command in a new pane (`roux run`)
 - Push notifications (`roux notify`)
-- Emit hook status transitions (`roux hook`)
+- Emit hook status transitions and run automation hooks (`roux hook`)
 - Read, append, write, or search the multi-scoped notes vault (`roux notes <scope> <verb>` — experimental; see [Notes](notes.md))
 
 ## Context-aware defaults
@@ -213,7 +213,9 @@ Session resolution order is:
 
 ### `roux hook`
 
-Handle a Claude Code hook event. This is intended for automation/hooks, not normal interactive use.
+Handle Claude Code status hooks and Roux automation hooks.
+
+Claude status events are installed by Roux's setup flow:
 
 ```sh
 roux hook working
@@ -224,6 +226,17 @@ roux hook disconnected
 ```
 
 It reads a JSON payload from stdin and writes provider/session status state for Roux to consume.
+
+Automation hook commands talk to the running app over the socket:
+
+```sh
+roux hook show
+roux hook show --repo-path ~/src/my-repo
+roux hook run post-watch-success --repo-path ~/src/my-repo
+roux hook run post-worktree-create --repo-path ~/src/my-repo --branch feat/x --provider worktrunk
+```
+
+See [Automation hooks](hooks.md) for config files, event names, conditions, templates, logs, and Worktrunk differences.
 
 ### `roux status` and `roux clear`
 

--- a/docs/features/hooks.md
+++ b/docs/features/hooks.md
@@ -101,7 +101,7 @@ Supported conditions:
 |---|---|
 | `when.provider` | `"git"`, `"worktrunk"`, or `"auto"` context values |
 | `when.worktrunk` | `true` or `false` |
-| `when.scope` | `"user"`, `"project"`, `"global"`, or `"session"` |
+| `when.scope` | `"global"`, `"project"`, or `"session"` |
 
 For conditions, `when.provider = "git"` and `when.provider = "worktrunk"` match the effective provider Roux intends to use for the operation. `when.provider = "auto"` matches when the user's configured provider is `auto`. The rendered context includes both `provider` and `configured_provider` when you need to distinguish those values in a template or stdin JSON.
 

--- a/docs/features/hooks.md
+++ b/docs/features/hooks.md
@@ -1,0 +1,249 @@
+# Automation hooks
+
+Roux automation hooks are shell commands that run around app-level lifecycle events: watches, worktree creation/removal, sessions, and tasks.
+
+They are inspired by [Worktrunk hooks](https://worktrunk.dev/hook/), but they are Roux-owned. Worktrunk hooks still live in `.config/wt.toml` and run when `wt` owns a git/worktree operation. Roux hooks live in Roux config and can react to Roux-specific context such as sessions, watches, task panes, and the active worktree provider.
+
+## Config files
+
+Roux loads hooks from:
+
+| Scope | Path | Trust |
+|---|---|---|
+| User | `~/.config/roux/hooks.toml` | trusted by default |
+| Project | `<repo>/.config/roux/hooks.toml` | requires approval |
+
+Project approvals are keyed by config path, event, command name, and command text. If a project command changes, Roux treats it as a new command and requires approval again.
+
+## Hook forms
+
+A string is one command:
+
+```toml
+post-watch-success = "roux-cli notify --title 'Watch passed'"
+```
+
+A table is multiple named commands in the same step:
+
+```toml
+[post-watch-failure]
+notify = "roux-cli notify --title '{{ watch.name }} failed' --level error"
+log = "printf '%s\n' '{{ watch.name }} failed' >> /tmp/roux-watch.log"
+```
+
+A pipeline is an ordered sequence of `[[event]]` blocks. Blocks run in order; multiple commands inside one block run as the same step.
+
+```toml
+[[post-worktree-create]]
+install = "npm ci"
+
+[[post-worktree-create]]
+dev = "npm run dev"
+test = "npm test -- --watch"
+```
+
+## Event types
+
+`pre-*` hooks are blocking. If a blocking hook exits non-zero, Roux aborts or skips the operation and returns the hook error.
+
+`post-*` hooks run in the background. Their failures are logged but do not retroactively fail the operation that already completed.
+
+### Watches
+
+| Event | When it runs |
+|---|---|
+| `pre-watch-run` | Before executing a watch check. Failure skips the check and records a failed watch result. |
+| `post-watch-run` | After every completed watch check. |
+| `post-watch-change` | Only when the watch outcome changes. |
+| `post-watch-failure` | Only when the outcome transitions into failure. |
+| `post-watch-success` | Only when the outcome transitions into success. |
+
+### Worktrees
+
+| Event | When it runs |
+|---|---|
+| `pre-worktree-create` | Before Roux invokes the selected provider. |
+| `post-worktree-create` | After a worktree is created. |
+| `pre-worktree-remove` | Before Roux removes a worktree. |
+| `post-worktree-remove` | After removal completes. |
+
+When the effective provider is Worktrunk, Roux marks Worktrunk's provider-owned hooks as already handled in the hook context. Roux does not try to rerun Worktrunk's `pre-start`, `post-start`, `pre-remove`, or `post-remove`.
+
+### Sessions and tasks
+
+| Event | When it runs |
+|---|---|
+| `post-session-create` | After Roux creates a session record and primary PTY. |
+| `pre-session-close` | Before Roux archives a session and kills its PTYs. |
+| `post-session-close` | After session close cleanup completes. |
+| `pre-task-run` | Before Roux spawns a task command. |
+| `post-task-run` | After Roux successfully spawns a task command. |
+| `post-task-success` | When a task PTY exits with code `0`. |
+| `post-task-failure` | When a task PTY exits with any non-zero or unknown code. |
+
+## Conditions
+
+Add a `when` table to a hook step to run only in matching contexts:
+
+```toml
+[[post-worktree-create]]
+when.provider = "worktrunk"
+notify = "roux-cli notify --title 'Worktrunk worktree ready'"
+
+[[post-worktree-create]]
+when.provider = "git"
+install = "npm ci"
+```
+
+Supported conditions:
+
+| Condition | Values |
+|---|---|
+| `when.provider` | `"git"`, `"worktrunk"`, or `"auto"` context values |
+| `when.worktrunk` | `true` or `false` |
+| `when.scope` | `"user"`, `"project"`, `"global"`, or `"session"` |
+
+For conditions, `when.provider = "git"` and `when.provider = "worktrunk"` match the effective provider Roux intends to use for the operation. `when.provider = "auto"` matches when the user's configured provider is `auto`. The rendered context includes both `provider` and `configured_provider` when you need to distinguish those values in a template or stdin JSON.
+
+## Templates
+
+Roux renders hook commands with [MiniJinja](https://docs.rs/minijinja/latest/minijinja/), a Rust implementation of Jinja-style templates:
+
+```toml
+post-watch-success = "echo '{{ watch.name }} passed in {{ cwd }}'"
+post-worktree-create = "echo '{{ branch }} -> {{ worktree_path }}'"
+```
+
+Templates can use variables, conditionals, loops, expressions, and MiniJinja's built-in filters:
+
+```toml
+post-watch-failure = "{% if watch.name %}echo '{{ watch.name }} failed'{% endif %}"
+post-worktree-create = "createdb {{ branch | sanitize_db }}"
+```
+
+Common variables:
+
+| Variable | Meaning |
+|---|---|
+| `hook_type` | Event name, such as `post-watch-success`. |
+| `hook_name` | Named command key, such as `notify`. |
+| `provider` | Effective provider, usually `git` or `worktrunk`. |
+| `configured_provider` | User setting: `auto`, `git`, or `worktrunk`. |
+| `worktrunk` | Boolean convenience flag. |
+| `repo_path` | Repository root when known. |
+| `worktree_path` | Worktree path when known. |
+| `branch` | Branch name when known. |
+| `cwd` | Directory where Roux runs the hook command. |
+| `session_id` | Roux session id when known. |
+| `project_id` | Roux project id when known. |
+| `task_id` | Task PTY id for task hooks. |
+| `watch.id` | Watch id for watch hooks. |
+| `watch.name` | Watch name for watch hooks. |
+| `outcome` | Current watch outcome when known. |
+| `previous_outcome` | Previous watch outcome when known. |
+| `args` | Extra tokens passed by `roux-cli hook run ... -- ...`. |
+
+Roux also provides Worktrunk-inspired helper filters and functions:
+
+| Helper | Example | Meaning |
+|---|---|---|
+| `sanitize` | `{{ branch | sanitize }}` | Lowercase path/shell-friendly token. |
+| `sanitize_hash` | `{{ branch | sanitize_hash }}` | Sanitized token with a short stable hash when the original needed rewriting or was long. |
+| `sanitize_db` | `{{ branch | sanitize_db }}` | Lowercase database-safe identifier, capped at 63 characters. |
+| `hash_port` | `{{ branch | hash_port }}` | Stable port in the `10000..49999` range. |
+| `worktree_path_of_branch` | `{{ worktree_path_of_branch("main") }}` | Looks up a local git worktree path for a branch when `repo_path` is known. |
+
+!!! note "Shell escaping"
+    MiniJinja renders text; it does not automatically shell-escape values. Quote variables in commands when paths, branch names, or watch names can contain spaces or shell metacharacters.
+
+## JSON context on stdin
+
+Every hook command receives the full context as JSON on stdin. Use this for logic that is too complex for simple templates:
+
+```toml
+[pre-watch-run]
+gate = "python3 scripts/should-run-watch.py"
+```
+
+```python
+import json
+import sys
+
+ctx = json.load(sys.stdin)
+watch = ctx.get("watch") or {}
+
+if watch.get("name") == "expensive-ci" and ctx.get("provider") == "git":
+    print("skip expensive CI outside worktrunk", file=sys.stderr)
+    sys.exit(1)
+```
+
+For a `pre-*` hook, exiting non-zero blocks the operation. For a `post-*` hook, the failure is logged.
+
+## Logs
+
+Background hook output is written under:
+
+```text
+~/.config/roux/logs/hooks/
+```
+
+Each log file records:
+
+- event name
+- command name
+- source (`user` or `project`)
+- config path
+- original and rendered command
+- exit code
+- stdout and stderr
+- start and finish timestamps
+
+## CLI
+
+Show configured hooks:
+
+```sh
+roux-cli hook show
+roux-cli hook show --repo-path ~/src/my-repo
+```
+
+Run a hook manually through the running app:
+
+```sh
+roux-cli hook run post-watch-success --repo-path ~/src/my-repo
+roux-cli hook run post-worktree-create \
+  --repo-path ~/src/my-repo \
+  --worktree-path ~/src/my-repo/.worktrees/feat-x \
+  --branch feat/x \
+  --provider worktrunk
+```
+
+Forward extra tokens into `args`:
+
+```sh
+roux-cli hook run post-watch-run --repo-path ~/src/my-repo -- --verbose
+```
+
+The legacy Claude status bridge still uses the same top-level group:
+
+```sh
+roux-cli hook working
+roux-cli hook idle
+roux-cli hook attention
+roux-cli hook error
+roux-cli hook disconnected
+```
+
+## Worktrunk relationship
+
+Use Worktrunk hooks for git/worktree lifecycle automation that should run everywhere `wt` runs.
+
+Use Roux automation hooks for app-aware behavior:
+
+- notifying or focusing Roux sessions
+- reacting to watch outcome transitions
+- starting or logging task runs
+- running different automation depending on whether Roux used git or Worktrunk
+- coordinating with Roux project/session IDs
+
+The two systems are intentionally separate so Roux can be useful without `wt`, while still exposing provider context when Worktrunk is active.

--- a/docs/features/watches.md
+++ b/docs/features/watches.md
@@ -23,3 +23,4 @@ When a watch is pinned to a pane, Roux keeps the output buffer alive even if you
 
 - [Panes](panes.md)
 - [CLI bridge](cli.md) — drive watches from scripts via `roux-cli`
+- [Automation hooks](hooks.md) — react to watch runs and outcome transitions

--- a/docs/features/worktrees.md
+++ b/docs/features/worktrees.md
@@ -196,3 +196,4 @@ Hook-output rows additionally show the source (`user` / `project` / `internal`),
 - Worktrees share hooks and git config with the main repo. Be aware of any `post-checkout` or `post-commit` hooks that assume a single working copy.
 - Do not `git worktree remove` the directory a running session is using — stop the session first.
 - Worktrunk hooks and Roux's own agent hooks are separate systems. Roux does not install, route, or interfere with `wt`'s hook machinery; likewise `wt` has no visibility into Roux sessions. If you configure a `wt` post-start hook that needs the Roux session's environment, pass it explicitly in your hook template.
+- [Automation hooks](hooks.md) can wrap Roux's own worktree create/remove operations and receive provider context (`git` vs `worktrunk`) without replacing Worktrunk's hook machinery.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
       - Layouts: features/layouts.md
       - Worktrees: features/worktrees.md
       - Watches: features/watches.md
+      - Automation hooks: features/hooks.md
       - CLI: features/cli.md
       - Notes: features/notes.md
       - Keymap: features/keymap.md

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,6 +32,7 @@ tauri = { version = "2", features = [] }
 tauri-plugin-shell = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sha2 = "0.10"
 uuid = { version = "1", features = ["v4"] }
 portable-pty = "0.9"
 base64 = "0.22"
@@ -48,6 +49,8 @@ url = "2"
 octocrab = "0.44"
 tauri-plugin-opener = "2.5.3"
 thiserror = "2"
+toml = "0.8"
+minijinja = "2"
 roux-core = { path = "../crates/roux-core" }
 roux-worktrunk = { path = "../crates/roux-worktrunk" }
 specta = { version = "=2.0.0-rc.24", features = ["derive", "serde_json"] }

--- a/src-tauri/src/automation_hooks/mod.rs
+++ b/src-tauri/src/automation_hooks/mod.rs
@@ -5,6 +5,7 @@ use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 use thiserror::Error;
 use tokio::io::AsyncWriteExt;
@@ -159,23 +160,32 @@ impl HookContext {
     }
 
     pub fn for_watch(event: HookEvent, watch: &Watch) -> Self {
+        let mut session_id = None;
+        let mut project_id = None;
         let scope = match &watch.scope {
             roux_core::WatchScope::Global => Some("global".to_string()),
-            roux_core::WatchScope::Session { session_id } => Some({
-                let _ = session_id;
-                "session".to_string()
-            }),
-            roux_core::WatchScope::Project { project_id } => Some({
-                let _ = project_id;
-                "project".to_string()
-            }),
+            roux_core::WatchScope::Session { session_id: sid } => {
+                session_id = Some(sid.clone());
+                Some("session".to_string())
+            }
+            roux_core::WatchScope::Project { project_id: pid } => {
+                project_id = Some(pid.clone());
+                Some("project".to_string())
+            }
         };
         let cwd = match &watch.kind {
             roux_core::WatchKind::ShellCommand { working_dir, .. } => working_dir.clone(),
             roux_core::WatchKind::Task { working_dir, .. } => Some(working_dir.clone()),
             _ => None,
         };
-        Self { scope, cwd, watch: Some(watch.clone()), ..Self::new(event) }
+        Self {
+            scope,
+            cwd,
+            session_id,
+            project_id,
+            watch: Some(watch.clone()),
+            ..Self::new(event)
+        }
     }
 
     pub fn with_provider(mut self, configured: WorktreeProvider, wt_available: bool) -> Self {
@@ -306,6 +316,8 @@ pub enum HookError {
     ParseConfig { path: String, source: toml::de::Error },
     #[error("failed to create hook log directory: {0}")]
     CreateLogDir(std::io::Error),
+    #[error("failed to write hook log: {0}")]
+    WriteLog(std::io::Error),
     #[error("project hook requires approval: {0}")]
     ApprovalRequired(String),
     #[error("hook `{name}` failed with exit code {code}: {stderr}")]
@@ -348,13 +360,21 @@ impl AutomationHookManager {
     ) -> Result<usize, HookError> {
         context.hook_type = event.as_str().to_string();
         let commands = self.matching_commands(event, &context)?;
+        let worktrees = precompute_worktrees(context.repo_path.as_deref()).await;
         let mut ran = 0;
         for step in group_by_step(commands) {
             for command in step {
                 self.ensure_approved(&command)?;
-                let rendered = render_template(&command.command, &context, &command.name)?;
+                let rendered = render_template(
+                    &command.command,
+                    &context,
+                    &command.name,
+                    worktrees.as_deref(),
+                )?;
                 let result = execute_command(&command, &rendered, &context).await?;
-                self.write_log(&command, &rendered, &result).await?;
+                if let Err(e) = self.write_log(&command, &rendered, &result).await {
+                    rlog!("automation hook log write failed for `{}`: {e}", command.name);
+                }
                 ran += 1;
                 if result.exit_code != 0 {
                     return Err(HookError::CommandFailed {
@@ -385,16 +405,23 @@ impl AutomationHookManager {
     ) -> Result<usize, HookError> {
         context.hook_type = event.as_str().to_string();
         let commands = self.matching_commands(event, &context)?;
+        let worktrees = precompute_worktrees(context.repo_path.as_deref()).await;
         let mut ran = 0;
         for step in group_by_step(commands) {
             let mut joins = Vec::new();
             for command in step {
                 let manager = self.clone();
                 let ctx = context.clone();
+                let worktrees = worktrees.clone();
                 joins.push(tauri::async_runtime::spawn(async move {
                     if let Err(e) = manager.ensure_approved(&command) {
-                        let rendered = render_template(&command.command, &ctx, &command.name)
-                            .unwrap_or_else(|e| format!("<template error: {e}>"));
+                        let rendered = render_template(
+                            &command.command,
+                            &ctx,
+                            &command.name,
+                            worktrees.as_deref(),
+                        )
+                        .unwrap_or_else(|e| format!("<template error: {e}>"));
                         let result = HookCommandResult {
                             exit_code: -1,
                             stdout: String::new(),
@@ -405,7 +432,12 @@ impl AutomationHookManager {
                         let _ = manager.write_log(&command, &rendered, &result).await;
                         return 0;
                     }
-                    match render_template(&command.command, &ctx, &command.name) {
+                    match render_template(
+                        &command.command,
+                        &ctx,
+                        &command.name,
+                        worktrees.as_deref(),
+                    ) {
                         Ok(rendered) => match execute_command(&command, &rendered, &ctx).await {
                             Ok(result) => {
                                 let _ = manager.write_log(&command, &rendered, &result).await;
@@ -490,8 +522,13 @@ impl AutomationHookManager {
                     config_path: command.config_path.to_string_lossy().into_owned(),
                     name: command.name.clone(),
                     command: command.command.clone(),
-                    rendered_command: render_template(&command.command, context, &command.name)
-                        .unwrap_or_else(|e| format!("<template error: {e}>")),
+                    rendered_command: render_template(
+                        &command.command,
+                        context,
+                        &command.name,
+                        None,
+                    )
+                    .unwrap_or_else(|e| format!("<template error: {e}>")),
                     approval_id,
                     approved,
                     matched,
@@ -628,14 +665,17 @@ impl AutomationHookManager {
             "startedAt": result.started_at,
             "finishedAt": result.finished_at,
         });
+        static LOG_SEQ: AtomicU64 = AtomicU64::new(0);
+        let seq = LOG_SEQ.fetch_add(1, Ordering::Relaxed);
         let file = format!(
-            "{}-{}-{}.json",
+            "{}-{}-{}-{}.json",
             result.finished_at,
+            seq,
             command.event.as_str(),
             sanitize_file_component(&command.name)
         );
         let json = serde_json::to_string_pretty(&payload).map_err(HookError::SerializeContext)?;
-        tokio::fs::write(self.log_dir.join(file), json).await.map_err(HookError::CreateLogDir)
+        tokio::fs::write(self.log_dir.join(file), json).await.map_err(HookError::WriteLog)
     }
 }
 
@@ -830,6 +870,7 @@ fn render_template(
     command: &str,
     context: &HookContext,
     hook_name: &str,
+    worktrees: Option<&[(String, String)]>,
 ) -> Result<String, HookError> {
     let mut env = Environment::new();
     env.set_auto_escape_callback(|_| AutoEscape::None);
@@ -840,7 +881,15 @@ fn render_template(
     env.add_filter("hash_port", hash_port_filter);
 
     let repo_path = context.repo_path.clone();
+    let precomputed: Option<Vec<(String, String)>> = worktrees.map(|w| w.to_vec());
     env.add_function("worktree_path_of_branch", move |branch: String| -> String {
+        if let Some(map) = precomputed.as_ref() {
+            return map
+                .iter()
+                .find(|(b, _)| b == &branch)
+                .map(|(_, p)| p.clone())
+                .unwrap_or_default();
+        }
         repo_path
             .as_deref()
             .and_then(|repo| roux_core::list_worktrees(repo).ok())
@@ -853,6 +902,15 @@ fn render_template(
     let data = context.as_json(hook_name);
     env.render_str(command, MiniValue::from_serialize(&data))
         .map_err(|source| HookError::RenderTemplate { name: hook_name.to_string(), source })
+}
+
+async fn precompute_worktrees(repo_path: Option<&str>) -> Option<Vec<(String, String)>> {
+    let repo = repo_path?.to_string();
+    tokio::task::spawn_blocking(move || roux_core::list_worktrees(&repo).ok())
+        .await
+        .ok()
+        .flatten()
+        .map(|ws| ws.into_iter().map(|w| (w.branch, w.path)).collect())
 }
 
 fn sanitize_filter(value: String) -> String {
@@ -1188,9 +1246,13 @@ one = "echo b"
             ..HookContext::new(HookEvent::PostWatchSuccess)
         };
 
-        let rendered =
-            render_template("echo {{ hook_type }} {{ branch }} {{ session_id }}", &context, "ci")
-                .unwrap();
+        let rendered = render_template(
+            "echo {{ hook_type }} {{ branch }} {{ session_id }}",
+            &context,
+            "ci",
+            None,
+        )
+        .unwrap();
 
         assert_eq!(rendered, "echo post-watch-success feature/search s1");
     }
@@ -1207,6 +1269,7 @@ one = "echo b"
             "{% if provider == 'worktrunk' %}wt{% endif %} {{ missing | default('fallback') }}",
             &context,
             "notify",
+            None,
         )
         .unwrap();
 
@@ -1224,6 +1287,7 @@ one = "echo b"
             "{{ branch | sanitize }} {{ branch | sanitize_db }} {{ branch | hash_port }}",
             &context,
             "ports",
+            None,
         )
         .unwrap();
         let parts = rendered.split_whitespace().collect::<Vec<_>>();

--- a/src-tauri/src/automation_hooks/mod.rs
+++ b/src-tauri/src/automation_hooks/mod.rs
@@ -1,0 +1,1254 @@
+use minijinja::{AutoEscape, Environment, UndefinedBehavior, Value as MiniValue};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Map, Value};
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::{SystemTime, UNIX_EPOCH};
+use thiserror::Error;
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command as TokioCommand;
+
+use crate::rlog;
+use roux_core::{Watch, WatchOutcome, WorktreeProvider};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "kebab-case")]
+pub enum HookEvent {
+    PreWatchRun,
+    PostWatchRun,
+    PostWatchChange,
+    PostWatchFailure,
+    PostWatchSuccess,
+    PreWorktreeCreate,
+    PostWorktreeCreate,
+    PreWorktreeRemove,
+    PostWorktreeRemove,
+    PostSessionCreate,
+    PreSessionClose,
+    PostSessionClose,
+    PreTaskRun,
+    PostTaskRun,
+    PostTaskFailure,
+    PostTaskSuccess,
+}
+
+impl HookEvent {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::PreWatchRun => "pre-watch-run",
+            Self::PostWatchRun => "post-watch-run",
+            Self::PostWatchChange => "post-watch-change",
+            Self::PostWatchFailure => "post-watch-failure",
+            Self::PostWatchSuccess => "post-watch-success",
+            Self::PreWorktreeCreate => "pre-worktree-create",
+            Self::PostWorktreeCreate => "post-worktree-create",
+            Self::PreWorktreeRemove => "pre-worktree-remove",
+            Self::PostWorktreeRemove => "post-worktree-remove",
+            Self::PostSessionCreate => "post-session-create",
+            Self::PreSessionClose => "pre-session-close",
+            Self::PostSessionClose => "post-session-close",
+            Self::PreTaskRun => "pre-task-run",
+            Self::PostTaskRun => "post-task-run",
+            Self::PostTaskFailure => "post-task-failure",
+            Self::PostTaskSuccess => "post-task-success",
+        }
+    }
+
+    pub fn is_blocking(self) -> bool {
+        self.as_str().starts_with("pre-")
+    }
+}
+
+impl std::str::FromStr for HookEvent {
+    type Err = HookError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "pre-watch-run" => Ok(Self::PreWatchRun),
+            "post-watch-run" => Ok(Self::PostWatchRun),
+            "post-watch-change" => Ok(Self::PostWatchChange),
+            "post-watch-failure" => Ok(Self::PostWatchFailure),
+            "post-watch-success" => Ok(Self::PostWatchSuccess),
+            "pre-worktree-create" => Ok(Self::PreWorktreeCreate),
+            "post-worktree-create" => Ok(Self::PostWorktreeCreate),
+            "pre-worktree-remove" => Ok(Self::PreWorktreeRemove),
+            "post-worktree-remove" => Ok(Self::PostWorktreeRemove),
+            "post-session-create" => Ok(Self::PostSessionCreate),
+            "pre-session-close" => Ok(Self::PreSessionClose),
+            "post-session-close" => Ok(Self::PostSessionClose),
+            "pre-task-run" => Ok(Self::PreTaskRun),
+            "post-task-run" => Ok(Self::PostTaskRun),
+            "post-task-failure" => Ok(Self::PostTaskFailure),
+            "post-task-success" => Ok(Self::PostTaskSuccess),
+            _ => Err(HookError::InvalidEvent(s.to_string())),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub enum HookSourceKind {
+    User,
+    Project,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct HookCondition {
+    pub provider: Option<String>,
+    pub worktrunk: Option<bool>,
+    pub scope: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct HookCommand {
+    event: HookEvent,
+    source: HookSourceKind,
+    config_path: PathBuf,
+    step_index: usize,
+    name: String,
+    command: String,
+    when: Option<HookCondition>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct HookContext {
+    pub hook_type: String,
+    pub provider: Option<String>,
+    pub configured_provider: Option<String>,
+    pub worktrunk: bool,
+    pub provider_hooks_ran: Vec<String>,
+    pub scope: Option<String>,
+    pub repo_path: Option<String>,
+    pub worktree_path: Option<String>,
+    pub branch: Option<String>,
+    pub session_id: Option<String>,
+    pub project_id: Option<String>,
+    pub task_id: Option<String>,
+    pub watch: Option<Watch>,
+    pub previous_outcome: Option<WatchOutcome>,
+    pub outcome: Option<WatchOutcome>,
+    pub args: Vec<String>,
+    pub cwd: Option<String>,
+}
+
+impl HookContext {
+    pub fn new(event: HookEvent) -> Self {
+        Self {
+            hook_type: event.as_str().to_string(),
+            provider: None,
+            configured_provider: None,
+            worktrunk: false,
+            provider_hooks_ran: Vec::new(),
+            scope: None,
+            repo_path: None,
+            worktree_path: None,
+            branch: None,
+            session_id: None,
+            project_id: None,
+            task_id: None,
+            watch: None,
+            previous_outcome: None,
+            outcome: None,
+            args: Vec::new(),
+            cwd: None,
+        }
+    }
+
+    pub fn for_watch(event: HookEvent, watch: &Watch) -> Self {
+        let scope = match &watch.scope {
+            roux_core::WatchScope::Global => Some("global".to_string()),
+            roux_core::WatchScope::Session { session_id } => Some({
+                let _ = session_id;
+                "session".to_string()
+            }),
+            roux_core::WatchScope::Project { project_id } => Some({
+                let _ = project_id;
+                "project".to_string()
+            }),
+        };
+        let cwd = match &watch.kind {
+            roux_core::WatchKind::ShellCommand { working_dir, .. } => working_dir.clone(),
+            roux_core::WatchKind::Task { working_dir, .. } => Some(working_dir.clone()),
+            _ => None,
+        };
+        Self { scope, cwd, watch: Some(watch.clone()), ..Self::new(event) }
+    }
+
+    pub fn with_provider(mut self, configured: WorktreeProvider, wt_available: bool) -> Self {
+        let configured_provider = provider_name(configured).to_string();
+        let provider = match configured {
+            WorktreeProvider::Git => "git",
+            WorktreeProvider::Auto | WorktreeProvider::Worktrunk if wt_available => "worktrunk",
+            WorktreeProvider::Auto | WorktreeProvider::Worktrunk => "git",
+        };
+        self.configured_provider = Some(configured_provider);
+        self.provider = Some(provider.to_string());
+        self.worktrunk = provider == "worktrunk";
+        self
+    }
+
+    fn as_json(&self, hook_name: &str) -> Value {
+        let mut value = serde_json::to_value(self).unwrap_or_else(|_| json!({}));
+        if let Value::Object(ref mut map) = value {
+            map.insert("hook_name".into(), Value::String(hook_name.to_string()));
+            insert_string_alias(map, "hook_type", &self.hook_type);
+            insert_opt_string_alias(map, "configured_provider", self.configured_provider.as_ref());
+            insert_opt_string_alias(map, "repo_path", self.repo_path.as_ref());
+            insert_opt_string_alias(map, "worktree_path", self.worktree_path.as_ref());
+            insert_opt_string_alias(map, "session_id", self.session_id.as_ref());
+            insert_opt_string_alias(map, "project_id", self.project_id.as_ref());
+            insert_opt_string_alias(map, "task_id", self.task_id.as_ref());
+            if let Some(previous) = self.previous_outcome.as_ref() {
+                map.insert(
+                    "previous_outcome".into(),
+                    serde_json::to_value(previous).unwrap_or(Value::Null),
+                );
+            }
+            map.insert(
+                "provider_hooks_ran".into(),
+                serde_json::to_value(&self.provider_hooks_ran).unwrap_or(Value::Array(Vec::new())),
+            );
+        }
+        value
+    }
+
+    fn cwd_path(&self) -> Option<PathBuf> {
+        self.cwd
+            .as_ref()
+            .or(self.worktree_path.as_ref())
+            .or(self.repo_path.as_ref())
+            .map(PathBuf::from)
+    }
+}
+
+fn insert_string_alias(map: &mut Map<String, Value>, key: &str, value: &str) {
+    map.insert(key.into(), Value::String(value.to_string()));
+}
+
+fn insert_opt_string_alias(map: &mut Map<String, Value>, key: &str, value: Option<&String>) {
+    if let Some(value) = value {
+        insert_string_alias(map, key, value);
+    }
+}
+
+#[derive(Debug, Clone, Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct HookListItem {
+    pub event: String,
+    pub source: HookSourceKind,
+    pub config_path: String,
+    pub name: String,
+    pub command: String,
+    pub approval_id: Option<String>,
+    pub approved: bool,
+}
+
+#[derive(Debug, Clone, Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct HookPreviewItem {
+    pub event: String,
+    pub source: HookSourceKind,
+    pub config_path: String,
+    pub name: String,
+    pub command: String,
+    pub rendered_command: String,
+    pub approval_id: Option<String>,
+    pub approved: bool,
+    pub matched: bool,
+}
+
+#[derive(Debug, Clone, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct HookRunRequest {
+    pub event: String,
+    pub repo_path: Option<String>,
+    pub worktree_path: Option<String>,
+    pub branch: Option<String>,
+    pub session_id: Option<String>,
+    pub project_id: Option<String>,
+    pub task_id: Option<String>,
+    pub scope: Option<String>,
+    pub provider: Option<String>,
+    pub args: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct HookRunSummary {
+    pub event: String,
+    pub ran: usize,
+}
+
+#[derive(Debug, Clone, Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct HookLogEntry {
+    pub file: String,
+    pub path: String,
+    pub event: Option<String>,
+    pub name: Option<String>,
+    pub source: Option<HookSourceKind>,
+    pub exit_code: Option<i32>,
+    pub started_at: Option<u64>,
+    pub finished_at: Option<u64>,
+}
+
+#[derive(Debug, Error)]
+pub enum HookError {
+    #[error("invalid hook event: {0}")]
+    InvalidEvent(String),
+    #[error("failed to read {path}: {source}")]
+    ReadConfig { path: String, source: std::io::Error },
+    #[error("failed to parse {path}: {source}")]
+    ParseConfig { path: String, source: toml::de::Error },
+    #[error("failed to create hook log directory: {0}")]
+    CreateLogDir(std::io::Error),
+    #[error("project hook requires approval: {0}")]
+    ApprovalRequired(String),
+    #[error("hook `{name}` failed with exit code {code}: {stderr}")]
+    CommandFailed { name: String, code: i32, stderr: String },
+    #[error("failed to execute hook `{name}`: {source}")]
+    Execute { name: String, source: std::io::Error },
+    #[error("failed to serialize hook context: {0}")]
+    SerializeContext(serde_json::Error),
+    #[error("failed to render hook template `{name}`: {source}")]
+    RenderTemplate { name: String, source: minijinja::Error },
+    #[error("failed to write approvals: {0}")]
+    WriteApprovals(std::io::Error),
+    #[error("failed to read hook log: {0}")]
+    ReadLog(std::io::Error),
+    #[error("refusing to read hook log outside Roux hook logs")]
+    LogPathOutsideRoot,
+}
+
+#[derive(Clone)]
+pub struct AutomationHookManager {
+    user_config_path: PathBuf,
+    approval_path: PathBuf,
+    log_dir: PathBuf,
+}
+
+impl AutomationHookManager {
+    pub fn new() -> Self {
+        let root = roux_lib::paths::roux_config_dir();
+        Self {
+            user_config_path: root.join("hooks.toml"),
+            approval_path: root.join("hook-approvals.json"),
+            log_dir: root.join("logs").join("hooks"),
+        }
+    }
+
+    pub async fn run_blocking(
+        &self,
+        event: HookEvent,
+        mut context: HookContext,
+    ) -> Result<usize, HookError> {
+        context.hook_type = event.as_str().to_string();
+        let commands = self.matching_commands(event, &context)?;
+        let mut ran = 0;
+        for step in group_by_step(commands) {
+            for command in step {
+                self.ensure_approved(&command)?;
+                let rendered = render_template(&command.command, &context, &command.name)?;
+                let result = execute_command(&command, &rendered, &context).await?;
+                self.write_log(&command, &rendered, &result).await?;
+                ran += 1;
+                if result.exit_code != 0 {
+                    return Err(HookError::CommandFailed {
+                        name: command.name,
+                        code: result.exit_code,
+                        stderr: result.stderr,
+                    });
+                }
+            }
+        }
+        Ok(ran)
+    }
+
+    pub fn spawn_background(&self, event: HookEvent, mut context: HookContext) {
+        context.hook_type = event.as_str().to_string();
+        let manager = self.clone();
+        tauri::async_runtime::spawn(async move {
+            if let Err(e) = manager.run_background(event, context).await {
+                rlog!("automation hook {event:?} failed: {e}");
+            }
+        });
+    }
+
+    pub async fn run_background(
+        &self,
+        event: HookEvent,
+        mut context: HookContext,
+    ) -> Result<usize, HookError> {
+        context.hook_type = event.as_str().to_string();
+        let commands = self.matching_commands(event, &context)?;
+        let mut ran = 0;
+        for step in group_by_step(commands) {
+            let mut joins = Vec::new();
+            for command in step {
+                let manager = self.clone();
+                let ctx = context.clone();
+                joins.push(tauri::async_runtime::spawn(async move {
+                    if let Err(e) = manager.ensure_approved(&command) {
+                        let rendered = render_template(&command.command, &ctx, &command.name)
+                            .unwrap_or_else(|e| format!("<template error: {e}>"));
+                        let result = HookCommandResult {
+                            exit_code: -1,
+                            stdout: String::new(),
+                            stderr: e.to_string(),
+                            started_at: now_ms(),
+                            finished_at: now_ms(),
+                        };
+                        let _ = manager.write_log(&command, &rendered, &result).await;
+                        return 0;
+                    }
+                    match render_template(&command.command, &ctx, &command.name) {
+                        Ok(rendered) => match execute_command(&command, &rendered, &ctx).await {
+                            Ok(result) => {
+                                let _ = manager.write_log(&command, &rendered, &result).await;
+                                1
+                            }
+                            Err(e) => {
+                                let result = HookCommandResult {
+                                    exit_code: -1,
+                                    stdout: String::new(),
+                                    stderr: e.to_string(),
+                                    started_at: now_ms(),
+                                    finished_at: now_ms(),
+                                };
+                                let _ = manager.write_log(&command, &rendered, &result).await;
+                                0
+                            }
+                        },
+                        Err(e) => {
+                            let rendered = format!("<template error: {e}>");
+                            let result = HookCommandResult {
+                                exit_code: -1,
+                                stdout: String::new(),
+                                stderr: e.to_string(),
+                                started_at: now_ms(),
+                                finished_at: now_ms(),
+                            };
+                            let _ = manager.write_log(&command, &rendered, &result).await;
+                            0
+                        }
+                    }
+                }));
+            }
+            for join in joins {
+                ran += join.await.unwrap_or(0);
+            }
+        }
+        Ok(ran)
+    }
+
+    pub fn list_hooks(&self, repo_path: Option<&str>) -> Result<Vec<HookListItem>, HookError> {
+        let approvals = self.load_approvals();
+        Ok(self
+            .load_commands(repo_path)?
+            .into_iter()
+            .map(|command| {
+                let approval_id =
+                    (command.source == HookSourceKind::Project).then(|| approval_id(&command));
+                let approved =
+                    approval_id.as_ref().map(|id| approvals.contains(id)).unwrap_or(true);
+                HookListItem {
+                    event: command.event.as_str().to_string(),
+                    source: command.source,
+                    config_path: command.config_path.to_string_lossy().into_owned(),
+                    name: command.name,
+                    command: command.command,
+                    approval_id,
+                    approved,
+                }
+            })
+            .collect())
+    }
+
+    pub fn preview(
+        &self,
+        event: HookEvent,
+        context: &HookContext,
+    ) -> Result<Vec<HookPreviewItem>, HookError> {
+        let approvals = self.load_approvals();
+        Ok(self
+            .load_commands(context.repo_path.as_deref())?
+            .into_iter()
+            .filter(|command| command.event == event)
+            .map(|command| {
+                let approval_id =
+                    (command.source == HookSourceKind::Project).then(|| approval_id(&command));
+                let approved =
+                    approval_id.as_ref().map(|id| approvals.contains(id)).unwrap_or(true);
+                let matched = condition_matches(command.when.as_ref(), context);
+                HookPreviewItem {
+                    event: command.event.as_str().to_string(),
+                    source: command.source,
+                    config_path: command.config_path.to_string_lossy().into_owned(),
+                    name: command.name.clone(),
+                    command: command.command.clone(),
+                    rendered_command: render_template(&command.command, context, &command.name)
+                        .unwrap_or_else(|e| format!("<template error: {e}>")),
+                    approval_id,
+                    approved,
+                    matched,
+                }
+            })
+            .collect())
+    }
+
+    pub fn approve(&self, approval_id: &str) -> Result<(), HookError> {
+        let mut approvals = self.load_approvals();
+        approvals.insert(approval_id.to_string());
+        self.write_approvals(&approvals)
+    }
+
+    pub fn clear_approvals(&self) -> Result<(), HookError> {
+        self.write_approvals(&BTreeSet::new())
+    }
+
+    pub fn list_logs(&self) -> Vec<HookLogEntry> {
+        let mut entries = Vec::new();
+        let Ok(read_dir) = std::fs::read_dir(&self.log_dir) else {
+            return entries;
+        };
+        for entry in read_dir.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+            let content = std::fs::read_to_string(&path).unwrap_or_default();
+            let value: Value = serde_json::from_str(&content).unwrap_or(Value::Null);
+            entries.push(HookLogEntry {
+                file: path.file_name().unwrap_or_default().to_string_lossy().into_owned(),
+                path: path.to_string_lossy().into_owned(),
+                event: value.get("event").and_then(Value::as_str).map(str::to_string),
+                name: value.get("name").and_then(Value::as_str).map(str::to_string),
+                source: value.get("source").and_then(Value::as_str).and_then(|s| match s {
+                    "user" => Some(HookSourceKind::User),
+                    "project" => Some(HookSourceKind::Project),
+                    _ => None,
+                }),
+                exit_code: value.get("exitCode").and_then(Value::as_i64).map(|n| n as i32),
+                started_at: value.get("startedAt").and_then(Value::as_u64),
+                finished_at: value.get("finishedAt").and_then(Value::as_u64),
+            });
+        }
+        entries.sort_by_key(|e| std::cmp::Reverse(e.finished_at.unwrap_or(0)));
+        entries
+    }
+
+    pub fn read_log(&self, path: &str) -> Result<String, HookError> {
+        let root = self.log_dir.canonicalize().map_err(HookError::ReadLog)?;
+        let target = PathBuf::from(path).canonicalize().map_err(HookError::ReadLog)?;
+        if !target.starts_with(root) {
+            return Err(HookError::LogPathOutsideRoot);
+        }
+        std::fs::read_to_string(target).map_err(HookError::ReadLog)
+    }
+
+    fn matching_commands(
+        &self,
+        event: HookEvent,
+        context: &HookContext,
+    ) -> Result<Vec<HookCommand>, HookError> {
+        Ok(self
+            .load_commands(context.repo_path.as_deref())?
+            .into_iter()
+            .filter(|command| command.event == event)
+            .filter(|command| condition_matches(command.when.as_ref(), context))
+            .collect())
+    }
+
+    fn load_commands(&self, repo_path: Option<&str>) -> Result<Vec<HookCommand>, HookError> {
+        let mut commands = Vec::new();
+        commands.extend(load_config_commands(&self.user_config_path, HookSourceKind::User)?);
+        if let Some(repo_path) = repo_path {
+            commands.extend(load_config_commands(
+                &Path::new(repo_path).join(".config").join("roux").join("hooks.toml"),
+                HookSourceKind::Project,
+            )?);
+        }
+        Ok(commands)
+    }
+
+    fn load_approvals(&self) -> BTreeSet<String> {
+        let Ok(content) = std::fs::read_to_string(&self.approval_path) else {
+            return BTreeSet::new();
+        };
+        serde_json::from_str(&content).unwrap_or_default()
+    }
+
+    fn write_approvals(&self, approvals: &BTreeSet<String>) -> Result<(), HookError> {
+        if let Some(parent) = self.approval_path.parent() {
+            std::fs::create_dir_all(parent).map_err(HookError::WriteApprovals)?;
+        }
+        let json = serde_json::to_string_pretty(approvals).map_err(|e| {
+            HookError::WriteApprovals(std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+        })?;
+        std::fs::write(&self.approval_path, json).map_err(HookError::WriteApprovals)
+    }
+
+    fn ensure_approved(&self, command: &HookCommand) -> Result<(), HookError> {
+        if command.source == HookSourceKind::User {
+            return Ok(());
+        }
+        let id = approval_id(command);
+        if self.load_approvals().contains(&id) {
+            Ok(())
+        } else {
+            Err(HookError::ApprovalRequired(id))
+        }
+    }
+
+    async fn write_log(
+        &self,
+        command: &HookCommand,
+        rendered: &str,
+        result: &HookCommandResult,
+    ) -> Result<(), HookError> {
+        tokio::fs::create_dir_all(&self.log_dir).await.map_err(HookError::CreateLogDir)?;
+        let source = match command.source {
+            HookSourceKind::User => "user",
+            HookSourceKind::Project => "project",
+        };
+        let payload = json!({
+            "event": command.event.as_str(),
+            "name": command.name,
+            "source": source,
+            "configPath": command.config_path,
+            "command": command.command,
+            "renderedCommand": rendered,
+            "exitCode": result.exit_code,
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+            "startedAt": result.started_at,
+            "finishedAt": result.finished_at,
+        });
+        let file = format!(
+            "{}-{}-{}.json",
+            result.finished_at,
+            command.event.as_str(),
+            sanitize_file_component(&command.name)
+        );
+        let json = serde_json::to_string_pretty(&payload).map_err(HookError::SerializeContext)?;
+        tokio::fs::write(self.log_dir.join(file), json).await.map_err(HookError::CreateLogDir)
+    }
+}
+
+impl Default for AutomationHookManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub fn context_from_run_request(
+    req: HookRunRequest,
+    configured_provider: Option<WorktreeProvider>,
+    wt_available: bool,
+) -> Result<(HookEvent, HookContext), HookError> {
+    let event: HookEvent = req.event.parse()?;
+    let mut context = HookContext::new(event);
+    context.repo_path = req.repo_path;
+    context.worktree_path = req.worktree_path;
+    context.branch = req.branch;
+    context.session_id = req.session_id;
+    context.project_id = req.project_id;
+    context.task_id = req.task_id;
+    context.scope = req.scope;
+    context.args = req.args.unwrap_or_default();
+    if let Some(provider) = req.provider {
+        context.provider = Some(provider.clone());
+        context.worktrunk = provider == "worktrunk";
+    } else if let Some(provider) = configured_provider {
+        context = context.with_provider(provider, wt_available);
+    }
+    if context.cwd.is_none() {
+        context.cwd = context.worktree_path.clone().or(context.repo_path.clone());
+    }
+    Ok((event, context))
+}
+
+fn provider_name(provider: WorktreeProvider) -> &'static str {
+    match provider {
+        WorktreeProvider::Auto => "auto",
+        WorktreeProvider::Git => "git",
+        WorktreeProvider::Worktrunk => "worktrunk",
+    }
+}
+
+fn load_config_commands(
+    path: &Path,
+    source: HookSourceKind,
+) -> Result<Vec<HookCommand>, HookError> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let content = std::fs::read_to_string(path).map_err(|source| HookError::ReadConfig {
+        path: path.to_string_lossy().into_owned(),
+        source,
+    })?;
+    let root: toml::Value = toml::from_str(&content).map_err(|source| HookError::ParseConfig {
+        path: path.to_string_lossy().into_owned(),
+        source,
+    })?;
+    parse_config_value(&root, path, source)
+}
+
+fn parse_config_value(
+    root: &toml::Value,
+    path: &Path,
+    source: HookSourceKind,
+) -> Result<Vec<HookCommand>, HookError> {
+    let Some(table) = root.as_table() else {
+        return Ok(Vec::new());
+    };
+    let mut commands = Vec::new();
+    for (event_name, value) in table {
+        let Ok(event) = event_name.parse::<HookEvent>() else {
+            continue;
+        };
+        match value {
+            toml::Value::String(command) => {
+                commands.push(HookCommand {
+                    event,
+                    source,
+                    config_path: path.to_path_buf(),
+                    step_index: 0,
+                    name: "default".into(),
+                    command: command.clone(),
+                    when: None,
+                });
+            }
+            toml::Value::Table(table) => {
+                let when = parse_when(table.get("when"));
+                for (name, command_value) in table {
+                    if name == "when" {
+                        continue;
+                    }
+                    if let Some(command) = command_value.as_str() {
+                        commands.push(HookCommand {
+                            event,
+                            source,
+                            config_path: path.to_path_buf(),
+                            step_index: 0,
+                            name: name.clone(),
+                            command: command.to_string(),
+                            when: when.clone(),
+                        });
+                    }
+                }
+            }
+            toml::Value::Array(steps) => {
+                for (step_index, step) in steps.iter().enumerate() {
+                    let Some(step_table) = step.as_table() else {
+                        continue;
+                    };
+                    let when = parse_when(step_table.get("when"));
+                    for (name, command_value) in step_table {
+                        if name == "when" {
+                            continue;
+                        }
+                        if let Some(command) = command_value.as_str() {
+                            commands.push(HookCommand {
+                                event,
+                                source,
+                                config_path: path.to_path_buf(),
+                                step_index,
+                                name: name.clone(),
+                                command: command.to_string(),
+                                when: when.clone(),
+                            });
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(commands)
+}
+
+fn parse_when(value: Option<&toml::Value>) -> Option<HookCondition> {
+    let table = value?.as_table()?;
+    Some(HookCondition {
+        provider: table.get("provider").and_then(toml::Value::as_str).map(str::to_string),
+        worktrunk: table.get("worktrunk").and_then(toml::Value::as_bool),
+        scope: table.get("scope").and_then(toml::Value::as_str).map(str::to_string),
+    })
+}
+
+fn group_by_step(commands: Vec<HookCommand>) -> Vec<Vec<HookCommand>> {
+    let mut steps: BTreeMap<usize, Vec<HookCommand>> = BTreeMap::new();
+    for command in commands {
+        steps.entry(command.step_index).or_default().push(command);
+    }
+    steps.into_values().collect()
+}
+
+fn condition_matches(condition: Option<&HookCondition>, context: &HookContext) -> bool {
+    let Some(condition) = condition else {
+        return true;
+    };
+    if let Some(provider) = condition.provider.as_deref() {
+        let matches_effective = context.provider.as_deref() == Some(provider);
+        let matches_configured_auto =
+            provider == "auto" && context.configured_provider.as_deref() == Some("auto");
+        if !matches_effective && !matches_configured_auto {
+            return false;
+        }
+    }
+    if let Some(worktrunk) = condition.worktrunk {
+        if context.worktrunk != worktrunk {
+            return false;
+        }
+    }
+    if let Some(scope) = condition.scope.as_deref() {
+        if context.scope.as_deref() != Some(scope) {
+            return false;
+        }
+    }
+    true
+}
+
+fn approval_id(command: &HookCommand) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(command.config_path.to_string_lossy().as_bytes());
+    hasher.update(b"\0");
+    hasher.update(command.event.as_str().as_bytes());
+    hasher.update(b"\0");
+    hasher.update(command.name.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(command.command.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+fn render_template(
+    command: &str,
+    context: &HookContext,
+    hook_name: &str,
+) -> Result<String, HookError> {
+    let mut env = Environment::new();
+    env.set_auto_escape_callback(|_| AutoEscape::None);
+    env.set_undefined_behavior(UndefinedBehavior::Strict);
+    env.add_filter("sanitize", sanitize_filter);
+    env.add_filter("sanitize_hash", sanitize_hash_filter);
+    env.add_filter("sanitize_db", sanitize_db_filter);
+    env.add_filter("hash_port", hash_port_filter);
+
+    let repo_path = context.repo_path.clone();
+    env.add_function("worktree_path_of_branch", move |branch: String| -> String {
+        repo_path
+            .as_deref()
+            .and_then(|repo| roux_core::list_worktrees(repo).ok())
+            .and_then(|worktrees| {
+                worktrees.into_iter().find(|worktree| worktree.branch == branch).map(|w| w.path)
+            })
+            .unwrap_or_default()
+    });
+
+    let data = context.as_json(hook_name);
+    env.render_str(command, MiniValue::from_serialize(&data))
+        .map_err(|source| HookError::RenderTemplate { name: hook_name.to_string(), source })
+}
+
+fn sanitize_filter(value: String) -> String {
+    sanitize_template_token(&value)
+}
+
+fn sanitize_hash_filter(value: String) -> String {
+    let sanitized = sanitize_template_token(&value);
+    if sanitized == value && sanitized.len() <= 48 {
+        sanitized
+    } else {
+        format!("{}-{}", truncate_token(&sanitized, 39), short_hash(&value))
+    }
+}
+
+fn sanitize_db_filter(value: String) -> String {
+    let mut out = String::new();
+    for ch in value.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+        } else if ch == '_' || ch == '-' || ch.is_whitespace() || ch == '/' || ch == '.' {
+            push_single_separator(&mut out, '_');
+        }
+    }
+    let out = out.trim_matches('_').to_string();
+    let mut out = if out.is_empty() { "value".to_string() } else { out };
+    if out.chars().next().is_some_and(|ch| ch.is_ascii_digit()) {
+        out = format!("x_{out}");
+    }
+    truncate_token(&out, 63)
+}
+
+fn hash_port_filter(value: String) -> u16 {
+    let mut hasher = Sha256::new();
+    hasher.update(value.as_bytes());
+    let digest = hasher.finalize();
+    let raw = u16::from_be_bytes([digest[0], digest[1]]) as u32;
+    (10_000 + (raw % 40_000)) as u16
+}
+
+fn sanitize_template_token(value: &str) -> String {
+    let mut out = String::new();
+    for ch in value.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+        } else if ch == '_' || ch == '-' {
+            push_single_separator(&mut out, ch);
+        } else if ch.is_whitespace() || ch == '/' || ch == '.' || ch == ':' {
+            push_single_separator(&mut out, '-');
+        }
+    }
+    let out = out.trim_matches('-').trim_matches('_').to_string();
+    if out.is_empty() {
+        "value".to_string()
+    } else {
+        out
+    }
+}
+
+fn push_single_separator(out: &mut String, separator: char) {
+    if !out.ends_with(separator) {
+        out.push(separator);
+    }
+}
+
+fn truncate_token(value: &str, max_len: usize) -> String {
+    value.chars().take(max_len).collect::<String>().trim_matches('-').trim_matches('_').to_string()
+}
+
+fn short_hash(value: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(value.as_bytes());
+    format!("{:x}", hasher.finalize())[..8].to_string()
+}
+
+struct HookCommandResult {
+    exit_code: i32,
+    stdout: String,
+    stderr: String,
+    started_at: u64,
+    finished_at: u64,
+}
+
+async fn execute_command(
+    command: &HookCommand,
+    rendered: &str,
+    context: &HookContext,
+) -> Result<HookCommandResult, HookError> {
+    let shell = if cfg!(target_os = "windows") { "cmd" } else { "sh" };
+    let flag = if cfg!(target_os = "windows") { "/C" } else { "-c" };
+    let started_at = now_ms();
+    let mut child = TokioCommand::new(shell);
+    child.arg(flag).arg(rendered);
+    child.stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::piped());
+    if let Some(cwd) = context.cwd_path() {
+        child.current_dir(cwd);
+    }
+    let mut child = child
+        .spawn()
+        .map_err(|source| HookError::Execute { name: command.name.clone(), source })?;
+    if let Some(mut stdin) = child.stdin.take() {
+        let json = serde_json::to_vec(&context.as_json(&command.name))
+            .map_err(HookError::SerializeContext)?;
+        stdin
+            .write_all(&json)
+            .await
+            .map_err(|source| HookError::Execute { name: command.name.clone(), source })?;
+    }
+    let output = child
+        .wait_with_output()
+        .await
+        .map_err(|source| HookError::Execute { name: command.name.clone(), source })?;
+    Ok(HookCommandResult {
+        exit_code: output.status.code().unwrap_or(-1),
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        started_at,
+        finished_at: now_ms(),
+    })
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_millis() as u64
+}
+
+fn sanitize_file_component(s: &str) -> String {
+    s.chars()
+        .map(|c| if c.is_ascii_alphanumeric() || c == '-' || c == '_' { c } else { '-' })
+        .collect()
+}
+
+pub fn worktree_provider_hooks(event: HookEvent, worktrunk: bool) -> Vec<String> {
+    if !worktrunk {
+        return Vec::new();
+    }
+    match event {
+        HookEvent::PostWorktreeCreate => vec!["pre-start".into(), "post-start".into()],
+        HookEvent::PostWorktreeRemove => vec!["pre-remove".into(), "post-remove".into()],
+        _ => Vec::new(),
+    }
+}
+
+#[tauri::command]
+#[specta::specta]
+pub(crate) fn cmd_list_automation_hooks(
+    repo_path: Option<String>,
+    state: tauri::State<'_, crate::state::AppState>,
+) -> Result<Vec<HookListItem>, String> {
+    state.automation_hooks.list_hooks(repo_path.as_deref()).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub(crate) fn cmd_preview_automation_hooks(
+    request: HookRunRequest,
+    state: tauri::State<'_, crate::state::AppState>,
+) -> Result<Vec<HookPreviewItem>, String> {
+    let settings = state.settings.lock().map_err(|e| e.to_string())?.clone();
+    let wt_available = crate::services::setup::resolve_wt_binary().is_some();
+    let (event, context) =
+        context_from_run_request(request, Some(settings.worktree_provider), wt_available)
+            .map_err(|e| e.to_string())?;
+    state.automation_hooks.preview(event, &context).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub(crate) async fn cmd_run_automation_hook(
+    request: HookRunRequest,
+    state: tauri::State<'_, crate::state::AppState>,
+) -> Result<HookRunSummary, String> {
+    let settings = state.settings.lock().map_err(|e| e.to_string())?.clone();
+    let wt_available = crate::services::setup::resolve_wt_binary().is_some();
+    let (event, context) =
+        context_from_run_request(request, Some(settings.worktree_provider), wt_available)
+            .map_err(|e| e.to_string())?;
+    let ran = if event.is_blocking() {
+        state.automation_hooks.run_blocking(event, context).await.map_err(|e| e.to_string())?
+    } else {
+        state.automation_hooks.run_background(event, context).await.map_err(|e| e.to_string())?
+    };
+    Ok(HookRunSummary { event: event.as_str().into(), ran })
+}
+
+#[tauri::command]
+#[specta::specta]
+pub(crate) fn cmd_approve_automation_hook(
+    approval_id: String,
+    state: tauri::State<'_, crate::state::AppState>,
+) -> Result<(), String> {
+    state.automation_hooks.approve(&approval_id).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub(crate) fn cmd_clear_automation_hook_approvals(
+    state: tauri::State<'_, crate::state::AppState>,
+) -> Result<(), String> {
+    state.automation_hooks.clear_approvals().map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub(crate) fn cmd_list_automation_hook_logs(
+    state: tauri::State<'_, crate::state::AppState>,
+) -> Vec<HookLogEntry> {
+    state.automation_hooks.list_logs()
+}
+
+#[tauri::command]
+#[specta::specta]
+pub(crate) fn cmd_read_automation_hook_log(
+    path: String,
+    state: tauri::State<'_, crate::state::AppState>,
+) -> Result<String, String> {
+    state.automation_hooks.read_log(&path).map_err(|e| e.to_string())
+}
+
+pub(crate) fn request_from_socket_args(args: Value) -> Result<HookRunRequest, String> {
+    serde_json::from_value(args).map_err(|e| format!("invalid hook args: {e}"))
+}
+
+pub(crate) fn hook_list_to_value(items: Vec<HookListItem>) -> Value {
+    serde_json::to_value(items).unwrap_or_else(|_| Value::Array(Vec::new()))
+}
+
+pub(crate) fn hook_run_to_value(summary: HookRunSummary) -> Value {
+    serde_json::to_value(summary).unwrap_or_else(|_| Value::Object(Map::new()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn parse(content: &str) -> Vec<HookCommand> {
+        let value: toml::Value = toml::from_str(content).unwrap();
+        parse_config_value(
+            &value,
+            Path::new("/repo/.config/roux/hooks.toml"),
+            HookSourceKind::Project,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn parses_string_table_and_pipeline_forms() {
+        let commands = parse(
+            r#"
+pre-watch-run = "echo one"
+
+[post-watch-run]
+a = "echo a"
+b = "echo b"
+
+[[post-watch-failure]]
+collect = "echo collect"
+
+[[post-watch-failure]]
+notify = "echo notify"
+"#,
+        );
+
+        assert_eq!(commands.len(), 5);
+        assert!(commands.iter().any(|c| c.event == HookEvent::PreWatchRun && c.name == "default"));
+        assert!(commands.iter().any(|c| c.event == HookEvent::PostWatchRun && c.name == "a"));
+        assert!(commands
+            .iter()
+            .any(|c| c.event == HookEvent::PostWatchFailure && c.step_index == 1));
+    }
+
+    #[test]
+    fn condition_matching_checks_provider_worktrunk_and_scope() {
+        let condition = HookCondition {
+            provider: Some("worktrunk".into()),
+            worktrunk: Some(true),
+            scope: Some("session".into()),
+        };
+        let context = HookContext {
+            provider: Some("worktrunk".into()),
+            worktrunk: true,
+            scope: Some("session".into()),
+            ..HookContext::new(HookEvent::PostWatchRun)
+        };
+
+        assert!(condition_matches(Some(&condition), &context));
+
+        let context = HookContext { provider: Some("git".into()), ..context };
+        assert!(!condition_matches(Some(&condition), &context));
+    }
+
+    #[test]
+    fn condition_matching_allows_configured_auto_provider() {
+        let condition =
+            HookCondition { provider: Some("auto".into()), worktrunk: None, scope: None };
+        let context = HookContext {
+            provider: Some("worktrunk".into()),
+            configured_provider: Some("auto".into()),
+            ..HookContext::new(HookEvent::PostWorktreeCreate)
+        };
+
+        assert!(condition_matches(Some(&condition), &context));
+
+        let context = HookContext { configured_provider: Some("worktrunk".into()), ..context };
+        assert!(!condition_matches(Some(&condition), &context));
+    }
+
+    #[test]
+    fn approval_identity_changes_when_command_changes() {
+        let mut commands = parse(
+            r#"
+[post-watch-run]
+one = "echo a"
+"#,
+        );
+        let first = approval_id(&commands.remove(0));
+        let mut commands = parse(
+            r#"
+[post-watch-run]
+one = "echo b"
+"#,
+        );
+        let second = approval_id(&commands.remove(0));
+
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn renders_template_from_context() {
+        let context = HookContext {
+            session_id: Some("s1".into()),
+            branch: Some("feature/search".into()),
+            ..HookContext::new(HookEvent::PostWatchSuccess)
+        };
+
+        let rendered =
+            render_template("echo {{ hook_type }} {{ branch }} {{ session_id }}", &context, "ci")
+                .unwrap();
+
+        assert_eq!(rendered, "echo post-watch-success feature/search s1");
+    }
+
+    #[test]
+    fn renders_template_conditionals_and_default_values() {
+        let context = HookContext {
+            provider: Some("worktrunk".into()),
+            worktrunk: true,
+            ..HookContext::new(HookEvent::PostWorktreeCreate)
+        };
+
+        let rendered = render_template(
+            "{% if provider == 'worktrunk' %}wt{% endif %} {{ missing | default('fallback') }}",
+            &context,
+            "notify",
+        )
+        .unwrap();
+
+        assert_eq!(rendered, "wt fallback");
+    }
+
+    #[test]
+    fn renders_template_filters() {
+        let context = HookContext {
+            branch: Some("Feature/Login Flow".into()),
+            ..HookContext::new(HookEvent::PostWorktreeCreate)
+        };
+
+        let rendered = render_template(
+            "{{ branch | sanitize }} {{ branch | sanitize_db }} {{ branch | hash_port }}",
+            &context,
+            "ports",
+        )
+        .unwrap();
+        let parts = rendered.split_whitespace().collect::<Vec<_>>();
+
+        assert_eq!(parts[0], "feature-login-flow");
+        assert_eq!(parts[1], "feature_login_flow");
+        assert!(parts[2].parse::<u16>().is_ok());
+    }
+
+    #[tokio::test]
+    async fn run_blocking_executes_user_hook() {
+        let temp = TempDir::new().unwrap();
+        let config = temp.path().join("hooks.toml");
+        std::fs::write(&config, r#"pre-watch-run = "cat >/dev/null""#).unwrap();
+        let manager = AutomationHookManager {
+            user_config_path: config,
+            approval_path: temp.path().join("approvals.json"),
+            log_dir: temp.path().join("logs"),
+        };
+
+        let ran = manager
+            .run_blocking(HookEvent::PreWatchRun, HookContext::new(HookEvent::PreWatchRun))
+            .await
+            .unwrap();
+
+        assert_eq!(ran, 1);
+    }
+}

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -18,10 +18,10 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Handle a Claude Code hook event (called by hooks in ~/.claude/settings.json)
+    /// Hook commands. Status variants are called by hooks in ~/.claude/settings.json.
     Hook {
-        /// Status to set: working, idle, attention, error, disconnected
-        status: String,
+        #[command(subcommand)]
+        action: HookAction,
     },
     /// Show current session statuses
     Status,
@@ -160,6 +160,50 @@ enum SessionAction {
     Panes {
         #[command(subcommand)]
         action: PaneAction,
+    },
+}
+
+#[derive(Subcommand)]
+enum HookAction {
+    /// Claude status: working
+    Working,
+    /// Claude status: idle
+    Idle,
+    /// Claude status: attention
+    Attention,
+    /// Claude status: error
+    Error,
+    /// Claude status: disconnected
+    Disconnected,
+    /// Show configured Roux automation hooks
+    Show {
+        /// Repo path whose project hooks should be included
+        #[arg(long)]
+        repo_path: Option<String>,
+    },
+    /// Run a Roux automation hook through the running app
+    Run {
+        /// Hook event name, e.g. post-watch-success
+        event: String,
+        #[arg(long)]
+        repo_path: Option<String>,
+        #[arg(long)]
+        worktree_path: Option<String>,
+        #[arg(long)]
+        branch: Option<String>,
+        #[arg(long)]
+        session: Option<String>,
+        #[arg(long)]
+        project: Option<String>,
+        #[arg(long)]
+        task: Option<String>,
+        #[arg(long)]
+        scope: Option<String>,
+        #[arg(long)]
+        provider: Option<String>,
+        /// Extra args passed into the hook context. Use `--` before values.
+        #[arg(last = true)]
+        extra: Vec<String>,
     },
 }
 
@@ -476,6 +520,75 @@ fn handle_hook(status: &str) {
     let _ = fs::write(path, json);
 }
 
+fn handle_hook_action(action: HookAction) {
+    match action {
+        HookAction::Working => handle_hook("working"),
+        HookAction::Idle => handle_hook("idle"),
+        HookAction::Attention => handle_hook("attention"),
+        HookAction::Error => handle_hook("error"),
+        HookAction::Disconnected => handle_hook("disconnected"),
+        HookAction::Show { repo_path } => {
+            let mut args = serde_json::Map::new();
+            if let Some(path) = repo_path {
+                args.insert("repo_path".into(), Value::String(path));
+            }
+            run_socket_command(serde_json::json!({
+                "command": "hook-show",
+                "args": Value::Object(args),
+            }));
+        }
+        HookAction::Run {
+            event,
+            repo_path,
+            worktree_path,
+            branch,
+            session,
+            project,
+            task,
+            scope,
+            provider,
+            extra,
+        } => {
+            let mut args = serde_json::Map::new();
+            args.insert("event".into(), Value::String(event));
+            if let Some(path) = repo_path {
+                args.insert("repoPath".into(), Value::String(path));
+            }
+            if let Some(path) = worktree_path {
+                args.insert("worktreePath".into(), Value::String(path));
+            }
+            if let Some(branch) = branch {
+                args.insert("branch".into(), Value::String(branch));
+            }
+            if let Some(session) = session.or_else(get_session_id) {
+                args.insert("sessionId".into(), Value::String(session));
+            }
+            if let Some(project) = project {
+                args.insert("projectId".into(), Value::String(project));
+            }
+            if let Some(task) = task {
+                args.insert("taskId".into(), Value::String(task));
+            }
+            if let Some(scope) = scope {
+                args.insert("scope".into(), Value::String(scope));
+            }
+            if let Some(provider) = provider {
+                args.insert("provider".into(), Value::String(provider));
+            }
+            if !extra.is_empty() {
+                args.insert(
+                    "args".into(),
+                    Value::Array(extra.into_iter().map(Value::String).collect()),
+                );
+            }
+            run_socket_command(serde_json::json!({
+                "command": "hook-run",
+                "args": Value::Object(args),
+            }));
+        }
+    }
+}
+
 fn show_status() {
     let dir = status_dir();
     if !dir.exists() {
@@ -523,11 +636,10 @@ fn clear_status() {
     }
 }
 
-
 fn main() {
     let cli = Cli::parse();
     match cli.command {
-        Commands::Hook { status } => handle_hook(&status),
+        Commands::Hook { action } => handle_hook_action(action),
         Commands::Status => show_status(),
         Commands::Clear => clear_status(),
 
@@ -754,10 +866,7 @@ fn scope_name(a: &NotesAction) -> Option<&'static str> {
     }
 }
 
-fn build_target(
-    scope: &str,
-    topic: Option<String>,
-) -> serde_json::Value {
+fn build_target(scope: &str, topic: Option<String>) -> serde_json::Value {
     serde_json::json!({
         "scope": scope,
         "sessionId": get_session_id(),
@@ -911,6 +1020,82 @@ mod tests {
         match cli.command {
             Commands::Session { action: SessionAction::List } => {}
             _ => panic!("expected Session::List"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_hook_status_compat_command() {
+        let cli = Cli::try_parse_from(["roux-cli", "hook", "working"]).unwrap();
+        match cli.command {
+            Commands::Hook { action: HookAction::Working } => {}
+            _ => panic!("expected Hook::Working"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_hook_show_with_repo_path() {
+        let cli =
+            Cli::try_parse_from(["roux-cli", "hook", "show", "--repo-path", "/repo"]).unwrap();
+        match cli.command {
+            Commands::Hook { action: HookAction::Show { repo_path } } => {
+                assert_eq!(repo_path.as_deref(), Some("/repo"));
+            }
+            _ => panic!("expected Hook::Show"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_hook_run_with_context_and_extra_args() {
+        let cli = Cli::try_parse_from([
+            "roux-cli",
+            "hook",
+            "run",
+            "post-watch-success",
+            "--repo-path",
+            "/repo",
+            "--worktree-path",
+            "/repo/.worktrees/x",
+            "--branch",
+            "feat/x",
+            "--session",
+            "sid",
+            "--task",
+            "tid",
+            "--scope",
+            "session",
+            "--provider",
+            "worktrunk",
+            "--",
+            "--verbose",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Hook {
+                action:
+                    HookAction::Run {
+                        event,
+                        repo_path,
+                        worktree_path,
+                        branch,
+                        session,
+                        task,
+                        scope,
+                        provider,
+                        extra,
+                        ..
+                    },
+            } => {
+                assert_eq!(event, "post-watch-success");
+                assert_eq!(repo_path.as_deref(), Some("/repo"));
+                assert_eq!(worktree_path.as_deref(), Some("/repo/.worktrees/x"));
+                assert_eq!(branch.as_deref(), Some("feat/x"));
+                assert_eq!(session.as_deref(), Some("sid"));
+                assert_eq!(task.as_deref(), Some("tid"));
+                assert_eq!(scope.as_deref(), Some("session"));
+                assert_eq!(provider.as_deref(), Some("worktrunk"));
+                assert_eq!(extra, vec!["--verbose"]);
+            }
+            _ => panic!("expected Hook::Run"),
         }
     }
 

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 use serde_json::Value;
 use std::fs;
 use std::io::Read;
@@ -176,35 +176,41 @@ enum HookAction {
     /// Claude status: disconnected
     Disconnected,
     /// Show configured Roux automation hooks
-    Show {
-        /// Repo path whose project hooks should be included
-        #[arg(long)]
-        repo_path: Option<String>,
-    },
+    Show(HookShowArgs),
     /// Run a Roux automation hook through the running app
-    Run {
-        /// Hook event name, e.g. post-watch-success
-        event: String,
-        #[arg(long)]
-        repo_path: Option<String>,
-        #[arg(long)]
-        worktree_path: Option<String>,
-        #[arg(long)]
-        branch: Option<String>,
-        #[arg(long)]
-        session: Option<String>,
-        #[arg(long)]
-        project: Option<String>,
-        #[arg(long)]
-        task: Option<String>,
-        #[arg(long)]
-        scope: Option<String>,
-        #[arg(long)]
-        provider: Option<String>,
-        /// Extra args passed into the hook context. Use `--` before values.
-        #[arg(last = true)]
-        extra: Vec<String>,
-    },
+    Run(Box<HookRunArgs>),
+}
+
+#[derive(Args)]
+struct HookShowArgs {
+    /// Repo path whose project hooks should be included
+    #[arg(long)]
+    repo_path: Option<String>,
+}
+
+#[derive(Args)]
+struct HookRunArgs {
+    /// Hook event name, e.g. post-watch-success
+    event: String,
+    #[arg(long)]
+    repo_path: Option<String>,
+    #[arg(long)]
+    worktree_path: Option<String>,
+    #[arg(long)]
+    branch: Option<String>,
+    #[arg(long)]
+    session: Option<String>,
+    #[arg(long)]
+    project: Option<String>,
+    #[arg(long)]
+    task: Option<String>,
+    #[arg(long)]
+    scope: Option<String>,
+    #[arg(long)]
+    provider: Option<String>,
+    /// Extra args passed into the hook context. Use `--` before values.
+    #[arg(last = true)]
+    extra: Vec<String>,
 }
 
 #[derive(Subcommand)]
@@ -527,7 +533,7 @@ fn handle_hook_action(action: HookAction) {
         HookAction::Attention => handle_hook("attention"),
         HookAction::Error => handle_hook("error"),
         HookAction::Disconnected => handle_hook("disconnected"),
-        HookAction::Show { repo_path } => {
+        HookAction::Show(HookShowArgs { repo_path }) => {
             let mut args = serde_json::Map::new();
             if let Some(path) = repo_path {
                 args.insert("repo_path".into(), Value::String(path));
@@ -537,18 +543,19 @@ fn handle_hook_action(action: HookAction) {
                 "args": Value::Object(args),
             }));
         }
-        HookAction::Run {
-            event,
-            repo_path,
-            worktree_path,
-            branch,
-            session,
-            project,
-            task,
-            scope,
-            provider,
-            extra,
-        } => {
+        HookAction::Run(args) => {
+            let HookRunArgs {
+                event,
+                repo_path,
+                worktree_path,
+                branch,
+                session,
+                project,
+                task,
+                scope,
+                provider,
+                extra,
+            } = *args;
             let mut args = serde_json::Map::new();
             args.insert("event".into(), Value::String(event));
             if let Some(path) = repo_path {
@@ -1037,7 +1044,7 @@ mod tests {
         let cli =
             Cli::try_parse_from(["roux-cli", "hook", "show", "--repo-path", "/repo"]).unwrap();
         match cli.command {
-            Commands::Hook { action: HookAction::Show { repo_path } } => {
+            Commands::Hook { action: HookAction::Show(HookShowArgs { repo_path }) } => {
                 assert_eq!(repo_path.as_deref(), Some("/repo"));
             }
             _ => panic!("expected Hook::Show"),
@@ -1070,21 +1077,19 @@ mod tests {
         ])
         .unwrap();
         match cli.command {
-            Commands::Hook {
-                action:
-                    HookAction::Run {
-                        event,
-                        repo_path,
-                        worktree_path,
-                        branch,
-                        session,
-                        task,
-                        scope,
-                        provider,
-                        extra,
-                        ..
-                    },
-            } => {
+            Commands::Hook { action: HookAction::Run(args) } => {
+                let HookRunArgs {
+                    event,
+                    repo_path,
+                    worktree_path,
+                    branch,
+                    session,
+                    task,
+                    scope,
+                    provider,
+                    extra,
+                    ..
+                } = *args;
                 assert_eq!(event, "post-watch-success");
                 assert_eq!(repo_path.as_deref(), Some("/repo"));
                 assert_eq!(worktree_path.as_deref(), Some("/repo/.worktrees/x"));

--- a/src-tauri/src/commands/sessions.rs
+++ b/src-tauri/src/commands/sessions.rs
@@ -128,7 +128,7 @@ pub(crate) fn spawn_shell(
 
 #[tauri::command]
 #[specta::specta]
-pub(crate) fn spawn_task(
+pub(crate) async fn spawn_task(
     id: String,
     command: String,
     working_dir: String,
@@ -136,11 +136,25 @@ pub(crate) fn spawn_task(
     pane_id: Option<String>,
     profile: Option<String>,
     initial_size: Option<(u16, u16)>,
-    state: tauri::State<AppState>,
+    state: tauri::State<'_, AppState>,
     app: tauri::AppHandle,
 ) -> Result<(), String> {
     // See spawn_shell above: project/worktree env is deferred for the
     // secondary-pane path until this command goes async.
+    let context = crate::automation_hooks::HookContext {
+        repo_path: Some(working_dir.clone()),
+        worktree_path: Some(working_dir.clone()),
+        task_id: Some(id.clone()),
+        session_id: session_id.clone(),
+        scope: session_id.as_ref().map(|_| "session".to_string()),
+        cwd: Some(working_dir.clone()),
+        ..crate::automation_hooks::HookContext::new(crate::automation_hooks::HookEvent::PreTaskRun)
+    };
+    state
+        .automation_hooks
+        .run_blocking(crate::automation_hooks::HookEvent::PreTaskRun, context)
+        .await
+        .map_err(|e| e.to_string())?;
     state
         .pty_manager
         .spawn_task(
@@ -157,7 +171,20 @@ pub(crate) fn spawn_task(
             profile.as_deref(),
             app.clone(),
         )
-        .map_err(|e| e.to_string())
+        .map_err(|e| e.to_string())?;
+    let context = crate::automation_hooks::HookContext {
+        repo_path: Some(working_dir.clone()),
+        worktree_path: Some(working_dir.clone()),
+        task_id: Some(id),
+        session_id,
+        scope: Some("session".into()),
+        cwd: Some(working_dir),
+        ..crate::automation_hooks::HookContext::new(crate::automation_hooks::HookEvent::PostTaskRun)
+    };
+    state
+        .automation_hooks
+        .spawn_background(crate::automation_hooks::HookEvent::PostTaskRun, context);
+    Ok(())
 }
 
 #[tauri::command]
@@ -185,9 +212,47 @@ pub(crate) async fn kill_session(
     id: String,
     state: tauri::State<'_, AppState>,
 ) -> Result<(), String> {
+    let session = state.session_handle.get(&id).await.map_err(|e| e.to_string())?;
+    if let Some(session) = session.as_ref() {
+        let context = crate::automation_hooks::HookContext {
+            repo_path: Some(session.repo_root.clone()),
+            worktree_path: Some(session.worktree_path.clone()),
+            branch: Some(session.branch.clone()),
+            session_id: Some(session.id.clone()),
+            project_id: session.project_id.clone(),
+            scope: Some("session".into()),
+            cwd: Some(session.worktree_path.clone()),
+            ..crate::automation_hooks::HookContext::new(
+                crate::automation_hooks::HookEvent::PreSessionClose,
+            )
+        };
+        state
+            .automation_hooks
+            .run_blocking(crate::automation_hooks::HookEvent::PreSessionClose, context)
+            .await
+            .map_err(|e| e.to_string())?;
+    }
     svc::kill_session(&state.pty_manager, &state.session_handle, &id)
         .await
-        .map_err(|e| e.to_string())
+        .map_err(|e| e.to_string())?;
+    if let Some(session) = session {
+        let context = crate::automation_hooks::HookContext {
+            repo_path: Some(session.repo_root.clone()),
+            worktree_path: Some(session.worktree_path.clone()),
+            branch: Some(session.branch.clone()),
+            session_id: Some(session.id.clone()),
+            project_id: session.project_id.clone(),
+            scope: Some("session".into()),
+            cwd: Some(session.worktree_path.clone()),
+            ..crate::automation_hooks::HookContext::new(
+                crate::automation_hooks::HookEvent::PostSessionClose,
+            )
+        };
+        state
+            .automation_hooks
+            .spawn_background(crate::automation_hooks::HookEvent::PostSessionClose, context);
+    }
+    Ok(())
 }
 
 /// Bring an archived session back to the active list.
@@ -307,6 +372,7 @@ pub(crate) async fn create_session_shell(
         nono.as_ref(),
         opts.profile.as_deref(),
         initial_size,
+        Some(&state.automation_hooks),
         &app,
     )
     .await

--- a/src-tauri/src/commands/sessions.rs
+++ b/src-tauri/src/commands/sessions.rs
@@ -172,12 +172,13 @@ pub(crate) async fn spawn_task(
             app.clone(),
         )
         .map_err(|e| e.to_string())?;
+    let scope = session_id.as_ref().map(|_| "session".to_string());
     let context = crate::automation_hooks::HookContext {
         repo_path: Some(working_dir.clone()),
         worktree_path: Some(working_dir.clone()),
         task_id: Some(id),
         session_id,
-        scope: Some("session".into()),
+        scope,
         cwd: Some(working_dir),
         ..crate::automation_hooks::HookContext::new(crate::automation_hooks::HookEvent::PostTaskRun)
     };

--- a/src-tauri/src/commands/worktrees.rs
+++ b/src-tauri/src/commands/worktrees.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use serde::Serialize;
 
+use crate::automation_hooks::{worktree_provider_hooks, HookContext, HookEvent};
 use crate::services::worktrees as svc;
 use crate::state::AppState;
 
@@ -24,17 +25,32 @@ pub(crate) async fn cmd_create_worktree(
     // the blocking task.
     let (base_path, provider) = {
         let settings = state.settings.lock().unwrap();
-        (
-            settings.worktree_base_path.clone(),
-            settings.worktree_provider,
-        )
+        (settings.worktree_base_path.clone(), settings.worktree_provider)
     };
     let fetch_first = fetch_first.unwrap_or(false);
+    let wt = crate::services::setup::resolve_wt_binary();
+    let wt_available = wt.is_some();
+    let pre_context =
+        HookContext::new(HookEvent::PreWorktreeCreate).with_provider(provider, wt_available);
+    let pre_context = HookContext {
+        repo_path: Some(repo_path.clone()),
+        branch: Some(branch.clone()),
+        cwd: Some(repo_path.clone()),
+        ..pre_context
+    };
+    state
+        .automation_hooks
+        .run_blocking(HookEvent::PreWorktreeCreate, pre_context)
+        .await
+        .map_err(|e| e.to_string())?;
+    let post_hooks = state.automation_hooks.clone();
+    let post_provider = provider;
+    let post_repo_path = repo_path.clone();
+    let post_branch = branch.clone();
     tauri::async_runtime::spawn_blocking(move || {
         if fetch_first {
             roux_core::fetch_origin(&repo_path).map_err(|e| e.to_string())?;
         }
-        let wt = crate::services::setup::resolve_wt_binary();
         roux_core::create_worktree_with_provider(
             &repo_path,
             &branch,
@@ -47,6 +63,18 @@ pub(crate) async fn cmd_create_worktree(
     })
     .await
     .map_err(|e| format!("create_worktree task panicked: {e}"))?
+    .map(|worktree_path| {
+        let mut context = HookContext::new(HookEvent::PostWorktreeCreate)
+            .with_provider(post_provider, wt_available);
+        context.repo_path = Some(post_repo_path.clone());
+        context.worktree_path = Some(worktree_path.clone());
+        context.branch = Some(post_branch);
+        context.cwd = Some(worktree_path.clone());
+        context.provider_hooks_ran =
+            worktree_provider_hooks(HookEvent::PostWorktreeCreate, context.worktrunk);
+        post_hooks.spawn_background(HookEvent::PostWorktreeCreate, context);
+        worktree_path
+    })
 }
 
 #[tauri::command]
@@ -59,8 +87,23 @@ pub(crate) async fn cmd_remove_worktree(
 ) -> Result<(), String> {
     let provider = state.settings.lock().unwrap().worktree_provider;
     let also_branch = also_branch.unwrap_or(false);
+    let wt = crate::services::setup::resolve_wt_binary();
+    let wt_available = wt.is_some();
+    let pre_context = HookContext {
+        repo_path: Some(repo_path.clone()),
+        worktree_path: Some(worktree_path.clone()),
+        cwd: Some(worktree_path.clone()),
+        ..HookContext::new(HookEvent::PreWorktreeRemove).with_provider(provider, wt_available)
+    };
+    state
+        .automation_hooks
+        .run_blocking(HookEvent::PreWorktreeRemove, pre_context)
+        .await
+        .map_err(|e| e.to_string())?;
+    let post_hooks = state.automation_hooks.clone();
+    let post_repo_path = repo_path.clone();
+    let post_worktree_path = worktree_path.clone();
     tauri::async_runtime::spawn_blocking(move || {
-        let wt = crate::services::setup::resolve_wt_binary();
         roux_core::remove_worktree_with_provider(
             &repo_path,
             &worktree_path,
@@ -72,6 +115,16 @@ pub(crate) async fn cmd_remove_worktree(
     })
     .await
     .map_err(|e| format!("remove_worktree task panicked: {e}"))?
+    .map(|()| {
+        let mut context =
+            HookContext::new(HookEvent::PostWorktreeRemove).with_provider(provider, wt_available);
+        context.repo_path = Some(post_repo_path);
+        context.worktree_path = Some(post_worktree_path.clone());
+        context.cwd = Some(post_worktree_path);
+        context.provider_hooks_ran =
+            worktree_provider_hooks(HookEvent::PostWorktreeRemove, context.worktrunk);
+        post_hooks.spawn_background(HookEvent::PostWorktreeRemove, context);
+    })
 }
 
 #[tauri::command]
@@ -100,11 +153,9 @@ pub(crate) async fn cmd_list_branches(repo_path: String) -> Result<Vec<String>, 
 #[tauri::command]
 #[specta::specta]
 pub(crate) async fn git_init(path: String) -> Result<(), String> {
-    tauri::async_runtime::spawn_blocking(move || {
-        svc::git_init(&path).map_err(|e| e.to_string())
-    })
-    .await
-    .map_err(|e| format!("git_init task panicked: {e}"))?
+    tauri::async_runtime::spawn_blocking(move || svc::git_init(&path).map_err(|e| e.to_string()))
+        .await
+        .map_err(|e| format!("git_init task panicked: {e}"))?
 }
 
 /// Resolve a worktree-base-path template (`{project_dir}`, `{git_root}`,
@@ -296,15 +347,11 @@ pub(crate) async fn cmd_worktrunk_read_log(
         let canonical_root = logs_root
             .canonicalize()
             .map_err(|_| "worktrunk logs directory does not exist for this repo".to_string())?;
-        let canonical_target = target
-            .canonicalize()
-            .map_err(|e| format!("cannot resolve log path: {e}"))?;
+        let canonical_target =
+            target.canonicalize().map_err(|e| format!("cannot resolve log path: {e}"))?;
 
         if !canonical_target.starts_with(&canonical_root) {
-            return Err(format!(
-                "refusing to read {path}: not under {}",
-                canonical_root.display()
-            ));
+            return Err(format!("refusing to read {path}: not under {}", canonical_root.display()));
         }
 
         roux_worktrunk::read_log_file(&canonical_target, MAX_BYTES).map_err(|e| e.to_string())
@@ -338,20 +385,21 @@ pub(crate) async fn cmd_open_terminal_at(path: String) -> Result<(), String> {
                 .arg(&path)
                 .status()
                 .map_err(|e| format!("open failed: {e}"))
-                .and_then(|s| {
-                    if s.success() {
-                        Ok(())
-                    } else {
-                        Err(format!("open exited with {s}"))
-                    }
-                })
+                .and_then(
+                    |s| {
+                        if s.success() {
+                            Ok(())
+                        } else {
+                            Err(format!("open exited with {s}"))
+                        }
+                    },
+                )
         }
 
         #[cfg(target_os = "linux")]
         {
-            if let Ok(status) = Command::new("xdg-terminal-exec")
-                .env("TERMINAL_EXEC_WORKDIR", &path)
-                .status()
+            if let Ok(status) =
+                Command::new("xdg-terminal-exec").env("TERMINAL_EXEC_WORKDIR", &path).status()
             {
                 if status.success() {
                     return Ok(());
@@ -391,13 +439,15 @@ pub(crate) async fn cmd_open_terminal_at(path: String) -> Result<(), String> {
                 .args(["/c", "start", "cmd", "/k", &cd_command])
                 .status()
                 .map_err(|e| format!("cmd failed: {e}"))
-                .and_then(|s| {
-                    if s.success() {
-                        Ok(())
-                    } else {
-                        Err(format!("cmd exited with {s}"))
-                    }
-                })
+                .and_then(
+                    |s| {
+                        if s.success() {
+                            Ok(())
+                        } else {
+                            Err(format!("cmd exited with {s}"))
+                        }
+                    },
+                )
         }
     })
     .await
@@ -409,20 +459,13 @@ pub(crate) async fn cmd_open_terminal_at(path: String) -> Result<(), String> {
 pub(crate) async fn cmd_detect_worktrunk(repo_path: Option<String>) -> WorktrunkDetection {
     tauri::async_runtime::spawn_blocking(move || detect_worktrunk_inner(repo_path))
         .await
-        .unwrap_or(WorktrunkDetection {
-            binary_path: None,
-            version: None,
-            has_config: false,
-        })
+        .unwrap_or(WorktrunkDetection { binary_path: None, version: None, has_config: false })
 }
 
 fn detect_worktrunk_inner(repo_path: Option<String>) -> WorktrunkDetection {
     let wt = crate::services::setup::resolve_wt_binary();
     let (binary_path, version) = match wt {
-        Some(w) => (
-            Some(w.path.to_string_lossy().into_owned()),
-            Some(w.version.to_string()),
-        ),
+        Some(w) => (Some(w.path.to_string_lossy().into_owned()), Some(w.version.to_string())),
         None => (None, None),
     };
     let has_config = repo_path

--- a/src-tauri/src/commands/worktrees.rs
+++ b/src-tauri/src/commands/worktrees.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use roux_core::WorktreeProvider;
 use serde::Serialize;
 
 use crate::automation_hooks::{worktree_provider_hooks, HookContext, HookEvent};
@@ -11,6 +12,40 @@ use crate::state::AppState;
 // Without this, `wt remove` (which can run user-defined post-remove hooks
 // for seconds) blocks Tauri's webview thread and the user sees a macOS
 // beachball until the subprocess returns.
+
+fn build_post_worktree_create_context(
+    provider: WorktreeProvider,
+    wt_available: bool,
+    repo_path: &str,
+    branch: &str,
+    worktree_path: &str,
+) -> HookContext {
+    let mut context =
+        HookContext::new(HookEvent::PostWorktreeCreate).with_provider(provider, wt_available);
+    context.repo_path = Some(repo_path.to_string());
+    context.worktree_path = Some(worktree_path.to_string());
+    context.branch = Some(branch.to_string());
+    context.cwd = Some(worktree_path.to_string());
+    context.provider_hooks_ran =
+        worktree_provider_hooks(HookEvent::PostWorktreeCreate, context.worktrunk);
+    context
+}
+
+fn build_post_worktree_remove_context(
+    provider: WorktreeProvider,
+    wt_available: bool,
+    repo_path: &str,
+    worktree_path: &str,
+) -> HookContext {
+    let mut context =
+        HookContext::new(HookEvent::PostWorktreeRemove).with_provider(provider, wt_available);
+    context.repo_path = Some(repo_path.to_string());
+    context.worktree_path = Some(worktree_path.to_string());
+    context.cwd = Some(worktree_path.to_string());
+    context.provider_hooks_ran =
+        worktree_provider_hooks(HookEvent::PostWorktreeRemove, context.worktrunk);
+    context
+}
 
 #[tauri::command]
 #[specta::specta]
@@ -47,7 +82,7 @@ pub(crate) async fn cmd_create_worktree(
     let post_provider = provider;
     let post_repo_path = repo_path.clone();
     let post_branch = branch.clone();
-    tauri::async_runtime::spawn_blocking(move || {
+    let worktree_path = tauri::async_runtime::spawn_blocking(move || {
         if fetch_first {
             roux_core::fetch_origin(&repo_path).map_err(|e| e.to_string())?;
         }
@@ -63,18 +98,16 @@ pub(crate) async fn cmd_create_worktree(
     })
     .await
     .map_err(|e| format!("create_worktree task panicked: {e}"))?
-    .map(|worktree_path| {
-        let mut context = HookContext::new(HookEvent::PostWorktreeCreate)
-            .with_provider(post_provider, wt_available);
-        context.repo_path = Some(post_repo_path.clone());
-        context.worktree_path = Some(worktree_path.clone());
-        context.branch = Some(post_branch);
-        context.cwd = Some(worktree_path.clone());
-        context.provider_hooks_ran =
-            worktree_provider_hooks(HookEvent::PostWorktreeCreate, context.worktrunk);
-        post_hooks.spawn_background(HookEvent::PostWorktreeCreate, context);
-        worktree_path
-    })
+    .map_err(|e| e.to_string())?;
+    let context = build_post_worktree_create_context(
+        post_provider,
+        wt_available,
+        &post_repo_path,
+        &post_branch,
+        &worktree_path,
+    );
+    post_hooks.spawn_background(HookEvent::PostWorktreeCreate, context);
+    Ok(worktree_path)
 }
 
 #[tauri::command]
@@ -115,16 +148,15 @@ pub(crate) async fn cmd_remove_worktree(
     })
     .await
     .map_err(|e| format!("remove_worktree task panicked: {e}"))?
-    .map(|()| {
-        let mut context =
-            HookContext::new(HookEvent::PostWorktreeRemove).with_provider(provider, wt_available);
-        context.repo_path = Some(post_repo_path);
-        context.worktree_path = Some(post_worktree_path.clone());
-        context.cwd = Some(post_worktree_path);
-        context.provider_hooks_ran =
-            worktree_provider_hooks(HookEvent::PostWorktreeRemove, context.worktrunk);
-        post_hooks.spawn_background(HookEvent::PostWorktreeRemove, context);
-    })
+    .map_err(|e| e.to_string())?;
+    let context = build_post_worktree_remove_context(
+        provider,
+        wt_available,
+        &post_repo_path,
+        &post_worktree_path,
+    );
+    post_hooks.spawn_background(HookEvent::PostWorktreeRemove, context);
+    Ok(())
 }
 
 #[tauri::command]
@@ -473,4 +505,60 @@ fn detect_worktrunk_inner(repo_path: Option<String>) -> WorktrunkDetection {
         .map(|p| roux_worktrunk::detect_wt_config(&PathBuf::from(p)))
         .unwrap_or(false);
     WorktrunkDetection { binary_path, version, has_config }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn post_create_context_sets_worktrunk_provider_hooks() {
+        let context = build_post_worktree_create_context(
+            WorktreeProvider::Worktrunk,
+            true,
+            "/repo",
+            "feat/x",
+            "/repo/.worktrees/feat-x",
+        );
+
+        assert_eq!(context.provider.as_deref(), Some("worktrunk"));
+        assert!(context.worktrunk);
+        assert_eq!(context.repo_path.as_deref(), Some("/repo"));
+        assert_eq!(context.worktree_path.as_deref(), Some("/repo/.worktrees/feat-x"));
+        assert_eq!(context.branch.as_deref(), Some("feat/x"));
+        assert_eq!(context.cwd.as_deref(), Some("/repo/.worktrees/feat-x"));
+        assert_eq!(context.provider_hooks_ran, vec!["pre-start", "post-start"]);
+    }
+
+    #[test]
+    fn post_create_context_uses_git_when_worktrunk_unavailable() {
+        let context = build_post_worktree_create_context(
+            WorktreeProvider::Worktrunk,
+            false,
+            "/repo",
+            "feat/x",
+            "/repo/.worktrees/feat-x",
+        );
+
+        assert_eq!(context.provider.as_deref(), Some("git"));
+        assert!(!context.worktrunk);
+        assert!(context.provider_hooks_ran.is_empty());
+    }
+
+    #[test]
+    fn post_remove_context_sets_worktrunk_provider_hooks() {
+        let context = build_post_worktree_remove_context(
+            WorktreeProvider::Worktrunk,
+            true,
+            "/repo",
+            "/repo/.worktrees/feat-x",
+        );
+
+        assert_eq!(context.provider.as_deref(), Some("worktrunk"));
+        assert!(context.worktrunk);
+        assert_eq!(context.repo_path.as_deref(), Some("/repo"));
+        assert_eq!(context.worktree_path.as_deref(), Some("/repo/.worktrees/feat-x"));
+        assert_eq!(context.cwd.as_deref(), Some("/repo/.worktrees/feat-x"));
+        assert_eq!(context.provider_hooks_ran, vec!["pre-remove", "post-remove"]);
+    }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,6 +2,7 @@
 
 mod agent_registry;
 mod agent_sources;
+mod automation_hooks;
 mod hooks;
 #[macro_use]
 mod logging;
@@ -89,6 +90,13 @@ fn main() {
         commands::worktrees::cmd_worktrunk_diagnostics,
         commands::worktrees::cmd_worktrunk_read_log,
         commands::worktrees::cmd_open_terminal_at,
+        automation_hooks::cmd_list_automation_hooks,
+        automation_hooks::cmd_preview_automation_hooks,
+        automation_hooks::cmd_run_automation_hook,
+        automation_hooks::cmd_approve_automation_hook,
+        automation_hooks::cmd_clear_automation_hook_approvals,
+        automation_hooks::cmd_list_automation_hook_logs,
+        automation_hooks::cmd_read_automation_hook_log,
         commands::sessions::write_to_session,
         commands::sessions::resize_session,
         commands::sessions::spawn_shell,
@@ -199,6 +207,7 @@ fn main() {
             session_handle,
             project_handle,
             watch_manager: watches::WatchManager::new(watch_store_handle),
+            automation_hooks: automation_hooks::AutomationHookManager::new(),
             notification_manager: notifications::NotificationManager::new(),
             pending_replies: Mutex::new(std::collections::HashMap::new()),
         })
@@ -214,9 +223,16 @@ fn main() {
             commands::worktrees::cmd_list_worktrees,
             commands::worktrees::cmd_preview_worktree_base,
             commands::worktrees::cmd_detect_worktrunk,
-        commands::worktrees::cmd_worktrunk_diagnostics,
-        commands::worktrees::cmd_worktrunk_read_log,
-        commands::worktrees::cmd_open_terminal_at,
+            commands::worktrees::cmd_worktrunk_diagnostics,
+            commands::worktrees::cmd_worktrunk_read_log,
+            commands::worktrees::cmd_open_terminal_at,
+            automation_hooks::cmd_list_automation_hooks,
+            automation_hooks::cmd_preview_automation_hooks,
+            automation_hooks::cmd_run_automation_hook,
+            automation_hooks::cmd_approve_automation_hook,
+            automation_hooks::cmd_clear_automation_hook_approvals,
+            automation_hooks::cmd_list_automation_hook_logs,
+            automation_hooks::cmd_read_automation_hook_log,
             commands::sessions::write_to_session,
             commands::sessions::resize_session,
             commands::sessions::attach_pty_output,
@@ -349,16 +365,16 @@ fn main() {
                 let ctx = pty_lifecycle::LifecycleHandlerContext {
                     pty_manager: state.pty_manager.clone(),
                     agent_registry_tx: agent_input_tx.clone(),
+                    automation_hooks: state.automation_hooks.clone(),
                     app: app.handle().clone(),
                 };
                 let lifecycle_tx = pty_lifecycle::spawn_handler(ctx);
                 state.pty_manager.set_lifecycle_tx(lifecycle_tx);
             }
 
-            if let Err(e) = agent_sources::file_status::start_watching(
-                app.handle().clone(),
-                agent_input_tx,
-            ) {
+            if let Err(e) =
+                agent_sources::file_status::start_watching(app.handle().clone(), agent_input_tx)
+            {
                 eprintln!("Warning: failed to start file status source: {}", e);
             }
             socket::start_socket_server(app.handle().clone());
@@ -470,14 +486,10 @@ async fn run_notes_migration(app: tauri::AppHandle) {
     let mut svc = services::notes::NotesService::new(vault_root);
     let now = {
         use std::time::{SystemTime, UNIX_EPOCH};
-        let secs = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
+        let secs = SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or(0);
         format!("migration-{secs}")
     };
-    let migrated =
-        services::notes::migrate_legacy_project_notes(&legacy, &lookup, &mut svc, &now);
+    let migrated = services::notes::migrate_legacy_project_notes(&legacy, &lookup, &mut svc, &now);
     rlog!("notes migration: {migrated} file(s) moved into vault at startup");
 
     mark_migrated(&state);

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -1303,6 +1303,21 @@ impl PtyManager {
         self.sessions.lock().unwrap().get(session_id).map(|s| s.generation)
     }
 
+    pub(crate) fn get_info_direct(&self, pty_id: &str) -> Option<PtyInfo> {
+        let sessions = self.sessions.lock().unwrap();
+        sessions.get(pty_id).map(|s| PtyInfo {
+            id: pty_id.to_string(),
+            session_id: s.session_id.clone(),
+            role: s.role.clone(),
+            status: s.status.clone(),
+            name: s.name.clone(),
+            working_dir: s.working_dir.clone(),
+            profile: s.profile.clone(),
+            unread_output: s.unread_output,
+            bell_pending: s.bell_pending,
+        })
+    }
+
     /// List PTY info snapshots for a given session (for picker UI).
     pub fn list_for_session(&self, session_id: &str) -> Vec<PtyInfo> {
         let sessions = self.sessions.lock().unwrap();

--- a/src-tauri/src/pty_lifecycle.rs
+++ b/src-tauri/src/pty_lifecycle.rs
@@ -130,6 +130,7 @@ pub fn channel() -> (LifecycleTx, LifecycleRx) {
 pub struct LifecycleHandlerContext {
     pub pty_manager: Arc<crate::pty::PtyManager>,
     pub agent_registry_tx: mpsc::Sender<crate::agent_registry::RegistryMessage>,
+    pub automation_hooks: crate::automation_hooks::AutomationHookManager,
     pub app: tauri::AppHandle,
 }
 
@@ -177,6 +178,7 @@ fn handle_event(ctx: &LifecycleHandlerContext, event: PtyLifecycleEvent) {
                 );
                 return;
             }
+            let pty_info = ctx.pty_manager.get_info_direct(&pty_id);
 
             // 2. Emit frontend event
             use tauri::Emitter;
@@ -197,6 +199,26 @@ fn handle_event(ctx: &LifecycleHandlerContext, event: PtyLifecycleEvent) {
                         session_id: sid,
                     },
                 );
+            }
+
+            if let Some(info) = pty_info {
+                if info.profile.as_deref() == Some("task") {
+                    let event = if code == Some(0) {
+                        crate::automation_hooks::HookEvent::PostTaskSuccess
+                    } else {
+                        crate::automation_hooks::HookEvent::PostTaskFailure
+                    };
+                    let context = crate::automation_hooks::HookContext {
+                        repo_path: info.working_dir.clone(),
+                        worktree_path: info.working_dir.clone(),
+                        task_id: Some(pty_id.clone()),
+                        session_id: info.session_id.clone(),
+                        scope: info.session_id.as_ref().map(|_| "session".to_string()),
+                        cwd: info.working_dir,
+                        ..crate::automation_hooks::HookContext::new(event)
+                    };
+                    ctx.automation_hooks.spawn_background(event, context);
+                }
             }
 
             rlog!(

--- a/src-tauri/src/services/sessions.rs
+++ b/src-tauri/src/services/sessions.rs
@@ -2,6 +2,9 @@ use anyhow::anyhow;
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
+use crate::automation_hooks::{
+    worktree_provider_hooks, AutomationHookManager, HookContext, HookEvent,
+};
 use crate::paths::default_notes_vault_root;
 use crate::pty::{NotesEnvInputs, PtyManager};
 use crate::services::notes::{self as notes_svc, NotesService};
@@ -82,7 +85,11 @@ fn git_origin_url(repo_path: &str) -> Option<String> {
         return None;
     }
     let url = String::from_utf8(output.stdout).ok()?.trim().to_string();
-    if url.is_empty() { None } else { Some(url) }
+    if url.is_empty() {
+        None
+    } else {
+        Some(url)
+    }
 }
 
 pub(crate) fn is_git_repo(path: &str) -> bool {
@@ -118,11 +125,7 @@ pub(crate) enum SessionTarget<'a> {
     /// created from `sp` instead of HEAD. When `fetch_first` is true, we
     /// `git fetch origin` before resolving the start point (used for
     /// `origin/main`-style bases that may be stale).
-    NewWorktree {
-        branch: &'a str,
-        start_point: Option<&'a str>,
-        fetch_first: bool,
-    },
+    NewWorktree { branch: &'a str, start_point: Option<&'a str>, fetch_first: bool },
 }
 
 /// Create a session with a plain shell in its primary PTY. The shell is
@@ -143,6 +146,7 @@ pub(crate) async fn create_session_shell(
     nono: Option<&crate::pty::NonoConfig>,
     profile: Option<&str>,
     initial_size: Option<(u16, u16)>,
+    hooks: Option<&AutomationHookManager>,
     app: &tauri::AppHandle,
 ) -> anyhow::Result<Session> {
     let session_id = uuid::Uuid::new_v4().to_string();
@@ -166,6 +170,16 @@ pub(crate) async fn create_session_shell(
             // Session dialog was the only signal the provider was even
             // active.
             let wt = crate::services::setup::resolve_wt_binary();
+            if let Some(hooks) = hooks {
+                let context = HookContext {
+                    repo_path: Some(repo_path.to_string()),
+                    branch: Some(branch.to_string()),
+                    cwd: Some(repo_path.to_string()),
+                    ..HookContext::new(HookEvent::PreWorktreeCreate)
+                        .with_provider(settings.worktree_provider, wt.is_some())
+                };
+                hooks.run_blocking(HookEvent::PreWorktreeCreate, context).await?;
+            }
             let wt_path = roux_core::create_worktree_with_provider(
                 repo_path,
                 branch,
@@ -174,6 +188,19 @@ pub(crate) async fn create_session_shell(
                 settings.worktree_provider,
                 wt.as_ref(),
             )?;
+            if let Some(hooks) = hooks {
+                let mut context = HookContext {
+                    repo_path: Some(repo_path.to_string()),
+                    worktree_path: Some(wt_path.clone()),
+                    branch: Some(branch.to_string()),
+                    cwd: Some(wt_path.clone()),
+                    ..HookContext::new(HookEvent::PostWorktreeCreate)
+                        .with_provider(settings.worktree_provider, wt.is_some())
+                };
+                context.provider_hooks_ran =
+                    worktree_provider_hooks(HookEvent::PostWorktreeCreate, context.worktrunk);
+                hooks.spawn_background(HookEvent::PostWorktreeCreate, context);
+            }
             (wt_path, branch.to_string(), true)
         }
         SessionTarget::Repo => {
@@ -195,12 +222,8 @@ pub(crate) async fn create_session_shell(
     // tier-1 hook routing happy the moment the user starts an agent.
     let pane_id = format!("{}-main", session_id);
     let worktree_env = if is_wt { Some(work_dir.as_str()) } else { None };
-    let notes_env = Some(build_notes_env_for_new_session(
-        settings,
-        &session_id,
-        &actual_branch,
-        repo_path,
-    ));
+    let notes_env =
+        Some(build_notes_env_for_new_session(settings, &session_id, &actual_branch, repo_path));
     let spawn_result = pty_manager.spawn_shell(
         &session_id,
         &work_dir,
@@ -260,6 +283,19 @@ pub(crate) async fn create_session_shell(
         }
         return Err(e.into());
     }
+    if let Some(hooks) = hooks {
+        let context = HookContext {
+            repo_path: Some(session.repo_root.clone()),
+            worktree_path: Some(session.worktree_path.clone()),
+            branch: Some(session.branch.clone()),
+            session_id: Some(session.id.clone()),
+            project_id: session.project_id.clone(),
+            scope: Some("session".into()),
+            cwd: Some(session.worktree_path.clone()),
+            ..HookContext::new(HookEvent::PostSessionCreate)
+        };
+        hooks.spawn_background(HookEvent::PostSessionCreate, context);
+    }
     Ok(session)
 }
 
@@ -295,7 +331,8 @@ pub(crate) async fn reconnect_session_shell(
     // id matches the frontend's formula so tier-1 hook routing stays
     // deterministic the moment the user starts an agent in the shell.
     let pane_id = format!("{}-main", id);
-    let worktree_env = if session.is_worktree { Some(session.worktree_path.as_str()) } else { None };
+    let worktree_env =
+        if session.is_worktree { Some(session.worktree_path.as_str()) } else { None };
     let notes_env =
         Some(build_notes_env_for_existing_session(settings, project_handle, &session).await);
     pty_manager
@@ -593,11 +630,8 @@ mod tests {
 
         std::fs::create_dir_all(root.join("repo-main/.git")).unwrap();
         std::fs::create_dir_all(root.join("repo-wt")).unwrap();
-        std::fs::write(
-            root.join("repo-wt/.git"),
-            "gitdir: /tmp/project/.git/worktrees/repo-wt\n",
-        )
-        .unwrap();
+        std::fs::write(root.join("repo-wt/.git"), "gitdir: /tmp/project/.git/worktrees/repo-wt\n")
+            .unwrap();
 
         let roots = [root.to_string_lossy().to_string()];
         let included = list_git_repos_in_roots(&roots, false);

--- a/src-tauri/src/socket.rs
+++ b/src-tauri/src/socket.rs
@@ -181,12 +181,55 @@ async fn handle_request(req: Request, app: &tauri::AppHandle) -> Response {
         "notes-path" => handle_notes_path(req, app).await,
         "notes-search" => handle_notes_search(req, app).await,
         "notes-vault-root" => handle_notes_vault_root(app),
+        "hook-show" => handle_hook_show(req, app).await,
+        "hook-run" => handle_hook_run(req, app).await,
         "session-list" => handle_session_list(req, app).await,
         "session-poll" => handle_session_poll(req, app).await,
         "session-panes-list" => handle_session_panes_list(req, app).await,
         "session-panes-create" => handle_session_panes_create(req, app).await,
         "app-open" => handle_app_open(req, app).await,
         _ => Response::err(format!("unknown command: {}", req.command)),
+    }
+}
+
+async fn handle_hook_show(req: Request, app: &tauri::AppHandle) -> Response {
+    let state: tauri::State<AppState> = app.state();
+    let repo_path = req.args.get("repo_path").and_then(|v| v.as_str());
+    match state.automation_hooks.list_hooks(repo_path) {
+        Ok(items) => Response::success(crate::automation_hooks::hook_list_to_value(items)),
+        Err(e) => Response::err(e.to_string()),
+    }
+}
+
+async fn handle_hook_run(req: Request, app: &tauri::AppHandle) -> Response {
+    let state: tauri::State<AppState> = app.state();
+    let request = match crate::automation_hooks::request_from_socket_args(req.args) {
+        Ok(request) => request,
+        Err(e) => return Response::err(e),
+    };
+    let settings = match state.settings.lock() {
+        Ok(settings) => settings.clone(),
+        Err(e) => return Response::err(e.to_string()),
+    };
+    let wt_available = crate::services::setup::resolve_wt_binary().is_some();
+    let (event, context) = match crate::automation_hooks::context_from_run_request(
+        request,
+        Some(settings.worktree_provider),
+        wt_available,
+    ) {
+        Ok(parts) => parts,
+        Err(e) => return Response::err(e.to_string()),
+    };
+    let result = if event.is_blocking() {
+        state.automation_hooks.run_blocking(event, context).await
+    } else {
+        state.automation_hooks.run_background(event, context).await
+    };
+    match result {
+        Ok(ran) => Response::success(crate::automation_hooks::hook_run_to_value(
+            crate::automation_hooks::HookRunSummary { event: event.as_str().into(), ran },
+        )),
+        Err(e) => Response::err(e.to_string()),
     }
 }
 
@@ -588,6 +631,7 @@ async fn handle_app_open(req: Request, app: &tauri::AppHandle) -> Response {
         None, // profile - CLI-initiated, frontend will set via profile runner
         // CLI-initiated sessions have no pane context yet.
         None,
+        Some(&state.automation_hooks),
         app,
     )
     .await
@@ -716,6 +760,7 @@ async fn handle_session_create(req: Request, app: &tauri::AppHandle) -> Response
         nono_config.as_ref(),
         Some(&profile),
         None,
+        Some(&state.automation_hooks),
         app,
     )
     .await
@@ -854,6 +899,24 @@ async fn handle_run(req: Request, app: &tauri::AppHandle) -> Response {
         std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_millis()
     );
 
+    let pre_context = crate::automation_hooks::HookContext {
+        repo_path: Some(working_dir.clone()),
+        worktree_path: Some(working_dir.clone()),
+        task_id: Some(pty_id.clone()),
+        session_id: Some(session_id.to_string()),
+        project_id: project_id.clone(),
+        scope: Some("session".into()),
+        cwd: Some(working_dir.clone()),
+        ..crate::automation_hooks::HookContext::new(crate::automation_hooks::HookEvent::PreTaskRun)
+    };
+    if let Err(e) = state
+        .automation_hooks
+        .run_blocking(crate::automation_hooks::HookEvent::PreTaskRun, pre_context)
+        .await
+    {
+        return Response::err(e.to_string());
+    }
+
     if let Err(e) = state.pty_manager.spawn_task(
         &pty_id,
         &command,
@@ -865,11 +928,24 @@ async fn handle_run(req: Request, app: &tauri::AppHandle) -> Response {
         None, // notes env snapshot — wired only from session creation path
         None,
         crate::pty::PtyRole::Secondary,
-        None, // profile — CLI-spawned task
+        Some("task"),
         app.clone(),
     ) {
         return Response::err(format!("Failed to spawn task: {}", e));
     }
+    let post_context = crate::automation_hooks::HookContext {
+        repo_path: Some(working_dir.clone()),
+        worktree_path: Some(working_dir.clone()),
+        task_id: Some(pty_id.clone()),
+        session_id: Some(session_id.to_string()),
+        project_id,
+        scope: Some("session".into()),
+        cwd: Some(working_dir.clone()),
+        ..crate::automation_hooks::HookContext::new(crate::automation_hooks::HookEvent::PostTaskRun)
+    };
+    state
+        .automation_hooks
+        .spawn_background(crate::automation_hooks::HookEvent::PostTaskRun, post_context);
 
     use tauri::Emitter;
     let _ = app.emit(
@@ -993,7 +1069,16 @@ async fn handle_notify(req: Request, app: &tauri::AppHandle) -> Response {
     });
 
     let notification = state.notification_manager.push(
-        NReq { level, source: NotificationSource::Cli, title, subtitle, body, session_id, actions, dedup_key: None },
+        NReq {
+            level,
+            source: NotificationSource::Cli,
+            title,
+            subtitle,
+            body,
+            session_id,
+            actions,
+            dedup_key: None,
+        },
         Some(app),
     );
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -21,6 +21,7 @@ pub(crate) struct AppState {
     pub(crate) session_handle: SessionHandle,
     pub(crate) project_handle: ProjectHandle,
     pub(crate) watch_manager: crate::watches::WatchManager,
+    pub(crate) automation_hooks: crate::automation_hooks::AutomationHookManager,
     pub(crate) notification_manager: NotificationManager,
     pub(crate) pending_replies: PendingReplies,
 }

--- a/src-tauri/src/watches/manager.rs
+++ b/src-tauri/src/watches/manager.rs
@@ -143,14 +143,41 @@ impl WatchManager {
                     _ => Duration::from_secs(30),
                 };
 
-                let result = tokio::select! {
-                    r = tokio::time::timeout(check_timeout, checks::execute_check(&watch.kind)) => {
-                        match r {
-                            Ok(result) => result,
-                            Err(_) => checks::timeout_result(&watch.kind),
+                let state = app.state::<AppState>();
+                let mut hook_context = crate::automation_hooks::HookContext::for_watch(
+                    crate::automation_hooks::HookEvent::PreWatchRun,
+                    &watch,
+                );
+                let pre_hook_result = state
+                    .automation_hooks
+                    .run_blocking(
+                        crate::automation_hooks::HookEvent::PreWatchRun,
+                        hook_context.clone(),
+                    )
+                    .await;
+
+                let result = match pre_hook_result {
+                    Ok(_) => {
+                        tokio::select! {
+                            r = tokio::time::timeout(check_timeout, checks::execute_check(&watch.kind)) => {
+                                match r {
+                                    Ok(result) => result,
+                                    Err(_) => checks::timeout_result(&watch.kind),
+                                }
+                            }
+                            _ = cancel_clone.cancelled() => break,
                         }
                     }
-                    _ = cancel_clone.cancelled() => break,
+                    Err(e) => {
+                        hook_context.hook_type =
+                            crate::automation_hooks::HookEvent::PreWatchRun.as_str().to_string();
+                        WatchResult::CommandRun {
+                            exit_code: -1,
+                            stdout: String::new(),
+                            stderr: format!("pre-watch-run hook failed: {e}"),
+                            outcome: WatchOutcome::Failure,
+                        }
+                    }
                 };
 
                 let new_outcome = result.outcome().clone();
@@ -177,6 +204,56 @@ impl WatchManager {
                         previous_outcome,
                     };
                     let _ = app.emit("watch-update", &event);
+
+                    let mut post_context = crate::automation_hooks::HookContext::for_watch(
+                        crate::automation_hooks::HookEvent::PostWatchRun,
+                        &updated_watch,
+                    );
+                    post_context.previous_outcome = event.previous_outcome.clone();
+                    post_context.outcome =
+                        updated_watch.last_result.as_ref().map(|r| r.outcome().clone());
+                    state.automation_hooks.spawn_background(
+                        crate::automation_hooks::HookEvent::PostWatchRun,
+                        post_context.clone(),
+                    );
+                    if changed {
+                        state.automation_hooks.spawn_background(
+                            crate::automation_hooks::HookEvent::PostWatchChange,
+                            crate::automation_hooks::HookContext {
+                                hook_type: crate::automation_hooks::HookEvent::PostWatchChange
+                                    .as_str()
+                                    .into(),
+                                ..post_context.clone()
+                            },
+                        );
+                        match post_context.outcome.as_ref() {
+                            Some(WatchOutcome::Failure) => {
+                                state.automation_hooks.spawn_background(
+                                    crate::automation_hooks::HookEvent::PostWatchFailure,
+                                    crate::automation_hooks::HookContext {
+                                        hook_type:
+                                            crate::automation_hooks::HookEvent::PostWatchFailure
+                                                .as_str()
+                                                .into(),
+                                        ..post_context.clone()
+                                    },
+                                );
+                            }
+                            Some(WatchOutcome::Success) => {
+                                state.automation_hooks.spawn_background(
+                                    crate::automation_hooks::HookEvent::PostWatchSuccess,
+                                    crate::automation_hooks::HookContext {
+                                        hook_type:
+                                            crate::automation_hooks::HookEvent::PostWatchSuccess
+                                                .as_str()
+                                                .into(),
+                                        ..post_context.clone()
+                                    },
+                                );
+                            }
+                            _ => {}
+                        }
+                    }
 
                     // Desktop notification with flap debouncing
                     if changed {


### PR DESCRIPTION
## Summary
Adds a Roux-owned automation hooks system that runs shell commands around watches, worktree create/remove, session lifecycle, and task runs. Inspired by Worktrunk hooks but Roux-scoped so it can react to Roux-specific context (sessions, watches, active provider, etc.).

## What's in
- **Events**: `pre/post-watch-run`, `post-watch-{change,failure,success}`, `pre/post-worktree-{create,remove}`, `post-session-create`, `pre/post-session-close`, `pre/post-task-run`, `post-task-{success,failure}`.
- **Config**: `~/.config/roux/hooks.toml` (user, trusted) and `<repo>/.config/roux/hooks.toml` (project, requires approval). String, table, and `[[event]]` pipeline forms.
- **Conditions**: `when.provider`, `when.worktrunk`, `when.scope`.
- **Templates**: MiniJinja with Worktrunk-style helpers (`sanitize`, `sanitize_hash`, `sanitize_db`, `hash_port`, `worktree_path_of_branch`). Full context also piped as JSON on stdin.
- **Approvals**: per-command SHA256 fingerprint of `config_path + event + name + command`; any edit re-triggers the approval prompt. Stored in `~/.config/roux/hook-approvals.json`.
- **UI**: Hooks panel in sidebar dock (Zap icon) — list, approve, clear approvals, refresh. Per-attempt logs at `~/.config/roux/logs/hooks/`.
- **CLI**: `roux-cli hook show [--repo-path …]`, `roux-cli hook run <event> …`. Legacy Claude status bridge (`working`/`idle`/`attention`/`error`/`disconnected`) preserved.
- **Docs**: `docs/features/hooks.md`.

## Test plan
- [x] Project hooks load from `<repo>/.config/roux/hooks.toml` (verified via `roux-cli hook show`).
- [x] Hooks panel lists project hooks with pending/approved chips; approve flow persists to `hook-approvals.json`.
- [ ] Each event type fires end-to-end via the app (in progress).
- [ ] Blocking `pre-*` hook aborts its operation on non-zero exit (e.g., `pre-worktree-remove`).
- [ ] Fingerprint invalidation — editing a command flips it back to pending.
- [ ] `clear approvals` header button wipes all and flips project hooks back to pending.

## Known issues / follow-ups surfaced during testing
- **Repo-path input silently swallows leading whitespace.** `Path::new(" /…").join(".config/roux/hooks.toml")` resolves to a nonexistent path, `load_config_commands` returns `Ok(vec![])`, and the panel shows zero hooks with no error. Needs a trim on both the backend boundary (`load_commands`) and the panel input.
- **`HooksPanel` auto-fills `repoPath` from the active session's `repoRoot` without triggering `refresh()`.** The field displays the right path but the list is still the empty-user-hooks result from the onMount call until the user blurs the input or clicks refresh.
- **Project hooks don't travel with worktree sessions.** Hook dispatch uses `session.repo_root` (the main checkout) to locate project hooks, so a `.config/roux/hooks.toml` that lives inside a worktree is ignored. Worktrunk resolves its project config off the current worktree root (`current_worktree().prewarm_info().root` in `max-sixty/worktrunk:src/git/repository/config.rs`), i.e. `<worktree>/.config/wt.toml`. Roux should probably match — or at least prefer the worktree path and fall back to the repo root.