### PR TITLE
fix(tray): defer menu work to tokio + capture panics in log

### DIFF
--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -2,12 +2,19 @@ use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Mutex;
+use std::sync::{Mutex, OnceLock};
 
 static LOG_FILE: Mutex<Option<PathBuf>> = Mutex::new(None);
 static ENABLED: AtomicBool = AtomicBool::new(false);
 /// Initialize logging. Call once at startup.
 pub fn init(enabled: bool) {
+    // Install the panic hook unconditionally so panic messages always land
+    // in roux.log, even when settings have logging disabled. Stderr from a
+    // launchd-spawned `.app` bundle goes to /dev/null, so without this hook
+    // a panic on the FFI boundary aborts the process with no recoverable
+    // diagnostic.
+    install_panic_hook();
+
     ENABLED.store(enabled, Ordering::Relaxed);
 
     if !enabled {
@@ -95,4 +102,45 @@ macro_rules! rlog {
 
 fn log_dir() -> PathBuf {
     crate::paths::roux_config_dir().join("logs")
+}
+
+/// Install a process-wide panic hook that writes panic info to roux.log
+/// regardless of the `ENABLED` flag. Idempotent.
+fn install_panic_hook() {
+    static INSTALLED: OnceLock<()> = OnceLock::new();
+    if INSTALLED.set(()).is_err() {
+        return;
+    }
+    let prev = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let location = info
+            .location()
+            .map(|l| format!("{}:{}:{}", l.file(), l.line(), l.column()))
+            .unwrap_or_else(|| "<unknown>".into());
+        let payload = info
+            .payload()
+            .downcast_ref::<&str>()
+            .map(|s| (*s).to_string())
+            .or_else(|| info.payload().downcast_ref::<String>().cloned())
+            .unwrap_or_else(|| "<non-string panic payload>".into());
+        let thread = std::thread::current()
+            .name()
+            .map(String::from)
+            .unwrap_or_else(|| format!("{:?}", std::thread::current().id()));
+        force_log_panic(&format!("PANIC thread={thread} at {location}: {payload}"));
+        prev(info);
+    }));
+}
+
+/// Append `msg` to roux.log without consulting the `ENABLED` flag. Used by
+/// the panic hook so panics always land in the log even when the user has
+/// logging turned off — panic capture is critical for triage.
+fn force_log_panic(msg: &str) {
+    let dir = log_dir();
+    let _ = fs::create_dir_all(&dir);
+    let path = dir.join("roux.log");
+    if let Ok(mut f) = OpenOptions::new().create(true).append(true).open(&path) {
+        let _ = writeln!(f, "[{}] {}", chrono_now(), msg);
+    }
+    eprintln!("[roux] {}", msg);
 }

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -21,11 +21,33 @@ pub fn init(enabled: bool) {
         return;
     }
 
+    rotate_existing_logs();
+    initialize_log_file();
+}
+
+/// Enable or disable logging at runtime (e.g. when settings change).
+pub fn set_enabled(enabled: bool) {
+    let was_enabled = ENABLED.swap(enabled, Ordering::Relaxed);
+    if enabled && !was_enabled {
+        // Turning on — initialize the log file if not already done.
+        // Don't go through `init(true)` here because that would rotate
+        // any existing `roux.log` to `roux.1.log`, hiding panic data
+        // captured by the panic hook while logging was disabled. Rotation
+        // is reserved for actual process startup.
+        let guard = LOG_FILE.lock().unwrap();
+        if guard.is_none() {
+            drop(guard);
+            initialize_log_file();
+        }
+    }
+}
+
+/// Rotate existing log files. Called once at process startup.
+fn rotate_existing_logs() {
     let dir = log_dir();
     let _ = fs::create_dir_all(&dir);
-
-    // Keep last 5 log files, rotate on startup
     let path = dir.join("roux.log");
+    // Keep last 5 log files
     for i in (1..5).rev() {
         let old = dir.join(format!("roux.{}.log", i));
         let new = dir.join(format!("roux.{}.log", i + 1));
@@ -34,25 +56,20 @@ pub fn init(enabled: bool) {
     if path.exists() {
         let _ = fs::rename(&path, dir.join("roux.1.log"));
     }
+}
 
+/// Set up the in-memory `LOG_FILE` pointer and write the session-start
+/// header lines. Does not rotate — safe to call from `set_enabled` when
+/// logging is toggled on at runtime.
+fn initialize_log_file() {
+    let dir = log_dir();
+    let _ = fs::create_dir_all(&dir);
+    let path = dir.join("roux.log");
     *LOG_FILE.lock().unwrap() = Some(path.clone());
     log(&format!("=== Roux started at {} ===", chrono_now()));
     log(&format!("Log file: {}", path.display()));
     log(&format!("OS: {} {}", std::env::consts::OS, std::env::consts::ARCH));
     log(&format!("SHELL: {}", std::env::var("SHELL").unwrap_or_else(|_| "(unset)".into())));
-}
-
-/// Enable or disable logging at runtime (e.g. when settings change).
-pub fn set_enabled(enabled: bool) {
-    let was_enabled = ENABLED.swap(enabled, Ordering::Relaxed);
-    if enabled && !was_enabled {
-        // Turning on — initialize the log file if not already done
-        let guard = LOG_FILE.lock().unwrap();
-        if guard.is_none() {
-            drop(guard);
-            init(true);
-        }
-    }
 }
 
 fn chrono_now() -> String {
@@ -127,20 +144,27 @@ fn install_panic_hook() {
             .name()
             .map(String::from)
             .unwrap_or_else(|| format!("{:?}", std::thread::current().id()));
-        force_log_panic(&format!("PANIC thread={thread} at {location}: {payload}"));
+        log_unconditional(&format!("PANIC thread={thread} at {location}: {payload}"));
+        // The previous (default) hook handles stderr output for dev/CLI runs.
         prev(info);
     }));
 }
 
-/// Append `msg` to roux.log without consulting the `ENABLED` flag. Used by
-/// the panic hook so panics always land in the log even when the user has
-/// logging turned off — panic capture is critical for triage.
-fn force_log_panic(msg: &str) {
+/// Append `msg` to roux.log regardless of the `ENABLED` flag.
+///
+/// Used by the panic hook so panics always land in the log even when the
+/// user has logging turned off, and exposed for callers like
+/// `tray::handle_menu_event`'s `catch_unwind` recovery path that need to
+/// record diagnostics whose loss would defeat the purpose of catching.
+///
+/// Does not write to stderr — the default panic hook (chained from
+/// `install_panic_hook`) already prints to stderr in dev/CLI runs, and
+/// production `.app` bundles route stderr to /dev/null.
+pub fn log_unconditional(msg: &str) {
     let dir = log_dir();
     let _ = fs::create_dir_all(&dir);
     let path = dir.join("roux.log");
     if let Ok(mut f) = OpenOptions::new().create(true).append(true).open(&path) {
         let _ = writeln!(f, "[{}] {}", chrono_now(), msg);
     }
-    eprintln!("[roux] {}", msg);
 }

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -364,25 +364,61 @@ fn level_glyph(level: NotificationLevel) -> &'static str {
     }
 }
 
+/// Tray menu callbacks fire on the macOS main thread, inside tao's
+/// `extern "C" fn send_event`. A panic anywhere downstream of this fn
+/// can't unwind across the Cocoa FFI boundary — Rust force-aborts. So
+/// we keep this fn as a thin classifier: own the id as a `String`,
+/// hand the actual work to a tokio task, and wrap the dispatcher body
+/// in `catch_unwind` so even classification errors can't crash us.
 fn handle_menu_event(app: &AppHandle, event: tauri::menu::MenuEvent) {
-    let id = event.id().as_ref();
+    let app = app.clone();
+    let id = event.id().as_ref().to_string();
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        dispatch_menu_event(app, id);
+    }));
+    if let Err(e) = result {
+        let msg = e
+            .downcast_ref::<&str>()
+            .map(|s| (*s).to_string())
+            .or_else(|| e.downcast_ref::<String>().cloned())
+            .unwrap_or_else(|| "<non-string panic payload>".into());
+        rlog!("tray: handle_menu_event panicked: {msg}");
+    }
+}
+
+fn dispatch_menu_event(app: AppHandle, id: String) {
     if id == MENU_ID_SHOW {
-        show_main_window(app);
+        tauri::async_runtime::spawn(async move {
+            show_main_window(&app);
+        });
     } else if id == MENU_ID_QUIT {
         // Match the existing quit path: emit `quit-requested` and let the
         // frontend confirm + call back into the app to actually exit.
-        let _ = app.emit("quit-requested", ());
+        tauri::async_runtime::spawn(async move {
+            let _ = app.emit("quit-requested", ());
+        });
     } else if id == MENU_ID_MARK_ALL_READ {
-        let state = app.state::<AppState>();
-        state.notification_manager.mark_all_read(None, Some(app));
+        tauri::async_runtime::spawn(async move {
+            let state = app.state::<AppState>();
+            state.notification_manager.mark_all_read(None, Some(&app));
+        });
     } else if id == MENU_ID_CLEAR_ALL {
-        let state = app.state::<AppState>();
-        state.notification_manager.clear(None, Some(app));
+        tauri::async_runtime::spawn(async move {
+            let state = app.state::<AppState>();
+            state.notification_manager.clear(None, Some(&app));
+        });
     } else if let Some(notif_id) = id.strip_prefix(NOTIF_PREFIX) {
-        handle_notification_click(app, notif_id);
+        let notif_id = notif_id.to_string();
+        tauri::async_runtime::spawn(async move {
+            handle_notification_click(&app, &notif_id);
+        });
     } else if let Some(session_id) = id.strip_prefix(SESSION_PREFIX) {
-        show_main_window(app);
-        let _ = app.emit("tray-focus-session", session_id.to_string());
+        let session_id = session_id.to_string();
+        tauri::async_runtime::spawn(async move {
+            show_main_window(&app);
+            let _ = app.emit("tray-focus-session", session_id);
+        });
     }
 }
 

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -383,7 +383,13 @@ fn handle_menu_event(app: &AppHandle, event: tauri::menu::MenuEvent) {
             .map(|s| (*s).to_string())
             .or_else(|| e.downcast_ref::<String>().cloned())
             .unwrap_or_else(|| "<non-string panic payload>".into());
-        rlog!("tray: handle_menu_event panicked: {msg}");
+        // Log unconditionally: the panic hook captures the underlying panic
+        // location regardless of `ENABLED`, but this contextual line is
+        // worth preserving too — `rlog!` would silently drop it when the
+        // user has logging disabled, defeating the diagnostic goal.
+        crate::logging::log_unconditional(&format!(
+            "tray: handle_menu_event panicked: {msg}"
+        ));
     }
 }
 


### PR DESCRIPTION
## Summary

- Move tray menu event work off the Cocoa main thread into a tokio task, so panics in `mark_all_read` / `clear` / notification clicks no longer abort the process when they cross the FFI boundary.
- Install a process-wide panic hook that writes panic thread + location + payload to `~/.config/roux/logs/roux.log` unconditionally, since stderr from a launchd-spawned `.app` bundle goes to `/dev/null` and panic messages were otherwise unrecoverable.

## Why

User reported a deterministic crash on macOS when clicking **Mark all as read** in the tray icon's Notifications submenu (Roux v0.5.3-pre.12, crash report at `~/Library/Logs/DiagnosticReports/roux-2026-05-03-143309.ips`). Stack confirmed `EXC_CRASH (SIGABRT)` from `panic_cannot_unwind` inside `tao::send_event` on the main thread — a Rust panic propagating across the Cocoa FFI boundary.

`handle_menu_event` was running synchronously on the main thread and calling `notification_manager.mark_all_read(None, Some(app))`, which holds a `Mutex` and emits an event. Any panic downstream of that — poisoned mutex, internal tauri lock, wry/muda assertion — was force-aborting because tao's `extern "C" fn send_event` can't unwind.

## What changed

**`src-tauri/src/tray.rs`** — `handle_menu_event` is now a thin classifier wrapped in `catch_unwind`. It owns the menu id as a `String`, then for each id branch it calls `tauri::async_runtime::spawn` so the actual work (`mark_all_read`, `clear`, `handle_notification_click`, `app.emit`, `show_main_window`) runs on a tokio worker. Panics on the worker are caught by tokio instead of crashing the process. `catch_unwind` is defensive — even classification errors can't escape into Cocoa.

**`src-tauri/src/logging.rs`** — added `install_panic_hook()` called from `init()`. It writes `PANIC thread=… at <file:line:col>: <payload>` to `roux.log` regardless of the `enable_logging` setting (the file is created on demand) and chains the previous panic hook so `task dev` still gets stderr output. Without this, the panic string was lost: not in the `.ips`, not in unified log, not in our log.

## Known limitation — not a complete fix

After landing this branch locally, repro confirmed the panic hook works (we got an actual panic message for the first time):

```
PANIC thread=main at muda-0.17.2/src/platform_impl/macos/icon.rs:34:53:
called `Result::unwrap()` on an `Err` value: Format(FormatError { inner: ZeroWidth })
```

This panic happens during tray menu refresh on agent notification — i.e. via `tauri::run_main_thread!` dispatch from `do_refresh`, **not** through `handle_menu_event`. The `catch_unwind` in this PR doesn't cover that path because `run_main_thread!`'s task is run inside Tauri's own event loop and we can't wrap it from outside.

The source of the zero-width `muda::Icon` is still unidentified — none of our menu items use icons, and tauri's defaults don't either. The dependency chain is `tauri::tray::TrayIcon::set_menu` → `tray-icon` → `muda` (since `tray-icon` re-exports/depends on `muda`).

This PR ships the diagnostic + the click-path defense. The remaining `muda` panic needs separate investigation; the hook will capture every future repro.

## Test plan

- [x] `cargo check` in `src-tauri/` — clean
- [x] `cargo test --workspace` — 647 passed, 0 failed
- [x] `npm run check` — 0 errors, 0 warnings (922 files)
- [x] `npm run test` — 879 passed, 2 skipped, 0 failed
- [x] Confirmed panic-hook captures panic message in `~/.config/roux/logs/roux.log` via real repro
- [ ] Manual: click **Mark all as read** in tray Notifications submenu — should no longer abort, even if a panic occurs the process should stay up. (The agent-notification crash is not fixed in this PR — see "Known limitation" above.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS tray menu handling to prevent crashes crossing native boundaries and increase stability.

* **Improvements**
  * Enhanced crash diagnostics with richer panic details (location, thread, payload) recorded to the application log.
  * Logging now initializes and rotates logs more predictably and supports appending diagnostics even when regular logging is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->