### PR TITLE
fix(editor): resolve `code` via login-shell PATH

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -15,10 +15,11 @@ pub(crate) fn frontend_log(message: String) {
 #[tauri::command]
 #[specta::specta]
 pub(crate) fn cmd_open_in_editor(path: String) -> Result<(), String> {
-    std::process::Command::new("code")
+    let code = crate::services::setup::code_command();
+    std::process::Command::new(&code)
         .arg(&path)
         .spawn()
-        .map_err(|e| format!("Failed to open VS Code: {}", e))?;
+        .map_err(|e| format!("Failed to open VS Code (resolved binary: {code:?}): {e}"))?;
     Ok(())
 }
 

--- a/src-tauri/src/services/setup.rs
+++ b/src-tauri/src/services/setup.rs
@@ -103,6 +103,40 @@ fn find_wt_via_login_shell() -> Option<String> {
         .clone()
 }
 
+/// Resolve the `code` (VS Code) binary Roux should invoke for "Open in Code".
+///
+/// Mirrors [`gh_command`] precedence (minus the settings override — there is
+/// no editor setting yet):
+///   1. First match in the login-shell `PATH` — GUI launches on macOS get a
+///      minimal launchd PATH that excludes `/opt/homebrew/bin` etc., so the
+///      `code` shim is invisible without this step.
+///   2. Process `PATH`.
+///   3. Bare `"code"` — lets `Command::new` error naturally.
+pub(crate) fn code_command() -> String {
+    if let Some(path) = find_code_via_login_shell() {
+        return path;
+    }
+    if let Some(path) = crate::platform::find_executable_on_path("code") {
+        return path.to_string_lossy().to_string();
+    }
+    "code".to_string()
+}
+
+fn find_code_via_login_shell() -> Option<String> {
+    use std::sync::OnceLock;
+    static CACHED: OnceLock<Option<String>> = OnceLock::new();
+    CACHED
+        .get_or_init(|| {
+            let path = crate::pty::get_user_path();
+            if path.is_empty() {
+                return None;
+            }
+            crate::platform::find_executable_in_paths(path.as_str(), "code")
+                .map(|p| p.to_string_lossy().to_string())
+        })
+        .clone()
+}
+
 pub(crate) fn is_cli_installed() -> bool {
     crate::hooks::cli_is_installed()
 }

--- a/src/lib/components/SessionTabs.svelte
+++ b/src/lib/components/SessionTabs.svelte
@@ -283,8 +283,13 @@
 
   async function handleOpenInCode() {
     if (!contextMenu) return;
-    await openInEditor(contextMenu.session.worktreePath).catch(() => {});
-    closeContextMenu();
+    try {
+      await openInEditor(contextMenu.session.worktreePath);
+    } catch (e) {
+      logError("Failed to open in editor", e);
+    } finally {
+      closeContextMenu();
+    }
   }
 
   $effect(() => {


### PR DESCRIPTION
## Summary

- "Open in Code" (right-click on a session and the command palette entry) silently did nothing when Roux was launched as an `.app` from Finder/Dock. Root cause: `Command::new("code")` resolves against the process PATH, but macOS GUI launches inherit launchd's minimal PATH which excludes `/opt/homebrew/bin` (where the `code` shim lives).
- Adds `code_command()` next to `gh_command()`/`resolve_wt_binary()` in `services/setup.rs`, mirroring the established login-shell PATH lookup. The result is cached in a `OnceLock` to avoid spawning a shell on every invoke.
- Surfaces the resolved binary in the error message and replaces the `.catch(() => {})` in the right-click handler with `logError`, so the next failure is diagnosable instead of silent.

## Test plan

- [x] `cargo check` (src-tauri)
- [x] `npm run check`
- [x] `npm run test` (52 files / 667 tests)
- [ ] Build and launch the `.app` from Finder/Dock; right-click a session → "Open in Code" opens the worktree in VS Code
- [ ] Same via command palette ("Open in Editor")
- [ ] Verify under `task dev` (process PATH already has `code`) — should also still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)