### PR TITLE
feat: system tray with sessions, notifications, and attention indicator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,6 +406,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1929,7 +1935,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e795dff5605e0f04bff85ca41b51a96b83e80b281e96231bcaaf1ac35103371"
 dependencies = [
  "byteorder",
- "png",
+ "png 0.17.16",
 ]
 
 [[package]]
@@ -2045,6 +2051,19 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
 ]
 
 [[package]]
@@ -2552,6 +2571,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "muda"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2566,7 +2595,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation",
  "once_cell",
- "png",
+ "png 0.17.16",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
@@ -3415,6 +3444,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3556,6 +3598,12 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "quick-xml"
@@ -3909,12 +3957,13 @@ dependencies = [
 
 [[package]]
 name = "roux"
-version = "0.5.3-pre.2"
+version = "0.5.3-pre.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
  "clap",
  "dirs",
+ "image",
  "libc",
  "minijinja",
  "notify",
@@ -4960,6 +5009,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "image",
  "jni",
  "libc",
  "log",
@@ -5028,7 +5078,7 @@ dependencies = [
  "ico",
  "json-patch",
  "plist",
- "png",
+ "png 0.17.16",
  "proc-macro2",
  "quote",
  "semver",
@@ -5731,7 +5781,7 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation",
  "once_cell",
- "png",
+ "png 0.17.16",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,7 +28,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["tray-icon", "image-png"] }
 tauri-plugin-shell = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -58,6 +58,7 @@ specta = { version = "=2.0.0-rc.24", features = ["derive", "serde_json"] }
 specta-typescript = "0.0.11"
 tauri-specta = { version = "=2.0.0-rc.24", features = ["derive", "typescript"] }
 vte = "0.15"
+image = { version = "0.25", default-features = false, features = ["png"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -412,38 +412,30 @@ fn main() {
             }
 
             // Refresh the tray menu when any session's status changes.
-            {
-                let app_handle = app.handle().clone();
-                app.listen("roux-status-update", move |_event| {
-                    tray::refresh(app_handle.clone());
-                });
-            }
+            // `tray::refresh` is a cheap signal — the worker started in
+            // `tray::setup` does the actual work.
+            app.listen("roux-status-update", |_event| {
+                tray::refresh();
+            });
 
             // Refresh the tray menu when notifications change (added,
             // read, removed, cleared). Surfaces the unread count and
             // the recent-unread submenu without polling.
-            {
-                let app_handle = app.handle().clone();
-                app.listen(notifications::NOTIFICATION_EVENT, move |_event| {
-                    tray::refresh(app_handle.clone());
-                });
-            }
+            app.listen(notifications::NOTIFICATION_EVENT, |_event| {
+                tray::refresh();
+            });
 
             // Low-frequency poll catches session add/remove/archive
-            // (no dedicated event bus for those today). 3s is fine — the
-            // refresh is just a list + menu rebuild.
-            {
-                let app_handle = app.handle().clone();
-                tauri::async_runtime::spawn(async move {
-                    let mut ticker =
-                        tokio::time::interval(std::time::Duration::from_secs(3));
-                    ticker.tick().await; // skip the immediate first tick
-                    loop {
-                        ticker.tick().await;
-                        tray::refresh(app_handle.clone());
-                    }
-                });
-            }
+            // (no dedicated event bus for those today). 3s is fine —
+            // the refresh worker coalesces overlapping signals.
+            tauri::async_runtime::spawn(async move {
+                let mut ticker = tokio::time::interval(std::time::Duration::from_secs(3));
+                ticker.tick().await; // skip the immediate first tick
+                loop {
+                    ticker.tick().await;
+                    tray::refresh();
+                }
+            });
 
             // Experimental notes vault: one-shot migration of legacy
             // project notes (`~/.config/roux/notes/<id>.txt`) into the

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -29,12 +29,13 @@ mod skill;
 mod socket;
 mod state;
 mod tasks;
+mod tray;
 mod updater;
 mod watches;
 mod worktree;
 
 use std::sync::Mutex;
-use tauri::{Emitter, Manager};
+use tauri::{Emitter, Listener, Manager};
 #[cfg(debug_assertions)]
 use tauri_specta::{collect_commands, Builder};
 
@@ -403,6 +404,46 @@ fn main() {
                 eprintln!("Warning: failed to start file status source: {}", e);
             }
             socket::start_socket_server(app.handle().clone());
+
+            // System tray: shows active sessions + status, plus Show/Quit.
+            // Failure here is non-fatal (e.g. headless CI); log and continue.
+            if let Err(e) = tray::setup(app.handle()) {
+                eprintln!("Warning: failed to set up tray: {}", e);
+            }
+
+            // Refresh the tray menu when any session's status changes.
+            {
+                let app_handle = app.handle().clone();
+                app.listen("roux-status-update", move |_event| {
+                    tray::refresh(app_handle.clone());
+                });
+            }
+
+            // Refresh the tray menu when notifications change (added,
+            // read, removed, cleared). Surfaces the unread count and
+            // the recent-unread submenu without polling.
+            {
+                let app_handle = app.handle().clone();
+                app.listen(notifications::NOTIFICATION_EVENT, move |_event| {
+                    tray::refresh(app_handle.clone());
+                });
+            }
+
+            // Low-frequency poll catches session add/remove/archive
+            // (no dedicated event bus for those today). 3s is fine — the
+            // refresh is just a list + menu rebuild.
+            {
+                let app_handle = app.handle().clone();
+                tauri::async_runtime::spawn(async move {
+                    let mut ticker =
+                        tokio::time::interval(std::time::Duration::from_secs(3));
+                    ticker.tick().await; // skip the immediate first tick
+                    loop {
+                        ticker.tick().await;
+                        tray::refresh(app_handle.clone());
+                    }
+                });
+            }
 
             // Experimental notes vault: one-shot migration of legacy
             // project notes (`~/.config/roux/notes/<id>.txt`) into the

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -13,7 +13,7 @@
 //! `main.rs`).
 
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 
 use image::{ImageBuffer, Rgba};
 use tauri::{
@@ -22,6 +22,7 @@ use tauri::{
     tray::TrayIconBuilder,
     AppHandle, Emitter, Manager, Wry,
 };
+use tokio::sync::Notify;
 
 use crate::state::AppState;
 use roux_core::{Notification, NotificationLevel, Session, SessionStatus};
@@ -57,80 +58,110 @@ pub fn setup(app: &AppHandle) -> tauri::Result<()> {
         .on_menu_event(handle_menu_event)
         .build(app)?;
 
-    refresh(app.clone());
+    start_refresh_worker(app.clone());
+    refresh();
     Ok(())
 }
 
-/// Rebuild the tray menu from current session + notification state.
-/// Spawns a tokio task because `SessionHandle::list` is async; safe to
-/// call from any context.
-pub fn refresh(app: AppHandle) {
+/// Single `Notify` shared by every `refresh()` caller and consumed by
+/// the worker started in `setup()`. `notify_one` is idempotent when no
+/// waiter is parked, so a burst of triggers (status events +
+/// notification events + ticker) coalesces into at most one extra run
+/// after the in-progress one finishes — no overlapping tasks, no
+/// chance of an older snapshot's `set_menu` clobbering a newer one's.
+static REFRESH_SIGNAL: OnceLock<Arc<Notify>> = OnceLock::new();
+
+fn start_refresh_worker(app: AppHandle) {
+    let notify = Arc::new(Notify::new());
+    if REFRESH_SIGNAL.set(notify.clone()).is_err() {
+        // Worker already running (e.g. `setup` called twice in tests).
+        return;
+    }
     tauri::async_runtime::spawn(async move {
-        let sessions = {
-            let state = app.state::<AppState>();
-            match state.session_handle.list().await {
-                Ok(list) => list,
-                Err(e) => {
-                    rlog!("tray: list_sessions failed: {e}");
-                    return;
-                }
-            }
-        };
-        let active: Vec<Session> = sessions.into_iter().filter(|s| !s.archived).collect();
-
-        let (unread, total_unread) = {
-            let state = app.state::<AppState>();
-            let all = state.notification_manager.list();
-            let total = all.iter().filter(|n| !n.read).count();
-            let top: Vec<Notification> = all
-                .into_iter()
-                .filter(|n| !n.read)
-                .take(MAX_NOTIFS_IN_TRAY)
-                .collect();
-            (top, total)
-        };
-
-        let needs_attention = active
-            .iter()
-            .any(|s| matches!(s.status, SessionStatus::Attention));
-
-        let menu = match build_menu(&app, &active, &unread, total_unread) {
-            Ok(m) => m,
-            Err(e) => {
-                rlog!("tray: build_menu failed: {e}");
-                return;
-            }
-        };
-        if let Some(tray) = app.tray_by_id(TRAY_ID) {
-            if let Err(e) = tray.set_menu(Some(menu)) {
-                rlog!("tray: set_menu failed: {e}");
-            }
-            // macOS: surface the unread count next to the icon. No-op
-            // on platforms where set_title isn't supported.
-            let _ = tray.set_title(if total_unread > 0 {
-                Some(format!("{}", total_unread))
-            } else {
-                None
-            });
-
-            // Swap the icon only when the attention state actually flips.
-            // Avoids per-tick set_icon churn (cheap but visible flicker on
-            // some platforms) when nothing changed.
-            let prev = ATTENTION_ICON_ACTIVE.swap(needs_attention, Ordering::Relaxed);
-            if prev != needs_attention {
-                let icons = tray_icons();
-                if needs_attention {
-                    let _ = tray.set_icon(Some(icons.attention.clone()));
-                    // Attention dot is colored; template mode would
-                    // strip the color on macOS.
-                    let _ = tray.set_icon_as_template(false);
-                } else {
-                    let _ = tray.set_icon(Some(icons.normal.clone()));
-                    let _ = tray.set_icon_as_template(true);
-                }
-            }
+        loop {
+            notify.notified().await;
+            do_refresh(&app).await;
         }
     });
+}
+
+/// Request a tray refresh. Cheap and lock-free: signals the worker and
+/// returns. Safe to call from any context, including event listener
+/// callbacks that fire on the main thread.
+pub fn refresh() {
+    if let Some(signal) = REFRESH_SIGNAL.get() {
+        signal.notify_one();
+    }
+}
+
+/// Rebuild the tray menu from current session + notification state.
+/// Always runs on the worker task, so completions are serialized and
+/// the latest call wins.
+async fn do_refresh(app: &AppHandle) {
+    let sessions = {
+        let state = app.state::<AppState>();
+        match state.session_handle.list().await {
+            Ok(list) => list,
+            Err(e) => {
+                rlog!("tray: list_sessions failed: {e}");
+                return;
+            }
+        }
+    };
+    let active: Vec<Session> = sessions.into_iter().filter(|s| !s.archived).collect();
+
+    let (unread, total_unread) = {
+        let state = app.state::<AppState>();
+        let all = state.notification_manager.list();
+        let total = all.iter().filter(|n| !n.read).count();
+        let top: Vec<Notification> = all
+            .into_iter()
+            .filter(|n| !n.read)
+            .take(MAX_NOTIFS_IN_TRAY)
+            .collect();
+        (top, total)
+    };
+
+    let needs_attention = active
+        .iter()
+        .any(|s| matches!(s.status, SessionStatus::Attention));
+
+    let menu = match build_menu(app, &active, &unread, total_unread) {
+        Ok(m) => m,
+        Err(e) => {
+            rlog!("tray: build_menu failed: {e}");
+            return;
+        }
+    };
+    if let Some(tray) = app.tray_by_id(TRAY_ID) {
+        if let Err(e) = tray.set_menu(Some(menu)) {
+            rlog!("tray: set_menu failed: {e}");
+        }
+        // macOS: surface the unread count next to the icon. No-op
+        // on platforms where set_title isn't supported.
+        let _ = tray.set_title(if total_unread > 0 {
+            Some(format!("{}", total_unread))
+        } else {
+            None
+        });
+
+        // Swap the icon only when the attention state actually flips.
+        // Avoids per-tick set_icon churn (cheap but visible flicker on
+        // some platforms) when nothing changed.
+        let prev = ATTENTION_ICON_ACTIVE.swap(needs_attention, Ordering::Relaxed);
+        if prev != needs_attention {
+            let icons = tray_icons();
+            if needs_attention {
+                let _ = tray.set_icon(Some(icons.attention.clone()));
+                // Attention dot is colored; template mode would
+                // strip the color on macOS.
+                let _ = tray.set_icon_as_template(false);
+            } else {
+                let _ = tray.set_icon(Some(icons.normal.clone()));
+                let _ = tray.set_icon_as_template(true);
+            }
+        }
+    }
 }
 
 /// Tracks whether the tray currently shows the attention-state icon, so

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -148,17 +148,31 @@ async fn do_refresh(app: &AppHandle) {
         // Swap the icon only when the attention state actually flips.
         // Avoids per-tick set_icon churn (cheap but visible flicker on
         // some platforms) when nothing changed.
-        let prev = ATTENTION_ICON_ACTIVE.swap(needs_attention, Ordering::Relaxed);
-        if prev != needs_attention {
+        //
+        // The cache is updated only on success — if `set_icon` or
+        // `set_icon_as_template` fails (rare, but possible on platform
+        // edge cases), leaving the cache stale would mean future
+        // refreshes skip the retry and the tray gets stuck in the
+        // wrong state.
+        if ATTENTION_ICON_ACTIVE.load(Ordering::Relaxed) != needs_attention {
             let icons = tray_icons();
-            if needs_attention {
-                let _ = tray.set_icon(Some(icons.attention.clone()));
-                // Attention dot is colored; template mode would
-                // strip the color on macOS.
-                let _ = tray.set_icon_as_template(false);
+            // Attention dot is colored; template mode would strip the
+            // color on macOS, so flip template off for the dotted icon
+            // and back on for the normal one.
+            let result = if needs_attention {
+                tray.set_icon(Some(icons.attention.clone()))
+                    .and_then(|_| tray.set_icon_as_template(false))
             } else {
-                let _ = tray.set_icon(Some(icons.normal.clone()));
-                let _ = tray.set_icon_as_template(true);
+                tray.set_icon(Some(icons.normal.clone()))
+                    .and_then(|_| tray.set_icon_as_template(true))
+            };
+            match result {
+                Ok(()) => {
+                    ATTENTION_ICON_ACTIVE.store(needs_attention, Ordering::Relaxed);
+                }
+                Err(e) => {
+                    rlog!("tray: icon swap failed (will retry next refresh): {e}");
+                }
             }
         }
     }

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -1,0 +1,375 @@
+//! System tray (macOS menu bar / Windows task bar) integration.
+//!
+//! Surface today: a tray icon whose menu lists active (non-archived)
+//! sessions with their status, surfaces unread notifications in a
+//! submenu, and offers Show/Quit actions. Clicking a session entry
+//! brings the main window to front and emits `tray-focus-session` so
+//! the frontend can route focus.
+//!
+//! The menu is rebuilt from scratch on every refresh — both sessions
+//! and notifications are cheap to list and Tauri's menu API doesn't
+//! support targeted updates. Refresh is driven by `roux-status-update`,
+//! `notification-event`, and a low-frequency polling timer (see
+//! `main.rs`).
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::OnceLock;
+
+use image::{ImageBuffer, Rgba};
+use tauri::{
+    image::Image,
+    menu::{Menu, MenuBuilder, MenuItemBuilder, SubmenuBuilder},
+    tray::TrayIconBuilder,
+    AppHandle, Emitter, Manager, Wry,
+};
+
+use crate::state::AppState;
+use roux_core::{Notification, NotificationLevel, Session, SessionStatus};
+
+/// Source bitmap for the tray icon. Embedded so the binary is self-
+/// contained (no runtime file lookup) and so we can decode it once and
+/// composite an "attention" variant from the same pixels.
+const TRAY_ICON_PNG: &[u8] = include_bytes!("../icons/32x32.png");
+
+const TRAY_ID: &str = "roux-main-tray";
+const MENU_ID_SHOW: &str = "tray::show";
+const MENU_ID_QUIT: &str = "tray::quit";
+const MENU_ID_MARK_ALL_READ: &str = "tray::notif::mark-all-read";
+const MENU_ID_CLEAR_ALL: &str = "tray::notif::clear-all";
+const SESSION_PREFIX: &str = "tray::session::";
+const NOTIF_PREFIX: &str = "tray::notif::item::";
+
+/// How many unread notifications to surface in the tray submenu before
+/// collapsing the rest behind a "+ N more" entry. Keeps the menu
+/// scannable when a flood of hooks/watches has piled up.
+const MAX_NOTIFS_IN_TRAY: usize = 10;
+
+pub fn setup(app: &AppHandle) -> tauri::Result<()> {
+    let menu = build_menu(app, &[], &[], 0)?;
+    let icons = tray_icons();
+
+    TrayIconBuilder::with_id(TRAY_ID)
+        .icon(icons.normal.clone())
+        .icon_as_template(true)
+        .menu(&menu)
+        .show_menu_on_left_click(true)
+        .tooltip("Roux")
+        .on_menu_event(handle_menu_event)
+        .build(app)?;
+
+    refresh(app.clone());
+    Ok(())
+}
+
+/// Rebuild the tray menu from current session + notification state.
+/// Spawns a tokio task because `SessionHandle::list` is async; safe to
+/// call from any context.
+pub fn refresh(app: AppHandle) {
+    tauri::async_runtime::spawn(async move {
+        let sessions = {
+            let state = app.state::<AppState>();
+            match state.session_handle.list().await {
+                Ok(list) => list,
+                Err(e) => {
+                    rlog!("tray: list_sessions failed: {e}");
+                    return;
+                }
+            }
+        };
+        let active: Vec<Session> = sessions.into_iter().filter(|s| !s.archived).collect();
+
+        let (unread, total_unread) = {
+            let state = app.state::<AppState>();
+            let all = state.notification_manager.list();
+            let total = all.iter().filter(|n| !n.read).count();
+            let top: Vec<Notification> = all
+                .into_iter()
+                .filter(|n| !n.read)
+                .take(MAX_NOTIFS_IN_TRAY)
+                .collect();
+            (top, total)
+        };
+
+        let needs_attention = active
+            .iter()
+            .any(|s| matches!(s.status, SessionStatus::Attention));
+
+        let menu = match build_menu(&app, &active, &unread, total_unread) {
+            Ok(m) => m,
+            Err(e) => {
+                rlog!("tray: build_menu failed: {e}");
+                return;
+            }
+        };
+        if let Some(tray) = app.tray_by_id(TRAY_ID) {
+            if let Err(e) = tray.set_menu(Some(menu)) {
+                rlog!("tray: set_menu failed: {e}");
+            }
+            // macOS: surface the unread count next to the icon. No-op
+            // on platforms where set_title isn't supported.
+            let _ = tray.set_title(if total_unread > 0 {
+                Some(format!("{}", total_unread))
+            } else {
+                None
+            });
+
+            // Swap the icon only when the attention state actually flips.
+            // Avoids per-tick set_icon churn (cheap but visible flicker on
+            // some platforms) when nothing changed.
+            let prev = ATTENTION_ICON_ACTIVE.swap(needs_attention, Ordering::Relaxed);
+            if prev != needs_attention {
+                let icons = tray_icons();
+                if needs_attention {
+                    let _ = tray.set_icon(Some(icons.attention.clone()));
+                    // Attention dot is colored; template mode would
+                    // strip the color on macOS.
+                    let _ = tray.set_icon_as_template(false);
+                } else {
+                    let _ = tray.set_icon(Some(icons.normal.clone()));
+                    let _ = tray.set_icon_as_template(true);
+                }
+            }
+        }
+    });
+}
+
+/// Tracks whether the tray currently shows the attention-state icon, so
+/// `refresh` can detect transitions and only call `set_icon` when the
+/// state actually flips.
+static ATTENTION_ICON_ACTIVE: AtomicBool = AtomicBool::new(false);
+
+struct TrayIcons {
+    normal: Image<'static>,
+    attention: Image<'static>,
+}
+
+fn tray_icons() -> &'static TrayIcons {
+    static ICONS: OnceLock<TrayIcons> = OnceLock::new();
+    ICONS.get_or_init(|| {
+        // include_bytes! guarantees the PNG was present at build time;
+        // a decode failure here is a packaging bug, not a runtime
+        // condition we can recover from.
+        let base = image::load_from_memory(TRAY_ICON_PNG)
+            .expect("tray: embedded 32x32.png failed to decode")
+            .to_rgba8();
+        let (w, h) = base.dimensions();
+
+        let normal = Image::new_owned(base.clone().into_raw(), w, h);
+
+        let mut with_dot = base;
+        draw_attention_dot(&mut with_dot);
+        let attention = Image::new_owned(with_dot.into_raw(), w, h);
+
+        TrayIcons { normal, attention }
+    })
+}
+
+/// Paint a filled red disc in the bottom-right corner of the icon as a
+/// "needs attention" badge. Anti-aliased so it doesn't look pixelated
+/// when macOS upscales the 32×32 source for retina displays.
+fn draw_attention_dot(img: &mut ImageBuffer<Rgba<u8>, Vec<u8>>) {
+    let (w, h) = img.dimensions();
+    // Dot covers ~⅜ of the icon, anchored 1px in from the corner.
+    let radius = (w.min(h) as f32) * 0.32;
+    let cx = w as f32 - radius - 1.0;
+    let cy = h as f32 - radius - 1.0;
+    let red = Rgba([0xE0, 0x2A, 0x2A, 0xFF]);
+
+    for y in 0..h {
+        for x in 0..w {
+            let dx = x as f32 + 0.5 - cx;
+            let dy = y as f32 + 0.5 - cy;
+            let dist = (dx * dx + dy * dy).sqrt();
+            if dist <= radius - 0.5 {
+                img.put_pixel(x, y, red);
+            } else if dist < radius + 0.5 {
+                // Single-pixel anti-aliased edge. `t` is how much of the
+                // pixel sits inside the disc (0..1).
+                let t = (radius + 0.5 - dist).clamp(0.0, 1.0);
+                let bg = *img.get_pixel(x, y);
+                img.put_pixel(x, y, blend_rgba(bg, red, t));
+            }
+        }
+    }
+}
+
+fn blend_rgba(a: Rgba<u8>, b: Rgba<u8>, t: f32) -> Rgba<u8> {
+    let lerp = |x: u8, y: u8| (x as f32 * (1.0 - t) + y as f32 * t).round() as u8;
+    Rgba([lerp(a[0], b[0]), lerp(a[1], b[1]), lerp(a[2], b[2]), lerp(a[3], b[3])])
+}
+
+fn build_menu(
+    app: &AppHandle,
+    sessions: &[Session],
+    unread: &[Notification],
+    total_unread: usize,
+) -> tauri::Result<Menu<Wry>> {
+    let header_label = format_header(sessions.len(), total_unread);
+    let header = MenuItemBuilder::with_id("tray::header", header_label)
+        .enabled(false)
+        .build(app)?;
+
+    let mut builder = MenuBuilder::new(app).item(&header).separator();
+
+    if total_unread > 0 {
+        let submenu = build_notifications_submenu(app, unread, total_unread)?;
+        builder = builder.item(&submenu).separator();
+    }
+
+    for s in sessions {
+        let label = format!("{}  {} — {}", status_glyph(&s.status), s.name, s.status);
+        let id = format!("{SESSION_PREFIX}{}", s.id);
+        builder = builder.text(id, label);
+    }
+
+    if !sessions.is_empty() {
+        builder = builder.separator();
+    }
+
+    builder
+        .text(MENU_ID_SHOW, "Show Roux")
+        .text(MENU_ID_QUIT, "Quit Roux")
+        .build()
+}
+
+fn format_header(active_sessions: usize, unread: usize) -> String {
+    let sessions_part = if active_sessions == 0 {
+        "no active sessions".to_string()
+    } else {
+        format!(
+            "{} active session{}",
+            active_sessions,
+            if active_sessions == 1 { "" } else { "s" }
+        )
+    };
+    if unread > 0 {
+        format!("Roux — {sessions_part} · {unread} unread")
+    } else {
+        format!("Roux — {sessions_part}")
+    }
+}
+
+fn build_notifications_submenu(
+    app: &AppHandle,
+    unread: &[Notification],
+    total_unread: usize,
+) -> tauri::Result<tauri::menu::Submenu<Wry>> {
+    let title = format!("Notifications ({total_unread})");
+    let mut sub = SubmenuBuilder::new(app, title);
+
+    for n in unread {
+        let label = format_notification_label(n);
+        let id = format!("{NOTIF_PREFIX}{}", n.id);
+        sub = sub.text(id, label);
+    }
+
+    if total_unread > unread.len() {
+        let extra = total_unread - unread.len();
+        let more = MenuItemBuilder::with_id(
+            "tray::notif::more",
+            format!("+ {extra} more in app"),
+        )
+        .enabled(false)
+        .build(app)?;
+        sub = sub.item(&more);
+    }
+
+    sub = sub
+        .separator()
+        .text(MENU_ID_MARK_ALL_READ, "Mark all as read")
+        .text(MENU_ID_CLEAR_ALL, "Clear all");
+
+    sub.build()
+}
+
+fn format_notification_label(n: &Notification) -> String {
+    let mut label = format!("{}  {}", level_glyph(n.level), n.title);
+    // macOS truncates long menu items mid-glyph, so trim ourselves.
+    // 80 chars covers most titles plus a short subtitle.
+    if let Some(sub) = n.subtitle.as_deref().filter(|s| !s.is_empty()) {
+        label.push_str(" — ");
+        label.push_str(sub);
+    }
+    if label.chars().count() > 80 {
+        let truncated: String = label.chars().take(77).collect();
+        format!("{truncated}…")
+    } else {
+        label
+    }
+}
+
+fn status_glyph(status: &SessionStatus) -> &'static str {
+    match status {
+        SessionStatus::Idle => "○",
+        SessionStatus::Thinking => "◐",
+        SessionStatus::Generating => "●",
+        SessionStatus::Error => "✕",
+        SessionStatus::Disconnected => "⊘",
+        SessionStatus::Attention => "!",
+    }
+}
+
+fn level_glyph(level: NotificationLevel) -> &'static str {
+    match level {
+        NotificationLevel::Info => "ℹ",
+        NotificationLevel::Success => "✓",
+        NotificationLevel::Attention => "!",
+        NotificationLevel::Warning => "⚠",
+        NotificationLevel::Error => "✕",
+    }
+}
+
+fn handle_menu_event(app: &AppHandle, event: tauri::menu::MenuEvent) {
+    let id = event.id().as_ref();
+    if id == MENU_ID_SHOW {
+        show_main_window(app);
+    } else if id == MENU_ID_QUIT {
+        // Match the existing quit path: emit `quit-requested` and let the
+        // frontend confirm + call back into the app to actually exit.
+        let _ = app.emit("quit-requested", ());
+    } else if id == MENU_ID_MARK_ALL_READ {
+        let state = app.state::<AppState>();
+        state.notification_manager.mark_all_read(None, Some(app));
+    } else if id == MENU_ID_CLEAR_ALL {
+        let state = app.state::<AppState>();
+        state.notification_manager.clear(None, Some(app));
+    } else if let Some(notif_id) = id.strip_prefix(NOTIF_PREFIX) {
+        handle_notification_click(app, notif_id);
+    } else if let Some(session_id) = id.strip_prefix(SESSION_PREFIX) {
+        show_main_window(app);
+        let _ = app.emit("tray-focus-session", session_id.to_string());
+    }
+}
+
+fn handle_notification_click(app: &AppHandle, notif_id: &str) {
+    // Resolve the target session before mutating state — the
+    // `mark_read` event will trigger a tray refresh that drops the
+    // entry, which is fine, but we still need the session id to focus.
+    let target_session = {
+        let state = app.state::<AppState>();
+        state
+            .notification_manager
+            .list()
+            .into_iter()
+            .find(|n| n.id == notif_id)
+            .and_then(|n| n.session_id)
+    };
+
+    {
+        let state = app.state::<AppState>();
+        state.notification_manager.mark_read(notif_id, Some(app));
+    }
+
+    show_main_window(app);
+    if let Some(sid) = target_session {
+        let _ = app.emit("tray-focus-session", sid);
+    }
+}
+
+fn show_main_window(app: &AppHandle) {
+    if let Some(win) = app.get_webview_window("main") {
+        let _ = win.show();
+        let _ = win.unminimize();
+        let _ = win.set_focus();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a macOS menu bar / Windows task bar tray for Roux. Menu lists active (non-archived) sessions with status glyphs (idle / thinking / generating / error / disconnected / attention), plus Show Roux / Quit Roux.
- Surfaces unread notifications: header shows the count, a Notifications submenu lists up to 10 most-recent unread items with level glyphs and mark-all-read / clear-all actions. macOS title text shows the unread count next to the icon.
- Tray icon swaps to a procedurally-generated red-dotted variant whenever any session is in `Attention`. Switch is gated by an `AtomicBool` so only flips trigger `set_icon`.
- Refresh is event-driven (`roux-status-update`, `notification-event`) plus a 3s tick to catch session add/remove. Clicking a session or notification shows the window and emits `tray-focus-session { sessionId }` for the frontend to route focus (handler is a follow-up).

Implementation notes:
- Enables `tray-icon` + `image-png` features on `tauri`. Adds `image` as a direct dep (already a transitive dep, so the cost is zero).
- New module `src-tauri/src/tray.rs`. Setup happens after `socket::start_socket_server` in `main.rs` and is non-fatal on failure (e.g. headless CI).
- `Quit Roux` emits `quit-requested` to honor the existing graceful-quit handshake rather than calling `app.exit(0)` directly.
- Uses `MenuBuilder` / `SubmenuBuilder` per Tauri 2 docs, with `MenuItemBuilder` for the disabled header.

## Test plan

- [ ] `task dev` (or `npm run tauri dev`) — Roux icon appears in the macOS menu bar.
- [ ] Header reads `Roux — N active session(s)` and updates as sessions are added/archived.
- [ ] Status glyph next to each session updates as Claude transitions idle ↔ thinking ↔ generating.
- [ ] Trigger a notification (watch failure, hook prompt, or `notificationsPush` from the frontend) — Notifications submenu appears, unread count shows in the header and next to the icon.
- [ ] Click a notification → marks it read, shows the window.
- [ ] Mark all as read / Clear all in the submenu work and the menu collapses immediately.
- [ ] Force a session into `Attention` — icon swaps to red-dotted; clear it, icon goes back.
- [ ] Quit Roux from the tray triggers the normal quit-confirmation flow.
- [ ] Windows: tray icon appears in the system tray; menu and switching behave (icon-as-template no-op'd, dot still visible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System tray integration: quick access to active sessions and unread notifications.
  * Tray shows session statuses, unread count as the tray title, and an attention badge when needed.
  * Notifications submenu with truncated-list hint, plus actions to open or mark/clear notifications from the tray.
  * Background refresh (periodic + coalesced updates) keeps tray in sync without blocking startup.

* **Bug Fixes**
  * Tray initialization is best-effort—app startup continues if tray setup fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->