### PR TITLE
[codex] Update Claude notifications

### DIFF
--- a/src-tauri/src/agent_sources/file_status.rs
+++ b/src-tauri/src/agent_sources/file_status.rs
@@ -40,6 +40,8 @@ pub struct StatusUpdate {
     pub tool_name: Option<String>,
     pub tool_input: Option<Value>,
     pub message: Option<String>,
+    pub query: Option<String>,
+    pub response: Option<String>,
 }
 
 #[derive(Debug, Error)]
@@ -107,6 +109,16 @@ pub fn parse_status_payload(parsed: &Value) -> Option<StatusUpdate> {
         .and_then(|s| s.as_str())
         .filter(|s| !s.is_empty())
         .map(|s| s.to_string());
+    let query = parsed
+        .get("query")
+        .and_then(|s| s.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
+    let response = parsed
+        .get("response")
+        .and_then(|s| s.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
 
     Some(StatusUpdate {
         status: map_status(&raw_status).to_string(),
@@ -118,6 +130,8 @@ pub fn parse_status_payload(parsed: &Value) -> Option<StatusUpdate> {
         tool_name,
         tool_input,
         message,
+        query,
+        response,
     })
 }
 
@@ -153,11 +167,7 @@ pub fn payload_to_identity(update: &StatusUpdate) -> AgentIdentity {
     AgentIdentity {
         pane_id: update.roux_pane_id.clone(),
         session_id: update.roux_session_id.clone(),
-        cwd: if update.cwd.is_empty() {
-            None
-        } else {
-            Some(PathBuf::from(&update.cwd))
-        },
+        cwd: if update.cwd.is_empty() { None } else { Some(PathBuf::from(&update.cwd)) },
     }
 }
 
@@ -215,7 +225,11 @@ pub fn start_watching(
 
             for path in &changed_paths {
                 if let Err(e) = process_path_change(&app, &tx, path) {
-                    crate::rlog!("file_status: process_path_change error {}: {}", path.display(), e);
+                    crate::rlog!(
+                        "file_status: process_path_change error {}: {}",
+                        path.display(),
+                        e
+                    );
                 }
             }
 
@@ -240,11 +254,7 @@ pub fn start_watching(
     Ok(())
 }
 
-fn collect_paths(
-    event: &Event,
-    changed: &mut HashSet<PathBuf>,
-    removed: &mut HashSet<PathBuf>,
-) {
+fn collect_paths(event: &Event, changed: &mut HashSet<PathBuf>, removed: &mut HashSet<PathBuf>) {
     let is_json = |path: &Path| path.extension().and_then(|e| e.to_str()) == Some("json");
     match event.kind {
         EventKind::Create(_) | EventKind::Modify(_) => {
@@ -272,7 +282,8 @@ fn process_path_change(
 ) -> Result<(), String> {
     let content = fs::read_to_string(path).map_err(|e| e.to_string())?;
     let parsed: Value = serde_json::from_str(&content).map_err(|e| e.to_string())?;
-    let update = parse_status_payload(&parsed).ok_or_else(|| "payload missing status".to_string())?;
+    let update =
+        parse_status_payload(&parsed).ok_or_else(|| "payload missing status".to_string())?;
 
     let _ = app.emit("roux-status-update", &update);
 
@@ -284,11 +295,7 @@ fn process_path_change(
 
     let identity = payload_to_identity(&update);
     let context = payload_to_event_context(&update);
-    let input = AgentInput {
-        identity,
-        event: AgentEvent::HookStatus(mapped),
-        context,
-    };
+    let input = AgentInput { identity, event: AgentEvent::HookStatus(mapped), context };
     tx.send(RegistryMessage::Input(Box::new(input))).map_err(|e| e.to_string())?;
     Ok(())
 }
@@ -307,6 +314,8 @@ mod tests {
             "provider": "claude",
             "roux_session_id": "sess-1",
             "roux_pane_id": "pane-1",
+            "query": "please fix it",
+            "response": "fixed",
         });
         let update = parse_status_payload(&payload).expect("parse ok");
         assert_eq!(update.status, "generating");
@@ -315,6 +324,8 @@ mod tests {
         assert_eq!(update.provider, "claude");
         assert_eq!(update.roux_session_id.as_deref(), Some("sess-1"));
         assert_eq!(update.roux_pane_id.as_deref(), Some("pane-1"));
+        assert_eq!(update.query.as_deref(), Some("please fix it"));
+        assert_eq!(update.response.as_deref(), Some("fixed"));
     }
 
     #[test]
@@ -446,6 +457,8 @@ mod tests {
             tool_name: None,
             tool_input: None,
             message: None,
+            query: None,
+            response: None,
         }
     }
 }

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -433,6 +433,75 @@ fn get_pane_id() -> Option<String> {
     std::env::var("ROUX_PANE_ID").ok()
 }
 
+fn text_from_content(content: &Value) -> Option<String> {
+    match content {
+        Value::String(s) => {
+            let trimmed = s.trim();
+            (!trimmed.is_empty()).then(|| trimmed.to_string())
+        }
+        Value::Array(parts) => {
+            let text = parts
+                .iter()
+                .filter_map(|part| {
+                    let obj = part.as_object()?;
+                    (obj.get("type").and_then(|v| v.as_str()) == Some("text"))
+                        .then(|| obj.get("text").and_then(|v| v.as_str()))
+                        .flatten()
+                })
+                .collect::<Vec<_>>()
+                .join(" ");
+            let trimmed = text.trim();
+            (!trimmed.is_empty()).then(|| trimmed.to_string())
+        }
+        _ => None,
+    }
+}
+
+fn truncate_summary(s: String) -> String {
+    const MAX_CHARS: usize = 200;
+    if s.chars().count() <= MAX_CHARS {
+        return s;
+    }
+    let mut out = s.chars().take(MAX_CHARS - 3).collect::<String>();
+    out.push_str("...");
+    out
+}
+
+fn extract_transcript_summary(path: &str) -> Option<(Option<String>, Option<String>)> {
+    let content = fs::read_to_string(path).ok()?;
+    let mut query = None;
+    let mut response = None;
+
+    for line in content.lines() {
+        let Ok(entry) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        let entry_type = entry.get("type").and_then(|v| v.as_str());
+        let message = entry.get("message").unwrap_or(&Value::Null);
+        let message_content = message.get("content").unwrap_or(&Value::Null);
+
+        match entry_type {
+            Some("user") => {
+                if let Some(text) = text_from_content(message_content) {
+                    query = Some(truncate_summary(text));
+                }
+            }
+            Some("assistant") => {
+                if let Some(text) = text_from_content(message_content) {
+                    response = Some(truncate_summary(text));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if query.is_some() || response.is_some() {
+        Some((query, response))
+    } else {
+        None
+    }
+}
+
 fn run_socket_command(request: Value) {
     match send_socket_command(request) {
         Ok(response) => {
@@ -465,6 +534,10 @@ fn handle_hook(status: &str) {
         Ok(v) => v,
         Err(_) => return,
     };
+
+    if status == "idle" && data.get("stop_hook_active").and_then(|v| v.as_bool()).unwrap_or(false) {
+        return;
+    }
 
     let sid = match data.get("session_id").and_then(|s| s.as_str()) {
         Some(s) if !s.is_empty() => s.to_string(),
@@ -507,6 +580,22 @@ fn handle_hook(status: &str) {
         }
         if let Some(msg) = data.get("message") {
             out["message"] = msg.clone();
+        }
+    }
+
+    if status == "idle" {
+        if let Some(path) =
+            data.get("transcript_path").and_then(|s| s.as_str()).filter(|s| !s.is_empty())
+        {
+            out["transcript_path"] = Value::String(path.to_string());
+            if let Some((query, response)) = extract_transcript_summary(path) {
+                if let Some(query) = query {
+                    out["query"] = Value::String(query);
+                }
+                if let Some(response) = response {
+                    out["response"] = Value::String(response);
+                }
+            }
         }
     }
 
@@ -1002,6 +1091,46 @@ mod tests {
     }
 
     // ── Cli parsing ─────────────────────────────────────────
+
+    #[test]
+    fn transcript_summary_extracts_last_user_prompt_and_assistant_response() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("transcript.jsonl");
+        std::fs::write(
+            &path,
+            r#"{"type":"user","message":{"content":"first prompt"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"first response"}]}}
+{"type":"user","message":{"content":[{"type":"tool_result","content":"ignored"}]}}
+{"type":"user","message":{"content":[{"type":"text","text":"final prompt"}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"final response"}]}}
+"#,
+        )
+        .unwrap();
+
+        let (query, response) = extract_transcript_summary(path.to_str().unwrap()).unwrap();
+        assert_eq!(query.as_deref(), Some("final prompt"));
+        assert_eq!(response.as_deref(), Some("final response"));
+    }
+
+    #[test]
+    fn transcript_summary_truncates_long_text() {
+        let long = "x".repeat(250);
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("transcript.jsonl");
+        std::fs::write(
+            &path,
+            format!(
+                r#"{{"type":"user","message":{{"content":{long:?}}}}}
+"#
+            ),
+        )
+        .unwrap();
+
+        let (query, _) = extract_transcript_summary(path.to_str().unwrap()).unwrap();
+        let query = query.unwrap();
+        assert_eq!(query.chars().count(), 200);
+        assert!(query.ends_with("..."));
+    }
 
     #[test]
     fn cli_parses_app_with_default_path() {

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -1,7 +1,7 @@
 use clap::{Args, Parser, Subcommand};
 use serde_json::Value;
 use std::fs;
-use std::io::Read;
+use std::io::{BufRead, BufReader, Read};
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -468,12 +468,13 @@ fn truncate_summary(s: String) -> String {
 }
 
 fn extract_transcript_summary(path: &str) -> Option<(Option<String>, Option<String>)> {
-    let content = fs::read_to_string(path).ok()?;
+    let file = fs::File::open(path).ok()?;
+    let reader = BufReader::new(file);
     let mut query = None;
     let mut response = None;
 
-    for line in content.lines() {
-        let Ok(entry) = serde_json::from_str::<Value>(line) else {
+    for line in reader.lines().map_while(Result::ok) {
+        let Ok(entry) = serde_json::from_str::<Value>(&line) else {
             continue;
         };
         let entry_type = entry.get("type").and_then(|v| v.as_str());

--- a/src-tauri/src/hooks.rs
+++ b/src-tauri/src/hooks.rs
@@ -209,6 +209,16 @@ fn roux_hooks_config(cli_path: &Path) -> Value {
                     ]
                 }
             ],
+            "PostToolUse": [
+                {
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": hook_command(cli_path, "working")
+                        }
+                    ]
+                }
+            ],
             "StopFailure": [
                 {
                     "hooks": [
@@ -475,6 +485,18 @@ mod tests {
         let cli_path = Path::new("C:\\Program Files\\Roux\\roux-cli.exe");
         let settings = roux_hooks_config(cli_path);
         assert!(hook_config_contains_expected_entries(&settings, &roux_hooks_config(cli_path)));
+    }
+
+    #[test]
+    fn hook_config_marks_post_tool_use_as_working() {
+        let cli_path = Path::new("/Applications/Roux.app/Contents/MacOS/roux-cli");
+        let settings = roux_hooks_config(cli_path);
+        let entries = settings["hooks"]["PostToolUse"].as_array().unwrap();
+        assert_eq!(entries.len(), 1);
+        assert!(hook_entry_contains_command(
+            &entries[0],
+            "/Applications/Roux.app/Contents/MacOS/roux-cli hook working"
+        ));
     }
 
     #[test]

--- a/src-tauri/src/notifications/osc_parser.rs
+++ b/src-tauri/src/notifications/osc_parser.rs
@@ -85,11 +85,12 @@ impl OscState {
         // `rest` is everything after the "9;" prefix; join with ';' to
         // preserve any literal semicolons in the user's message.
         let raw = join_params(rest);
-        if raw.trim().is_empty() {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("osc 9") {
             return;
         }
 
-        if let Some(parsed) = parse_osc9_payload(&raw) {
+        if let Some(parsed) = parse_osc9_payload(trimmed) {
             self.push(
                 NotificationSource::Osc { code: 9, sender_id: None },
                 parsed.title,
@@ -100,7 +101,13 @@ impl OscState {
             return;
         }
 
-        self.push(NotificationSource::Osc { code: 9, sender_id: None }, raw, None, None, None);
+        self.push(
+            NotificationSource::Osc { code: 9, sender_id: None },
+            trimmed.to_string(),
+            None,
+            None,
+            None,
+        );
     }
 
     fn handle_osc_777(&mut self, rest: &[&[u8]]) {
@@ -303,15 +310,15 @@ fn parse_osc9_payload(raw: &str) -> Option<ParsedOsc9Payload> {
             let subtitle = first_string(&obj, &["subtitle", "subTitle"]);
             let title = first_string(&obj, &["title", "summary", "subject"]);
             let detail = first_string(&obj, &["detail", "details"]);
-            let message =
-                first_string(&obj, &["body", "message", "text"]).or_else(|| detail.clone());
+            let message = first_string(&obj, &["body", "message", "text"]);
 
             let final_title = title
                 .clone()
-                .or_else(|| detail.as_ref().map(|_| "Terminal notification".to_string()))
-                .or_else(|| message.clone())?;
+                .or_else(|| message.clone())
+                .or_else(|| detail.as_ref().map(|_| "Terminal notification".to_string()))?;
             let body = match message {
-                Some(m) if detail.is_some() || (title.is_some() && m != final_title) => Some(m),
+                _ if detail.is_some() => detail,
+                Some(m) if title.is_some() && m != final_title => Some(m),
                 _ => None,
             };
 
@@ -391,6 +398,14 @@ mod tests {
         let parsed = parse_osc9_payload(r#"{"detail":"Claude needs attention"}"#).unwrap();
         assert_eq!(parsed.title, "Terminal notification");
         assert_eq!(parsed.body.as_deref(), Some("Claude needs attention"));
+    }
+
+    #[test]
+    fn osc_9_json_detail_wins_body_when_message_is_present() {
+        let parsed =
+            parse_osc9_payload(r#"{"message":"Build failed","detail":"exit code 1"}"#).unwrap();
+        assert_eq!(parsed.title, "Build failed");
+        assert_eq!(parsed.body.as_deref(), Some("exit code 1"));
     }
 
     #[test]

--- a/src-tauri/src/notifications/osc_parser.rs
+++ b/src-tauri/src/notifications/osc_parser.rs
@@ -306,13 +306,10 @@ fn parse_osc9_payload(raw: &str) -> Option<ParsedOsc9Payload> {
             let message =
                 first_string(&obj, &["body", "message", "text"]).or_else(|| detail.clone());
 
-            let Some(final_title) = title
+            let final_title = title
                 .clone()
                 .or_else(|| detail.as_ref().map(|_| "Terminal notification".to_string()))
-                .or_else(|| message.clone())
-            else {
-                return None;
-            };
+                .or_else(|| message.clone())?;
             let body = match message {
                 Some(m) if detail.is_some() || (title.is_some() && m != final_title) => Some(m),
                 _ => None,

--- a/src-tauri/src/notifications/osc_parser.rs
+++ b/src-tauri/src/notifications/osc_parser.rs
@@ -287,6 +287,9 @@ fn parse_osc9_payload(raw: &str) -> Option<ParsedOsc9Payload> {
     if trimmed.is_empty() {
         return None;
     }
+    if trimmed.eq_ignore_ascii_case("osc 9") {
+        return None;
+    }
 
     match serde_json::from_str::<Value>(trimmed).ok()? {
         Value::String(s) => {
@@ -299,11 +302,19 @@ fn parse_osc9_payload(raw: &str) -> Option<ParsedOsc9Payload> {
         Value::Object(obj) => {
             let subtitle = first_string(&obj, &["subtitle", "subTitle"]);
             let title = first_string(&obj, &["title", "summary", "subject"]);
-            let message = first_string(&obj, &["body", "message", "text", "detail", "details"]);
+            let detail = first_string(&obj, &["detail", "details"]);
+            let message =
+                first_string(&obj, &["body", "message", "text"]).or_else(|| detail.clone());
 
-            let final_title = title.clone().or_else(|| message.clone())?;
-            let body = match (title.is_some(), message) {
-                (true, Some(m)) if m != final_title => Some(m),
+            let Some(final_title) = title
+                .clone()
+                .or_else(|| detail.as_ref().map(|_| "Terminal notification".to_string()))
+                .or_else(|| message.clone())
+            else {
+                return None;
+            };
+            let body = match message {
+                Some(m) if detail.is_some() || (title.is_some() && m != final_title) => Some(m),
                 _ => None,
             };
 
@@ -370,6 +381,19 @@ mod tests {
         let captured = parse(seq);
         assert_eq!(captured.len(), 1);
         assert_eq!(captured[0][2], b"hello");
+    }
+
+    #[test]
+    fn osc_9_protocol_only_payload_is_ignored() {
+        assert_eq!(parse_osc9_payload("osc 9"), None);
+        assert_eq!(parse_osc9_payload(" OSC 9 "), None);
+    }
+
+    #[test]
+    fn osc_9_json_detail_without_title_becomes_body() {
+        let parsed = parse_osc9_payload(r#"{"detail":"Claude needs attention"}"#).unwrap();
+        assert_eq!(parsed.title, "Terminal notification");
+        assert_eq!(parsed.body.as_deref(), Some("Claude needs attention"));
     }
 
     #[test]

--- a/src/lib/components/NotificationsPane.svelte
+++ b/src/lib/components/NotificationsPane.svelte
@@ -66,7 +66,7 @@
       case "watch": return "watch";
       case "task": return "task";
       case "cli": return "cli";
-      case "osc": return `osc ${source.code}`;
+      case "osc": return source.code === 9 ? "terminal" : `osc ${source.code}`;
       case "internal": return "roux";
     }
   }

--- a/src/lib/panes/__tests__/agentNotifications.test.ts
+++ b/src/lib/panes/__tests__/agentNotifications.test.ts
@@ -88,6 +88,30 @@ describe("agentNotifications", () => {
     expect(request.actions[0].kind).toEqual({ type: "focusPane", paneId: "pane-1" });
   });
 
+  it("includes Claude Stop transcript summaries when present", async () => {
+    updateAgentState("pane-1", {
+      provider: "claude",
+      status: "generating",
+      source: "hook",
+    });
+    updateAgentState("pane-1", {
+      provider: "claude",
+      status: "idle",
+      completionSummary: {
+        query: "update the notifications",
+        response: "notifications now include summaries",
+      },
+      source: "hook",
+    });
+    await waitTick();
+
+    expect(notificationsPush).toHaveBeenCalledTimes(1);
+    const request = vi.mocked(notificationsPush).mock.calls[0][0];
+    expect(request.body).toBe(
+      "Prompt: update the notifications\nResponse: notifications now include summaries",
+    );
+  });
+
   it("fires once per pane — two panes finishing in the same session produces two notifications", async () => {
     updateAgentState("pane-a", {
       provider: "claude",

--- a/src/lib/panes/__tests__/agentState.test.ts
+++ b/src/lib/panes/__tests__/agentState.test.ts
@@ -93,6 +93,30 @@ describe("agentState store", () => {
       });
       expect(get(agentStates).get("pane-1")?.permissionInfo?.toolName).toBe("Bash");
     });
+
+    it("does not carry a stale completionSummary into later events", () => {
+      updateAgentState("pane-1", {
+        provider: "claude",
+        status: "idle",
+        completionSummary: { query: "old prompt", response: "old response" },
+        source: "hook",
+      });
+      expect(get(agentStates).get("pane-1")?.completionSummary?.query).toBe("old prompt");
+
+      updateAgentState("pane-1", {
+        provider: "claude",
+        status: "generating",
+        source: "hook",
+      });
+      expect(get(agentStates).get("pane-1")?.completionSummary).toBeUndefined();
+
+      updateAgentState("pane-1", {
+        provider: "claude",
+        status: "idle",
+        source: "hook",
+      });
+      expect(get(agentStates).get("pane-1")?.completionSummary).toBeUndefined();
+    });
   });
 
   describe("clearPermissionInfo", () => {

--- a/src/lib/panes/__tests__/statusRouting.test.ts
+++ b/src/lib/panes/__tests__/statusRouting.test.ts
@@ -19,6 +19,8 @@ function ev(partial: Partial<StatusUpdate> = {}): StatusUpdate {
     toolName: null,
     toolInput: null,
     message: null,
+    query: null,
+    response: null,
     ...partial,
   };
 }
@@ -148,6 +150,23 @@ describe("routeStatusUpdate", () => {
       toolName: "Edit",
       toolInput: { file: "README.md" },
       message: "Allow tool use?",
+    });
+  });
+
+  it("builds completionSummary from Stop transcript fields", () => {
+    const routing = routeStatusUpdate(
+      ev({
+        status: "idle",
+        query: "make it work",
+        response: "done",
+      }),
+      trustAll,
+    );
+    expect(routing.kind).toBe("pane");
+    if (routing.kind !== "pane") throw new Error("unreachable");
+    expect(routing.event.completionSummary).toEqual({
+      query: "make it work",
+      response: "done",
     });
   });
 });

--- a/src/lib/panes/agentNotifications.ts
+++ b/src/lib/panes/agentNotifications.ts
@@ -87,7 +87,7 @@ async function fireCompletionNotification(
   const instance = get(paneInstances).get(paneId);
   const profile = resolveProfileRef(instance?.spawnProfileRef);
   const title = deriveTitle(instance?.name, profile?.name, state.provider);
-  const body = `${capitalize(state.provider)} finished generating.`;
+  const body = deriveBody(state);
 
   try {
     await notificationsPush({
@@ -127,6 +127,21 @@ function deriveTitle(
   if (paneName) return `${paneName} is idle`;
   if (profileName) return `${profileName} is idle`;
   return `${capitalize(provider)} is idle`;
+}
+
+function deriveBody(state: AgentState): string {
+  const query = state.completionSummary?.query;
+  const response = state.completionSummary?.response;
+  if (query && response) {
+    return `Prompt: ${query}\nResponse: ${response}`;
+  }
+  if (query) {
+    return `Prompt: ${query}`;
+  }
+  if (response) {
+    return `Response: ${response}`;
+  }
+  return `${capitalize(state.provider)} finished generating.`;
 }
 
 function capitalize(s: string): string {

--- a/src/lib/panes/agentState.ts
+++ b/src/lib/panes/agentState.ts
@@ -79,7 +79,7 @@ export function updateAgentState(paneId: string, event: AgentStateEvent): void {
       provider: event.provider,
       status: event.status,
       permissionInfo: event.permissionInfo ?? prev?.permissionInfo,
-      completionSummary: event.completionSummary ?? prev?.completionSummary,
+      completionSummary: event.status === "idle" ? event.completionSummary : undefined,
       providerSessionId: event.providerSessionId ?? prev?.providerSessionId,
       source: event.source,
       updatedAt: Date.now(),

--- a/src/lib/panes/agentState.ts
+++ b/src/lib/panes/agentState.ts
@@ -25,6 +25,11 @@ export interface PermissionInfo {
   message?: string;
 }
 
+export interface CompletionSummary {
+  query?: string;
+  response?: string;
+}
+
 /**
  * Runtime-only view of what an agent is doing in a particular pane. Never
  * persisted — entries are populated by incoming hook / OSC / `roux notify`
@@ -34,6 +39,7 @@ export interface AgentState {
   provider: Provider;
   status: AgentStatus;
   permissionInfo?: PermissionInfo;
+  completionSummary?: CompletionSummary;
   providerSessionId?: string;
   /** Which event stream set this state last — useful for tracing. */
   source: "hook" | "osc" | "notify";
@@ -54,6 +60,7 @@ export interface AgentStateEvent {
   provider: Provider;
   status: AgentStatus;
   permissionInfo?: PermissionInfo;
+  completionSummary?: CompletionSummary;
   providerSessionId?: string;
   source: AgentState["source"];
 }
@@ -72,6 +79,7 @@ export function updateAgentState(paneId: string, event: AgentStateEvent): void {
       provider: event.provider,
       status: event.status,
       permissionInfo: event.permissionInfo ?? prev?.permissionInfo,
+      completionSummary: event.completionSummary ?? prev?.completionSummary,
       providerSessionId: event.providerSessionId ?? prev?.providerSessionId,
       source: event.source,
       updatedAt: Date.now(),

--- a/src/lib/panes/statusRouting.ts
+++ b/src/lib/panes/statusRouting.ts
@@ -107,6 +107,7 @@ export function routeStatusUpdate(
       provider,
       status: routed,
       permissionInfo,
+      completionSummary: buildCompletionSummary(update),
       providerSessionId: update.providerSessionId ?? undefined,
       source: "hook",
     },
@@ -163,5 +164,15 @@ function buildPermissionInfo(update: StatusUpdate): PermissionInfo | undefined {
     toolName: update.toolName ?? undefined,
     toolInput: (update.toolInput as Record<string, unknown> | null) ?? undefined,
     message: update.message ?? undefined,
+  };
+}
+
+function buildCompletionSummary(update: StatusUpdate): { query?: string; response?: string } | undefined {
+  const query = update.query?.trim();
+  const response = update.response?.trim();
+  if (!query && !response) return undefined;
+  return {
+    query: query || undefined,
+    response: response || undefined,
   };
 }

--- a/src/lib/panes/statusRouting.ts
+++ b/src/lib/panes/statusRouting.ts
@@ -1,6 +1,11 @@
 import { get } from "svelte/store";
 import type { StatusUpdate } from "$lib/tauri";
-import { updateAgentState, type AgentStateEvent, type PermissionInfo } from "./agentState";
+import {
+  updateAgentState,
+  type AgentStateEvent,
+  type CompletionSummary,
+  type PermissionInfo,
+} from "./agentState";
 import { sessionLayouts, collectLeafIds } from "./layout";
 import type { Provider } from "./profiles";
 
@@ -167,7 +172,7 @@ function buildPermissionInfo(update: StatusUpdate): PermissionInfo | undefined {
   };
 }
 
-function buildCompletionSummary(update: StatusUpdate): { query?: string; response?: string } | undefined {
+function buildCompletionSummary(update: StatusUpdate): CompletionSummary | undefined {
   const query = update.query?.trim();
   const response = update.response?.trim();
   if (!query && !response) return undefined;

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -541,6 +541,10 @@ export interface StatusUpdate {
   toolName: string | null;
   toolInput: Record<string, any> | null;
   message: string | null;
+  /** Last human prompt extracted from Claude's transcript on Stop, when available. */
+  query: string | null;
+  /** Last assistant response extracted from Claude's transcript on Stop, when available. */
+  response: string | null;
 }
 
 export function onRouxStatusUpdate(


### PR DESCRIPTION
## Summary

- Add the Claude `PostToolUse` hook to Roux's installed hook config so completed tool calls move pane state back to working/generating.
- Extract Claude Stop transcript prompt/response summaries and carry them through status routing into completion notifications.
- Improve OSC 9 terminal notifications by ignoring protocol-only `osc 9`, labeling OSC 9 as terminal in the UI, and surfacing JSON `detail`/`details` as notification body text.

## Why

Warp's Claude Code integration uses Claude hooks to keep terminal session state current and to provide richer task-complete notifications. Roux already has its own hook/status/notification pipeline, so this adapts the useful behavior into that pipeline instead of adding Warp's OSC transport.

## Validation

- `npm run test`
- `npm run check`
- `CI=1 cargo test --manifest-path src-tauri/Cargo.toml hook_config_marks_post_tool_use_as_working`
- `CI=1 cargo test --manifest-path src-tauri/Cargo.toml transcript_summary`
- `CI=1 cargo test --manifest-path src-tauri/Cargo.toml parse_payload_extracts_all_tier1_fields`
- `CI=1 cargo test --manifest-path src-tauri/Cargo.toml osc_9_`

Note: `CI=1` is used for focused Rust tests so the Tauri build script creates the ignored sidecar placeholder required by externalBin validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Idle hook enriches status with recent transcript data (query and response) when available.
  * Agent completion notifications now include the generated prompt and response.
  * Added a PostToolUse hook event to hook configuration.

* **Bug Fixes**
  * Terminal (OSC) notifications handle protocol-only payloads and show clearer "terminal" labeling for OSC code 9.

* **Tests**
  * Added unit tests covering transcript extraction, notification formatting, and OSC parsing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->