### PR TITLE
[codex] Add draggable pane dividers

### DIFF
--- a/src/lib/components/SplitPane.svelte
+++ b/src/lib/components/SplitPane.svelte
@@ -1,17 +1,28 @@
 <script lang="ts">
+  import { onDestroy } from "svelte";
   import SplitPane from "./SplitPane.svelte";
   import PaneShell from "./PaneShell.svelte";
   import { fullscreenPaneId } from "$lib/panes/focus";
   import { paneInstances } from "$lib/panes/instances";
-  import { containsPaneId, setActiveStackIndex, type LayoutNode } from "$lib/panes/layout";
+  import {
+    containsPaneId,
+    resizeSplitDivider,
+    setActiveStackIndex,
+    type LayoutNode,
+  } from "$lib/panes/layout";
 
   interface Props {
     node: LayoutNode;
     sessionId: string;
     visible?: boolean;
+    path?: number[];
   }
 
-  let { node, sessionId, visible = true }: Props = $props();
+  let { node, sessionId, visible = true, path = [] }: Props = $props();
+
+  let splitEl: HTMLDivElement | null = $state(null);
+  let activeDivider = $state<number | null>(null);
+  let dragTeardown: (() => void) | null = null;
 
   function getStackDisplayLabel(node: LayoutNode): string {
     if (node.kind === "leaf") {
@@ -20,6 +31,53 @@
     }
     return node.children.map(getStackDisplayLabel).join(" | ");
   }
+
+  function endDividerDrag(): void {
+    dragTeardown?.();
+    dragTeardown = null;
+    activeDivider = null;
+  }
+
+  function installDividerDragHandlers(onMove: (ev: PointerEvent) => void): void {
+    const onUp = () => endDividerDrag();
+    const onKey = (ev: KeyboardEvent) => {
+      if (ev.key === "Escape") endDividerDrag();
+    };
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+    window.addEventListener("pointercancel", onUp);
+    window.addEventListener("blur", endDividerDrag);
+    window.addEventListener("keydown", onKey);
+    dragTeardown = () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+      window.removeEventListener("pointercancel", onUp);
+      window.removeEventListener("blur", endDividerDrag);
+      window.removeEventListener("keydown", onKey);
+    };
+  }
+
+  function onDividerPointerDown(ev: PointerEvent, dividerIndex: number): void {
+    if (node.kind !== "split" || node.stacked || !splitEl) return;
+
+    ev.preventDefault();
+    ev.stopPropagation();
+    endDividerDrag();
+    activeDivider = dividerIndex;
+
+    let lastPosition = node.direction === "h" ? ev.clientX : ev.clientY;
+    const rect = splitEl.getBoundingClientRect();
+    const containerSize = node.direction === "h" ? rect.width : rect.height;
+    const splitPath = [...path];
+
+    installDividerDragHandlers((moveEv) => {
+      const position = node.direction === "h" ? moveEv.clientX : moveEv.clientY;
+      resizeSplitDivider(sessionId, splitPath, dividerIndex, position - lastPosition, containerSize);
+      lastPosition = position;
+    });
+  }
+
+  onDestroy(() => endDividerDrag());
 </script>
 
 {#if node.kind === "leaf"}
@@ -47,13 +105,19 @@
             suppressTitleAccent={i === (node.activeIndex ?? 0)}
           />
         {:else}
-          <SplitPane node={child} {sessionId} visible={visible && i === (node.activeIndex ?? 0)} />
+          <SplitPane
+            node={child}
+            {sessionId}
+            visible={visible && i === (node.activeIndex ?? 0)}
+            path={[...path, i]}
+          />
         {/if}
       </div>
     {/each}
   </div>
 {:else}
   <div
+    bind:this={splitEl}
     class="flex flex-1 min-h-0 min-w-0 gap-px bg-hairline"
     class:flex-row={node.direction === "h"}
     class:flex-col={node.direction === "v"}
@@ -68,8 +132,32 @@
         class="flex flex-col min-h-0 min-w-0 {childVisible ? '' : 'hidden'}"
         style={childVisible ? `flex: ${size ?? 1}` : ''}
       >
-        <SplitPane node={child} {sessionId} visible={visible && childVisible} />
+        <SplitPane
+          node={child}
+          {sessionId}
+          visible={visible && childVisible}
+          path={[...path, i]}
+        />
       </div>
+      {#if childVisible && i < node.children.length - 1}
+        {@const nextChild = node.children[i + 1]}
+        {@const nextVisible = !isFullscreenActive || (fsId ? containsPaneId(nextChild, fsId) : false)}
+        {#if nextVisible}
+          <!-- svelte-ignore a11y_no_static_element_interactions -->
+          <div
+            data-testid={`pane-divider-${node.direction}-${i}`}
+            role="separator"
+            aria-orientation={node.direction === "h" ? "vertical" : "horizontal"}
+            class="group relative z-10 shrink-0 select-none touch-none {node.direction === 'h' ? 'cursor-col-resize w-2 -mx-1' : 'cursor-row-resize h-2 -my-1'}"
+            onpointerdown={(ev) => onDividerPointerDown(ev, i)}
+          >
+            <div
+              class="pointer-events-none absolute bg-transparent transition-colors duration-150 group-hover:bg-accent-dim/40 {node.direction === 'h' ? 'inset-y-0 left-1/2 w-px -translate-x-1/2' : 'inset-x-0 top-1/2 h-px -translate-y-1/2'}"
+              class:bg-accent-dim={activeDivider === i}
+            ></div>
+          </div>
+        {/if}
+      {/if}
     {/each}
   </div>
 {/if}

--- a/src/lib/panes/__tests__/layout.test.ts
+++ b/src/lib/panes/__tests__/layout.test.ts
@@ -18,6 +18,7 @@ import {
   getStackLabel,
   movePane,
   resizePane,
+  resizeSplitDivider,
   type LayoutNode,
 } from "../layout";
 import { focusedPaneId, setLogicalFocus, resetFocus } from "../focus";
@@ -393,6 +394,133 @@ describe("resizePane", () => {
       expect(tree.sizes).toBeDefined();
       expect(tree.sizes![0]).toBeGreaterThan(0.5);
     }
+  });
+});
+
+describe("resizeSplitDivider", () => {
+  beforeEach(() => {
+    resetLayouts();
+    resetFocus();
+  });
+
+  it("resizes adjacent children in a two-pane split", () => {
+    sessionLayouts.set(new Map([
+      ["s1", {
+        kind: "split",
+        direction: "h",
+        children: [
+          { kind: "leaf", paneId: "p1" },
+          { kind: "leaf", paneId: "p2" },
+        ],
+      }],
+    ]));
+
+    resizeSplitDivider("s1", [], 0, 100, 1000);
+
+    const tree = getLayout("s1");
+    expect(tree.kind).toBe("split");
+    if (tree.kind === "split") {
+      expect(tree.sizes).toEqual([0.6, 0.4]);
+    }
+  });
+
+  it("only changes the adjacent pair in a multi-child split", () => {
+    sessionLayouts.set(new Map([
+      ["s1", {
+        kind: "split",
+        direction: "h",
+        children: [
+          { kind: "leaf", paneId: "p1" },
+          { kind: "leaf", paneId: "p2" },
+          { kind: "leaf", paneId: "p3" },
+        ],
+        sizes: [0.2, 0.5, 0.3],
+      }],
+    ]));
+
+    resizeSplitDivider("s1", [], 1, -100, 1000);
+
+    const tree = getLayout("s1");
+    expect(tree.kind).toBe("split");
+    if (tree.kind === "split") {
+      expect(tree.sizes).toEqual([0.2, 0.4, 0.4]);
+    }
+  });
+
+  it("clamps adjacent children to the minimum size", () => {
+    sessionLayouts.set(new Map([
+      ["s1", {
+        kind: "split",
+        direction: "h",
+        children: [
+          { kind: "leaf", paneId: "p1" },
+          { kind: "leaf", paneId: "p2" },
+        ],
+        sizes: [0.5, 0.5],
+      }],
+    ]));
+
+    resizeSplitDivider("s1", [], 0, 900, 1000);
+
+    const tree = getLayout("s1");
+    expect(tree.kind).toBe("split");
+    if (tree.kind === "split") {
+      expect(tree.sizes![0]).toBeCloseTo(0.95);
+      expect(tree.sizes![1]).toBeCloseTo(0.05);
+    }
+  });
+
+  it("resizes a nested split by path without changing the root split", () => {
+    sessionLayouts.set(new Map([
+      ["s1", {
+        kind: "split",
+        direction: "h",
+        children: [
+          { kind: "leaf", paneId: "p1" },
+          {
+            kind: "split",
+            direction: "v",
+            children: [
+              { kind: "leaf", paneId: "p2" },
+              { kind: "leaf", paneId: "p3" },
+            ],
+          },
+        ],
+        sizes: [0.3, 0.7],
+      }],
+    ]));
+
+    resizeSplitDivider("s1", [1], 0, 50, 500);
+
+    const tree = getLayout("s1");
+    expect(tree.kind).toBe("split");
+    if (tree.kind === "split") {
+      expect(tree.sizes).toEqual([0.3, 0.7]);
+      const nested = tree.children[1];
+      expect(nested.kind).toBe("split");
+      if (nested.kind === "split") {
+        expect(nested.sizes).toEqual([0.6, 0.4]);
+      }
+    }
+  });
+
+  it("does nothing for invalid divider inputs", () => {
+    const tree: LayoutNode = {
+      kind: "split",
+      direction: "h",
+      children: [
+        { kind: "leaf", paneId: "p1" },
+        { kind: "leaf", paneId: "p2" },
+      ],
+      sizes: [0.25, 0.75],
+    };
+    sessionLayouts.set(new Map([["s1", tree]]));
+
+    resizeSplitDivider("s1", [], 1, 100, 1000);
+    resizeSplitDivider("s1", [9], 0, 100, 1000);
+    resizeSplitDivider("s1", [], 0, 100, 0);
+
+    expect(getLayout("s1")).toEqual(tree);
   });
 });
 

--- a/src/lib/panes/layout.ts
+++ b/src/lib/panes/layout.ts
@@ -243,6 +243,8 @@ const dropSideToDirection: Record<DropSide, SplitDirection> = {
   bottom: "v",
 };
 
+const MIN_PANE_FRACTION = 0.05;
+
 // ── Internal tree helpers ────────────────────────────────────────────────────
 
 /** Builds the path of { parent, childIndex } entries from root to target leaf. */
@@ -345,6 +347,52 @@ function splitAtPath(
   }
   if (node.kind !== "split") throw new Error("Expected split at path");
   return node;
+}
+
+function splitAtExactPath(
+  root: LayoutNode,
+  path: readonly number[]
+): (LayoutNode & { kind: "split" }) | null {
+  let node = root;
+  for (const index of path) {
+    if (node.kind !== "split") return null;
+    if (!Number.isInteger(index) || index < 0 || index >= node.children.length) return null;
+    node = node.children[index];
+  }
+  return node.kind === "split" ? node : null;
+}
+
+function replaceSplitAtPath(
+  root: LayoutNode,
+  path: readonly number[],
+  replacement: LayoutNode & { kind: "split" },
+  depth = 0
+): LayoutNode {
+  if (depth === path.length) return replacement;
+  if (root.kind === "leaf") return root;
+
+  const childIdx = path[depth];
+  const newChildren = root.children.map((child, i) =>
+    i === childIdx ? replaceSplitAtPath(child, path, replacement, depth + 1) : child
+  );
+  if (newChildren.every((c, i) => c === root.children[i])) return root;
+  return { ...root, children: newChildren };
+}
+
+function normalizedSplitSizes(split: LayoutNode & { kind: "split" }): number[] {
+  const count = split.children.length;
+  const sizes = split.sizes;
+  if (
+    !sizes ||
+    sizes.length !== count ||
+    sizes.some((size) => !Number.isFinite(size) || size < 0)
+  ) {
+    return Array(count).fill(1 / count);
+  }
+
+  const total = sizes.reduce((sum, size) => sum + size, 0);
+  if (total <= 0) return Array(count).fill(1 / count);
+  return sizes.map((size) => size / total);
 }
 
 /** Collect the depths of ancestor split nodes along the path. */
@@ -718,13 +766,12 @@ export function resizePane(sessionId: string, direction: Direction, step: number
     const newSizes = [...currentSizes];
 
     const delta = Math.abs(step);
-    const MIN_SIZE = 0.05;
 
     newSizes[childIndex] = Math.min(
-      1 - MIN_SIZE * (count - 1),
+      1 - MIN_PANE_FRACTION * (count - 1),
       newSizes[childIndex] + delta
     );
-    newSizes[neighborIndex] = Math.max(MIN_SIZE, newSizes[neighborIndex] - delta);
+    newSizes[neighborIndex] = Math.max(MIN_PANE_FRACTION, newSizes[neighborIndex] - delta);
 
     const total = newSizes.reduce((a, b) => a + b, 0);
     for (let j = 0; j < newSizes.length; j++) newSizes[j] /= total;
@@ -738,4 +785,55 @@ export function resizePane(sessionId: string, direction: Direction, step: number
     });
     return;
   }
+}
+
+/** Resize the two children adjacent to a rendered split divider. */
+export function resizeSplitDivider(
+  sessionId: string,
+  splitPath: readonly number[],
+  dividerIndex: number,
+  deltaPx: number,
+  containerPx: number
+): void {
+  if (
+    !Number.isInteger(dividerIndex) ||
+    !Number.isFinite(deltaPx) ||
+    !Number.isFinite(containerPx) ||
+    containerPx <= 0
+  ) {
+    return;
+  }
+
+  sessionLayouts.update((m) => {
+    const root = m.get(sessionId);
+    if (!root) return m;
+
+    const split = splitAtExactPath(root, splitPath);
+    if (!split || split.stacked) return m;
+
+    const count = split.children.length;
+    if (count < 2 || dividerIndex < 0 || dividerIndex >= count - 1) return m;
+
+    const leftIndex = dividerIndex;
+    const rightIndex = dividerIndex + 1;
+    const sizes = normalizedSplitSizes(split);
+    const pairTotal = sizes[leftIndex] + sizes[rightIndex];
+    const minSize = Math.min(MIN_PANE_FRACTION, pairTotal / 2);
+    const delta = deltaPx / containerPx;
+    const nextLeft = Math.max(
+      minSize,
+      Math.min(pairTotal - minSize, sizes[leftIndex] + delta)
+    );
+
+    const newSizes = [...sizes];
+    newSizes[leftIndex] = nextLeft;
+    newSizes[rightIndex] = pairTotal - nextLeft;
+
+    const total = newSizes.reduce((sum, size) => sum + size, 0);
+    const normalized = total > 0 ? newSizes.map((size) => size / total) : newSizes;
+
+    const next = new Map(m);
+    next.set(sessionId, replaceSplitAtPath(root, splitPath, { ...split, sizes: normalized }));
+    return next;
+  });
 }

--- a/src/lib/panes/layout.ts
+++ b/src/lib/panes/layout.ts
@@ -349,6 +349,7 @@ function splitAtPath(
   return node;
 }
 
+/** Safely resolve a split node at the given path; returns null if path is invalid or target is not a split. */
 function splitAtExactPath(
   root: LayoutNode,
   path: readonly number[]
@@ -362,6 +363,7 @@ function splitAtExactPath(
   return node.kind === "split" ? node : null;
 }
 
+/** Immutably replace a split node at the given path with a replacement split, returning the updated root. */
 function replaceSplitAtPath(
   root: LayoutNode,
   path: readonly number[],
@@ -379,6 +381,7 @@ function replaceSplitAtPath(
   return { ...root, children: newChildren };
 }
 
+/** Return normalized split sizes (sum to 1); returns equal distribution if sizes are missing or invalid. */
 function normalizedSplitSizes(split: LayoutNode & { kind: "split" }): number[] {
   const count = split.children.length;
   const sizes = split.sizes;
@@ -623,6 +626,7 @@ export function movePaneInDirection(sessionId: string, direction: Direction): vo
   setLogicalFocus(focused);
 }
 
+/** Move a pane within the tree (swap, enter a split, or extract from nesting); returns null if not possible. */
 function movePaneInTree(
   root: LayoutNode,
   paneId: string,


### PR DESCRIPTION
## Summary
Add draggable dividers to split panes by updating the existing layout `sizes` ratios instead of introducing a separate resizing model.

## What changed
- Added a path-based divider resize helper in `src/lib/panes/layout.ts` that adjusts only the two panes adjacent to the dragged divider.
- Rendered draggable divider handles in `src/lib/components/SplitPane.svelte` and wired pointer drag handling with cleanup on blur, Escape, pointer cancel, and destroy.
- Added layout tests covering two-pane, multi-pane, nested, clamp, and invalid-input cases.

## Validation
- `npm run test -- src/lib/panes/__tests__/layout.test.ts`
- `npm run check`
- `npm run test`

## Notes
The worktree still has unrelated local changes in `Cargo.lock` and `src/lib/bindings.ts`; those were not included in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Split-pane dividers are now interactive—drag to resize adjacent panes.
  * Resizing respects minimum pane sizes to keep panes usable.
  * Nested split layouts automatically normalize sizes when resized.
  * Visible dividers/separators added between panes for clearer interaction.

* **Tests**
  * Added comprehensive tests covering divider resizing, clamping, nesting, and invalid inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->