### PR TITLE
feat: auto WebGL terminal renderer with gpuAcceleration setting

### DIFF
--- a/crates/roux-core/src/models/settings.rs
+++ b/crates/roux-core/src/models/settings.rs
@@ -151,6 +151,20 @@ pub enum OnPaneCloseMode {
     Kill,
 }
 
+/// xterm.js renderer selection. `Auto` (default) tries WebGL and silently
+/// falls back to the built-in DOM renderer if construction fails or the
+/// WebGL context is lost. `On` is identical to `Auto` today — kept as a
+/// distinct option because users have a clear mental model from VSCode's
+/// `terminal.integrated.gpuAcceleration`. `Off` skips WebGL entirely.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, specta::Type, Default)]
+#[serde(rename_all = "camelCase")]
+pub enum GpuAcceleration {
+    #[default]
+    Auto,
+    On,
+    Off,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
 #[serde(rename_all = "camelCase")]
 pub struct RouxSettings {
@@ -308,6 +322,11 @@ pub struct RouxSettings {
     /// `Detach`: the process keeps running and can be re-attached.
     #[serde(default)]
     pub on_pane_close: OnPaneCloseMode,
+    /// xterm.js renderer hint. `Auto` (default) tries WebGL with DOM fallback.
+    /// Setting changes apply to terminals created afterward; existing panes
+    /// keep their renderer until reopened.
+    #[serde(default)]
+    pub gpu_acceleration: GpuAcceleration,
 }
 
 impl Default for RouxSettings {
@@ -362,6 +381,7 @@ impl Default for RouxSettings {
             show_pane_hints_on_option: false,
             show_session_hints_on_command: true,
             on_pane_close: OnPaneCloseMode::Kill,
+            gpu_acceleration: GpuAcceleration::Auto,
         }
     }
 }

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -10,7 +10,7 @@ Settings are grouped into categories in a sidebar modal. Changes are persisted a
 
 - **General** — theme, tab position, status bar position.
 - **Sessions** — close/reconnect behavior, default project path, repo roots quick-pick sources, worktree base template, worktree cleanup mode, and the New Worktree default starting point.
-- **Terminal** — independent terminal theme selection, user-imported `.itermcolors` themes, font, scrollback, and cursor settings.
+- **Terminal** — independent terminal theme selection, user-imported `.itermcolors` themes, font, scrollback, cursor, and GPU acceleration settings.
 - **Claude** — binary path override, default model, additional flags.
 - **Integrations** — GitHub CLI (`gh`) path override for PR/session integrations.
 - **Notifications** — OS notification master switch and test notification trigger.
@@ -25,6 +25,16 @@ The **Terminal** section controls xterm's palette separately from the rest of th
 - **Terminal theme** (`terminalTheme`) — choose between auto-follow, built-in app-matched palettes, built-in editor-style palettes, or user themes.
 - **User themes** — drop iTerm2 `.itermcolors` files into `~/.config/roux/themes/`, then use **Reload** to rescan them or **Reveal** to open the folder in your file manager.
 - Missing user themes are preserved as setting values until you restore the file or pick a different theme, so Roux does not silently overwrite a temporarily unavailable palette.
+
+## GPU acceleration
+
+Terminal panes use a WebGL renderer by default for smooth rendering of large output buffers. The **Terminal** section exposes a **GPU acceleration** dropdown for the rare cases where the default isn't right.
+
+- **Auto** (default) — try WebGL; if construction fails or the WebGL context is lost (GPU process crash, suspended tab, too many WebGL contexts on the page), fall back silently to xterm's built-in DOM renderer. Recommended for almost everyone.
+- **On (WebGL)** — same fallback behavior as Auto today; reserved as a distinct option in case future Roux versions add a Canvas tier or stricter "WebGL only" semantics.
+- **Off (DOM)** — skip WebGL entirely and use the DOM renderer. Useful if you suspect a driver/GPU issue, are running over a remote desktop with poor GL passthrough, or just want lower power draw at the cost of slower scrollback rendering.
+
+The setting (`gpuAcceleration`) applies to terminal panes opened **after** you change it. Existing panes keep their current renderer until they're closed and reopened (or the session is restarted).
 
 ## Notes (experimental)
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -80,3 +80,7 @@ This page tracks major shipped features across Roux's full history.
 - **Clipboard-seeded editor**: ++cmd+shift+v++ opens the multi-line editor pre-populated with clipboard contents.
 - **Smart editor positioning**: the floating editor panel positions intelligently—near the top for new shells (to avoid obscuring output) and near the bottom for active ones. Drag by the header; position persists across restarts.
 - **Draggable pane dividers**: split pane dividers are now draggable for quick manual resize, in addition to the existing keybindings.
+
+## April 28, 2026
+
+- **Auto WebGL terminal renderer**: terminal panes now recover gracefully when the WebGL context is lost (GPU process crash, suspended tab, too many WebGL contexts) — the WebGL addon is disposed and xterm reverts to its built-in DOM renderer without dropping the pane. Settings → Terminal gained a **GPU acceleration** dropdown (`Auto` / `On (WebGL)` / `Off (DOM)`) modeled on VSCode's `terminal.integrated.gpuAcceleration`. Setting changes apply to terminals opened afterward. See [Settings → GPU acceleration](settings.md#gpu-acceleration).

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -331,6 +331,15 @@ export type CreateWatchConfig = {
 
 export type CursorStyle = "block" | "underline" | "bar";
 
+/**
+ * xterm.js renderer selection. `Auto` (default) tries WebGL and silently
+ * falls back to the built-in DOM renderer if construction fails or the
+ * WebGL context is lost. `On` is identical to `Auto` today — kept as a
+ * distinct option because users have a clear mental model from VSCode's
+ * `terminal.integrated.gpuAcceleration`. `Off` skips WebGL entirely.
+ */
+export type GpuAcceleration = "auto" | "on" | "off";
+
 export type DocFile = {
 	path: string,
 	name: string,
@@ -911,6 +920,12 @@ export type RouxSettings = {
 	 *  `Detach`: the process keeps running and can be re-attached.
 	 */
 	onPaneClose?: OnPaneCloseMode,
+	/**
+	 *  xterm.js renderer hint. `Auto` (default) tries WebGL with DOM fallback.
+	 *  Setting changes apply to terminals created afterward; existing panes
+	 *  keep their renderer until reopened.
+	 */
+	gpuAcceleration?: GpuAcceleration,
 };
 
 export type RuntimeState = { type: "pending" } | { type: "active" } | { type: "paused" } | { type: "stopped" } | { type: "error"; message: string };

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -13,6 +13,7 @@
   import { notificationsPush } from "$lib/tauri";
   import { commands } from "$lib/bindings";
   import type {
+    GpuAcceleration,
     IntegrationDetection,
     OnPaneCloseMode,
     UpdateChannel,
@@ -692,6 +693,21 @@
                 value={$settings.scrollback}
                 oninput={(e) => updateSetting("scrollback", parseInt(e.currentTarget.value) || 5000)}
               />
+            </div>
+            <div class="flex items-center justify-between py-2">
+              <div>
+                <div class="text-[13px]">GPU acceleration</div>
+                <div class="text-[11px] text-text-muted mt-0.5">Applies to terminals opened after this change.</div>
+              </div>
+              <select
+                class="bg-bg-deep border border-border rounded px-2 py-1 text-xs text-text-primary outline-none cursor-pointer appearance-none pr-6"
+                value={$settings.gpuAcceleration ?? "auto"}
+                onchange={(e) => updateSetting("gpuAcceleration", e.currentTarget.value as GpuAcceleration)}
+              >
+                <option value="auto">Auto</option>
+                <option value="on">On (WebGL)</option>
+                <option value="off">Off (DOM)</option>
+              </select>
             </div>
           {:else if selected === "claude"}
             <div class="flex items-center justify-between py-2">

--- a/src/lib/panes/__tests__/xtermController.test.ts
+++ b/src/lib/panes/__tests__/xtermController.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => {
     webglConstructor: vi.fn(),
     webglDispose: vi.fn(),
     webglOnContextLoss: vi.fn(),
+    contextLossSubDispose: vi.fn(),
     nextWebglShouldThrow: false,
     lastWebglContextLossHandler: null as (() => void) | null,
   };
@@ -98,7 +99,7 @@ vi.mock("@xterm/addon-webgl", () => ({
     this.onContextLoss = (handler: () => void) => {
       mocks.lastWebglContextLossHandler = handler;
       mocks.webglOnContextLoss(handler);
-      return { dispose: vi.fn() };
+      return { dispose: mocks.contextLossSubDispose };
     };
   }),
 }));
@@ -111,6 +112,7 @@ beforeEach(() => {
   mocks.webglConstructor.mockClear();
   mocks.webglDispose.mockClear();
   mocks.webglOnContextLoss.mockClear();
+  mocks.contextLossSubDispose.mockClear();
   mocks.lastWebglContextLossHandler = null;
   mocks.nextWebglShouldThrow = false;
   mocks.settingsStore.set({ ...DEFAULT_SETTINGS });
@@ -193,5 +195,41 @@ describe("XtermTerminalController renderer setup", () => {
 
     expect(mocks.webglDispose).toHaveBeenCalledTimes(1);
     expect(mocks.terminalDispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("disposes the onContextLoss subscription when the controller is disposed", () => {
+    mocks.settingsStore.set({ ...DEFAULT_SETTINGS, gpuAcceleration: "auto" });
+
+    const controller = createXtermTerminalController();
+    expect(mocks.contextLossSubDispose).not.toHaveBeenCalled();
+
+    controller.dispose();
+
+    expect(mocks.contextLossSubDispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores a context-loss event that fires after the controller is disposed", () => {
+    mocks.settingsStore.set({ ...DEFAULT_SETTINGS, gpuAcceleration: "auto" });
+
+    const controller = createXtermTerminalController();
+    controller.dispose();
+    expect(mocks.webglDispose).toHaveBeenCalledTimes(1);
+
+    // Simulate a stray late event despite the subscription being disposed.
+    mocks.lastWebglContextLossHandler?.();
+
+    // The handler's guard (`this.webglAddon !== webgl`) drops the late event,
+    // so no second dispose() call lands on the WebGL addon.
+    expect(mocks.webglDispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("only disposes the WebglAddon once if onContextLoss fires twice", () => {
+    mocks.settingsStore.set({ ...DEFAULT_SETTINGS, gpuAcceleration: "auto" });
+
+    createXtermTerminalController();
+    mocks.lastWebglContextLossHandler?.();
+    mocks.lastWebglContextLossHandler?.();
+
+    expect(mocks.webglDispose).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/panes/__tests__/xtermController.test.ts
+++ b/src/lib/panes/__tests__/xtermController.test.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { writable } from "svelte/store";
+
+import { DEFAULT_SETTINGS } from "$lib/types";
+
+const mocks = vi.hoisted(() => {
+  return {
+    settingsStore: null as unknown as ReturnType<typeof writable<unknown>>,
+    terminalLoadAddon: vi.fn(),
+    terminalDispose: vi.fn(),
+    webglConstructor: vi.fn(),
+    webglDispose: vi.fn(),
+    webglOnContextLoss: vi.fn(),
+    nextWebglShouldThrow: false,
+    lastWebglContextLossHandler: null as (() => void) | null,
+  };
+});
+
+// hoisted block can't import the writable factory cleanly across all setups;
+// initialize the store after hoist using a top-level statement that runs
+// before the dynamic import of the module under test.
+const { writable: makeStore } = await import("svelte/store");
+mocks.settingsStore = makeStore({ ...DEFAULT_SETTINGS });
+
+vi.mock("$lib/stores/settings", () => ({
+  get settings() {
+    return mocks.settingsStore;
+  },
+}));
+
+vi.mock("$lib/stores/userTerminalThemes", async () => {
+  const { writable } = await import("svelte/store");
+  return { userTerminalThemes: writable([]) };
+});
+
+vi.mock("$lib/themes", () => ({
+  resolveTerminalTheme: () => ({
+    background: "#000",
+    foreground: "#fff",
+    cursor: "#fff",
+    selectionBackground: "#444",
+    ansi: {
+      black: "#000", red: "#f00", green: "#0f0", yellow: "#ff0",
+      blue: "#00f", magenta: "#f0f", cyan: "#0ff", white: "#fff",
+      brightBlack: "#888", brightRed: "#f88", brightGreen: "#8f8", brightYellow: "#ff8",
+      brightBlue: "#88f", brightMagenta: "#f8f", brightCyan: "#8ff", brightWhite: "#fff",
+    },
+  }),
+}));
+
+vi.mock("@tauri-apps/plugin-opener", () => ({
+  openUrl: vi.fn(),
+}));
+
+vi.mock("../xtermWatchDecorations", () => ({
+  installXtermWatchDecorations: vi.fn(),
+}));
+
+vi.mock("../promptSnapshot", () => ({
+  readPromptSnapshot: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock("@xterm/xterm", () => ({
+  Terminal: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+    this.loadAddon = mocks.terminalLoadAddon;
+    this.dispose = mocks.terminalDispose;
+    this.options = {};
+    this.buffer = { active: { length: 0 } };
+    this.onData = vi.fn().mockReturnValue({ dispose: vi.fn() });
+    this.attachCustomKeyEventHandler = vi.fn();
+    this.focus = vi.fn();
+    this.write = vi.fn();
+    this.clear = vi.fn();
+    this.reset = vi.fn();
+    this.open = vi.fn();
+    this.element = null;
+  }),
+}));
+
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+    this.fit = vi.fn();
+    this.proposeDimensions = vi.fn().mockReturnValue(null);
+  }),
+}));
+
+vi.mock("@xterm/addon-web-links", () => ({
+  WebLinksAddon: vi.fn().mockImplementation(function () {}),
+}));
+
+vi.mock("@xterm/addon-webgl", () => ({
+  WebglAddon: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+    mocks.webglConstructor();
+    if (mocks.nextWebglShouldThrow) {
+      throw new Error("WebGL unavailable");
+    }
+    this.dispose = mocks.webglDispose;
+    this.onContextLoss = (handler: () => void) => {
+      mocks.lastWebglContextLossHandler = handler;
+      mocks.webglOnContextLoss(handler);
+      return { dispose: vi.fn() };
+    };
+  }),
+}));
+
+const { createXtermTerminalController } = await import("../xtermController");
+
+beforeEach(() => {
+  mocks.terminalLoadAddon.mockClear();
+  mocks.terminalDispose.mockClear();
+  mocks.webglConstructor.mockClear();
+  mocks.webglDispose.mockClear();
+  mocks.webglOnContextLoss.mockClear();
+  mocks.lastWebglContextLossHandler = null;
+  mocks.nextWebglShouldThrow = false;
+  mocks.settingsStore.set({ ...DEFAULT_SETTINGS });
+});
+
+describe("XtermTerminalController renderer setup", () => {
+  it("loads WebglAddon when gpuAcceleration is 'auto'", () => {
+    mocks.settingsStore.set({ ...DEFAULT_SETTINGS, gpuAcceleration: "auto" });
+
+    createXtermTerminalController();
+
+    expect(mocks.webglConstructor).toHaveBeenCalledTimes(1);
+    expect(mocks.webglOnContextLoss).toHaveBeenCalledTimes(1);
+  });
+
+  it("loads WebglAddon when gpuAcceleration is 'on'", () => {
+    mocks.settingsStore.set({ ...DEFAULT_SETTINGS, gpuAcceleration: "on" });
+
+    createXtermTerminalController();
+
+    expect(mocks.webglConstructor).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT load WebglAddon when gpuAcceleration is 'off'", () => {
+    mocks.settingsStore.set({ ...DEFAULT_SETTINGS, gpuAcceleration: "off" });
+
+    createXtermTerminalController();
+
+    expect(mocks.webglConstructor).not.toHaveBeenCalled();
+  });
+
+  it("treats missing gpuAcceleration as 'auto'", () => {
+    const settings: Record<string, unknown> = { ...DEFAULT_SETTINGS };
+    delete settings.gpuAcceleration;
+    mocks.settingsStore.set(settings);
+
+    createXtermTerminalController();
+
+    expect(mocks.webglConstructor).toHaveBeenCalledTimes(1);
+  });
+
+  it("survives WebglAddon construction failure", () => {
+    mocks.settingsStore.set({ ...DEFAULT_SETTINGS, gpuAcceleration: "auto" });
+    mocks.nextWebglShouldThrow = true;
+
+    expect(() => createXtermTerminalController()).not.toThrow();
+    expect(mocks.webglConstructor).toHaveBeenCalledTimes(1);
+    expect(mocks.webglOnContextLoss).not.toHaveBeenCalled();
+  });
+
+  it("disposes the WebglAddon when context is lost", () => {
+    mocks.settingsStore.set({ ...DEFAULT_SETTINGS, gpuAcceleration: "auto" });
+
+    createXtermTerminalController();
+    expect(mocks.lastWebglContextLossHandler).not.toBeNull();
+
+    mocks.lastWebglContextLossHandler?.();
+
+    expect(mocks.webglDispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("disposes the WebglAddon on controller dispose", () => {
+    mocks.settingsStore.set({ ...DEFAULT_SETTINGS, gpuAcceleration: "auto" });
+
+    const controller = createXtermTerminalController();
+    controller.dispose();
+
+    expect(mocks.webglDispose).toHaveBeenCalledTimes(1);
+    expect(mocks.terminalDispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not double-dispose the WebglAddon if context loss preceded controller dispose", () => {
+    mocks.settingsStore.set({ ...DEFAULT_SETTINGS, gpuAcceleration: "auto" });
+
+    const controller = createXtermTerminalController();
+    mocks.lastWebglContextLossHandler?.();
+    expect(mocks.webglDispose).toHaveBeenCalledTimes(1);
+
+    controller.dispose();
+
+    expect(mocks.webglDispose).toHaveBeenCalledTimes(1);
+    expect(mocks.terminalDispose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/panes/xtermController.ts
+++ b/src/lib/panes/xtermController.ts
@@ -22,6 +22,7 @@ class XtermTerminalController implements TerminalController {
   private readonly terminal: Terminal;
   private readonly fitAddon: FitAddon;
   private webglAddon: WebglAddon | null = null;
+  private webglContextLossSub: { dispose(): void } | null = null;
 
   constructor(options?: CreateTerminalControllerOptions) {
     const s = get(settings);
@@ -63,11 +64,13 @@ class XtermTerminalController implements TerminalController {
       const webgl = new WebglAddon();
       this.terminal.loadAddon(webgl);
       this.webglAddon = webgl;
-      webgl.onContextLoss(() => {
+      this.webglContextLossSub = webgl.onContextLoss(() => {
+        // Guard against the handler firing twice (xterm hands us an event
+        // disposable, not a one-shot) or after the controller is disposed.
+        // Null the ref before dispose() so a re-entrant call is a no-op.
+        if (this.webglAddon !== webgl) return;
+        this.webglAddon = null;
         webgl.dispose();
-        if (this.webglAddon === webgl) {
-          this.webglAddon = null;
-        }
       });
     } catch {
       this.webglAddon = null;
@@ -100,6 +103,8 @@ class XtermTerminalController implements TerminalController {
   }
 
   dispose(): void {
+    this.webglContextLossSub?.dispose();
+    this.webglContextLossSub = null;
     this.webglAddon?.dispose();
     this.webglAddon = null;
     this.terminal.dispose();

--- a/src/lib/panes/xtermController.ts
+++ b/src/lib/panes/xtermController.ts
@@ -8,6 +8,7 @@ import { get } from "svelte/store";
 import { settings } from "$lib/stores/settings";
 import { userTerminalThemes } from "$lib/stores/userTerminalThemes";
 import { resolveTerminalTheme, type TerminalTheme } from "$lib/themes";
+import type { GpuAcceleration } from "$lib/bindings";
 
 import { installXtermWatchDecorations } from "./xtermWatchDecorations";
 import { readPromptSnapshot, type PromptSnapshot } from "./promptSnapshot";
@@ -20,6 +21,7 @@ interface CreateTerminalControllerOptions {
 class XtermTerminalController implements TerminalController {
   private readonly terminal: Terminal;
   private readonly fitAddon: FitAddon;
+  private webglAddon: WebglAddon | null = null;
 
   constructor(options?: CreateTerminalControllerOptions) {
     const s = get(settings);
@@ -37,11 +39,7 @@ class XtermTerminalController implements TerminalController {
 
     this.fitAddon = new FitAddon();
     this.terminal.loadAddon(this.fitAddon);
-    try {
-      this.terminal.loadAddon(new WebglAddon());
-    } catch {
-      // WebGL not available — canvas fallback
-    }
+    this.setupRenderer(s.gpuAcceleration ?? "auto");
 
     if (options?.allowKeyboardEvent) {
       this.setCustomKeyHandler(options.allowKeyboardEvent);
@@ -52,6 +50,28 @@ class XtermTerminalController implements TerminalController {
     }));
 
     installXtermWatchDecorations(this.terminal);
+  }
+
+  private setupRenderer(mode: GpuAcceleration): void {
+    if (mode === "off") {
+      // DOM renderer (xterm's built-in default when no GPU addon is loaded).
+      return;
+    }
+    // "auto" and "on": try WebGL; on construction failure or context loss,
+    // dispose the addon so xterm reverts to its built-in DOM renderer.
+    try {
+      const webgl = new WebglAddon();
+      this.terminal.loadAddon(webgl);
+      this.webglAddon = webgl;
+      webgl.onContextLoss(() => {
+        webgl.dispose();
+        if (this.webglAddon === webgl) {
+          this.webglAddon = null;
+        }
+      });
+    } catch {
+      this.webglAddon = null;
+    }
   }
 
   attach(container: HTMLElement): void {
@@ -80,6 +100,8 @@ class XtermTerminalController implements TerminalController {
   }
 
   dispose(): void {
+    this.webglAddon?.dispose();
+    this.webglAddon = null;
     this.terminal.dispose();
   }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -110,6 +110,7 @@ export const DEFAULT_SETTINGS: RouxSettings = {
   librarySources: [],
   statusBarPosition: "bottom",
   onPaneClose: "kill",
+  gpuAcceleration: "auto",
 };
 
 // Re-export frontend-only task types


### PR DESCRIPTION
## Summary

- Terminal panes now recover from WebGL context loss (GPU crash, suspended tab, too many WebGL contexts) by disposing the WebGL addon and reverting to xterm's built-in DOM renderer — no pane drop, no scrollback loss.
- New **GPU acceleration** dropdown on the Terminal settings tab (`Auto` / `On (WebGL)` / `Off (DOM)`), modeled on VSCode's `terminal.integrated.gpuAcceleration`. Setting changes apply to terminals opened after the change; existing panes keep their renderer until reopened.
- `Auto` is the default and is identical to today's behavior on the happy path; the new value of this PR is graceful recovery + an opt-out for users on systems where WebGL is flaky.

## Implementation notes

- `crates/roux-core/src/models/settings.rs` — new `GpuAcceleration` enum + `gpu_acceleration` field on `RouxSettings`. `#[serde(default)]` means existing settings files load unchanged.
- `src/lib/panes/xtermController.ts` — replaced the unconditional `try { loadAddon(new WebglAddon()) }` with a `setupRenderer(mode)` helper that wires `WebglAddon.onContextLoss` for runtime recovery and tracks the addon for explicit disposal.
- `src/lib/components/SettingsPanel.svelte` — added the dropdown to the Terminal tab.
- `src/lib/bindings.ts` / `src/lib/types.ts` — generated type added (will be regenerated identically on the next debug build) plus new field in the hand-maintained `DEFAULT_SETTINGS`.
- Docs updated: `docs/settings.md` (new GPU acceleration subsection) and `docs/whats-new.md` (April 28 entry).

### About the fallback chain

Initial plan was WebGL → Canvas → DOM (matching VSCode), but `@xterm/addon-canvas` has no version compatible with `@xterm/xterm@6` (peer dep `^5.0.0` on every published version, and the addon was dropped from xterm.js master). Pivoted to WebGL → DOM only, which is what xterm@6 natively supports. The user-facing setting semantics are unchanged.

## Test plan

- [x] `cargo check -p roux-core` — green
- [x] `npm run check` — 0 errors, 0 warnings, 897 files
- [x] `npm run test` — 64 files / 735 passed (2 pre-existing skips), including 8 new tests in `src/lib/panes/__tests__/xtermController.test.ts` covering `auto`/`on`/`off`, missing-field default, WebGL construction failure, context-loss disposal, and double-dispose safety
- [ ] Manual: open a Claude pane, confirm `<canvas data-type="webgl">` is present
- [ ] Manual: switch GPU acceleration to **Off**, open a new pane, confirm DOM renderer (no `data-type=webgl` canvas)
- [ ] Manual: with WebGL active, run in DevTools console: `document.querySelector('.xterm canvas[data-type=webgl]').getContext('webgl2').getExtension('WEBGL_lose_context').loseContext()` — terminal should keep working and the WebGL canvas should be gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Terminal GPU acceleration setting (Auto default, On, Off) to choose WebGL or DOM rendering.
  * Terminals now gracefully fall back to DOM rendering if WebGL is unavailable or the context is lost; setting takes effect for newly opened panes.

* **Documentation**
  * Updated settings docs and release notes to describe the GPU acceleration options and behavior.

* **Tests**
  * Added tests verifying WebGL initialization, context-loss handling, disposal, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->