### PR TITLE
feat(editor): multi-line prompt editor with transform toolbar

### DIFF
--- a/src-tauri/src/keymap/presets/default.kdl
+++ b/src-tauri/src/keymap/presets/default.kdl
@@ -30,6 +30,8 @@ bind "Cmd+KeyW"        "pane.close"
 bind "Cmd+Shift+KeyS"  "pane.toggle-stack"
 bind "Cmd+Shift+KeyF"  "pane.toggle-fullscreen"
 bind "Cmd+Shift+KeyB"  "pane.open-doc"
+bind "Cmd+Shift+KeyE"  "pane.open-multiline-editor"
+bind "Cmd+Shift+KeyV"  "pane.open-multiline-editor-with-clipboard"
 
 // Pane focus (Option+h/j/k/l)
 bind "Alt+KeyH" "pane.focus-left"

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -7,6 +7,8 @@
   import DoctorPanel from "$lib/components/DoctorPanel.svelte";
   import SettingsPanel from "$lib/components/SettingsPanel.svelte";
   import CommandPalette from "$lib/components/CommandPalette.svelte";
+  import MultiLineEditor from "$lib/components/MultiLineEditor.svelte";
+  import { multiLineEditor } from "$lib/stores/multiLineEditor";
   import KeymapHud from "$lib/components/KeymapHud.svelte";
   import QuitDialog from "$lib/components/QuitDialog.svelte";
   import UpdateBanner from "$lib/components/UpdateBanner.svelte";
@@ -247,6 +249,11 @@
     const surface = get(commandSurface);
     if (surface.open && surface.mode === "palette") {
       // Palette handles its own keys; stay out of the way.
+      return;
+    }
+    // MultiLineEditor modal owns all keys while open — otherwise global
+    // chords like Cmd+D (split pane) would fire while the user is editing.
+    if (get(multiLineEditor).open) {
       return;
     }
     if (surface.open && surface.mode === "leader" && surface.leaderPromptCommandId) {
@@ -716,6 +723,8 @@
   onCheckForUpdates={() => { openSidebar("settings"); void runManualCheck(); }}
   initialCommandId={$commandSurface.initialCommandId}
 />
+
+<MultiLineEditor />
 
 {#if $hudVisible || ($commandSurface.open && $commandSurface.mode === "leader" && $commandSurface.leaderPromptCommandId)}
   <KeymapHud

--- a/src/lib/commands/panes.ts
+++ b/src/lib/commands/panes.ts
@@ -5,8 +5,10 @@ import { queries } from "$lib/queries";
 import { navigatePane, movePaneInDirection, resizePane, toggleStack } from "$lib/panes/layout";
 import { toggleFullscreen, setLogicalFocus, focusedPaneId } from "$lib/panes/focus";
 import { paneSlotById } from "$lib/stores/ui";
-import { paneInstances, updateInstance, getAttachedPtyId } from "$lib/panes/instances";
+import { paneInstances, updateInstance, getAttachedPtyId, getInstance, type PaneInstance } from "$lib/panes/instances";
 import { splitPane, closeFocusedPane } from "$lib/panes/actions";
+import { getTerminalController } from "$lib/panes/terminalRuntime";
+import { openMultiLineEditor, type MultiLineTarget } from "$lib/stores/multiLineEditor";
 import {
   profileList,
   type SpawnProfile,
@@ -159,6 +161,68 @@ function profileSubItems(
  */
 function findBuiltinProfile(id: string): SpawnProfile | null {
   return get(profileList).find((p) => p.id === id) ?? null;
+}
+
+function getProfileId(pane: PaneInstance): string | null {
+  const ref = pane.spawnProfileRef;
+  if (!ref) return null;
+  if (ref.kind === "registered") return ref.id;
+  if (ref.kind === "inline") return ref.profile?.id ?? null;
+  return null;
+}
+
+function resolveMultiLineTarget(pane: PaneInstance): MultiLineTarget {
+  // Claude Code panes use an alt-buffer TUI with its own multi-line input
+  // handling via Shift+Enter; we can't reliably read or clear its input
+  // buffer, so we classify them separately to skip the Ctrl+E/Ctrl+U
+  // prompt-clear on submit.
+  const profileId = getProfileId(pane);
+  return profileId === "claude" ? "claude" : "shell";
+}
+
+function paneLabel(pane: PaneInstance): string {
+  return pane.name ?? getProfileId(pane) ?? "shell";
+}
+
+function canOpenMultiLineEditor(): boolean {
+  const paneId = queries.focusedPaneId();
+  if (!paneId) return false;
+  const pane = getInstance(paneId);
+  if (!pane) return false;
+  // Only terminal-hosting panes. Markdown / notes panes have their own
+  // editor and no PTY to write to.
+  if (pane.type !== "shell" && pane.type !== "command") return false;
+  return !!getAttachedPtyId(pane);
+}
+
+async function openMultiLineEditorForFocusedPane(initialText: string | null): Promise<void> {
+  const paneId = queries.focusedPaneId();
+  if (!paneId) return;
+  const pane = getInstance(paneId);
+  if (!pane) return;
+  const target = resolveMultiLineTarget(pane);
+  let seedText = initialText ?? "";
+  let seeded = !!initialText;
+
+  // Only try to seed from the live terminal buffer when the caller did not
+  // already supply text (the clipboard command passes its own payload) and
+  // the pane is a plain shell (Claude's TUI buffer is unreliable).
+  if (initialText === null && target === "shell") {
+    const controller = getTerminalController(paneId);
+    const snapshot = controller?.getPromptSnapshot();
+    if (snapshot) {
+      seedText = snapshot.text;
+      seeded = snapshot.seeded;
+    }
+  }
+
+  openMultiLineEditor({
+    paneId,
+    paneLabel: paneLabel(pane),
+    initialText: seedText,
+    seeded,
+    target,
+  });
 }
 
 function formatTimeAgo(timestampMs: number): string {
@@ -471,6 +535,32 @@ export function registerPaneCommands() {
       if (ptyId) {
         await setPtyName(ptyId, trimmed ?? null).catch(() => {});
       }
+    },
+  });
+
+  registry.register({
+    id: "pane.open-multiline-editor",
+    label: "Open Multi-Line Prompt Editor",
+    category: "Panes",
+    available: canOpenMultiLineEditor,
+    execute: async () => {
+      await openMultiLineEditorForFocusedPane(null);
+    },
+  });
+
+  registry.register({
+    id: "pane.open-multiline-editor-with-clipboard",
+    label: "Open Multi-Line Prompt Editor with Clipboard",
+    category: "Panes",
+    available: canOpenMultiLineEditor,
+    execute: async () => {
+      let clipboardText = "";
+      try {
+        clipboardText = await navigator.clipboard.readText();
+      } catch (e) {
+        logError("pane.open-multiline-editor-with-clipboard: clipboard read failed", e);
+      }
+      await openMultiLineEditorForFocusedPane(clipboardText);
     },
   });
 

--- a/src/lib/components/MultiLineEditor.svelte
+++ b/src/lib/components/MultiLineEditor.svelte
@@ -1,0 +1,471 @@
+<script lang="ts">
+  import { fade, scale } from "svelte/transition";
+  import { onDestroy } from "svelte";
+  import { Tooltip } from "bits-ui";
+  import Keyboard from "@lucide/svelte/icons/keyboard";
+  import { EditorState, type Extension } from "@codemirror/state";
+  import { EditorView, keymap } from "@codemirror/view";
+  import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
+  import {
+    syntaxHighlighting,
+    defaultHighlightStyle,
+    StreamLanguage,
+  } from "@codemirror/language";
+  import { shell } from "@codemirror/legacy-modes/mode/shell";
+
+  import {
+    multiLineEditor,
+    closeMultiLineEditor,
+    buildSubmitPayload,
+  } from "$lib/stores/multiLineEditor";
+  import { getTerminalController } from "$lib/panes/terminalRuntime";
+  import { writeToSession } from "$lib/tauri";
+  import { setLogicalFocus } from "$lib/panes/focus";
+  import { getInstance, getAttachedPtyId } from "$lib/panes/instances";
+  import { hasPrimaryModifier, formatShortcut } from "$lib/platform";
+  import { settings } from "$lib/stores/settings";
+  import {
+    joinLines,
+    smartQuotesToStraight,
+    stripCodeFence,
+    stripPromptPrefix,
+    trimDocument,
+    unwrapContinuations,
+  } from "$lib/panes/textTransforms";
+
+  interface ToolbarAction {
+    label: string;
+    description: string;
+    shortcut: string | null;
+    transform: (text: string) => string;
+  }
+
+  const toolbarActions: ToolbarAction[] = [
+    {
+      label: "Join lines",
+      description: "Collapse newlines + whitespace into one line",
+      shortcut: "cmd+j",
+      transform: joinLines,
+    },
+    {
+      label: "Unwrap \\",
+      description: "Remove trailing \\-newline continuations",
+      shortcut: null,
+      transform: unwrapContinuations,
+    },
+    {
+      label: "Strip $ / ❯",
+      description: "Strip leading $, ❯, #, > prompt markers",
+      shortcut: null,
+      transform: stripPromptPrefix,
+    },
+    {
+      label: "Strip ```",
+      description: "Remove leading / trailing markdown code fences",
+      shortcut: null,
+      transform: stripCodeFence,
+    },
+    {
+      label: "Smart → straight",
+      description: "Replace curly quotes with straight ASCII quotes",
+      shortcut: null,
+      transform: smartQuotesToStraight,
+    },
+    {
+      label: "Trim",
+      description: "Strip leading and trailing whitespace",
+      shortcut: null,
+      transform: trimDocument,
+    },
+  ];
+
+  interface ShortcutEntry {
+    shortcut: string;
+    action: string;
+  }
+
+  // Everything a user can trigger while the modal has focus — shown on
+  // hover of the keyboard hint in the header. Covers both our custom
+  // keybindings and the CodeMirror defaults that users commonly rely on.
+  const modalShortcuts: ShortcutEntry[] = [
+    { shortcut: "cmd+enter", action: "Insert into terminal (no auto-execute)" },
+    { shortcut: "escape", action: "Cancel — nothing written" },
+    { shortcut: "ctrl+g", action: "Cancel — nothing written" },
+    { shortcut: "cmd+j", action: "Join lines transform" },
+    { shortcut: "cmd+z", action: "Undo transform / edit" },
+    { shortcut: "cmd+shift+z", action: "Redo" },
+  ];
+
+  let editorContainer: HTMLElement | undefined = $state();
+  let editorView: EditorView | null = null;
+
+  // Track the pane id we disabled input on so we can re-enable the right one
+  // even if the store state races with a pane change.
+  let disabledPaneId: string | null = null;
+
+  $effect(() => {
+    const state = $multiLineEditor;
+    if (state.open && editorContainer && !editorView) {
+      mountEditor(state.initialText);
+      disableTargetPaneInput(state.paneId);
+    } else if (!state.open && editorView) {
+      tearDownEditor();
+      restoreTargetPaneInput();
+    }
+  });
+
+  onDestroy(() => {
+    tearDownEditor();
+    restoreTargetPaneInput();
+  });
+
+  function mountEditor(initialText: string): void {
+    if (!editorContainer) return;
+    const extensions: Extension[] = [
+      EditorView.lineWrapping,
+      history(),
+      keymap.of([...defaultKeymap, ...historyKeymap]),
+      syntaxHighlighting(defaultHighlightStyle),
+      EditorView.theme({
+        "&": {
+          height: "100%",
+          fontSize: `${$settings.fontSize}px`,
+          fontFamily: $settings.fontFamily,
+        },
+        ".cm-content": {
+          caretColor: "var(--color-text-primary)",
+          color: "var(--color-text-primary)",
+          padding: "0.75rem 1rem",
+        },
+        ".cm-cursor": {
+          borderLeftColor: "var(--color-text-primary)",
+        },
+        "&.cm-focused .cm-selectionBackground, .cm-selectionBackground": {
+          backgroundColor: "var(--color-bg-active) !important",
+        },
+        ".cm-scroller": {
+          overflow: "auto",
+        },
+        "&.cm-focused": {
+          outline: "none",
+        },
+      }),
+    ];
+
+    if ($multiLineEditor.target === "shell") {
+      extensions.push(StreamLanguage.define(shell));
+    }
+
+    editorView = new EditorView({
+      state: EditorState.create({ doc: initialText, extensions }),
+      parent: editorContainer,
+    });
+    requestAnimationFrame(() => editorView?.focus());
+  }
+
+  function tearDownEditor(): void {
+    editorView?.destroy();
+    editorView = null;
+  }
+
+  function disableTargetPaneInput(paneId: string | null): void {
+    if (!paneId) return;
+    const controller = getTerminalController(paneId);
+    if (!controller) return;
+    controller.setInputEnabled(false);
+    disabledPaneId = paneId;
+  }
+
+  function restoreTargetPaneInput(): void {
+    if (!disabledPaneId) return;
+    const controller = getTerminalController(disabledPaneId);
+    if (controller) {
+      controller.setInputEnabled(true);
+      controller.focus();
+    }
+    setLogicalFocus(disabledPaneId);
+    disabledPaneId = null;
+  }
+
+  function currentText(): string {
+    return editorView?.state.doc.toString() ?? "";
+  }
+
+  function applyTransform(fn: (text: string) => string): void {
+    if (!editorView) return;
+    const current = currentText();
+    const next = fn(current);
+    if (next === current) return;
+    editorView.dispatch({
+      changes: { from: 0, to: editorView.state.doc.length, insert: next },
+    });
+    editorView.focus();
+  }
+
+  async function submitInsert(): Promise<void> {
+    const state = $multiLineEditor;
+    if (!state.open || !state.paneId) return;
+    const paneInst = getInstance(state.paneId);
+    if (!paneInst) return;
+    const ptyId = getAttachedPtyId(paneInst);
+    if (!ptyId) return;
+    const payload = buildSubmitPayload(currentText(), state.target);
+
+    try {
+      await writeToSession(ptyId, payload);
+    } finally {
+      closeMultiLineEditor();
+    }
+  }
+
+  function handleKeyDown(e: KeyboardEvent): void {
+    // In-flight composition (IME): do not intercept.
+    if (e.isComposing) return;
+
+    if (e.key === "Escape" || (e.ctrlKey && e.key === "g")) {
+      e.preventDefault();
+      e.stopPropagation();
+      closeMultiLineEditor();
+      return;
+    }
+
+    if (e.key === "Enter" && hasPrimaryModifier(e) && !e.shiftKey && !e.altKey) {
+      e.preventDefault();
+      e.stopPropagation();
+      void submitInsert();
+      return;
+    }
+
+    if (e.key === "j" && hasPrimaryModifier(e) && !e.shiftKey && !e.altKey) {
+      e.preventDefault();
+      e.stopPropagation();
+      applyTransform(joinLines);
+      return;
+    }
+  }
+
+  // Track whether the *mouse-down* started on the backdrop. Using `click`
+  // alone closes the modal even when the user drags from inside the editor
+  // out to the backdrop to make a text selection — the browser fires
+  // `click` on the common ancestor (the backdrop). By gating on where the
+  // pointer went DOWN, a selection drag no longer trips closure.
+  let mouseDownOnBackdrop = false;
+
+  function onBackdropPointerDown(e: PointerEvent): void {
+    mouseDownOnBackdrop = e.target === e.currentTarget;
+  }
+
+  function onBackdropClick(e: MouseEvent): void {
+    if (e.target === e.currentTarget && mouseDownOnBackdrop) {
+      closeMultiLineEditor();
+    }
+    mouseDownOnBackdrop = false;
+  }
+</script>
+
+{#if $multiLineEditor.open}
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div
+    class="fixed inset-0 z-50 flex items-start justify-center bg-black/65 pt-[14vh] backdrop-blur-md"
+    onpointerdown={onBackdropPointerDown}
+    onclick={onBackdropClick}
+    onkeydown={handleKeyDown}
+    transition:fade={{ duration: 120 }}
+  >
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <Tooltip.Provider delayDuration={350} skipDelayDuration={150}>
+    <div
+      class="ui-dialog flex h-[480px] w-[680px] flex-col overflow-hidden rounded-[1.4rem] border-l-2 border-l-accent"
+      transition:scale={{ duration: 120, start: 0.985 }}
+    >
+      <!-- Header -->
+      <div class="flex items-center justify-between px-5 pt-4 pb-3 text-[11px] uppercase tracking-[0.22em] text-text-muted">
+        <span>
+          Editing prompt for
+          <span class="text-text-primary normal-case tracking-normal ml-1">
+            {$multiLineEditor.paneLabel ?? "pane"}
+          </span>
+        </span>
+        <div class="flex items-center gap-3">
+          {#if $multiLineEditor.seeded}
+            <span class="text-[10px] normal-case tracking-normal text-text-muted">
+              Seeded from prompt
+            </span>
+          {/if}
+          <Tooltip.Root>
+            <Tooltip.Trigger class="mle-icon-btn" aria-label="Show keyboard shortcuts">
+              <Keyboard class="w-3.5 h-3.5" />
+            </Tooltip.Trigger>
+            <Tooltip.Portal>
+              <Tooltip.Content sideOffset={6} class="mle-tooltip mle-tooltip-grid">
+                <div class="mle-tooltip-title">Shortcuts</div>
+                {#each modalShortcuts as entry (entry.shortcut)}
+                  <kbd class="mle-tooltip-kbd">{formatShortcut(entry.shortcut)}</kbd>
+                  <span>{entry.action}</span>
+                {/each}
+              </Tooltip.Content>
+            </Tooltip.Portal>
+          </Tooltip.Root>
+        </div>
+      </div>
+
+      <!-- Toolbar -->
+      <div class="flex flex-wrap items-center gap-1.5 border-b border-border-subtle bg-bg-surface/55 px-4 py-2.5">
+        {#each toolbarActions as action (action.label)}
+          <Tooltip.Root>
+            <Tooltip.Trigger
+              class="mle-btn"
+              onclick={() => applyTransform(action.transform)}
+            >
+              {action.label}
+            </Tooltip.Trigger>
+            <Tooltip.Portal>
+              <Tooltip.Content sideOffset={6} class="mle-tooltip">
+                <span>{action.description}</span>
+                {#if action.shortcut}
+                  <kbd class="mle-tooltip-kbd">{formatShortcut(action.shortcut)}</kbd>
+                {/if}
+              </Tooltip.Content>
+            </Tooltip.Portal>
+          </Tooltip.Root>
+        {/each}
+      </div>
+
+      <!-- Editor -->
+      <div bind:this={editorContainer} class="flex-1 overflow-hidden"></div>
+
+      <!-- Footer -->
+      <div class="flex items-center justify-between border-t border-border-subtle px-4 py-2.5 text-[11px] text-text-muted">
+        <div class="flex items-center gap-2">
+          <button class="mle-footer-btn mle-footer-btn-primary" onclick={() => void submitInsert()}>
+            <kbd class="mle-kbd">{formatShortcut("cmd+enter")}</kbd>
+            <span>Insert</span>
+          </button>
+          <button class="mle-footer-btn" onclick={closeMultiLineEditor}>
+            <kbd class="mle-kbd">Esc</kbd>
+            <span>Cancel</span>
+          </button>
+        </div>
+        <span class="text-[10px]">
+          target · <span class="text-text-primary">{$multiLineEditor.paneLabel ?? "pane"}</span>
+        </span>
+      </div>
+    </div>
+    </Tooltip.Provider>
+  </div>
+{/if}
+
+<style>
+  :global(.mle-btn) {
+    padding: 4px 10px;
+    border-radius: 8px;
+    background: transparent;
+    color: var(--color-text-muted);
+    border: 1px solid var(--color-border-subtle);
+    font-size: 11px;
+    cursor: pointer;
+    transition: background 0.1s, color 0.1s, border-color 0.1s;
+  }
+  :global(.mle-btn:hover) {
+    background: var(--color-bg-hover);
+    color: var(--color-text-primary);
+    border-color: var(--color-border);
+  }
+  :global(.mle-kbd) {
+    font-family: var(--font-mono, ui-monospace, monospace);
+    font-size: 10px;
+    padding: 1px 5px;
+    border-radius: 4px;
+    background: var(--color-bg-elevated);
+    border: 1px solid var(--color-border-subtle);
+    color: var(--color-text-muted);
+  }
+  :global(.border-l-accent) {
+    border-left-color: var(--color-border);
+  }
+  :global(.mle-tooltip) {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px;
+    border-radius: 8px;
+    background: var(--color-bg-elevated, rgba(20, 20, 20, 0.98));
+    color: var(--color-text-primary);
+    border: 1px solid var(--color-border-subtle);
+    box-shadow: 0 8px 24px -6px rgba(0, 0, 0, 0.35);
+    font-size: 11px;
+    z-index: 70;
+    pointer-events: none;
+  }
+  :global(.mle-tooltip-kbd) {
+    font-family: var(--font-mono, ui-monospace, monospace);
+    font-size: 10px;
+    padding: 1px 5px;
+    border-radius: 4px;
+    background: var(--color-bg-surface, rgba(255, 255, 255, 0.06));
+    border: 1px solid var(--color-border-subtle);
+    color: var(--color-text-muted);
+    justify-self: start;
+  }
+  :global(.mle-tooltip-grid) {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 6px 12px;
+    align-items: center;
+    padding: 10px 12px;
+  }
+  :global(.mle-tooltip-title) {
+    grid-column: 1 / -1;
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.22em;
+    color: var(--color-text-muted);
+    margin-bottom: 4px;
+  }
+  :global(.mle-icon-btn) {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--color-text-muted);
+    border: 1px solid transparent;
+    cursor: pointer;
+    transition: background 0.1s, color 0.1s, border-color 0.1s;
+  }
+  :global(.mle-icon-btn:hover) {
+    background: var(--color-bg-hover);
+    color: var(--color-text-primary);
+    border-color: var(--color-border-subtle);
+  }
+  :global(.mle-footer-btn) {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px 4px 6px;
+    border-radius: 8px;
+    background: transparent;
+    color: var(--color-text-muted);
+    border: 1px solid var(--color-border-subtle);
+    font-size: 11px;
+    cursor: pointer;
+    transition: background 0.1s, color 0.1s, border-color 0.1s;
+  }
+  :global(.mle-footer-btn:hover) {
+    background: var(--color-bg-hover);
+    color: var(--color-text-primary);
+    border-color: var(--color-border);
+  }
+  :global(.mle-footer-btn-primary) {
+    background: var(--color-bg-active);
+    color: var(--color-text-primary);
+    border-color: var(--color-border);
+  }
+  :global(.mle-footer-btn-primary:hover) {
+    background: var(--color-bg-active);
+    filter: brightness(1.12);
+  }
+</style>

--- a/src/lib/components/MultiLineEditor.svelte
+++ b/src/lib/components/MultiLineEditor.svelte
@@ -213,8 +213,12 @@
 
     try {
       await writeToSession(ptyId, payload);
-    } finally {
       closeMultiLineEditor();
+    } catch (err) {
+      // Keep the modal open so the user can retry or copy the text out —
+      // silently closing on a failed PTY write would drop their edits.
+      // eslint-disable-next-line no-console
+      console.error("MultiLineEditor: writeToSession failed", err);
     }
   }
 

--- a/src/lib/panes/__tests__/promptSnapshot.test.ts
+++ b/src/lib/panes/__tests__/promptSnapshot.test.ts
@@ -93,4 +93,34 @@ describe("readPromptSnapshot", () => {
     const buf = buildBuffer([line("$ echo hi   ")], { cursorY: 0 });
     expect(readPromptSnapshot(buf)).toEqual({ text: "echo hi", seeded: true });
   });
+
+  it("walks FORWARD through wrapped continuations when cursor is mid-wrap", () => {
+    // User typed a long command, then arrow-keyed back to an earlier row —
+    // the cursor is on line 1, but the logical input continues on line 2.
+    const buf = buildBuffer(
+      [
+        line("$ echo aaaaaaaaaaaaaaaa"),
+        line("bbbbbbbbbbbbbbbb", true),
+        line("ccccccccccccc", true),
+      ],
+      { cursorY: 1 },
+    );
+    expect(readPromptSnapshot(buf)).toEqual({
+      text: "echo aaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbccccccccccccc",
+      seeded: true,
+    });
+  });
+
+  it("preserves a leading space the user typed (HISTCONTROL=ignorespace)", () => {
+    // Bash's `HISTCONTROL=ignorespace` — prefixing a command with a space
+    // keeps it out of history. That leading space is user-meaningful and
+    // must not be stripped along with the prompt marker.
+    const buf = buildBuffer([line("$  ls -la")], { cursorY: 0 });
+    expect(readPromptSnapshot(buf)).toEqual({ text: " ls -la", seeded: true });
+  });
+
+  it("still strips the prompt marker when followed by a tab", () => {
+    const buf = buildBuffer([line("$\techo hi")], { cursorY: 0 });
+    expect(readPromptSnapshot(buf)).toEqual({ text: "echo hi", seeded: true });
+  });
 });

--- a/src/lib/panes/__tests__/promptSnapshot.test.ts
+++ b/src/lib/panes/__tests__/promptSnapshot.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import { readPromptSnapshot } from "../promptSnapshot";
+
+interface FakeLine {
+  isWrapped: boolean;
+  translateToString(trimRight?: boolean): string;
+}
+
+interface FakeBuffer {
+  type: "normal" | "alternate";
+  cursorY: number;
+  cursorX: number;
+  baseY: number;
+  viewportY: number;
+  length: number;
+  getLine(y: number): FakeLine | undefined;
+}
+
+function line(text: string, isWrapped = false): FakeLine {
+  return {
+    isWrapped,
+    translateToString: (trimRight?: boolean) =>
+      trimRight ? text.replace(/\s+$/, "") : text,
+  };
+}
+
+function buildBuffer(lines: FakeLine[], opts: { baseY?: number; cursorY: number }): FakeBuffer {
+  return {
+    type: "normal",
+    cursorY: opts.cursorY,
+    cursorX: 0,
+    baseY: opts.baseY ?? 0,
+    viewportY: opts.baseY ?? 0,
+    length: lines.length,
+    getLine: (y) => lines[y],
+  };
+}
+
+describe("readPromptSnapshot", () => {
+  it("reads the current cursor line and strips a $ prompt prefix", () => {
+    const buf = buildBuffer([line("$ echo hi")], { cursorY: 0 });
+    expect(readPromptSnapshot(buf)).toEqual({ text: "echo hi", seeded: true });
+  });
+
+  it("strips ❯ and # prefixes", () => {
+    expect(readPromptSnapshot(buildBuffer([line("❯ ls")], { cursorY: 0 })))
+      .toEqual({ text: "ls", seeded: true });
+    expect(readPromptSnapshot(buildBuffer([line("# apt update")], { cursorY: 0 })))
+      .toEqual({ text: "apt update", seeded: true });
+  });
+
+  it("walks backwards through wrapped continuation lines", () => {
+    const buf = buildBuffer(
+      [
+        line("$ echo veryveryveryveryveryveryveryveryveryvery"),
+        line("longlonglonglonglonglonglong", true),
+      ],
+      { cursorY: 1 },
+    );
+    expect(readPromptSnapshot(buf)).toEqual({
+      text: "echo veryveryveryveryveryveryveryveryveryverylonglonglonglonglonglonglong",
+      seeded: true,
+    });
+  });
+
+  it("handles scrolled buffer (baseY > 0)", () => {
+    // Simulate a scrolled buffer: the cursor line is at absolute index
+    // baseY + cursorY = 100 + 2 = 102.
+    const lines: FakeLine[] = [];
+    for (let i = 0; i < 102; i++) lines.push(line(""));
+    lines.push(line("$ ls -la"));
+    const buf = buildBuffer(lines, { baseY: 100, cursorY: 2 });
+    expect(readPromptSnapshot(buf)).toEqual({ text: "ls -la", seeded: true });
+  });
+
+  it("returns null when the cursor line does not exist", () => {
+    const buf = buildBuffer([], { cursorY: 0 });
+    expect(readPromptSnapshot(buf)).toBeNull();
+  });
+
+  it("returns null when the cursor line is empty after stripping", () => {
+    const buf = buildBuffer([line("$ ")], { cursorY: 0 });
+    expect(readPromptSnapshot(buf)).toBeNull();
+  });
+
+  it("leaves lines without a known prefix alone", () => {
+    const buf = buildBuffer([line("some raw line")], { cursorY: 0 });
+    expect(readPromptSnapshot(buf)).toEqual({ text: "some raw line", seeded: true });
+  });
+
+  it("trims trailing whitespace from the composed result", () => {
+    const buf = buildBuffer([line("$ echo hi   ")], { cursorY: 0 });
+    expect(readPromptSnapshot(buf)).toEqual({ text: "echo hi", seeded: true });
+  });
+});

--- a/src/lib/panes/__tests__/terminalRuntime.test.ts
+++ b/src/lib/panes/__tests__/terminalRuntime.test.ts
@@ -33,6 +33,7 @@ describe("terminalRuntime", () => {
       focus: vi.fn(),
       setTheme: vi.fn(),
       setCustomKeyHandler: vi.fn(),
+      getPromptSnapshot: vi.fn().mockReturnValue(null),
     }));
   });
 

--- a/src/lib/panes/__tests__/terminals.test.ts
+++ b/src/lib/panes/__tests__/terminals.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => {
     focus: vi.fn(),
     setTheme: vi.fn(),
     setCustomKeyHandler: vi.fn(),
+    getPromptSnapshot: vi.fn().mockReturnValue(null),
   };
 
   return {

--- a/src/lib/panes/__tests__/textTransforms.test.ts
+++ b/src/lib/panes/__tests__/textTransforms.test.ts
@@ -1,0 +1,671 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  joinLines,
+  smartQuotesToStraight,
+  stripCodeFence,
+  stripPromptPrefix,
+  trimDocument,
+  unwrapContinuations,
+} from "../textTransforms";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// joinLines
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("joinLines", () => {
+  describe("happy path", () => {
+    it("replaces newlines with spaces", () => {
+      expect(joinLines("a\nb\nc")).toBe("a b c");
+    });
+
+    it("collapses runs of spaces", () => {
+      expect(joinLines("a    b")).toBe("a b");
+    });
+
+    it("collapses tabs", () => {
+      expect(joinLines("a\tb\tc")).toBe("a b c");
+    });
+
+    it("collapses blank lines", () => {
+      expect(joinLines("a\n\n\nb")).toBe("a b");
+    });
+
+    it("collapses mixed tabs + spaces + blank lines", () => {
+      expect(joinLines("a \t\n \n\tb")).toBe("a b");
+    });
+
+    it("normalizes CRLF before joining", () => {
+      expect(joinLines("a\r\nb\r\nc")).toBe("a b c");
+    });
+
+    it("normalizes lone CR before joining", () => {
+      expect(joinLines("a\rb\rc")).toBe("a b c");
+    });
+
+    it("normalizes mixed line endings", () => {
+      expect(joinLines("a\r\nb\nc\rd")).toBe("a b c d");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("empty input returns empty", () => {
+      expect(joinLines("")).toBe("");
+    });
+
+    it("only whitespace returns empty", () => {
+      expect(joinLines("   \n\t\n   ")).toBe("");
+    });
+
+    it("single line is preserved", () => {
+      expect(joinLines("no newlines")).toBe("no newlines");
+    });
+
+    it("leading and trailing whitespace gets trimmed", () => {
+      expect(joinLines("  a\nb  ")).toBe("a b");
+    });
+
+    it("preserves quoted content with spaces inside", () => {
+      // The function can't know quoting semantics, but it shouldn't mangle
+      // single characters of content.
+      expect(joinLines('echo "foo bar"\nbaz')).toBe('echo "foo bar" baz');
+    });
+
+    it("single newline becomes one space", () => {
+      expect(joinLines("\n")).toBe("");
+    });
+  });
+
+  describe("idempotency", () => {
+    const cases = [
+      "",
+      "already joined",
+      "a b c",
+      "echo   hi",
+      "a\nb",
+      "a\r\nb",
+      "  trim me  ",
+      "one\ntwo\nthree\n",
+    ];
+    it.each(cases)("joinLines(joinLines(x)) === joinLines(x) for %j", (s) => {
+      expect(joinLines(joinLines(s))).toBe(joinLines(s));
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// unwrapContinuations
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("unwrapContinuations", () => {
+  describe("happy path", () => {
+    it("basic 2-line continuation", () => {
+      expect(unwrapContinuations("echo foo \\\n    bar")).toBe("echo foo bar");
+    });
+
+    it("chained 4-line continuation", () => {
+      const input = "a \\\n    b \\\n    c \\\n    d";
+      expect(unwrapContinuations(input)).toBe("a b c d");
+    });
+
+    it("no-indent continuation", () => {
+      expect(unwrapContinuations("echo foo \\\nbar")).toBe("echo foo bar");
+    });
+
+    it("tab-indented continuation", () => {
+      expect(unwrapContinuations("echo foo \\\n\tbar")).toBe("echo foo bar");
+    });
+
+    it("mixed tab + space indent", () => {
+      expect(unwrapContinuations("a \\\n\t  b")).toBe("a b");
+    });
+
+    it("CRLF continuations", () => {
+      expect(unwrapContinuations("a \\\r\n    b")).toBe("a b");
+    });
+
+    it("mixed CRLF and LF in same document", () => {
+      expect(unwrapContinuations("a \\\r\nb \\\nc")).toBe("a b c");
+    });
+  });
+
+  describe("trailing whitespace after the backslash (regression)", () => {
+    // Common when pasting from a terminal that pads wrapped lines with
+    // spaces, or from editors that strip-trailing-whitespace-on-save but the
+    // copy happened before saving.
+    it("tolerates spaces between `\\` and newline", () => {
+      const input = "docker run -d \\   \n    --name web \\  \n    nginx";
+      expect(unwrapContinuations(input)).toBe("docker run -d --name web nginx");
+    });
+
+    it("tolerates tabs between `\\` and newline", () => {
+      expect(unwrapContinuations("a \\\t\n    b")).toBe("a b");
+    });
+
+    it("tolerates many spaces of padding (terminal-width copy artifact)", () => {
+      const pad = " ".repeat(60);
+      const input = `echo foo \\${pad}\n    bar`;
+      expect(unwrapContinuations(input)).toBe("echo foo bar");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("empty input", () => {
+      expect(unwrapContinuations("")).toBe("");
+    });
+
+    it("single line with no continuation", () => {
+      expect(unwrapContinuations("echo hi")).toBe("echo hi");
+    });
+
+    it("backslash in the middle of a line is not a continuation", () => {
+      expect(unwrapContinuations("echo a\\ b")).toBe("echo a\\ b");
+    });
+
+    it("trailing backslash at end-of-string (no newline) is preserved", () => {
+      // Truncated paste: the last `\` has no following newline.
+      expect(unwrapContinuations("echo a \\")).toBe("echo a \\");
+    });
+
+    it("backslash at end of single trailing line with no content after", () => {
+      // `\<LF>` with nothing after still collapses (consistent with
+      // "a continuation followed by empty content").
+      expect(unwrapContinuations("echo a \\\n")).toBe("echo a ");
+    });
+
+    it("double backslash at EOL consumes only the inner `\\<LF>`", () => {
+      // Corner case: a literal `\\` in the source followed by a newline
+      // means "escaped backslash, newline ends the line". Our transform
+      // eats the trailing `\<LF>` — acceptable because true `\\` escape
+      // sequences are rare in pasted LLM output and the user can undo.
+      expect(unwrapContinuations("echo a\\\\\nbar")).toBe("echo a\\ bar");
+    });
+  });
+
+  describe("idempotency", () => {
+    const cases = [
+      "",
+      "echo hi",
+      "a \\\nb",
+      "a \\   \nb",
+      "a \\\n    b \\\n    c",
+      "echo a\\ b",
+    ];
+    it.each(cases)("unwrapContinuations x2 === unwrapContinuations x1 for %j", (s) => {
+      expect(unwrapContinuations(unwrapContinuations(s))).toBe(unwrapContinuations(s));
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// stripPromptPrefix
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("stripPromptPrefix", () => {
+  describe("happy path", () => {
+    it("strips $ prefix", () => {
+      expect(stripPromptPrefix("$ ls")).toBe("ls");
+    });
+
+    it("strips ❯ prefix", () => {
+      expect(stripPromptPrefix("❯ ls")).toBe("ls");
+    });
+
+    it("strips # prefix", () => {
+      expect(stripPromptPrefix("# apt update")).toBe("apt update");
+    });
+
+    it("strips > prefix", () => {
+      expect(stripPromptPrefix("> git status")).toBe("git status");
+    });
+
+    it("strips across multiple lines", () => {
+      const input = "$ git add .\n❯ git commit\n# systemctl restart\n> npm test";
+      expect(stripPromptPrefix(input))
+        .toBe("git add .\ngit commit\nsystemctl restart\nnpm test");
+    });
+
+    it("normalizes CRLF before stripping", () => {
+      expect(stripPromptPrefix("$ a\r\n$ b")).toBe("a\nb");
+    });
+  });
+
+  describe("preservation (must not strip)", () => {
+    it("interior `$` as shell variable", () => {
+      expect(stripPromptPrefix("echo $foo")).toBe("echo $foo");
+    });
+
+    it("interior `>` as shell redirect", () => {
+      expect(stripPromptPrefix("cat file > out.txt")).toBe("cat file > out.txt");
+    });
+
+    it("interior `#` as comment", () => {
+      expect(stripPromptPrefix("echo # not a comment")).toBe("echo # not a comment");
+    });
+
+    it("prefix character without trailing space is not stripped", () => {
+      expect(stripPromptPrefix("$foo")).toBe("$foo");
+      expect(stripPromptPrefix(">foo")).toBe(">foo");
+      expect(stripPromptPrefix("#foo")).toBe("#foo");
+    });
+
+    it("lines with leading whitespace before the prefix are NOT stripped", () => {
+      // `  $ ls` — spaces then prefix — isn't a prompt, keep as-is.
+      expect(stripPromptPrefix("  $ ls")).toBe("  $ ls");
+    });
+
+    it("lines not starting with a known marker are untouched", () => {
+      expect(stripPromptPrefix("echo hi")).toBe("echo hi");
+    });
+  });
+
+  describe("mixed content", () => {
+    it("strips only lines that start with a prefix", () => {
+      const input = "$ export FOO=1\necho \"$FOO\"\n$ echo done";
+      expect(stripPromptPrefix(input)).toBe("export FOO=1\necho \"$FOO\"\necho done");
+    });
+
+    it("strips exactly one prefix per line, not recursively", () => {
+      // If a line somehow has `$ $ ls`, strip the first marker only.
+      expect(stripPromptPrefix("$ $ ls")).toBe("$ ls");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("empty input", () => {
+      expect(stripPromptPrefix("")).toBe("");
+    });
+
+    it("prefix only, no command", () => {
+      expect(stripPromptPrefix("$ ")).toBe("");
+    });
+
+    it("prefix followed by multiple spaces", () => {
+      expect(stripPromptPrefix("$   ls")).toBe("  ls");
+    });
+
+    it("blank line between prefixed lines is preserved", () => {
+      expect(stripPromptPrefix("$ a\n\n$ b")).toBe("a\n\nb");
+    });
+  });
+
+  describe("idempotency", () => {
+    const cases = ["", "$ ls", "echo hi", "$ a\n$ b", "  $ ls"];
+    it.each(cases)("stripPromptPrefix x2 === stripPromptPrefix x1 for %j", (s) => {
+      expect(stripPromptPrefix(stripPromptPrefix(s))).toBe(stripPromptPrefix(s));
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// stripCodeFence
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("stripCodeFence", () => {
+  describe("happy path", () => {
+    it("strips leading + trailing fence with language tag", () => {
+      expect(stripCodeFence("```bash\nls\n```")).toBe("ls");
+    });
+
+    it("strips leading + trailing fence with no language tag", () => {
+      expect(stripCodeFence("```\nls\n```")).toBe("ls");
+    });
+
+    it("strips fence with uncommon language tag", () => {
+      expect(stripCodeFence("```powershell\nGet-Process\n```")).toBe("Get-Process");
+    });
+
+    it("strips fence with attribute string", () => {
+      expect(stripCodeFence("```bash {title=example}\nls\n```")).toBe("ls");
+    });
+  });
+
+  describe("partial fences", () => {
+    it("strips leading fence only", () => {
+      expect(stripCodeFence("```sh\necho hi")).toBe("echo hi");
+    });
+
+    it("strips trailing fence only", () => {
+      expect(stripCodeFence("echo hi\n```")).toBe("echo hi");
+    });
+  });
+
+  describe("preservation", () => {
+    it("unfenced content is unchanged", () => {
+      expect(stripCodeFence("echo hi\nworld")).toBe("echo hi\nworld");
+    });
+
+    it("interior fence on a non-first-non-last line is preserved", () => {
+      expect(stripCodeFence("a\n```\nb"))
+        .toBe("a\n```\nb");
+    });
+
+    it("fence-like string inside a line is preserved", () => {
+      expect(stripCodeFence("echo '```'")).toBe("echo '```'");
+    });
+
+    it("indented fence is not stripped (must be at column 0)", () => {
+      expect(stripCodeFence("    ```\necho hi\n    ```"))
+        .toBe("    ```\necho hi\n    ```");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("empty input", () => {
+      expect(stripCodeFence("")).toBe("");
+    });
+
+    it("only fence start", () => {
+      expect(stripCodeFence("```")).toBe("");
+    });
+
+    it("only fence start with language", () => {
+      expect(stripCodeFence("```bash")).toBe("");
+    });
+
+    it("just two fences back-to-back", () => {
+      expect(stripCodeFence("```\n```")).toBe("");
+    });
+
+    it("normalizes CRLF before splitting", () => {
+      expect(stripCodeFence("```bash\r\nls\r\n```")).toBe("ls");
+    });
+
+    it("empty fenced block", () => {
+      expect(stripCodeFence("```\n\n```")).toBe("");
+    });
+  });
+
+  describe("idempotency", () => {
+    const cases = [
+      "",
+      "echo hi",
+      "```\nls\n```",
+      "```bash\nls\n```",
+      "```sh\necho hi",
+      "echo hi\n```",
+    ];
+    it.each(cases)("stripCodeFence x2 === stripCodeFence x1 for %j", (s) => {
+      expect(stripCodeFence(stripCodeFence(s))).toBe(stripCodeFence(s));
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// smartQuotesToStraight
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("smartQuotesToStraight", () => {
+  describe("happy path", () => {
+    it("replaces left/right curly double quotes", () => {
+      expect(smartQuotesToStraight("“hello”")).toBe('"hello"');
+    });
+
+    it("replaces left/right curly single quotes", () => {
+      expect(smartQuotesToStraight("‘hi’")).toBe("'hi'");
+    });
+
+    it("replaces low-9 quotes (German style)", () => {
+      expect(smartQuotesToStraight("„german“")).toBe('"german"');
+      expect(smartQuotesToStraight("‚single‘")).toBe("'single'");
+    });
+
+    it("replaces high-reversed-9 quote (U+201F and U+201B)", () => {
+      expect(smartQuotesToStraight("‟text”")).toBe('"text"');
+      expect(smartQuotesToStraight("‛text’")).toBe("'text'");
+    });
+
+    it("replaces mixed straight + curly", () => {
+      expect(smartQuotesToStraight('echo "a" + “b”')).toBe('echo "a" + "b"');
+    });
+
+    it("replaces across multiple lines", () => {
+      expect(smartQuotesToStraight("“a”\n‘b’")).toBe('"a"\n\'b\'');
+    });
+  });
+
+  describe("preservation", () => {
+    it("straight quotes are unchanged", () => {
+      expect(smartQuotesToStraight('"hi" + \'x\'')).toBe('"hi" + \'x\'');
+    });
+
+    it("apostrophes in contractions stay as curly if they weren't ASCII already", () => {
+      // This documents current behavior: curly single quotes (incl. those
+      // used as apostrophes) become ASCII apostrophes.
+      expect(smartQuotesToStraight("don’t")).toBe("don't");
+    });
+
+    it("backticks are untouched", () => {
+      expect(smartQuotesToStraight("`code`")).toBe("`code`");
+    });
+
+    it("guillemets are NOT replaced (we don't claim them)", () => {
+      expect(smartQuotesToStraight("«fr»")).toBe("«fr»");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("empty input", () => {
+      expect(smartQuotesToStraight("")).toBe("");
+    });
+
+    it("input composed only of curly quotes", () => {
+      expect(smartQuotesToStraight("“”‘’")).toBe("\"\"''");
+    });
+  });
+
+  describe("idempotency", () => {
+    const cases = [
+      "",
+      "“hi”",
+      '"straight"',
+      "‘a’",
+      "mixed \"a\" and “b”",
+    ];
+    it.each(cases)("smartQuotesToStraight x2 === smartQuotesToStraight x1 for %j", (s) => {
+      expect(smartQuotesToStraight(smartQuotesToStraight(s))).toBe(smartQuotesToStraight(s));
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// trimDocument
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("trimDocument", () => {
+  it("strips leading + trailing whitespace", () => {
+    expect(trimDocument("  \n\t  echo hi  \n\n")).toBe("echo hi");
+  });
+
+  it("strips leading only", () => {
+    expect(trimDocument("\n  echo hi")).toBe("echo hi");
+  });
+
+  it("strips trailing only", () => {
+    expect(trimDocument("echo hi\n  ")).toBe("echo hi");
+  });
+
+  it("preserves internal whitespace", () => {
+    expect(trimDocument("  a    b  ")).toBe("a    b");
+  });
+
+  it("preserves internal newlines", () => {
+    expect(trimDocument("\na\nb\n")).toBe("a\nb");
+  });
+
+  it("empty input", () => {
+    expect(trimDocument("")).toBe("");
+  });
+
+  it("only-whitespace input", () => {
+    expect(trimDocument("   \n\t   ")).toBe("");
+  });
+
+  it("single non-whitespace char", () => {
+    expect(trimDocument("x")).toBe("x");
+  });
+
+  describe("idempotency", () => {
+    const cases = ["", "x", "  x  ", "\na\n", "   \n   ", "a\nb"];
+    it.each(cases)("trimDocument x2 === trimDocument x1 for %j", (s) => {
+      expect(trimDocument(trimDocument(s))).toBe(trimDocument(s));
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Composed pipelines (real paste scenarios)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("composed cleanup", () => {
+  function fullClean(input: string): string {
+    return trimDocument(
+      joinLines(
+        smartQuotesToStraight(
+          stripPromptPrefix(
+            unwrapContinuations(stripCodeFence(input)),
+          ),
+        ),
+      ),
+    );
+  }
+
+  it("cleans a markdown-fenced `$`-prefixed curl with continuations and smart quotes", () => {
+    const input = [
+      "```bash",
+      "$ curl -X POST “https://api.example.com/endpoint” \\",
+      "    -H ‘Content-Type: application/json’ \\",
+      "    -d ‘{\"name\": \"foo\"}’ \\",
+      "    --fail",
+      "```",
+    ].join("\n");
+
+    // Without joinLines (keep line breaks from the original doc):
+    const withoutJoin = trimDocument(
+      smartQuotesToStraight(
+        stripPromptPrefix(
+          unwrapContinuations(stripCodeFence(input)),
+        ),
+      ),
+    );
+    expect(withoutJoin).toBe(
+      'curl -X POST "https://api.example.com/endpoint" -H \'Content-Type: application/json\' -d \'{"name": "foo"}\' --fail',
+    );
+
+    // With joinLines (force single line):
+    expect(fullClean(input)).toBe(
+      'curl -X POST "https://api.example.com/endpoint" -H \'Content-Type: application/json\' -d \'{"name": "foo"}\' --fail',
+    );
+  });
+
+  it("docker run with trailing whitespace after each backslash (the bug the user reported)", () => {
+    const pad = "                                                                  ";
+    const input = `docker run -d \\${pad}\n    --name web \\${pad}\n    -p 8080:80 \\${pad}\n    nginx`;
+    expect(unwrapContinuations(input)).toBe("docker run -d --name web -p 8080:80 nginx");
+  });
+
+  it("markdown blockquote-prefixed command from docs", () => {
+    const input = "> npm install\n> npm run dev";
+    expect(stripPromptPrefix(input)).toBe("npm install\nnpm run dev");
+  });
+
+  it("is idempotent when applied twice end-to-end", () => {
+    const input = [
+      "```bash",
+      "$ echo “hi” \\",
+      "    world",
+      "```",
+    ].join("\n");
+    expect(fullClean(fullClean(input))).toBe(fullClean(input));
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pseudo-random property tests
+//
+// Not "real" property-based fuzzing — no fast-check dep — but a cheap
+// randomized check that catches regressions across a wider input surface
+// than hand-picked cases. Seeded so failures reproduce.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function mulberry32(seed: number): () => number {
+  let s = seed >>> 0;
+  return () => {
+    s = (s + 0x6d2b79f5) >>> 0;
+    let t = s;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function randomString(rng: () => number, len: number): string {
+  // Alphabet biased toward characters that matter to our transforms:
+  // whitespace, newlines, backslash, fence ticks, quotes (smart + straight),
+  // prompt markers, and a handful of plain ASCII.
+  const alphabet = " \t\n\\`$>#❯\"'“”‘’abcde";
+  let out = "";
+  for (let i = 0; i < len; i++) {
+    out += alphabet[Math.floor(rng() * alphabet.length)];
+  }
+  return out;
+}
+
+describe("pseudo-fuzz: all transforms are idempotent", () => {
+  const transforms = {
+    joinLines,
+    unwrapContinuations,
+    stripPromptPrefix,
+    stripCodeFence,
+    smartQuotesToStraight,
+    trimDocument,
+  };
+
+  for (const [name, fn] of Object.entries(transforms)) {
+    it(`${name} is idempotent across 500 seeded random inputs`, () => {
+      const rng = mulberry32(0xC0FFEE ^ name.length);
+      for (let i = 0; i < 500; i++) {
+        const len = Math.floor(rng() * 60);
+        const input = randomString(rng, len);
+        const once = fn(input);
+        const twice = fn(once);
+        if (twice !== once) {
+          throw new Error(
+            `${name} NOT idempotent on input ${JSON.stringify(input)}\n` +
+              `  once:  ${JSON.stringify(once)}\n` +
+              `  twice: ${JSON.stringify(twice)}`,
+          );
+        }
+      }
+    });
+  }
+});
+
+describe("pseudo-fuzz: transforms never throw", () => {
+  const transforms = [
+    joinLines,
+    unwrapContinuations,
+    stripPromptPrefix,
+    stripCodeFence,
+    smartQuotesToStraight,
+    trimDocument,
+  ];
+
+  it("no transform throws on 1000 random inputs", () => {
+    const rng = mulberry32(0xDEADBEEF);
+    for (let i = 0; i < 1000; i++) {
+      const len = Math.floor(rng() * 120);
+      const input = randomString(rng, len);
+      for (const fn of transforms) {
+        expect(() => fn(input)).not.toThrow();
+      }
+    }
+  });
+});
+
+// NOTE: Full-pipeline composed idempotency is intentionally NOT asserted.
+// Fuzzing showed pathological inputs where `joinLines` can reintroduce a
+// `$ ` start sequence (by collapsing `$\t` whitespace) that a second
+// `stripPromptPrefix` pass would then strip. Not a user-facing concern —
+// each individual transform IS idempotent (covered above), which is the
+// property the user's "click twice = no-op" expectation actually rests on.

--- a/src/lib/panes/promptSnapshot.ts
+++ b/src/lib/panes/promptSnapshot.ts
@@ -1,0 +1,64 @@
+export interface PromptSnapshot {
+  text: string;
+  seeded: boolean;
+}
+
+/**
+ * The subset of xterm.js's `IBuffer` we actually read. Typed structurally
+ * so tests can pass a minimal fake without stubbing the full IBuffer API
+ * (getNullCell, length, viewportY, ...). xterm's real IBuffer satisfies
+ * this shape.
+ */
+export interface SnapshotBufferLine {
+  isWrapped: boolean;
+  translateToString(trimRight?: boolean): string;
+}
+
+export interface SnapshotBuffer {
+  cursorY: number;
+  baseY: number;
+  getLine(y: number): SnapshotBufferLine | undefined;
+}
+
+// Matches `$`, `>`, `❯`, `#` followed by whitespace OR end-of-string, so
+// a bare prompt marker on an otherwise empty line also gets stripped.
+const PROMPT_PREFIX_RE = /^(?:\$|>|❯|#)(?:\s+|$)/;
+
+/**
+ * Read the current logical prompt line from an xterm buffer. Walks backwards
+ * through wrapped continuation lines so a long command typed across multiple
+ * visual rows comes back as one string. Strips common prompt prefixes (`$ `,
+ * `> `, `❯ `, `# `) from the origin line.
+ *
+ * Uses absolute buffer indices (`baseY + cursorY`) so the lookup is correct
+ * when the terminal has been scrolled. Returns null if the line can't be
+ * read or is empty after stripping.
+ */
+export function readPromptSnapshot(buffer: SnapshotBuffer): PromptSnapshot | null {
+  const absCursor = buffer.baseY + buffer.cursorY;
+  const cursorLine = buffer.getLine(absCursor);
+  if (!cursorLine) return null;
+
+  // Walk backward to find the origin of a wrapped block. A line's
+  // `isWrapped` flag is true when it is the *continuation* of the previous
+  // line, so we keep stepping back while the current line is a continuation.
+  let startLine = absCursor;
+  while (startLine > 0) {
+    const line = buffer.getLine(startLine);
+    if (!line?.isWrapped) break;
+    startLine -= 1;
+  }
+
+  const pieces: string[] = [];
+  for (let y = startLine; y <= absCursor; y++) {
+    const line = buffer.getLine(y);
+    if (!line) continue;
+    pieces.push(line.translateToString(true));
+  }
+  const joined = pieces.join("");
+  const stripped = joined.replace(/^\s+/, "").replace(PROMPT_PREFIX_RE, "");
+  const text = stripped.trimEnd();
+
+  if (!text) return null;
+  return { text, seeded: true };
+}

--- a/src/lib/panes/promptSnapshot.ts
+++ b/src/lib/panes/promptSnapshot.ts
@@ -20,9 +20,12 @@ export interface SnapshotBuffer {
   getLine(y: number): SnapshotBufferLine | undefined;
 }
 
-// Matches `$`, `>`, `❯`, `#` followed by whitespace OR end-of-string, so
-// a bare prompt marker on an otherwise empty line also gets stripped.
-const PROMPT_PREFIX_RE = /^(?:\$|>|❯|#)(?:\s+|$)/;
+// Matches `$`, `>`, `❯`, `#` followed by EXACTLY ONE whitespace char or
+// end-of-string. One whitespace only — not `\s+` — so that if the user typed
+// an extra leading space (common with HISTCONTROL=ignorespace), it survives
+// the strip. `$ ` and `$  echo` both still get the marker stripped, but the
+// latter keeps the user's leading space.
+const PROMPT_PREFIX_RE = /^(?:\$|>|❯|#)(?:\s|$)/;
 
 /**
  * Read the current logical prompt line from an xterm buffer. Walks backwards
@@ -49,14 +52,24 @@ export function readPromptSnapshot(buffer: SnapshotBuffer): PromptSnapshot | nul
     startLine -= 1;
   }
 
+  // Walk forward too — when the cursor is positioned mid-way through a
+  // wrapped input (arrow-keyed back into the middle of a long command),
+  // the rest of the logical line lives below the cursor row.
+  let endLine = absCursor;
+  while (true) {
+    const next = buffer.getLine(endLine + 1);
+    if (!next?.isWrapped) break;
+    endLine += 1;
+  }
+
   const pieces: string[] = [];
-  for (let y = startLine; y <= absCursor; y++) {
+  for (let y = startLine; y <= endLine; y++) {
     const line = buffer.getLine(y);
     if (!line) continue;
     pieces.push(line.translateToString(true));
   }
   const joined = pieces.join("");
-  const stripped = joined.replace(/^\s+/, "").replace(PROMPT_PREFIX_RE, "");
+  const stripped = joined.replace(PROMPT_PREFIX_RE, "");
   const text = stripped.trimEnd();
 
   if (!text) return null;

--- a/src/lib/panes/terminalRuntime.ts
+++ b/src/lib/panes/terminalRuntime.ts
@@ -5,6 +5,7 @@ import type { TerminalTheme } from "$lib/themes";
 import { type PtyOutputPayload } from "$lib/tauri";
 
 import { createXtermTerminalController } from "./xtermController";
+import type { PromptSnapshot } from "./promptSnapshot";
 
 export interface TerminalDimensions {
   cols: number;
@@ -24,6 +25,8 @@ export interface TerminalController {
   focus(): void;
   setTheme(theme: TerminalTheme): void;
   setCustomKeyHandler(handler: ((event: KeyboardEvent) => boolean) | null): void;
+  /** Read the current logical prompt line from the xterm buffer. */
+  getPromptSnapshot(): PromptSnapshot | null;
 }
 
 interface PaneTerminalRuntime {

--- a/src/lib/panes/textTransforms.ts
+++ b/src/lib/panes/textTransforms.ts
@@ -1,0 +1,63 @@
+// Pure text transforms for the multi-line prompt editor's toolbar buttons.
+// Each function maps an input string to its cleaned-up form and is safe to
+// apply repeatedly (idempotent on already-clean input).
+
+const PROMPT_PREFIX_RE = /^(?:\$ |> |❯ |# )/;
+const FENCE_LINE_RE = /^```[^\n]*$/;
+
+/** Normalize line endings to \n so transforms don't have to handle CRLF. */
+function normalizeEol(text: string): string {
+  return text.replace(/\r\n?/g, "\n");
+}
+
+/** Replace newlines with spaces and collapse runs of whitespace. */
+export function joinLines(text: string): string {
+  const normalized = normalizeEol(text);
+  return normalized.replace(/\s+/g, " ").trim();
+}
+
+/** Remove trailing backslash-newline continuations, merging to one line. */
+export function unwrapContinuations(text: string): string {
+  const normalized = normalizeEol(text);
+  // Consume horizontal whitespace around the `\<LF>` split so the joined
+  // result uses exactly one space between tokens, not two. Trailing
+  // whitespace between the `\` and the newline is common in pasted text
+  // (terminal padding, copy-from-editor artifacts) and should still count
+  // as a continuation.
+  return normalized.replace(/[ \t]*\\[ \t]*\n[ \t]*/g, " ");
+}
+
+/** Strip leading `$ `, `> `, `❯ `, `# ` from each line. */
+export function stripPromptPrefix(text: string): string {
+  return normalizeEol(text)
+    .split("\n")
+    .map((line) => line.replace(PROMPT_PREFIX_RE, ""))
+    .join("\n");
+}
+
+/**
+ * Strip markdown code fences: leading/trailing lines starting with ``` are
+ * dropped. Useful for text copied out of Claude Code / Codex where the model
+ * wrapped the command in a fenced block.
+ */
+export function stripCodeFence(text: string): string {
+  const normalized = normalizeEol(text);
+  const lines = normalized.split("\n");
+  let start = 0;
+  let end = lines.length;
+  if (lines.length > 0 && FENCE_LINE_RE.test(lines[0])) start = 1;
+  if (end > start && FENCE_LINE_RE.test(lines[end - 1])) end -= 1;
+  return lines.slice(start, end).join("\n");
+}
+
+/** Replace curly single/double quotes with straight ASCII quotes. */
+export function smartQuotesToStraight(text: string): string {
+  return text
+    .replace(/[“”„‟]/g, '"')
+    .replace(/[‘’‚‛]/g, "'");
+}
+
+/** Trim leading and trailing whitespace from the whole document. */
+export function trimDocument(text: string): string {
+  return text.trim();
+}

--- a/src/lib/panes/xtermController.ts
+++ b/src/lib/panes/xtermController.ts
@@ -10,6 +10,7 @@ import { userTerminalThemes } from "$lib/stores/userTerminalThemes";
 import { resolveTerminalTheme, type TerminalTheme } from "$lib/themes";
 
 import { installXtermWatchDecorations } from "./xtermWatchDecorations";
+import { readPromptSnapshot, type PromptSnapshot } from "./promptSnapshot";
 import type { TerminalController, TerminalDimensions } from "./terminalRuntime";
 
 interface CreateTerminalControllerOptions {
@@ -122,6 +123,10 @@ class XtermTerminalController implements TerminalController {
       if (!handler) return true;
       return handler(event);
     });
+  }
+
+  getPromptSnapshot(): PromptSnapshot | null {
+    return readPromptSnapshot(this.terminal.buffer.active);
   }
 }
 

--- a/src/lib/stores/__tests__/multiLineEditor.test.ts
+++ b/src/lib/stores/__tests__/multiLineEditor.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { buildSubmitPayload } from "../multiLineEditor";
+
+describe("buildSubmitPayload", () => {
+  it("prefixes shell payloads with Ctrl+E + Ctrl+U and wraps in bracketed paste", () => {
+    expect(buildSubmitPayload("echo hi", "shell")).toBe(
+      "\x05\x15\x1b[200~echo hi\x1b[201~",
+    );
+  });
+
+  it("skips the prompt-clear bytes for Claude Code panes", () => {
+    expect(buildSubmitPayload("echo hi", "claude")).toBe(
+      "\x1b[200~echo hi\x1b[201~",
+    );
+  });
+
+  it("preserves multi-line content inside the bracketed-paste wrapper", () => {
+    const multiline = "echo one\necho two\necho three";
+    expect(buildSubmitPayload(multiline, "shell")).toBe(
+      `\x05\x15\x1b[200~${multiline}\x1b[201~`,
+    );
+  });
+
+  it("never appends Enter — user reviews and submits in the terminal", () => {
+    const payload = buildSubmitPayload("dangerous --force", "shell");
+    // Enter is \r (CR) or \n (LF); neither may appear at the end.
+    expect(payload.endsWith("\r")).toBe(false);
+    expect(payload.endsWith("\n")).toBe(false);
+    // The final 6 chars must be the bracketed-paste end marker.
+    expect(payload.endsWith("\x1b[201~")).toBe(true);
+  });
+
+  it("handles an empty editor without corrupting the markers", () => {
+    expect(buildSubmitPayload("", "shell")).toBe("\x05\x15\x1b[200~\x1b[201~");
+    expect(buildSubmitPayload("", "claude")).toBe("\x1b[200~\x1b[201~");
+  });
+});

--- a/src/lib/stores/multiLineEditor.ts
+++ b/src/lib/stores/multiLineEditor.ts
@@ -1,0 +1,67 @@
+import { get, writable } from "svelte/store";
+
+export type MultiLineTarget = "shell" | "claude";
+
+export interface MultiLineEditorState {
+  open: boolean;
+  paneId: string | null;
+  paneLabel: string | null;
+  initialText: string;
+  seeded: boolean;
+  target: MultiLineTarget;
+}
+
+const INITIAL_STATE: MultiLineEditorState = {
+  open: false,
+  paneId: null,
+  paneLabel: null,
+  initialText: "",
+  seeded: false,
+  target: "shell",
+};
+
+export const multiLineEditor = writable<MultiLineEditorState>(INITIAL_STATE);
+
+export interface OpenMultiLineEditorOpts {
+  paneId: string;
+  paneLabel: string | null;
+  initialText: string;
+  seeded: boolean;
+  target: MultiLineTarget;
+}
+
+export function openMultiLineEditor(opts: OpenMultiLineEditorOpts): void {
+  multiLineEditor.set({
+    open: true,
+    paneId: opts.paneId,
+    paneLabel: opts.paneLabel,
+    initialText: opts.initialText,
+    seeded: opts.seeded,
+    target: opts.target,
+  });
+}
+
+export function closeMultiLineEditor(): void {
+  multiLineEditor.set(INITIAL_STATE);
+}
+
+export function isMultiLineEditorOpen(): boolean {
+  return get(multiLineEditor).open;
+}
+
+/**
+ * Build the exact byte sequence written to the PTY on submit.
+ *
+ *   - Shell panes: `Ctrl+E` + `Ctrl+U` clears the current readline buffer
+ *     regardless of cursor position (Ctrl+U alone only kills cursor→BOL,
+ *     leaving trailing chars when the cursor is mid-line).
+ *   - All panes: content wrapped in bracketed-paste markers keeps multi-line
+ *     text atomic — the shell treats it as one paste instead of a sequence
+ *     of Enter-terminated lines.
+ *   - Enter is **never** appended: the user reviews in the real terminal
+ *     and submits themself.
+ */
+export function buildSubmitPayload(text: string, target: MultiLineTarget): string {
+  const clear = target === "shell" ? "\x05\x15" : "";
+  return `${clear}\x1b[200~${text}\x1b[201~`;
+}


### PR DESCRIPTION
## Summary

Opt-in modal editor per pane for cleaning up CLI commands pasted from Claude Code / Codex / other LLM output before inserting them into the terminal.

- `Cmd+Shift+E` opens the editor seeded from the current shell prompt (empty in Claude Code panes, which own their own multi-line input)
- `Cmd+Shift+V` opens the editor with clipboard contents pre-pasted — the paste-from-LLM fast path
- Six one-shot transform buttons in a toolbar: **Join lines**, **Unwrap `\`-continuations**, **Strip `$`/`❯`/`#`/`>` prefix**, **Strip ` ``` ` code fence**, **Smart→straight quotes**, **Trim**. CodeMirror's native undo (`Cmd+Z`) reverts
- **`Cmd+Enter` inserts via bracketed paste** — clears the current line with `Ctrl+E`+`Ctrl+U` on shell panes (handles mid-line cursor), skips clear on Claude panes, and never appends Enter. User reviews the final command in the real terminal before pressing Enter themselves
- `Esc` / `Ctrl+G` cancel, IME \`isComposing\` guarded on submit, modal owns keys while open (global chords don't leak)
- bits-ui \`Tooltip\` used for hover hints on each button + a keyboard cheatsheet indicator in the header

## Architecture

- Pure transforms live in \`src/lib/panes/textTransforms.ts\` — unit-tested with 131 cases including pseudo-fuzz idempotency and no-throw sweeps
- Prompt snapshot logic in \`src/lib/panes/promptSnapshot.ts\` — reads xterm buffer using absolute \`baseY + cursorY\` indices, walks \`isWrapped\` continuation lines, strips common prompt markers
- \`TerminalController\` interface gains \`getPromptSnapshot()\`; \`XtermTerminalController\` delegates
- State lives in \`src/lib/stores/multiLineEditor.ts\`; \`buildSubmitPayload()\` is extracted + unit-tested so the exact byte sequence sent to the PTY is covered by tests
- Entry commands (\`pane.open-multiline-editor\`, \`pane.open-multiline-editor-with-clipboard\`) registered in \`src/lib/commands/panes.ts\`; claude-vs-shell distinction via \`spawnProfileRef\`
- Default keybindings in \`src-tauri/src/keymap/presets/default.kdl\`; App.svelte mounts the modal and adds an early-return guard in \`handleKeyDown\` matching the existing palette pattern

## Out of scope for this PR (deferred)

- OSC 133 shell integration (stubbed for v1.1 — heuristic prompt-prefix strip covers the common case)
- Bracketed-paste-disabled shell detection
- Selection-scoped transforms (whole-document only for now)

## Test plan

- [x] \`npm run test\` — 664 pass / 2 skipped (up from 549 — added textTransforms fuzz, promptSnapshot, multiLineEditor store)
- [x] \`npm run check\` — 0 errors / 0 warnings
- [ ] Manual shell flow: type at prompt, \`Cmd+Shift+E\`, verify "Seeded from prompt" + inserted content matches
- [ ] Manual cursor-mid-line: type, press Left a few times, open editor, clear, type new, submit — verify no trailing chars from original
- [ ] Manual scrolled buffer: scroll terminal, open editor, confirm snapshot still works
- [ ] Manual Claude pane: open editor, verify empty start, submit multi-line content, verify no auto-submit
- [ ] Manual \`Cmd+Shift+V\` with messy LLM output: clean via buttons, submit, eyeball result
- [ ] Manual exits: \`Esc\` and \`Ctrl+G\` both close without writing
- [ ] Manual global guard: open editor, press \`Cmd+D\` — no split happens
- [ ] Manual drag-select: drag a selection in the editor out onto the backdrop — modal stays open

🤖 Generated with [Claude Code](https://claude.com/claude-code)