### PR TITLE
Fix spawn profile command submission

### DIFF
--- a/src/lib/panes/__tests__/layoutRunner.test.ts
+++ b/src/lib/panes/__tests__/layoutRunner.test.ts
@@ -513,6 +513,7 @@ describe("applyLayoutToSession", () => {
     // Both leaves get profile commands
     expect(runProfileInPane).toHaveBeenCalledTimes(2);
     expect(runProfileInPane).toHaveBeenCalledWith("s9", claude);
+    expect(runProfileInPane).toHaveBeenCalledWith(expect.any(String), shell);
   });
 
   // ── Nono config tests ─────────────────────────────────────────────────────

--- a/src/lib/panes/__tests__/profileRunner.test.ts
+++ b/src/lib/panes/__tests__/profileRunner.test.ts
@@ -40,10 +40,10 @@ describe("runProfileInPane", () => {
 
   it("types and auto-runs a startup command by default", async () => {
     await runProfileInPane("pty-1", profile({ startupCommand: "claude" }));
-    expect(writes()).toEqual(["claude", "\n"]);
+    expect(writes()).toEqual(["claude", "\r"]);
   });
 
-  it("types a startup command without a trailing newline when typeOnly", async () => {
+  it("types a startup command without pressing Enter when typeOnly", async () => {
     await runProfileInPane(
       "pty-1",
       profile({ startupCommand: "bun run dev", startupBehavior: "typeOnly" }),
@@ -51,7 +51,7 @@ describe("runProfileInPane", () => {
     expect(writes()).toEqual(["bun run dev"]);
   });
 
-  it("runs setup before startup, each with its own newline", async () => {
+  it("runs setup before startup, pressing Enter after each", async () => {
     await runProfileInPane(
       "pty-1",
       profile({
@@ -61,9 +61,9 @@ describe("runProfileInPane", () => {
     );
     expect(writes()).toEqual([
       "./scripts/start-mcp.sh",
-      "\n",
+      "\r",
       "claude --mcp-config ~/.mcp.json",
-      "\n",
+      "\r",
     ]);
   });
 
@@ -76,7 +76,7 @@ describe("runProfileInPane", () => {
         startupBehavior: "typeOnly",
       }),
     );
-    expect(writes()).toEqual(["export FOO=bar", "\n", "claude"]);
+    expect(writes()).toEqual(["export FOO=bar", "\r", "claude"]);
   });
 
   it("skips setup when it's only whitespace", async () => {
@@ -84,7 +84,7 @@ describe("runProfileInPane", () => {
       "pty-1",
       profile({ setupCommand: "   \n", startupCommand: "claude" }),
     );
-    expect(writes()).toEqual(["claude", "\n"]);
+    expect(writes()).toEqual(["claude", "\r"]);
   });
 
   it("propagates writeToSession errors so callers can surface them", async () => {
@@ -107,7 +107,7 @@ describe("runProfileInPane", () => {
           startupCommand: "claude",
         }),
       );
-      expect(writes()).toEqual(["cd '/tmp/workspace'", "\n", "claude", "\n"]);
+      expect(writes()).toEqual(["cd '/tmp/workspace'", "\r", "claude", "\r"]);
     });
 
     it("shell-escapes paths containing spaces and single quotes", async () => {
@@ -118,7 +118,7 @@ describe("runProfileInPane", () => {
         "pty-1",
         profile({ cwdOverride: "/tmp/it's my dir" }),
       );
-      expect(writes()).toEqual(["cd '/tmp/it'\\''s my dir'", "\n"]);
+      expect(writes()).toEqual(["cd '/tmp/it'\\''s my dir'", "\r"]);
     });
 
     it("skips cd for an empty or whitespace-only cwdOverride", async () => {
@@ -126,7 +126,7 @@ describe("runProfileInPane", () => {
         "pty-1",
         profile({ cwdOverride: "   ", startupCommand: "claude" }),
       );
-      expect(writes()).toEqual(["claude", "\n"]);
+      expect(writes()).toEqual(["claude", "\r"]);
     });
   });
 
@@ -147,7 +147,7 @@ describe("runProfileInPane", () => {
       const startupIdx = out.indexOf("claude");
       expect(startupIdx).toBeGreaterThan(-1);
       expect(out.slice(0, startupIdx)).toEqual(
-        expect.arrayContaining(["export FOO='bar'", "export BAZ='qux'", "\n"]),
+        expect.arrayContaining(["export FOO='bar'", "export BAZ='qux'", "\r"]),
       );
     });
 
@@ -158,7 +158,7 @@ describe("runProfileInPane", () => {
       );
       expect(writes()).toEqual([
         "export MSG='it'\\''s; $(whoami)'",
-        "\n",
+        "\r",
       ]);
     });
 
@@ -171,7 +171,7 @@ describe("runProfileInPane", () => {
           env: { "1BAD": "x", "WITH-DASH": "y", GOOD: "z" },
         }),
       );
-      expect(writes()).toEqual(["export GOOD='z'", "\n"]);
+      expect(writes()).toEqual(["export GOOD='z'", "\r"]);
     });
   });
 
@@ -187,13 +187,13 @@ describe("runProfileInPane", () => {
     );
     expect(writes()).toEqual([
       "cd '/work'",
-      "\n",
+      "\r",
       "export API='https://api'",
-      "\n",
+      "\r",
       "./seed.sh",
-      "\n",
+      "\r",
       "claude",
-      "\n",
+      "\r",
     ]);
   });
 });

--- a/src/lib/panes/profileRunner.ts
+++ b/src/lib/panes/profileRunner.ts
@@ -10,6 +10,9 @@ import { appendAgentSystemPrompt } from "./agentPrompt";
  * their use is almost always a typo in the profile editor.
  */
 const VALID_ENV_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+// PTY Enter is carriage return. LF can render a new line without submitting
+// the readline buffer in shells that expect terminal-style input.
+const TERMINAL_ENTER = "\r";
 
 /**
  * Wrap a value in single quotes for safe inclusion in a shell command.
@@ -88,22 +91,23 @@ export async function runProfileInPane(
       `runProfileInPane(${ptyId}): cd to override for profile "${profile.id}"`,
     );
     await writeToSession(ptyId, `cd ${shellSingleQuote(cwdOverride)}`);
-    await writeToSession(ptyId, "\n");
+    await writeToSession(ptyId, TERMINAL_ENTER);
   }
 
   for (const [name, value] of envEntries) {
     await writeToSession(ptyId, `export ${name}=${shellSingleQuote(value)}`);
-    await writeToSession(ptyId, "\n");
+    await writeToSession(ptyId, TERMINAL_ENTER);
   }
 
   if (hasSetup) {
     log(`runProfileInPane(${ptyId}): typing setup command for profile "${profile.id}"`);
     await writeToSession(ptyId, profile.setupCommand!);
-    await writeToSession(ptyId, "\n");
+    await writeToSession(ptyId, TERMINAL_ENTER);
   }
 
   if (hasStartup) {
-    const suffix = (profile.startupBehavior ?? "autoRun") === "typeOnly" ? "" : "\n";
+    const suffix =
+      (profile.startupBehavior ?? "autoRun") === "typeOnly" ? "" : TERMINAL_ENTER;
     log(
       `runProfileInPane(${ptyId}): typing startup command for profile "${profile.id}" (behavior=${profile.startupBehavior ?? "autoRun"})`,
     );

--- a/src/lib/sessions/__tests__/reconnect.test.ts
+++ b/src/lib/sessions/__tests__/reconnect.test.ts
@@ -154,7 +154,7 @@ describe("reconnectSession — existing behavior preserved", () => {
     await continueSession(session);
 
     expect(writeToSession).toHaveBeenCalledWith(session.id, "claude --continue");
-    expect(writeToSession).toHaveBeenCalledWith(session.id, "\n");
+    expect(writeToSession).toHaveBeenCalledWith(session.id, "\r");
   });
 
   it("continues a Claude primary profile by exact provider session id when available", async () => {
@@ -173,7 +173,7 @@ describe("reconnectSession — existing behavior preserved", () => {
       session.id,
       "claude --resume claude-session-123",
     );
-    expect(writeToSession).toHaveBeenCalledWith(session.id, "\n");
+    expect(writeToSession).toHaveBeenCalledWith(session.id, "\r");
   });
 
   it("falls back to Claude continue when provider session id contains shell metacharacters", async () => {
@@ -230,7 +230,7 @@ describe("reconnectSession — existing behavior preserved", () => {
 
     // Only the original attempt is made. We don't auto-fall-back to
     // `--continue` because runProfileInPane writes the command and the
-    // newline as separate PTY writes — a partial failure could leave a
+    // Enter as separate PTY writes — a partial failure could leave a
     // half-typed line, and a retry would compound the mess.
     expect(vi.mocked(writeToSession).mock.calls.map(([, data]) => data)).toEqual([
       "claude --resume claude-session-123",
@@ -256,7 +256,7 @@ describe("reconnectSession — existing behavior preserved", () => {
     await continueSession(session);
 
     expect(writeToSession).toHaveBeenCalledWith(session.id, "codex resume --last");
-    expect(writeToSession).toHaveBeenCalledWith(session.id, "\n");
+    expect(writeToSession).toHaveBeenCalledWith(session.id, "\r");
   });
 
   it("continues a Codex primary profile by exact provider session id when available", async () => {
@@ -283,7 +283,7 @@ describe("reconnectSession — existing behavior preserved", () => {
       session.id,
       "codex resume codex-session-123",
     );
-    expect(writeToSession).toHaveBeenCalledWith(session.id, "\n");
+    expect(writeToSession).toHaveBeenCalledWith(session.id, "\r");
   });
 
   it("falls back to Codex resume --last when provider session id has spaces", async () => {


### PR DESCRIPTION
Fixes spawn profile auto-run command submission by sending terminal Enter (CR) instead of LF. This covers Claude/Codex startup, setup commands, and reconnect commands. This PR does not fix Ctrl+Shift+R reload restoration; that will be separate. Verified with focused Vitest, full npm run test, and npm run check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal command execution handling to ensure proper Enter keystroke behavior in profile operations and session continuation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->