### PR TITLE
fix(cli,socket): route send/focus to the right session and PTY

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3957,7 +3957,7 @@ dependencies = [
 
 [[package]]
 name = "roux"
-version = "0.5.3-pre.7"
+version = "0.5.3-pre.8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -433,6 +433,32 @@ fn get_pane_id() -> Option<String> {
     std::env::var("ROUX_PANE_ID").ok()
 }
 
+/// Pick the session_id and pane_id to send over the wire, given explicit CLI
+/// flags and the current env. The invariant is that `$ROUX_PANE_ID` is only
+/// meaningful inside its own `$ROUX_SESSION_ID`, so when the caller redirects
+/// to a different session we must NOT inherit the env pane — that pane belongs
+/// to the calling session and would route the write to the wrong PTY (or, more
+/// often, fail outright because pane ids and pty ids live in different
+/// namespaces in the backend).
+fn resolve_target(
+    session: Option<String>,
+    pane: Option<String>,
+    env_session: Option<String>,
+    env_pane: Option<String>,
+) -> (Option<String>, Option<String>) {
+    match (session, pane) {
+        (Some(s), Some(p)) => (Some(s), Some(p)),
+        (Some(s), None) => {
+            // Only inherit the env pane if it belongs to the same session the
+            // caller is targeting.
+            let pane = if env_session.as_deref() == Some(s.as_str()) { env_pane } else { None };
+            (Some(s), pane)
+        }
+        (None, Some(p)) => (env_session, Some(p)),
+        (None, None) => (env_session, env_pane),
+    }
+}
+
 fn text_from_content(content: &Value) -> Option<String> {
     match content {
         Value::String(s) => {
@@ -812,10 +838,12 @@ fn main() {
                 }));
             }
             SessionAction::Send { text, session, pane, no_enter } => {
+                let (session_id, pane_id) =
+                    resolve_target(session, pane, get_session_id(), get_pane_id());
                 run_socket_command(serde_json::json!({
                     "command": "send",
-                    "session_id": session.or_else(get_session_id),
-                    "pane_id": pane.or_else(get_pane_id),
+                    "session_id": session_id,
+                    "pane_id": pane_id,
                     "args": { "text": text, "enter": !no_enter },
                 }));
             }
@@ -869,10 +897,12 @@ fn main() {
         }
 
         Commands::Focus { pane, session } => {
+            let (session_id, pane_id) =
+                resolve_target(session, pane, get_session_id(), get_pane_id());
             run_socket_command(serde_json::json!({
                 "command": "focus",
-                "session_id": session.or_else(get_session_id),
-                "pane_id": pane.or_else(get_pane_id),
+                "session_id": session_id,
+                "pane_id": pane_id,
             }));
         }
 
@@ -1089,6 +1119,64 @@ mod tests {
         let got = resolve_path("/definitely/not/a/real/path/roux-test");
         assert!(std::path::Path::new(&got).is_absolute(), "got {}", got);
         assert!(got.contains("roux-test"));
+    }
+
+    // ── resolve_target ──────────────────────────────────────
+
+    fn s(v: &str) -> Option<String> {
+        Some(v.to_string())
+    }
+
+    #[test]
+    fn resolve_target_no_flags_uses_env() {
+        // The vanilla in-session case: caller has env vars, no flags.
+        let (sid, pid) = resolve_target(None, None, s("env-sid"), s("env-pid"));
+        assert_eq!(sid.as_deref(), Some("env-sid"));
+        assert_eq!(pid.as_deref(), Some("env-pid"));
+    }
+
+    #[test]
+    fn resolve_target_explicit_session_drops_env_pane_for_other_session() {
+        // Issue #127: caller in session A targets session B with --session B.
+        // The env pane belongs to A and must NOT leak into the request — that
+        // is exactly what was routing writes back to the calling session's
+        // (nonexistent) PTY.
+        let (sid, pid) = resolve_target(s("other-sid"), None, s("env-sid"), s("env-pid"));
+        assert_eq!(sid.as_deref(), Some("other-sid"));
+        assert!(pid.is_none(), "env pane must be dropped when --session targets a different session");
+    }
+
+    #[test]
+    fn resolve_target_explicit_session_matching_env_keeps_env_pane() {
+        // If the caller redundantly passes --session matching their own env,
+        // the env pane is still applicable and should pass through.
+        let (sid, pid) = resolve_target(s("env-sid"), None, s("env-sid"), s("env-pid"));
+        assert_eq!(sid.as_deref(), Some("env-sid"));
+        assert_eq!(pid.as_deref(), Some("env-pid"));
+    }
+
+    #[test]
+    fn resolve_target_explicit_session_and_pane_pass_through() {
+        let (sid, pid) =
+            resolve_target(s("flag-sid"), s("flag-pid"), s("env-sid"), s("env-pid"));
+        assert_eq!(sid.as_deref(), Some("flag-sid"));
+        assert_eq!(pid.as_deref(), Some("flag-pid"));
+    }
+
+    #[test]
+    fn resolve_target_explicit_pane_only_uses_env_session() {
+        // Backwards-compatible behavior: --pane alone keeps inheriting the
+        // env session.
+        let (sid, pid) = resolve_target(None, s("flag-pid"), s("env-sid"), s("env-pid"));
+        assert_eq!(sid.as_deref(), Some("env-sid"));
+        assert_eq!(pid.as_deref(), Some("flag-pid"));
+    }
+
+    #[test]
+    fn resolve_target_no_env_no_flags_yields_none() {
+        let (sid, pid) = resolve_target(None, None, None, None);
+        assert!(sid.is_none());
+        assert!(pid.is_none());
     }
 
     // ── Cli parsing ─────────────────────────────────────────

--- a/src-tauri/src/socket.rs
+++ b/src-tauri/src/socket.rs
@@ -173,7 +173,7 @@ async fn handle_request(req: Request, app: &tauri::AppHandle) -> Response {
         "shell" => handle_shell(req, app).await,
         "focus" => handle_focus(req, app),
         "run" => handle_run(req, app).await,
-        "send" => handle_send(req, app),
+        "send" => handle_send(req, app).await,
         "notify" => handle_notify(req, app).await,
         "notes-read" => handle_notes_read(req, app).await,
         "notes-write" => handle_notes_write(req, app).await,
@@ -978,7 +978,41 @@ fn format_send_data(text: &str, enter: bool) -> String {
     }
 }
 
-fn handle_send(req: Request, app: &tauri::AppHandle) -> Response {
+/// Resolve which PTY to write to for `send`.
+///
+/// Frontend pane ids and pty ids live in different namespaces — the main
+/// pane has pane_id `{session}-main` while its pty_id is `{session}` — so
+/// when the caller passes a pane_id we have to look it up via the pane
+/// service rather than treating it as a pty_id directly. When no pane_id
+/// is given, fall back to the session's primary PTY.
+async fn resolve_send_pty_id(
+    pane_handle: &crate::pane_service::PaneHandle,
+    session_handle: &crate::session_service::SessionHandle,
+    session_id: &str,
+    pane_id: Option<&str>,
+) -> Result<String, String> {
+    if let Some(pane_id) = pane_id {
+        let records = pane_handle
+            .list_by_ids(vec![pane_id.to_string()])
+            .await
+            .map_err(|e| format!("pane lookup failed: {}", e))?;
+        return records
+            .into_iter()
+            .next()
+            .map(|r| r.pty_id)
+            .ok_or_else(|| format!("pane not found: {}", pane_id));
+    }
+
+    match session_handle.get(session_id).await {
+        Ok(Some(session)) => session
+            .primary_pty_id
+            .ok_or_else(|| format!("session {} has no primary PTY", session_id)),
+        Ok(None) => Err(format!("session not found: {}", session_id)),
+        Err(e) => Err(format!("session lookup failed: {}", e)),
+    }
+}
+
+async fn handle_send(req: Request, app: &tauri::AppHandle) -> Response {
     let text = match req.args.get("text").and_then(|t| t.as_str()) {
         Some(t) => t.to_string(),
         None => return Response::err("text argument required"),
@@ -986,21 +1020,29 @@ fn handle_send(req: Request, app: &tauri::AppHandle) -> Response {
 
     let state: tauri::State<AppState> = app.state();
 
-    // If a specific pane/session is given, use it. Otherwise emit to frontend
-    // to send to the active Claude pane.
-    if let Some(session_id) = &req.session_id {
-        // Write directly to the session's PTY (the main Claude pane uses session_id as pty_id)
-        let target_id = req.pane_id.as_deref().unwrap_or(session_id);
-        // Append \r to simulate Enter unless caller explicitly opts out.
-        let cr = req.args.get("enter").and_then(|v| v.as_bool()).unwrap_or(true);
-        let data = format_send_data(&text, cr);
-        if let Err(e) = state.pty_manager.write(target_id, data.as_bytes()) {
-            return Response::err(format!("Failed to write to session: {}", e));
-        }
-        Response::ok()
-    } else {
-        Response::err("session_id required")
+    let Some(session_id) = req.session_id.as_deref() else {
+        return Response::err("session_id required");
+    };
+
+    let pty_id = match resolve_send_pty_id(
+        &state.pane_handle,
+        &state.session_handle,
+        session_id,
+        req.pane_id.as_deref(),
+    )
+    .await
+    {
+        Ok(id) => id,
+        Err(e) => return Response::err(e),
+    };
+
+    // Append \r to simulate Enter unless caller explicitly opts out.
+    let cr = req.args.get("enter").and_then(|v| v.as_bool()).unwrap_or(true);
+    let data = format_send_data(&text, cr);
+    if let Err(e) = state.pty_manager.write(&pty_id, data.as_bytes()) {
+        return Response::err(format!("Failed to write to session: {}", e));
     }
+    Response::ok()
 }
 
 async fn handle_notify(req: Request, app: &tauri::AppHandle) -> Response {
@@ -1292,6 +1334,124 @@ mod tests {
         assert_eq!(req.args["profile"], "claude");
         assert_eq!(req.args["flags"].as_array().unwrap().len(), 2);
         assert_eq!(req.args["nono_allow_dirs"].as_array().unwrap().len(), 2);
+    }
+
+    // ── resolve_send_pty_id ──────────────────────────────────
+
+    fn pane_record(id: &str, pty_id: &str) -> crate::pane_service::PaneRecord {
+        crate::pane_service::PaneRecord {
+            id: id.into(),
+            pane_type: "claude".into(),
+            pty_id: pty_id.into(),
+            name: None,
+            working_dir: None,
+            command: None,
+            doc_path: None,
+            spawn_profile_ref: None,
+            provider: None,
+            provider_session_id: None,
+            nono_profile: None,
+            nono_allow_dirs: None,
+            notes_scope: None,
+            notes_view_mode: None,
+        }
+    }
+
+    fn session_with_pty(id: &str, primary_pty_id: Option<&str>) -> crate::session::Session {
+        crate::session::Session {
+            id: id.into(),
+            name: format!("Session {}", id),
+            repo_root: "/tmp/repo".into(),
+            worktree_path: "/tmp/repo".into(),
+            branch: "main".into(),
+            is_worktree: false,
+            status: roux_core::SessionStatus::Idle,
+            model: None,
+            cost: None,
+            created_at: 0,
+            project_id: None,
+            is_git_repo: false,
+            name_override: None,
+            primary_pty_id: primary_pty_id.map(String::from),
+            archived: false,
+            ended_at: None,
+            blueprint_id: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_send_pty_id_pane_lookup_returns_pty_id() {
+        // The main pane's frontend id is `{session}-main` while its pty_id
+        // is the session id itself. The handler must translate, not pass the
+        // pane id straight to pty_manager.
+        let (panes, _pjoin) = crate::pane_service::spawn();
+        let dir = tempfile::tempdir().unwrap();
+        let (sessions, _sjoin) =
+            crate::session_service::spawn_with_path(vec![], dir.path().join("sessions.json"));
+        panes.upsert(pane_record("sid-1-main", "sid-1")).await.unwrap();
+
+        let pty_id = resolve_send_pty_id(&panes, &sessions, "sid-1", Some("sid-1-main"))
+            .await
+            .unwrap();
+        assert_eq!(pty_id, "sid-1");
+    }
+
+    #[tokio::test]
+    async fn resolve_send_pty_id_no_pane_uses_session_primary_pty() {
+        // The common path: caller passes only --session. The session's primary
+        // PTY is the canonical write target.
+        let (panes, _pjoin) = crate::pane_service::spawn();
+        let dir = tempfile::tempdir().unwrap();
+        let (sessions, _sjoin) = crate::session_service::spawn_with_path(
+            vec![session_with_pty("sid-1", Some("sid-1"))],
+            dir.path().join("sessions.json"),
+        );
+
+        let pty_id = resolve_send_pty_id(&panes, &sessions, "sid-1", None).await.unwrap();
+        assert_eq!(pty_id, "sid-1");
+    }
+
+    #[tokio::test]
+    async fn resolve_send_pty_id_unknown_pane_errors() {
+        // Issue #127's failure mode pre-CLI-fix: a pane id from a different
+        // session leaks through. With the backend fix, unknown panes now
+        // surface a clean "pane not found" rather than misrouting to a
+        // nonexistent pty.
+        let (panes, _pjoin) = crate::pane_service::spawn();
+        let dir = tempfile::tempdir().unwrap();
+        let (sessions, _sjoin) = crate::session_service::spawn_with_path(
+            vec![session_with_pty("sid-2", Some("sid-2"))],
+            dir.path().join("sessions.json"),
+        );
+
+        let err = resolve_send_pty_id(&panes, &sessions, "sid-2", Some("sid-1-main"))
+            .await
+            .unwrap_err();
+        assert!(err.contains("pane not found"), "got: {}", err);
+    }
+
+    #[tokio::test]
+    async fn resolve_send_pty_id_unknown_session_errors() {
+        let (panes, _pjoin) = crate::pane_service::spawn();
+        let dir = tempfile::tempdir().unwrap();
+        let (sessions, _sjoin) =
+            crate::session_service::spawn_with_path(vec![], dir.path().join("sessions.json"));
+
+        let err = resolve_send_pty_id(&panes, &sessions, "missing-sid", None).await.unwrap_err();
+        assert!(err.contains("session not found"), "got: {}", err);
+    }
+
+    #[tokio::test]
+    async fn resolve_send_pty_id_session_without_primary_pty_errors() {
+        let (panes, _pjoin) = crate::pane_service::spawn();
+        let dir = tempfile::tempdir().unwrap();
+        let (sessions, _sjoin) = crate::session_service::spawn_with_path(
+            vec![session_with_pty("sid-1", None)],
+            dir.path().join("sessions.json"),
+        );
+
+        let err = resolve_send_pty_id(&panes, &sessions, "sid-1", None).await.unwrap_err();
+        assert!(err.contains("no primary PTY"), "got: {}", err);
     }
 
     // ── Pending-reply round-trip primitives ──────────────────

--- a/src-tauri/src/socket.rs
+++ b/src-tauri/src/socket.rs
@@ -1012,34 +1012,41 @@ async fn resolve_send_pty_id(
     }
 }
 
-async fn handle_send(req: Request, app: &tauri::AppHandle) -> Response {
-    let text = match req.args.get("text").and_then(|t| t.as_str()) {
-        Some(t) => t.to_string(),
-        None => return Response::err("text argument required"),
-    };
+/// Pure routing+formatting half of `handle_send`. Resolves the request to a
+/// `(pty_id, bytes_to_write)` pair without touching the PtyManager, so it can
+/// be exercised in headless tests without a real Tauri app or a live PTY.
+async fn prepare_send(
+    pane_handle: &crate::pane_service::PaneHandle,
+    session_handle: &crate::session_service::SessionHandle,
+    req: &Request,
+) -> Result<(String, Vec<u8>), String> {
+    let text = req
+        .args
+        .get("text")
+        .and_then(|t| t.as_str())
+        .ok_or_else(|| "text argument required".to_string())?
+        .to_string();
 
-    let state: tauri::State<AppState> = app.state();
+    let session_id =
+        req.session_id.as_deref().ok_or_else(|| "session_id required".to_string())?;
 
-    let Some(session_id) = req.session_id.as_deref() else {
-        return Response::err("session_id required");
-    };
+    let pty_id =
+        resolve_send_pty_id(pane_handle, session_handle, session_id, req.pane_id.as_deref())
+            .await?;
 
-    let pty_id = match resolve_send_pty_id(
-        &state.pane_handle,
-        &state.session_handle,
-        session_id,
-        req.pane_id.as_deref(),
-    )
-    .await
-    {
-        Ok(id) => id,
-        Err(e) => return Response::err(e),
-    };
-
-    // Append \r to simulate Enter unless caller explicitly opts out.
     let cr = req.args.get("enter").and_then(|v| v.as_bool()).unwrap_or(true);
-    let data = format_send_data(&text, cr);
-    if let Err(e) = state.pty_manager.write(&pty_id, data.as_bytes()) {
+    let data = format_send_data(&text, cr).into_bytes();
+    Ok((pty_id, data))
+}
+
+async fn handle_send(req: Request, app: &tauri::AppHandle) -> Response {
+    let state: tauri::State<AppState> = app.state();
+    let (pty_id, bytes) =
+        match prepare_send(&state.pane_handle, &state.session_handle, &req).await {
+            Ok(pair) => pair,
+            Err(e) => return Response::err(e),
+        };
+    if let Err(e) = state.pty_manager.write(&pty_id, &bytes) {
         return Response::err(format!("Failed to write to session: {}", e));
     }
     Response::ok()
@@ -1452,6 +1459,152 @@ mod tests {
 
         let err = resolve_send_pty_id(&panes, &sessions, "sid-1", None).await.unwrap_err();
         assert!(err.contains("no primary PTY"), "got: {}", err);
+    }
+
+    // ── prepare_send (issue #127 regression coverage) ────────
+
+    fn send_request(session_id: &str, pane_id: Option<&str>, text: &str, enter: bool) -> Request {
+        let mut args = serde_json::Map::new();
+        args.insert("text".into(), serde_json::Value::String(text.into()));
+        args.insert("enter".into(), serde_json::Value::Bool(enter));
+        Request {
+            command: "send".into(),
+            session_id: Some(session_id.into()),
+            pane_id: pane_id.map(String::from),
+            auth_token: None,
+            args: serde_json::Value::Object(args),
+        }
+    }
+
+    /// End-to-end exercise of the routing+formatting path on the bug-report
+    /// scenarios. These are the regression tests that would fail if either
+    /// half of the fix (CLI env handling, backend pane→pty translation) gets
+    /// reverted, without needing a running Tauri app or a live PTY.
+    #[tokio::test]
+    async fn prepare_send_main_pane_id_resolves_to_session_pty() {
+        // The main pane has frontend id `{session}-main` but its pty_id is
+        // `{session}`. Pre-fix, handle_send wrote to `{session}-main` and
+        // failed; now prepare_send must hand back `{session}` plus the
+        // formatted bytes.
+        let (panes, _pj) = crate::pane_service::spawn();
+        let dir = tempfile::tempdir().unwrap();
+        let (sessions, _sj) =
+            crate::session_service::spawn_with_path(vec![], dir.path().join("sessions.json"));
+        panes.upsert(pane_record("sid-1-main", "sid-1")).await.unwrap();
+
+        let req = send_request("sid-1", Some("sid-1-main"), "hello", true);
+        let (pty_id, bytes) = prepare_send(&panes, &sessions, &req).await.unwrap();
+        assert_eq!(pty_id, "sid-1");
+        assert_eq!(bytes, b"hello\r");
+    }
+
+    #[tokio::test]
+    async fn prepare_send_no_pane_uses_session_primary_pty() {
+        // The common in-session case: caller has no --pane.
+        let (panes, _pj) = crate::pane_service::spawn();
+        let dir = tempfile::tempdir().unwrap();
+        let (sessions, _sj) = crate::session_service::spawn_with_path(
+            vec![session_with_pty("sid-1", Some("sid-1"))],
+            dir.path().join("sessions.json"),
+        );
+
+        let req = send_request("sid-1", None, "hi", true);
+        let (pty_id, bytes) = prepare_send(&panes, &sessions, &req).await.unwrap();
+        assert_eq!(pty_id, "sid-1");
+        assert_eq!(bytes, b"hi\r");
+    }
+
+    #[tokio::test]
+    async fn prepare_send_no_enter_omits_carriage_return() {
+        let (panes, _pj) = crate::pane_service::spawn();
+        let dir = tempfile::tempdir().unwrap();
+        let (sessions, _sj) = crate::session_service::spawn_with_path(
+            vec![session_with_pty("sid-1", Some("sid-1"))],
+            dir.path().join("sessions.json"),
+        );
+
+        let req = send_request("sid-1", None, "raw", false);
+        let (_pty_id, bytes) = prepare_send(&panes, &sessions, &req).await.unwrap();
+        assert_eq!(bytes, b"raw");
+    }
+
+    #[tokio::test]
+    async fn prepare_send_cross_session_pane_lookup_returns_target_pty() {
+        // The exact issue #127 path AFTER the CLI fix: caller in session A
+        // sends to session B with --session B. Both sessions exist; B's main
+        // pane is registered. The result must route to B's pty_id, not A's.
+        let (panes, _pj) = crate::pane_service::spawn();
+        let dir = tempfile::tempdir().unwrap();
+        let (sessions, _sj) = crate::session_service::spawn_with_path(
+            vec![
+                session_with_pty("sid-A", Some("sid-A")),
+                session_with_pty("sid-B", Some("sid-B")),
+            ],
+            dir.path().join("sessions.json"),
+        );
+        panes.upsert(pane_record("sid-A-main", "sid-A")).await.unwrap();
+        panes.upsert(pane_record("sid-B-main", "sid-B")).await.unwrap();
+
+        // Caller targets B explicitly. With the CLI fix in place the env
+        // pane is dropped, so pane_id is None — backend falls back to B's
+        // primary_pty_id.
+        let req = send_request("sid-B", None, "for B", true);
+        let (pty_id, _) = prepare_send(&panes, &sessions, &req).await.unwrap();
+        assert_eq!(pty_id, "sid-B");
+    }
+
+    #[tokio::test]
+    async fn prepare_send_stale_cross_session_pane_id_errors_cleanly() {
+        // The pre-CLI-fix failure mode: the caller's env pane (`sid-A-main`)
+        // leaks into a request targeting B. Backend must surface a clean
+        // "pane not found" rather than silently writing to A's pty (which
+        // is what the OLD bug did via the pane_id == pty_id assumption).
+        let (panes, _pj) = crate::pane_service::spawn();
+        let dir = tempfile::tempdir().unwrap();
+        let (sessions, _sj) = crate::session_service::spawn_with_path(
+            vec![session_with_pty("sid-B", Some("sid-B"))],
+            dir.path().join("sessions.json"),
+        );
+        // Only B's pane is registered. A doesn't exist on this Roux instance.
+        panes.upsert(pane_record("sid-B-main", "sid-B")).await.unwrap();
+
+        let req = send_request("sid-B", Some("sid-A-main"), "leaked", true);
+        let err = prepare_send(&panes, &sessions, &req).await.unwrap_err();
+        assert!(err.contains("pane not found"), "got: {}", err);
+    }
+
+    #[tokio::test]
+    async fn prepare_send_missing_text_errors() {
+        let (panes, _pj) = crate::pane_service::spawn();
+        let dir = tempfile::tempdir().unwrap();
+        let (sessions, _sj) =
+            crate::session_service::spawn_with_path(vec![], dir.path().join("sessions.json"));
+        let req = Request {
+            command: "send".into(),
+            session_id: Some("sid".into()),
+            pane_id: None,
+            auth_token: None,
+            args: serde_json::json!({}),
+        };
+        let err = prepare_send(&panes, &sessions, &req).await.unwrap_err();
+        assert_eq!(err, "text argument required");
+    }
+
+    #[tokio::test]
+    async fn prepare_send_missing_session_id_errors() {
+        let (panes, _pj) = crate::pane_service::spawn();
+        let dir = tempfile::tempdir().unwrap();
+        let (sessions, _sj) =
+            crate::session_service::spawn_with_path(vec![], dir.path().join("sessions.json"));
+        let req = Request {
+            command: "send".into(),
+            session_id: None,
+            pane_id: None,
+            auth_token: None,
+            args: serde_json::json!({"text": "hi"}),
+        };
+        let err = prepare_send(&panes, &sessions, &req).await.unwrap_err();
+        assert_eq!(err, "session_id required");
     }
 
     // ── Pending-reply round-trip primitives ──────────────────

--- a/src-tauri/src/socket.rs
+++ b/src-tauri/src/socket.rs
@@ -996,21 +996,31 @@ async fn resolve_send_pty_id(
             .list_by_ids(vec![pane_id.to_string()])
             .await
             .map_err(|e| format!("pane lookup failed: {}", e))?;
-        return records
+        let record = records
             .into_iter()
             .next()
-            .map(|r| r.pty_id)
-            .ok_or_else(|| format!("pane not found: {}", pane_id));
+            .ok_or_else(|| format!("pane not found: {}", pane_id))?;
+
+        // Defensive: reject a pane that doesn't belong to the requested
+        // session. Pane IDs follow the `{session}-{suffix}` convention
+        // (see services/sessions.rs), so the prefix check is sufficient.
+        if !record.id.starts_with(&format!("{}-", session_id)) {
+            return Err(format!(
+                "pane {} does not belong to session {}",
+                pane_id, session_id
+            ));
+        }
+        return Ok(record.pty_id);
     }
 
     match session_handle.get(session_id).await {
-        // Primary pane's pty_id is the session id by convention (see
-        // services/sessions.rs::create_session_shell and reconnect_session_shell,
-        // both of which spawn with `pty_id = session.id`). `primary_pty_id` on
-        // the persisted record can lag — archive() clears it and reconnect
-        // doesn't re-set it — so prefer the convention and fall back to the
-        // recorded value only if it's set. This matches the pre-fix behavior
-        // where the handler wrote to `session_id` directly.
+        // The canonical PTY for a live session has `pty_id == session.id` by
+        // convention (see services/sessions.rs::create_session_shell and
+        // reconnect_session_shell). `primary_pty_id` on the persisted record
+        // can lag — archive() clears it and reconnect doesn't re-set it — so
+        // use the persisted value when set, falling back to session.id when
+        // it's None. This matches the pre-fix behavior where the handler
+        // wrote to `session_id` directly.
         Ok(Some(session)) => Ok(session.primary_pty_id.unwrap_or_else(|| session_id.to_string())),
         Ok(None) => Err(format!("session not found: {}", session_id)),
         Err(e) => Err(format!("session lookup failed: {}", e)),
@@ -1440,6 +1450,32 @@ mod tests {
             .await
             .unwrap_err();
         assert!(err.contains("pane not found"), "got: {}", err);
+    }
+
+    #[tokio::test]
+    async fn resolve_send_pty_id_cross_session_pane_errors() {
+        // The pane exists but belongs to a different session. The resolver
+        // must reject it rather than silently routing to the wrong PTY.
+        let (panes, _pjoin) = crate::pane_service::spawn();
+        let dir = tempfile::tempdir().unwrap();
+        let (sessions, _sjoin) = crate::session_service::spawn_with_path(
+            vec![
+                session_with_pty("sid-A", Some("sid-A")),
+                session_with_pty("sid-B", Some("sid-B")),
+            ],
+            dir.path().join("sessions.json"),
+        );
+        panes.upsert(pane_record("sid-A-main", "sid-A")).await.unwrap();
+        panes.upsert(pane_record("sid-B-main", "sid-B")).await.unwrap();
+
+        let err = resolve_send_pty_id(&panes, &sessions, "sid-B", Some("sid-A-main"))
+            .await
+            .unwrap_err();
+        assert!(
+            err.contains("does not belong to session"),
+            "got: {}",
+            err
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/socket.rs
+++ b/src-tauri/src/socket.rs
@@ -1004,9 +1004,14 @@ async fn resolve_send_pty_id(
     }
 
     match session_handle.get(session_id).await {
-        Ok(Some(session)) => session
-            .primary_pty_id
-            .ok_or_else(|| format!("session {} has no primary PTY", session_id)),
+        // Primary pane's pty_id is the session id by convention (see
+        // services/sessions.rs::create_session_shell and reconnect_session_shell,
+        // both of which spawn with `pty_id = session.id`). `primary_pty_id` on
+        // the persisted record can lag — archive() clears it and reconnect
+        // doesn't re-set it — so prefer the convention and fall back to the
+        // recorded value only if it's set. This matches the pre-fix behavior
+        // where the handler wrote to `session_id` directly.
+        Ok(Some(session)) => Ok(session.primary_pty_id.unwrap_or_else(|| session_id.to_string())),
         Ok(None) => Err(format!("session not found: {}", session_id)),
         Err(e) => Err(format!("session lookup failed: {}", e)),
     }
@@ -1449,7 +1454,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resolve_send_pty_id_session_without_primary_pty_errors() {
+    async fn resolve_send_pty_id_falls_back_to_session_id_when_primary_pty_unset() {
+        // Regression coverage for the restore/reconnect path: archive() clears
+        // primary_pty_id and reconnect_session_shell doesn't re-set it, but
+        // the live PTY is still registered under `pty_id == session.id` by
+        // convention. The resolver must use that convention when the
+        // persisted field is None, otherwise sends to restored sessions break.
         let (panes, _pjoin) = crate::pane_service::spawn();
         let dir = tempfile::tempdir().unwrap();
         let (sessions, _sjoin) = crate::session_service::spawn_with_path(
@@ -1457,8 +1467,8 @@ mod tests {
             dir.path().join("sessions.json"),
         );
 
-        let err = resolve_send_pty_id(&panes, &sessions, "sid-1", None).await.unwrap_err();
-        assert!(err.contains("no primary PTY"), "got: {}", err);
+        let pty_id = resolve_send_pty_id(&panes, &sessions, "sid-1", None).await.unwrap();
+        assert_eq!(pty_id, "sid-1");
     }
 
     // ── prepare_send (issue #127 regression coverage) ────────


### PR DESCRIPTION
Fixes #127 — two independent bugs combined to make `roux-cli session send "x" --session <other>` write to the calling session's (nonexistent) pane instead of the target.

**Changes:**

1. **CLI fix** — `$ROUX_PANE_ID` was inherited as `pane_id` even when `--session` named a different session. The env pane belongs to the calling session and is meaningless once the caller redirects elsewhere, so we now drop it in that case.

2. **Backend fix** — `handle_send` treated `pane_id` as if it were a `pty_id`, but the main pane's frontend id is `{session}-main` while its pty_id is just `{session}`. Now resolves `pane_id → pty_id` via the pane service, and falls back to `primary_pty_id` when no pane is given.

3. **Fallback fix** — `archive()` clears `Session.primary_pty_id` and `reconnect_session_shell` respawns the PTY without re-setting it, so restored sessions had a live PTY but `None` primary_pty_id. We now match the spawn convention (`pty_id = session.id`) and only use `primary_pty_id` when present.

4. **Tests** — Extracted `prepare_send` for headless testing and added regression coverage for the exact scenarios from the bug report (cross-session routing, stale pane IDs, enter=false, missing args).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented cross-session pane inheritance: when a target session differs from the env session, the env pane is no longer applied; fixes stale or misrouted sends.
  * Ensured send commands validate session/pane and respect the explicit "enter" flag when sending input.

* **Refactor**
  * Reworked command routing and send preparation to separate resolution, validation, and writing for more reliable behavior.

* **Tests**
  * Added unit tests covering session/pane resolution, ownership checks, and input formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->