### PR TITLE
[codex] Clean up integration shell resolution

### DIFF
--- a/crates/roux-core/src/models/settings.rs
+++ b/crates/roux-core/src/models/settings.rs
@@ -214,6 +214,11 @@ pub struct RouxSettings {
     /// when nothing is found.
     #[serde(default)]
     pub worktrunk_binary_path: Option<String>,
+    /// Absolute path to the shell binary for terminal panes and login-shell
+    /// PATH discovery. When set and non-empty, overrides automatic resolution
+    /// from the OS login shell, then $SHELL.
+    #[serde(default)]
+    pub shell_binary_path: Option<String>,
     /// Which backend Roux uses to create worktrees. Default `Auto` prefers
     /// `wt` when available and falls back to git when not.
     #[serde(default)]
@@ -333,6 +338,7 @@ impl Default for RouxSettings {
             gh_binary_path: None,
             git_binary_path: None,
             worktrunk_binary_path: None,
+            shell_binary_path: None,
             worktree_provider: WorktreeProvider::default(),
             additional_flags: Vec::new(),
             task_panel_split: 0.5,

--- a/crates/roux-git/src/lib.rs
+++ b/crates/roux-git/src/lib.rs
@@ -25,6 +25,10 @@ impl GitCli {
         Self { git_bin: path.into() }
     }
 
+    pub fn git_bin(&self) -> &Path {
+        &self.git_bin
+    }
+
     pub fn clone_repo(
         &self,
         url: &str,

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -16,6 +16,7 @@ pub(crate) fn update_settings(
     app: tauri::AppHandle,
 ) -> Result<(), String> {
     let settings = svc::update_settings(settings).map_err(|e| e.to_string())?;
+    crate::pty::set_shell_binary_path_override(settings.shell_binary_path.clone());
     *state.settings.lock().unwrap() = settings.clone();
     app.emit("settings-changed", &settings).map_err(|e| e.to_string())
 }

--- a/src-tauri/src/commands/setup.rs
+++ b/src-tauri/src/commands/setup.rs
@@ -2,6 +2,13 @@ use crate::services::setup as svc;
 
 #[derive(serde::Serialize, specta::Type)]
 #[serde(rename_all = "camelCase")]
+pub(crate) struct IntegrationDetection {
+    binary_path: Option<String>,
+    version: Option<String>,
+}
+
+#[derive(serde::Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
 pub(crate) struct SetupStatus {
     cli_installed: bool,
     gh_available: bool,
@@ -10,10 +17,7 @@ pub(crate) struct SetupStatus {
 #[tauri::command]
 #[specta::specta]
 pub(crate) fn check_setup_status() -> SetupStatus {
-    SetupStatus {
-        cli_installed: svc::is_cli_installed(),
-        gh_available: svc::is_gh_available(),
-    }
+    SetupStatus { cli_installed: svc::is_cli_installed(), gh_available: svc::is_gh_available() }
 }
 
 #[tauri::command]
@@ -168,4 +172,32 @@ pub(crate) fn install_all_missing() -> Result<(), String> {
         svc::install_skill().map_err(|e| e.to_string())?;
     }
     Ok(())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub(crate) async fn cmd_detect_gh() -> IntegrationDetection {
+    tauri::async_runtime::spawn_blocking(|| {
+        let result = crate::services::setup::detect_gh();
+        IntegrationDetection {
+            binary_path: result.as_ref().map(|(p, _)| p.clone()),
+            version: result.map(|(_, v)| v),
+        }
+    })
+    .await
+    .unwrap_or(IntegrationDetection { binary_path: None, version: None })
+}
+
+#[tauri::command]
+#[specta::specta]
+pub(crate) async fn cmd_detect_git() -> IntegrationDetection {
+    tauri::async_runtime::spawn_blocking(|| {
+        let result = crate::services::setup::detect_git();
+        IntegrationDetection {
+            binary_path: result.as_ref().map(|(p, _)| p.clone()),
+            version: result.map(|(_, v)| v),
+        }
+    })
+    .await
+    .unwrap_or(IntegrationDetection { binary_path: None, version: None })
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -56,6 +56,7 @@ fn main() {
     paths::migrate_legacy_config_dir();
 
     let initial_settings = settings::load_settings();
+    pty::set_shell_binary_path_override(initial_settings.shell_binary_path.clone());
     logging::init(initial_settings.enable_logging);
     rlog!("Settings loaded from {:?}", paths::roux_config_dir().join("settings.json"));
     if let Some(ref p) = initial_settings.claude_binary_path {
@@ -289,6 +290,8 @@ fn main() {
             commands::setup::reinstall_hooks,
             commands::setup::reinstall_skill,
             commands::setup::install_all_missing,
+            commands::setup::cmd_detect_gh,
+            commands::setup::cmd_detect_git,
             commands::pr::check_gh_installed,
             commands::pr::lookup_pr,
             commands::pr::fetch_pr_branch,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -137,6 +137,8 @@ fn main() {
         commands::setup::reinstall_hooks,
         commands::setup::reinstall_skill,
         commands::setup::install_all_missing,
+        commands::setup::cmd_detect_gh,
+        commands::setup::cmd_detect_git,
         commands::pr::check_gh_installed,
         commands::pr::lookup_pr,
         commands::pr::fetch_pr_branch,

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -1683,8 +1683,13 @@ fn get_user_path_impl() -> String {
 }
 
 fn resolve_default_shell() -> String {
+    let shell_binary_path = shell_binary_path_override();
+
     #[cfg(windows)]
     {
+        if let Some(shell) = shell_binary_path {
+            return shell;
+        }
         if platform::find_executable_on_path("pwsh").is_some()
             || platform::find_executable_on_path("pwsh.exe").is_some()
         {
@@ -1698,13 +1703,37 @@ fn resolve_default_shell() -> String {
 
     #[cfg(not(windows))]
     {
-        let settings = crate::settings::load_settings();
         resolve_default_shell_from_sources(
-            settings.shell_binary_path.as_deref(),
+            shell_binary_path.as_deref(),
             login_shell_for_current_user().as_deref(),
             std::env::var("SHELL").ok().as_deref(),
         )
     }
+}
+
+pub(crate) fn set_shell_binary_path_override(path: Option<String>) {
+    let cache = shell_binary_path_cache();
+    *cache.lock().unwrap() = Some(path.as_deref().and_then(nonempty_trimmed).map(str::to_string));
+}
+
+fn shell_binary_path_override() -> Option<String> {
+    let cache = shell_binary_path_cache();
+    let mut guard = cache.lock().unwrap();
+    if guard.is_none() {
+        *guard = Some(
+            crate::settings::load_settings()
+                .shell_binary_path
+                .as_deref()
+                .and_then(nonempty_trimmed)
+                .map(str::to_string),
+        );
+    }
+    guard.clone().flatten()
+}
+
+fn shell_binary_path_cache() -> &'static Mutex<Option<Option<String>>> {
+    static CACHE: std::sync::OnceLock<Mutex<Option<Option<String>>>> = std::sync::OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(None))
 }
 
 #[cfg(not(windows))]
@@ -1721,7 +1750,6 @@ fn resolve_default_shell_from_sources(
         .to_string()
 }
 
-#[cfg(not(windows))]
 fn nonempty_trimmed(value: &str) -> Option<&str> {
     let trimmed = value.trim();
     (!trimmed.is_empty()).then_some(trimmed)

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -1641,8 +1641,9 @@ fn apply_notes_env(cmd: &mut CommandBuilder, n: &NotesEnvInputs) {
     // so shell idioms like `${ROUX_SESSION_PROJECT:-no-project}` work.
 }
 
-/// Get the user's login shell PATH by invoking their actual shell (from $SHELL)
-/// instead of hardcoding /bin/bash. This ensures paths added in .zshrc etc. are found.
+/// Get the user's login shell PATH by invoking the same shell Roux would use
+/// for terminal panes. This keeps Homebrew and other shell-managed prefixes
+/// visible to GUI launches.
 pub fn get_user_path() -> String {
     get_user_path_impl()
 }
@@ -1654,7 +1655,7 @@ fn get_user_path_impl() -> String {
 
 #[cfg(not(windows))]
 fn get_user_path_impl() -> String {
-    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
+    let shell = resolve_default_shell();
     // Fish outputs $PATH as a space-separated list; other shells use colons.
     // Use fish's `string join` to get colon-separated output.
     let path_cmd = if shell.contains("fish") { "string join : $PATH" } else { "echo $PATH" };
@@ -1697,7 +1698,64 @@ fn resolve_default_shell() -> String {
 
     #[cfg(not(windows))]
     {
-        std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string())
+        let settings = crate::settings::load_settings();
+        resolve_default_shell_from_sources(
+            settings.shell_binary_path.as_deref(),
+            login_shell_for_current_user().as_deref(),
+            std::env::var("SHELL").ok().as_deref(),
+        )
+    }
+}
+
+#[cfg(not(windows))]
+fn resolve_default_shell_from_sources(
+    setting_shell: Option<&str>,
+    login_shell: Option<&str>,
+    env_shell: Option<&str>,
+) -> String {
+    setting_shell
+        .and_then(nonempty_trimmed)
+        .or_else(|| login_shell.and_then(nonempty_trimmed))
+        .or_else(|| env_shell.and_then(nonempty_trimmed))
+        .unwrap_or("/bin/zsh")
+        .to_string()
+}
+
+#[cfg(not(windows))]
+fn nonempty_trimmed(value: &str) -> Option<&str> {
+    let trimmed = value.trim();
+    (!trimmed.is_empty()).then_some(trimmed)
+}
+
+#[cfg(unix)]
+fn login_shell_for_current_user() -> Option<String> {
+    let uid = unsafe { libc::getuid() };
+    let mut result: *mut libc::passwd = std::ptr::null_mut();
+    let mut buf_size = unsafe { libc::sysconf(libc::_SC_GETPW_R_SIZE_MAX) };
+    if buf_size < 1024 {
+        buf_size = 16 * 1024;
+    }
+    let mut buf = vec![0 as libc::c_char; buf_size as usize];
+
+    loop {
+        let mut passwd = std::mem::MaybeUninit::<libc::passwd>::zeroed();
+        let rc = unsafe {
+            libc::getpwuid_r(uid, passwd.as_mut_ptr(), buf.as_mut_ptr(), buf.len(), &mut result)
+        };
+        if rc == libc::ERANGE {
+            buf.resize(buf.len() * 2, 0);
+            continue;
+        }
+        if rc != 0 || result.is_null() {
+            return None;
+        }
+
+        let passwd = unsafe { passwd.assume_init() };
+        if passwd.pw_shell.is_null() {
+            return None;
+        }
+        let shell = unsafe { std::ffi::CStr::from_ptr(passwd.pw_shell) };
+        return shell.to_str().ok().and_then(nonempty_trimmed).map(str::to_string);
     }
 }
 
@@ -1818,6 +1876,38 @@ mod tests {
             "PATH should contain standard bin directories, got: {}",
             path
         );
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn default_shell_prefers_explicit_setting_over_login_shell_and_env() {
+        let shell = resolve_default_shell_from_sources(
+            Some(" /custom/fish "),
+            Some("/bin/zsh"),
+            Some("/bin/bash"),
+        );
+
+        assert_eq!(shell, "/custom/fish");
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn default_shell_prefers_login_shell_over_env_shell() {
+        let shell = resolve_default_shell_from_sources(
+            None,
+            Some("/opt/homebrew/bin/fish"),
+            Some("/bin/zsh"),
+        );
+
+        assert_eq!(shell, "/opt/homebrew/bin/fish");
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn default_shell_uses_env_shell_when_login_shell_is_unavailable() {
+        let shell = resolve_default_shell_from_sources(None, None, Some("/bin/bash"));
+
+        assert_eq!(shell, "/bin/bash");
     }
 
     #[test]

--- a/src-tauri/src/services/setup.rs
+++ b/src-tauri/src/services/setup.rs
@@ -2,6 +2,32 @@ pub(crate) fn is_command_available(command: &str) -> bool {
     crate::platform::find_executable_on_path(command).is_some()
 }
 
+fn nonempty_path(value: Option<&str>) -> Option<String> {
+    value.map(str::trim).filter(|s| !s.is_empty()).map(str::to_string)
+}
+
+fn login_shell_path() -> Option<&'static str> {
+    use std::sync::OnceLock;
+    static CACHED: OnceLock<String> = OnceLock::new();
+    let path = CACHED.get_or_init(crate::pty::get_user_path);
+    (!path.is_empty()).then_some(path.as_str())
+}
+
+fn find_binary_via_login_shell(binary: &str) -> Option<String> {
+    let path = login_shell_path()?;
+    crate::platform::find_executable_in_paths(path, binary).map(|p| p.to_string_lossy().to_string())
+}
+
+fn find_binary_on_process_path(binary: &str) -> Option<String> {
+    crate::platform::find_executable_on_path(binary).map(|p| p.to_string_lossy().to_string())
+}
+
+fn resolve_binary_path(binary: &str, override_path: Option<String>) -> Option<String> {
+    override_path
+        .or_else(|| find_binary_via_login_shell(binary))
+        .or_else(|| find_binary_on_process_path(binary))
+}
+
 /// Resolve the `gh` binary Roux should invoke.
 ///
 /// Precedence:
@@ -12,16 +38,7 @@ pub(crate) fn is_command_available(command: &str) -> bool {
 ///   3. Process `PATH` (minimal on macOS GUI launches, but fine for CLI-dev).
 ///   4. Bare `"gh"` — lets `Command::new` error naturally.
 pub(crate) fn gh_command() -> String {
-    if let Some(path) = gh_override_path() {
-        return path;
-    }
-    if let Some(path) = find_gh_via_login_shell() {
-        return path;
-    }
-    if let Some(path) = crate::platform::find_executable_on_path("gh") {
-        return path.to_string_lossy().to_string();
-    }
-    "gh".to_string()
+    resolve_binary_path("gh", gh_override_path()).unwrap_or_else(|| "gh".to_string())
 }
 
 /// Resolve the `git` binary Roux should invoke for native git operations.
@@ -38,34 +55,14 @@ pub(crate) fn git_cli() -> roux_git::GitCli {
     if let Some(path) = std::env::var_os("ROUX_GIT").filter(|path| !path.is_empty()) {
         return roux_git::GitCli::new(path);
     }
-    if let Some(path) = find_git_via_login_shell() {
+    if let Some(path) = find_binary_via_login_shell("git") {
         return roux_git::GitCli::new(path);
     }
     roux_git::GitCli::default()
 }
 
 fn git_override_path() -> Option<String> {
-    crate::settings::load_settings()
-        .git_binary_path
-        .as_deref()
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(|s| s.to_string())
-}
-
-fn find_git_via_login_shell() -> Option<String> {
-    use std::sync::OnceLock;
-    static CACHED: OnceLock<Option<String>> = OnceLock::new();
-    CACHED
-        .get_or_init(|| {
-            let path = crate::pty::get_user_path();
-            if path.is_empty() {
-                return None;
-            }
-            crate::platform::find_executable_in_paths(path.as_str(), "git")
-                .map(|p| p.to_string_lossy().to_string())
-        })
-        .clone()
+    nonempty_path(crate::settings::load_settings().git_binary_path.as_deref())
 }
 
 /// True iff a usable `gh` can be found via any of the resolution steps in
@@ -74,35 +71,11 @@ pub(crate) fn is_gh_available() -> bool {
     if let Some(path) = gh_override_path() {
         return std::path::Path::new(&path).is_file();
     }
-    find_gh_via_login_shell().is_some() || is_command_available("gh")
+    find_binary_via_login_shell("gh").is_some() || is_command_available("gh")
 }
 
 fn gh_override_path() -> Option<String> {
-    crate::settings::load_settings()
-        .gh_binary_path
-        .as_deref()
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(|s| s.to_string())
-}
-
-fn find_gh_via_login_shell() -> Option<String> {
-    use std::sync::OnceLock;
-    // Cache the login-shell PATH lookup — `pty::get_user_path` spawns a
-    // shell and costs tens of ms. Cache the *resolved gh path*, not just
-    // the PATH, so we pay the lookup once per process. If the user moves
-    // gh mid-session, restart Roux.
-    static CACHED: OnceLock<Option<String>> = OnceLock::new();
-    CACHED
-        .get_or_init(|| {
-            let path = crate::pty::get_user_path();
-            if path.is_empty() {
-                return None;
-            }
-            crate::platform::find_executable_in_paths(path.as_str(), "gh")
-                .map(|p| p.to_string_lossy().to_string())
-        })
-        .clone()
+    nonempty_path(crate::settings::load_settings().gh_binary_path.as_deref())
 }
 
 /// Resolve the `wt` (worktrunk) binary as a typed `WtBinary`.
@@ -116,35 +89,46 @@ fn find_gh_via_login_shell() -> Option<String> {
 /// or the resolved version is below `roux_worktrunk::MIN_WT_VERSION`. A
 /// caller receiving `None` should fall back to the native git path.
 pub(crate) fn resolve_wt_binary() -> Option<roux_worktrunk::WtBinary> {
-    let override_path = crate::settings::load_settings()
-        .worktrunk_binary_path
-        .as_deref()
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(str::to_string);
+    let override_path =
+        nonempty_path(crate::settings::load_settings().worktrunk_binary_path.as_deref());
 
     if let Some(path) = override_path.as_deref() {
         return roux_worktrunk::detect_wt(Some(path));
     }
-    if let Some(path) = find_wt_via_login_shell() {
+    if let Some(path) = find_binary_via_login_shell("wt") {
         return roux_worktrunk::detect_wt(Some(&path));
     }
     roux_worktrunk::detect_wt(None)
 }
 
-fn find_wt_via_login_shell() -> Option<String> {
-    use std::sync::OnceLock;
-    static CACHED: OnceLock<Option<String>> = OnceLock::new();
-    CACHED
-        .get_or_init(|| {
-            let path = crate::pty::get_user_path();
-            if path.is_empty() {
-                return None;
-            }
-            crate::platform::find_executable_in_paths(path.as_str(), "wt")
-                .map(|p| p.to_string_lossy().to_string())
-        })
-        .clone()
+/// Resolve the `gh` binary and probe its version.
+///
+/// Returns `(binary_path, version_string)` when gh is found and responsive,
+/// `None` otherwise.
+pub(crate) fn detect_gh() -> Option<(String, String)> {
+    if !is_gh_available() {
+        return None;
+    }
+    let path = gh_command();
+    let out = std::process::Command::new(&path).arg("--version").output().ok()?;
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // "gh version 2.60.1 (2024-12-11)"
+    let version = stdout.lines().next()?.split_whitespace().nth(2)?.to_string();
+    Some((path, version))
+}
+
+/// Resolve the `git` binary and probe its version.
+///
+/// Returns `(binary_path, version_string)` when git is found and responsive,
+/// `None` otherwise.
+pub(crate) fn detect_git() -> Option<(String, String)> {
+    let cli = git_cli();
+    let path = cli.git_bin().to_string_lossy().into_owned();
+    let out = std::process::Command::new(&path).arg("--version").output().ok()?;
+    // "git version 2.47.2" or "git version 2.47.2 (Apple Git-148)"
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let version = stdout.lines().next()?.split_whitespace().nth(2)?.to_string();
+    Some((path, version))
 }
 
 /// Resolve the `code` (VS Code) binary Roux should invoke for "Open in Code".
@@ -157,28 +141,7 @@ fn find_wt_via_login_shell() -> Option<String> {
 ///   2. Process `PATH`.
 ///   3. Bare `"code"` — lets `Command::new` error naturally.
 pub(crate) fn code_command() -> String {
-    if let Some(path) = find_code_via_login_shell() {
-        return path;
-    }
-    if let Some(path) = crate::platform::find_executable_on_path("code") {
-        return path.to_string_lossy().to_string();
-    }
-    "code".to_string()
-}
-
-fn find_code_via_login_shell() -> Option<String> {
-    use std::sync::OnceLock;
-    static CACHED: OnceLock<Option<String>> = OnceLock::new();
-    CACHED
-        .get_or_init(|| {
-            let path = crate::pty::get_user_path();
-            if path.is_empty() {
-                return None;
-            }
-            crate::platform::find_executable_in_paths(path.as_str(), "code")
-                .map(|p| p.to_string_lossy().to_string())
-        })
-        .clone()
+    resolve_binary_path("code", None).unwrap_or_else(|| "code".to_string())
 }
 
 pub(crate) fn is_cli_installed() -> bool {

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -208,6 +208,8 @@ export const commands = {
 	reinstallHooks: () => typedError<null, string>(__TAURI_INVOKE("reinstall_hooks")),
 	reinstallSkill: () => typedError<null, string>(__TAURI_INVOKE("reinstall_skill")),
 	installAllMissing: () => typedError<null, string>(__TAURI_INVOKE("install_all_missing")),
+	cmdDetectGh: () => __TAURI_INVOKE<IntegrationDetection>("cmd_detect_gh"),
+	cmdDetectGit: () => __TAURI_INVOKE<IntegrationDetection>("cmd_detect_git"),
 	checkGhInstalled: () => __TAURI_INVOKE<boolean>("check_gh_installed"),
 	lookupPr: (repoPath: string | null, url: string) => typedError<PrInfo, string>(__TAURI_INVOKE("lookup_pr", { repoPath, url })),
 	fetchPrBranch: (repoPath: string, number: number, headRef: string, isCrossRepository: boolean) => typedError<string, string>(__TAURI_INVOKE("fetch_pr_branch", { repoPath, number, headRef, isCrossRepository })),
@@ -417,6 +419,11 @@ export type HookSourceKind = "user" | "project";
 
 // HUD visibility for a tree.
 export type HudMode = { kind: "always" } | { kind: "delayed"; ms: number } | { kind: "never" };
+
+export type IntegrationDetection = {
+	binaryPath: string | null,
+	version: string | null,
+};
 
 export type KeepOpen = "always" | "on-error" | "never";
 
@@ -799,6 +806,12 @@ export type RouxSettings = {
 	 *  when nothing is found.
 	 */
 	worktrunkBinaryPath?: string | null,
+	/**
+	 *  Absolute path to the shell binary for terminal panes and login-shell
+	 *  PATH discovery. When set and non-empty, overrides automatic resolution
+	 *  from the OS login shell, then $SHELL.
+	 */
+	shellBinaryPath?: string | null,
 	/**
 	 *  Which backend Roux uses to create worktrees. Default `Auto` prefers
 	 *  `wt` when available and falls back to git when not.

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -13,11 +13,13 @@
   import { notificationsPush } from "$lib/tauri";
   import { commands } from "$lib/bindings";
   import type {
+    IntegrationDetection,
     OnPaneCloseMode,
     UpdateChannel,
     WorktreeCleanupMode,
     WorktreeDefaultBase,
     WorktreeProvider,
+    WorktrunkDetection,
   } from "$lib/bindings";
   import { updateStatus, runManualCheck, performInstall } from "$lib/stores/updater";
   import { getVersion } from "@tauri-apps/api/app";
@@ -143,56 +145,76 @@
     if (selected) updateSetting("shellBinaryPath", selected as string);
   }
 
-  // Live detection state for integrations. Re-resolved on
-  // panel open and whenever the override path changes.
-  let ghDetection = $state<{ binaryPath: string | null; version: string | null } | null>(null);
-  let gitDetection = $state<{ binaryPath: string | null; version: string | null } | null>(null);
-  let worktrunkDetection = $state<{
-    binaryPath: string | null;
-    version: string | null;
-    hasConfig: boolean;
-  } | null>(null);
+  let ghDetection = $state<IntegrationDetection | null>(null);
+  let gitDetection = $state<IntegrationDetection | null>(null);
+  let worktrunkDetection = $state<WorktrunkDetection | null>(null);
+  let ghDetectionRun = 0;
+  let gitDetectionRun = 0;
+  let worktrunkDetectionRun = 0;
 
-  async function refreshGhDetection() {
+  async function refreshGhDetection(run: number) {
     try {
-      ghDetection = await commands.cmdDetectGh();
+      const result = await commands.cmdDetectGh();
+      if (run === ghDetectionRun) ghDetection = result;
     } catch {
-      ghDetection = { binaryPath: null, version: null };
+      if (run === ghDetectionRun) ghDetection = { binaryPath: null, version: null };
     }
   }
 
-  async function refreshGitDetection() {
+  async function refreshGitDetection(run: number) {
     try {
-      gitDetection = await commands.cmdDetectGit();
+      const result = await commands.cmdDetectGit();
+      if (run === gitDetectionRun) gitDetection = result;
     } catch {
-      gitDetection = { binaryPath: null, version: null };
+      if (run === gitDetectionRun) gitDetection = { binaryPath: null, version: null };
     }
   }
 
-  async function refreshWorktrunkDetection() {
+  async function refreshWorktrunkDetection(run: number) {
     try {
-      worktrunkDetection = await commands.cmdDetectWorktrunk(null);
+      const result = await commands.cmdDetectWorktrunk(null);
+      if (run === worktrunkDetectionRun) worktrunkDetection = result;
     } catch {
-      worktrunkDetection = { binaryPath: null, version: null, hasConfig: false };
+      if (run === worktrunkDetectionRun) {
+        worktrunkDetection = { binaryPath: null, version: null, hasConfig: false };
+      }
     }
   }
 
   $effect(() => {
-    void $settings.ghBinaryPath;
-    void refreshGhDetection();
+    const path = $settings.ghBinaryPath;
+    void path;
+    if (!visible || selected !== "integrations") {
+      ghDetectionRun += 1;
+      return;
+    }
+    const run = ++ghDetectionRun;
+    const timer = setTimeout(() => void refreshGhDetection(run), 250);
+    return () => clearTimeout(timer);
   });
 
   $effect(() => {
-    void $settings.gitBinaryPath;
-    void refreshGitDetection();
+    const path = $settings.gitBinaryPath;
+    void path;
+    if (!visible || selected !== "integrations") {
+      gitDetectionRun += 1;
+      return;
+    }
+    const run = ++gitDetectionRun;
+    const timer = setTimeout(() => void refreshGitDetection(run), 250);
+    return () => clearTimeout(timer);
   });
 
   $effect(() => {
-    // Re-probe whenever the override changes. Tauri's `cmdDetectWorktrunk`
-    // reads the current settings override internally, so a bare re-fetch
-    // is enough.
-    void $settings.worktrunkBinaryPath;
-    void refreshWorktrunkDetection();
+    const path = $settings.worktrunkBinaryPath;
+    void path;
+    if (!visible || selected !== "integrations") {
+      worktrunkDetectionRun += 1;
+      return;
+    }
+    const run = ++worktrunkDetectionRun;
+    const timer = setTimeout(() => void refreshWorktrunkDetection(run), 250);
+    return () => clearTimeout(timer);
   });
 
   async function browseWorktreeBase() {
@@ -757,7 +779,8 @@
                 (for finding <code class="font-mono">gh</code>, <code class="font-mono">git</code>,
                 <code class="font-mono">wt</code>, etc. via Homebrew). Defaults to your OS login shell,
                 then <code class="font-mono">$SHELL</code>. Set this only if auto-detection chooses the
-                wrong shell. Takes effect after restarting Roux.
+                wrong shell. New terminal panes use the updated shell right away; restart Roux if
+                integration PATH discovery needs to be refreshed.
               </div>
               <div class="mt-3 flex items-center justify-between gap-2">
                 <span class="text-[13px]">Binary path</span>
@@ -795,7 +818,6 @@
                 Used for "Session from PR" and PR watches. Roux auto-detects
                 <code class="font-mono">gh</code> via your login shell's PATH (including fish). Set this only if
                 auto-detection misses your install — paste the output of <code class="font-mono">which gh</code>.
-                Takes effect after restarting Roux.
               </div>
               {#if ghDetection?.binaryPath}
                 <div class="mt-2 font-mono text-[10px] text-text-muted">

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -135,13 +135,39 @@
     if (selected) updateSetting("worktrunkBinaryPath", selected as string);
   }
 
-  // Live detection state for the worktrunk subsection. Re-resolved on
+  async function browseShellBinary() {
+    const selected = await open({
+      directory: false,
+      title: "Select Shell Binary",
+    });
+    if (selected) updateSetting("shellBinaryPath", selected as string);
+  }
+
+  // Live detection state for integrations. Re-resolved on
   // panel open and whenever the override path changes.
+  let ghDetection = $state<{ binaryPath: string | null; version: string | null } | null>(null);
+  let gitDetection = $state<{ binaryPath: string | null; version: string | null } | null>(null);
   let worktrunkDetection = $state<{
     binaryPath: string | null;
     version: string | null;
     hasConfig: boolean;
   } | null>(null);
+
+  async function refreshGhDetection() {
+    try {
+      ghDetection = await commands.cmdDetectGh();
+    } catch {
+      ghDetection = { binaryPath: null, version: null };
+    }
+  }
+
+  async function refreshGitDetection() {
+    try {
+      gitDetection = await commands.cmdDetectGit();
+    } catch {
+      gitDetection = { binaryPath: null, version: null };
+    }
+  }
 
   async function refreshWorktrunkDetection() {
     try {
@@ -150,6 +176,16 @@
       worktrunkDetection = { binaryPath: null, version: null, hasConfig: false };
     }
   }
+
+  $effect(() => {
+    void $settings.ghBinaryPath;
+    void refreshGhDetection();
+  });
+
+  $effect(() => {
+    void $settings.gitBinaryPath;
+    void refreshGitDetection();
+  });
 
   $effect(() => {
     // Re-probe whenever the override changes. Tauri's `cmdDetectWorktrunk`
@@ -713,13 +749,59 @@
             </div>
           {:else if selected === "integrations"}
             <div class="rounded-xl border border-border-subtle bg-bg-surface/35 p-3">
-              <div class="text-[13px] font-semibold">GitHub CLI</div>
+              <div class="flex items-center justify-between">
+                <div class="text-[13px] font-semibold">Shell</div>
+              </div>
+              <div class="mt-0.5 text-[11px] text-text-muted">
+                Shell used for terminal panes and login-shell PATH discovery
+                (for finding <code class="font-mono">gh</code>, <code class="font-mono">git</code>,
+                <code class="font-mono">wt</code>, etc. via Homebrew). Defaults to your OS login shell,
+                then <code class="font-mono">$SHELL</code>. Set this only if auto-detection chooses the
+                wrong shell. Takes effect after restarting Roux.
+              </div>
+              <div class="mt-3 flex items-center justify-between gap-2">
+                <span class="text-[13px]">Binary path</span>
+                <div class="flex gap-1">
+                  <input
+                    class="bg-bg-deep border border-border rounded px-2 py-1 font-mono text-xs text-text-primary outline-none w-64 text-right focus:border-accent-dim"
+                    value={$settings.shellBinaryPath ?? ""}
+                    oninput={(e) => updateSetting("shellBinaryPath", e.currentTarget.value || null)}
+                    placeholder="/opt/homebrew/bin/fish"
+                  />
+                  <button
+                    class="px-2 py-1 bg-bg-elevated border border-border rounded text-text-secondary text-[10px] cursor-pointer hover:bg-bg-hover"
+                    onclick={browseShellBinary}
+                  >...</button>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-3 rounded-xl border border-border-subtle bg-bg-surface/35 p-3">
+              <div class="flex items-center justify-between">
+                <div class="text-[13px] font-semibold">GitHub CLI</div>
+                {#if ghDetection?.binaryPath}
+                  <span
+                    class="rounded bg-green/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-green"
+                    >detected{ghDetection.version ? ` ${ghDetection.version}` : ""}</span
+                  >
+                {:else if ghDetection !== null}
+                  <span
+                    class="rounded bg-red/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-red"
+                    >missing</span
+                  >
+                {/if}
+              </div>
               <div class="mt-0.5 text-[11px] text-text-muted">
                 Used for "Session from PR" and PR watches. Roux auto-detects
                 <code class="font-mono">gh</code> via your login shell's PATH (including fish). Set this only if
                 auto-detection misses your install — paste the output of <code class="font-mono">which gh</code>.
                 Takes effect after restarting Roux.
               </div>
+              {#if ghDetection?.binaryPath}
+                <div class="mt-2 font-mono text-[10px] text-text-muted">
+                  {ghDetection.binaryPath}
+                </div>
+              {/if}
               <div class="mt-3 flex items-center justify-between gap-2">
                 <span class="text-[13px]">Binary path</span>
                 <div class="flex gap-1">
@@ -738,12 +820,30 @@
             </div>
 
             <div class="mt-3 rounded-xl border border-border-subtle bg-bg-surface/35 p-3">
-              <div class="text-[13px] font-semibold">Git</div>
+              <div class="flex items-center justify-between">
+                <div class="text-[13px] font-semibold">Git</div>
+                {#if gitDetection?.binaryPath}
+                  <span
+                    class="rounded bg-green/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-green"
+                    >detected{gitDetection.version ? ` ${gitDetection.version}` : ""}</span
+                  >
+                {:else if gitDetection !== null}
+                  <span
+                    class="rounded bg-red/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-red"
+                    >missing</span
+                  >
+                {/if}
+              </div>
               <div class="mt-0.5 text-[11px] text-text-muted">
                 Used for git-backed Library sources. Roux checks this override,
                 then <code class="font-mono">ROUX_GIT</code>, then your login shell's PATH, then the app PATH.
                 Set this only if auto-detection misses your install.
               </div>
+              {#if gitDetection?.binaryPath}
+                <div class="mt-2 font-mono text-[10px] text-text-muted">
+                  {gitDetection.binaryPath}
+                </div>
+              {/if}
               <div class="mt-3 flex items-center justify-between gap-2">
                 <span class="text-[13px]">Binary path</span>
                 <div class="flex gap-1">


### PR DESCRIPTION
## Summary

- Resolve Roux terminal shells from the explicit setting, then the OS login shell, then `$SHELL`, then `/bin/zsh`.
- Reuse that shell choice for login-shell PATH discovery so macOS app launches find Homebrew-installed tools consistently.
- Centralize integration binary lookup for `gh`, `git`, `wt`, and `code`, and expose `gh`/`git` detection to the Settings panel.
- Regenerate the Tauri Specta bindings for the new integration detection commands and shell setting.

## Why

Finder/Dock-launched macOS apps do not inherit the same environment as interactive fish terminals. Roux was falling back to `$SHELL` or `/bin/zsh`, so terminal panes could start zsh even when the account login shell was fish.

## Validation

- `cargo test --manifest-path src-tauri/Cargo.toml pty::`
- `cargo test --manifest-path src-tauri/Cargo.toml setup`
- `npm run check`

## Notes

`Cargo.lock` has a pre-existing local version bump left unstaged and is not included in this PR commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable "Shell" setting with file picker to override the shell binary used by terminals
  * Live integration detection for GitHub CLI and Git, showing detected path, version, and status badges
  * Automatic application of shell override at startup and when settings change
  * Frontend bindings to probe and display integration detection results
<!-- end of auto-generated comment: release notes by coderabbit.ai -->