### PR TITLE
feat(keymap): add reset and open-in-editor commands

### DIFF
--- a/src/lib/commands/ui.ts
+++ b/src/lib/commands/ui.ts
@@ -384,47 +384,61 @@ export function registerUiCommands() {
         "Reset all keybindings to default?\n\nYour current keymap.kdl will be overwritten. This cannot be undone.",
       );
       if (!confirmed) return;
-      const presetResult = await commands.getBuiltinKeymapPreset("default");
-      if (presetResult.status === "error") {
-        logError(`keymap.reset-to-default: get preset failed: ${presetResult.error}`);
+      try {
+        const presetResult = await commands.getBuiltinKeymapPreset("default");
+        if (presetResult.status === "error") {
+          logError(`keymap.reset-to-default: get preset failed: ${presetResult.error}`);
+          void notificationsPush({
+            level: "error",
+            source: { type: "internal" },
+            title: "Reset keybindings failed",
+            subtitle: null,
+            body: presetResult.error,
+            sessionId: null,
+            actions: [],
+            dedupKey: "keymap-reset-error",
+          }).catch(() => {});
+          return;
+        }
+        const writeResult = await commands.setKeymap(presetResult.data);
+        if (writeResult.status === "error") {
+          logError(`keymap.reset-to-default: write failed: ${writeResult.error}`);
+          void notificationsPush({
+            level: "error",
+            source: { type: "internal" },
+            title: "Reset keybindings failed",
+            subtitle: null,
+            body: writeResult.error,
+            sessionId: null,
+            actions: [],
+            dedupKey: "keymap-reset-error",
+          }).catch(() => {});
+          return;
+        }
+        await loadKeymap();
+        void notificationsPush({
+          level: "info",
+          source: { type: "internal" },
+          title: "Keybindings reset to default",
+          subtitle: null,
+          body: null,
+          sessionId: null,
+          actions: [],
+          dedupKey: "keymap-reset-ok",
+        }).catch(() => {});
+      } catch (error) {
+        logError("keymap.reset-to-default failed", error);
         void notificationsPush({
           level: "error",
           source: { type: "internal" },
           title: "Reset keybindings failed",
           subtitle: null,
-          body: presetResult.error,
+          body: error instanceof Error ? error.message : String(error),
           sessionId: null,
           actions: [],
           dedupKey: "keymap-reset-error",
         }).catch(() => {});
-        return;
       }
-      const writeResult = await commands.setKeymap(presetResult.data);
-      if (writeResult.status === "error") {
-        logError(`keymap.reset-to-default: write failed: ${writeResult.error}`);
-        void notificationsPush({
-          level: "error",
-          source: { type: "internal" },
-          title: "Reset keybindings failed",
-          subtitle: null,
-          body: writeResult.error,
-          sessionId: null,
-          actions: [],
-          dedupKey: "keymap-reset-error",
-        }).catch(() => {});
-        return;
-      }
-      await loadKeymap();
-      void notificationsPush({
-        level: "info",
-        source: { type: "internal" },
-        title: "Keybindings reset to default",
-        subtitle: null,
-        body: null,
-        sessionId: null,
-        actions: [],
-        dedupKey: "keymap-reset-ok",
-      }).catch(() => {});
     },
   });
 

--- a/src/lib/commands/ui.ts
+++ b/src/lib/commands/ui.ts
@@ -3,6 +3,8 @@ import { queries } from "$lib/queries";
 import { settings, updateSetting } from "$lib/stores/settings";
 import { get } from "svelte/store";
 import { loadKeymap, exitTree as keymapExitTree } from "$lib/keymap/store";
+import { commands } from "$lib/bindings";
+import { openInEditor, notificationsPush } from "$lib/tauri";
 import {
   activeSidebar,
   openSidebar,
@@ -356,6 +358,73 @@ export function registerUiCommands() {
     category: "App",
     execute: () => {
       void loadKeymap();
+    },
+  });
+
+  registry.register({
+    id: "keymap.open-in-editor",
+    label: "Open Keybindings in Editor",
+    category: "App",
+    execute: async () => {
+      try {
+        const path = await commands.getKeymapPath();
+        await openInEditor(path);
+      } catch (e) {
+        logError("keymap.open-in-editor failed", e);
+      }
+    },
+  });
+
+  registry.register({
+    id: "keymap.reset-to-default",
+    label: "Reset Keybindings to Default",
+    category: "App",
+    execute: async () => {
+      const confirmed = window.confirm(
+        "Reset all keybindings to default?\n\nYour current keymap.kdl will be overwritten. This cannot be undone.",
+      );
+      if (!confirmed) return;
+      const presetResult = await commands.getBuiltinKeymapPreset("default");
+      if (presetResult.status === "error") {
+        logError(`keymap.reset-to-default: get preset failed: ${presetResult.error}`);
+        void notificationsPush({
+          level: "error",
+          source: { type: "internal" },
+          title: "Reset keybindings failed",
+          subtitle: null,
+          body: presetResult.error,
+          sessionId: null,
+          actions: [],
+          dedupKey: "keymap-reset-error",
+        }).catch(() => {});
+        return;
+      }
+      const writeResult = await commands.setKeymap(presetResult.data);
+      if (writeResult.status === "error") {
+        logError(`keymap.reset-to-default: write failed: ${writeResult.error}`);
+        void notificationsPush({
+          level: "error",
+          source: { type: "internal" },
+          title: "Reset keybindings failed",
+          subtitle: null,
+          body: writeResult.error,
+          sessionId: null,
+          actions: [],
+          dedupKey: "keymap-reset-error",
+        }).catch(() => {});
+        return;
+      }
+      await loadKeymap();
+      void notificationsPush({
+        level: "info",
+        source: { type: "internal" },
+        title: "Keybindings reset to default",
+        subtitle: null,
+        body: null,
+        sessionId: null,
+        actions: [],
+        dedupKey: "keymap-reset-ok",
+      }).catch(() => {});
     },
   });
 

--- a/src/lib/menu/appMenu.ts
+++ b/src/lib/menu/appMenu.ts
@@ -444,6 +444,8 @@ async function buildToolsMenu(ctx: BuildContext): Promise<Submenu> {
       await Submenu.new({ text: "Add Watch", items: watchItems }),
       await sep(),
       await cmdItem(ctx, "keymap.reload", "Reload Keymap"),
+      await cmdItem(ctx, "keymap.open-in-editor", "Open Keybindings in Editor"),
+      await cmdItem(ctx, "keymap.reset-to-default", "Reset Keybindings to Default…"),
     ],
   });
 }


### PR DESCRIPTION
## Summary
- Adds `keymap.open-in-editor` — opens `keymap.kdl` via the configured editor.
- Adds `keymap.reset-to-default` — overwrites the user keymap with the default preset after a `window.confirm` dialog, then reloads. Surfaces success/error via internal notifications.
- Wires both into the Tools menu next to the existing **Reload Keymap** entry. Both are also bindable from `keymap.kdl`.

## Test plan
- [x] `npm run check` — 0 errors / 0 warnings
- [x] `npm run test -- --run src/lib/menu src/lib/commands` — 30 pass
- [ ] Manual: run **Open Keybindings in Editor** from the palette and from Tools → confirm `keymap.kdl` opens in `\$EDITOR` / VS Code
- [ ] Manual: run **Reset Keybindings to Default…**, cancel the dialog → confirm nothing changes
- [ ] Manual: run it again, confirm → file is overwritten with the default preset, success notification appears, active keymap reflects defaults
- [ ] Manual: bind both new IDs in `keymap.kdl` and trigger via shortcut

🤖 Generated with [Claude Code](https://claude.com/claude-code)