### PR TITLE
feat(settings): add Experiments tab with boolean and enum feature flags

### DIFF
--- a/crates/roux-core/src/models/mod.rs
+++ b/crates/roux-core/src/models/mod.rs
@@ -28,9 +28,9 @@ pub use profile::{ProfileSource, Provider, SpawnProfile, StartupBehavior};
 pub use project::{Project, ProjectUpdate, SessionBlueprint};
 pub use session::{Session, SessionStatus};
 pub use settings::{
-    CursorStyle, GroupBy, LibrarySource, LibrarySourceKind, RouxSettings, SkillSyncMode,
-    StatusBarPosition, TabPosition, UpdateChannel, WorktreeCleanupMode, WorktreeDefaultBase,
-    WorktreeProvider,
+    CursorStyle, ExampleVariant, ExperimentsConfig, GroupBy, LibrarySource, LibrarySourceKind,
+    RouxSettings, SkillSyncMode, StatusBarPosition, TabPosition, UpdateChannel,
+    WorktreeCleanupMode, WorktreeDefaultBase, WorktreeProvider,
 };
 pub use task::{KeepOpen, TaskDefinition, TaskGroup};
 pub use user_terminal_themes::{

--- a/crates/roux-core/src/models/settings.rs
+++ b/crates/roux-core/src/models/settings.rs
@@ -189,6 +189,30 @@ pub enum GpuAcceleration {
     Off,
 }
 
+/// No-op variant used to verify the enum-experiment pipeline end to end.
+/// Replace or remove once a real enum experiment lands.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, specta::Type, Default)]
+#[serde(rename_all = "camelCase")]
+pub enum ExampleVariant {
+    #[default]
+    A,
+    B,
+    C,
+}
+
+/// Runtime feature flags surfaced under Settings → Experiments. Each field is
+/// either a `bool` (toggle) or a small enum (multi-choice). Adding a field
+/// here also requires adding a registry entry in `src/lib/experiments.ts` so
+/// the UI knows how to render it.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase", default)]
+pub struct ExperimentsConfig {
+    #[serde(default)]
+    pub example_flag: bool,
+    #[serde(default)]
+    pub example_variant: ExampleVariant,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
 #[serde(rename_all = "camelCase")]
 pub struct RouxSettings {
@@ -390,6 +414,9 @@ pub struct RouxSettings {
     /// Unix epoch milliseconds for the last successful MCP host config write.
     #[serde(default)]
     pub mcp_last_configured_at_ms: Option<u64>,
+    /// Runtime feature flags. See `ExperimentsConfig`.
+    #[serde(default)]
+    pub experiments: ExperimentsConfig,
 }
 
 impl Default for RouxSettings {
@@ -452,6 +479,7 @@ impl Default for RouxSettings {
             mcp_enabled: false,
             mcp_last_configured_host: None,
             mcp_last_configured_at_ms: None,
+            experiments: ExperimentsConfig::default(),
         }
     }
 }
@@ -690,8 +718,8 @@ mod theme_tests {
 #[cfg(test)]
 mod tests {
     use super::{
-        stable_source_id, LibrarySource, LibrarySourceKind, RouxSettings, SkillSyncMode,
-        UpdateChannel,
+        stable_source_id, ExampleVariant, ExperimentsConfig, LibrarySource, LibrarySourceKind,
+        RouxSettings, SkillSyncMode, UpdateChannel,
     };
 
     #[test]
@@ -833,6 +861,47 @@ mod tests {
     fn settings_default_skill_sync_is_off() {
         let settings = RouxSettings::default();
         assert_eq!(settings.library_skill_sync_default, SkillSyncMode::Off);
+    }
+
+    #[test]
+    fn settings_without_experiments_deserializes_with_default() {
+        // Pre-existing settings.json files written before the experiments
+        // field existed must continue to load with all flags off.
+        let json = r#"{
+            "tabPosition": "left",
+            "tabWidth": 260,
+            "fontSize": 14,
+            "fontFamily": "monospace",
+            "lineHeight": 1.2,
+            "scrollback": 5000,
+            "cursorStyle": "block",
+            "cursorBlink": true,
+            "defaultProjectPath": null,
+            "confirmOnClose": true,
+            "restoreSessionsOnLaunch": true,
+            "worktreeBasePath": null,
+            "cleanupWorktreesOnClose": false,
+            "theme": "deep-blue",
+            "defaultModel": null,
+            "additionalFlags": [],
+            "taskPanelSplit": 0.4,
+            "taskPanelCollapsed": false
+        }"#;
+
+        let settings: RouxSettings = serde_json::from_str(json).unwrap();
+        assert!(!settings.experiments.example_flag);
+        assert_eq!(settings.experiments.example_variant, ExampleVariant::A);
+    }
+
+    #[test]
+    fn experiments_partial_payload_fills_missing_with_defaults() {
+        // A flag added later (e.g. only `exampleVariant` set, `exampleFlag`
+        // absent) must not fail deserialization — each inner field is
+        // `#[serde(default)]`.
+        let json = r#"{ "exampleVariant": "c" }"#;
+        let exp: ExperimentsConfig = serde_json::from_str(json).unwrap();
+        assert!(!exp.example_flag);
+        assert_eq!(exp.example_variant, ExampleVariant::C);
     }
 
     #[test]

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -402,6 +402,23 @@ export type DoctorStatus = {
 	items: DoctorItem[],
 };
 
+/**
+ *  No-op variant used to verify the enum-experiment pipeline end to end.
+ *  Replace or remove once a real enum experiment lands.
+ */
+export type ExampleVariant = "a" | "b" | "c";
+
+/**
+ *  Runtime feature flags surfaced under Settings → Experiments. Each field is
+ *  either a `bool` (toggle) or a small enum (multi-choice). Adding a field
+ *  here also requires adding a registry entry in `src/lib/experiments.ts` so
+ *  the UI knows how to render it.
+ */
+export type ExperimentsConfig = {
+	exampleFlag?: boolean,
+	exampleVariant?: ExampleVariant,
+};
+
 export type GithubJob = {
 	name: string,
 	status: string,
@@ -482,38 +499,6 @@ export type IntegrationDetection = {
 };
 
 export type KeepOpen = "always" | "on-error" | "never";
-
-export type McpHostConfigPreview = {
-	host: McpHostId,
-	label: string,
-	configPath: string,
-	configExists: boolean,
-	action: string,
-	configured: boolean,
-	currentEntryJson: string | null,
-	nextEntryJson: string,
-};
-
-export type McpHostId = "claudeDesktop";
-
-export type McpHostStatus = {
-	id: McpHostId,
-	label: string,
-	configPath: string | null,
-	configExists: boolean,
-	configured: boolean,
-	error: string | null,
-};
-
-export type McpStatus = {
-	enabled: boolean,
-	cliInstalled: boolean,
-	cliCurrent: boolean,
-	cliPath: string,
-	lastConfiguredHost: string | null,
-	lastConfiguredAtMs: number | null,
-	hosts: McpHostStatus[],
-};
 
 // How a bound key is matched against a `KeyboardEvent`.
 export type KeyRef = 
@@ -624,6 +609,38 @@ export type LibrarySource = {
 };
 
 export type LibrarySourceKind = "localRepo" | "gitRepo";
+
+export type McpHostConfigPreview = {
+	host: McpHostId,
+	label: string,
+	configPath: string,
+	configExists: boolean,
+	action: string,
+	configured: boolean,
+	currentEntryJson: string | null,
+	nextEntryJson: string,
+};
+
+export type McpHostId = "claudeDesktop";
+
+export type McpHostStatus = {
+	id: McpHostId,
+	label: string,
+	configPath: string | null,
+	configExists: boolean,
+	configured: boolean,
+	error: string | null,
+};
+
+export type McpStatus = {
+	enabled: boolean,
+	cliInstalled: boolean,
+	cliCurrent: boolean,
+	cliPath: string,
+	lastConfiguredHost: string | null,
+	lastConfiguredAtMs: number | null,
+	hosts: McpHostStatus[],
+};
 
 /**
  *  A modifier key. `Cmd` is platform-dispatched: on macOS it matches Meta,
@@ -1075,10 +1092,10 @@ export type RouxSettings = {
 	 *  Settings status only; host config files remain the source of truth.
 	 */
 	mcpLastConfiguredHost?: string | null,
-	/**
-	 *  Unix epoch milliseconds for the last successful MCP host config write.
-	 */
+	// Unix epoch milliseconds for the last successful MCP host config write.
 	mcpLastConfiguredAtMs?: number | null,
+	// Runtime feature flags. See `ExperimentsConfig`.
+	experiments?: ExperimentsConfig,
 };
 
 export type RuntimeState = { type: "pending" } | { type: "active" } | { type: "paused" } | { type: "stopped" } | { type: "error"; message: string };
@@ -1450,3 +1467,4 @@ async function typedError<T, E>(result: Promise<T>): Promise<{ status: "ok"; dat
         return { status: "error", error: e as any };
     }
 }
+

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -37,10 +37,12 @@
   import Wrench from "@lucide/svelte/icons/wrench";
   import Plug from "@lucide/svelte/icons/plug";
   import NotebookPen from "@lucide/svelte/icons/notebook-pen";
+  import FlaskConical from "@lucide/svelte/icons/flask-conical";
   import X from "@lucide/svelte/icons/x";
   import DoctorPanel from "$lib/components/DoctorPanel.svelte";
+  import { EXPERIMENTS } from "$lib/experiments";
 
-  type CategoryId = "general" | "sessions" | "terminal" | "claude" | "notes" | "integrations" | "notifications" | "keyboard" | "advanced";
+  type CategoryId = "general" | "sessions" | "terminal" | "claude" | "notes" | "integrations" | "notifications" | "keyboard" | "experiments" | "advanced";
 
   const CATEGORIES: { id: CategoryId; label: string; icon: typeof Settings }[] = [
     { id: "general", label: "General", icon: Settings },
@@ -51,6 +53,7 @@
     { id: "integrations", label: "Integrations", icon: Plug },
     { id: "notifications", label: "Notifications", icon: Bell },
     { id: "keyboard", label: "Keyboard", icon: Keyboard },
+    { id: "experiments", label: "Experiments", icon: FlaskConical },
     { id: "advanced", label: "Advanced", icon: Wrench },
   ];
 
@@ -1263,6 +1266,51 @@
                   {$settings.showSessionHintsOnCommand !== false ? 'left-[18px] bg-accent' : 'left-0.5 bg-text-secondary'}"></div>
               </button>
             </div>
+          {:else if selected === "experiments"}
+            <p class="text-[11px] text-text-muted mb-3">
+              Toggle in-progress features. Experiments default to off and may change behavior, persistence, or performance. Disable if you hit issues.
+            </p>
+            {#each EXPERIMENTS as exp (exp.id)}
+              <div class="flex items-start justify-between gap-3 py-2">
+                <div>
+                  <div class="text-[13px]">{exp.label}</div>
+                  <div class="text-[11px] text-text-muted mt-0.5">{exp.description}</div>
+                </div>
+                {#if exp.kind === "boolean"}
+                  {@const current = ($settings.experiments?.[exp.id] ?? false) as boolean}
+                  <button
+                    aria-label="Toggle {exp.label}"
+                    class="w-9 h-5 rounded-full relative cursor-pointer transition-all border shrink-0
+                      {current ? 'bg-accent-dim border-accent' : 'bg-bg-deep border-border'}"
+                    onclick={() =>
+                      updateSetting("experiments", {
+                        ...$settings.experiments,
+                        [exp.id]: !current,
+                      })}
+                  >
+                    <div
+                      class="w-3.5 h-3.5 rounded-full absolute top-0.5 transition-all
+                        {current ? 'left-[18px] bg-accent' : 'left-0.5 bg-text-secondary'}"
+                    ></div>
+                  </button>
+                {:else}
+                  {@const current = ($settings.experiments?.[exp.id] ?? exp.options[0].value) as string}
+                  <select
+                    class="bg-bg-deep border border-border rounded px-2 py-1 text-xs text-text-primary outline-none cursor-pointer appearance-none pr-6 shrink-0"
+                    value={current}
+                    onchange={(e) =>
+                      updateSetting("experiments", {
+                        ...$settings.experiments,
+                        [exp.id]: e.currentTarget.value as (typeof exp.options)[number]["value"],
+                      })}
+                  >
+                    {#each exp.options as opt}
+                      <option value={opt.value}>{opt.label}</option>
+                    {/each}
+                  </select>
+                {/if}
+              </div>
+            {/each}
           {:else if selected === "advanced"}
             <div class="flex items-center justify-between py-2">
               <div>

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -40,7 +40,7 @@
   import FlaskConical from "@lucide/svelte/icons/flask-conical";
   import X from "@lucide/svelte/icons/x";
   import DoctorPanel from "$lib/components/DoctorPanel.svelte";
-  import { EXPERIMENTS } from "$lib/experiments";
+  import { EXPERIMENTS, EXPERIMENT_DEFAULTS } from "$lib/experiments";
 
   type CategoryId = "general" | "sessions" | "terminal" | "claude" | "notes" | "integrations" | "notifications" | "keyboard" | "experiments" | "advanced";
 
@@ -1277,7 +1277,7 @@
                   <div class="text-[11px] text-text-muted mt-0.5">{exp.description}</div>
                 </div>
                 {#if exp.kind === "boolean"}
-                  {@const current = ($settings.experiments?.[exp.id] ?? false) as boolean}
+                  {@const current = ($settings.experiments?.[exp.id] ?? EXPERIMENT_DEFAULTS[exp.id]) as boolean}
                   <button
                     aria-label="Toggle {exp.label}"
                     class="w-9 h-5 rounded-full relative cursor-pointer transition-all border shrink-0
@@ -1294,7 +1294,7 @@
                     ></div>
                   </button>
                 {:else}
-                  {@const current = ($settings.experiments?.[exp.id] ?? exp.options[0].value) as string}
+                  {@const current = ($settings.experiments?.[exp.id] ?? EXPERIMENT_DEFAULTS[exp.id]) as string}
                   <select
                     class="bg-bg-deep border border-border rounded px-2 py-1 text-xs text-text-primary outline-none cursor-pointer appearance-none pr-6 shrink-0"
                     value={current}

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -1296,6 +1296,7 @@
                 {:else}
                   {@const current = ($settings.experiments?.[exp.id] ?? EXPERIMENT_DEFAULTS[exp.id]) as string}
                   <select
+                    aria-label="Select {exp.label}"
                     class="bg-bg-deep border border-border rounded px-2 py-1 text-xs text-text-primary outline-none cursor-pointer appearance-none pr-6 shrink-0"
                     value={current}
                     onchange={(e) =>

--- a/src/lib/components/__tests__/SettingsPanel.test.ts
+++ b/src/lib/components/__tests__/SettingsPanel.test.ts
@@ -71,6 +71,7 @@ vi.mock("$lib/stores/updater", () => ({
 import { commands } from "$lib/bindings";
 import SettingsPanel from "../SettingsPanel.svelte";
 import { settings } from "$lib/stores/settings";
+import { updateSettings } from "$lib/tauri";
 
 describe("SettingsPanel MCP integration", () => {
   beforeEach(() => {
@@ -93,5 +94,63 @@ describe("SettingsPanel MCP integration", () => {
       expect(commands.cmdPreviewMcpHostConfig).toHaveBeenCalledWith("claudeDesktop");
     });
     expect(await screen.findByText("Preview ready.")).toBeDefined();
+  });
+});
+
+describe("SettingsPanel Experiments tab", () => {
+  beforeEach(() => {
+    settings.set({ ...DEFAULT_SETTINGS });
+    vi.mocked(updateSettings).mockClear();
+  });
+
+  it("renders boolean and enum experiments at their declared defaults", async () => {
+    render(SettingsPanel, { visible: true, onclose: vi.fn() });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Experiments" }));
+
+    const toggle = await screen.findByRole("button", { name: "Toggle Example flag" });
+    expect(toggle).toBeDefined();
+
+    expect(await screen.findByText("Example variant")).toBeDefined();
+    const select = document.querySelector(
+      "select",
+    ) as HTMLSelectElement | null;
+    expect(select).not.toBeNull();
+    expect(select!.value).toBe("a");
+  });
+
+  it("toggling a boolean experiment persists the new value", async () => {
+    render(SettingsPanel, { visible: true, onclose: vi.fn() });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Experiments" }));
+    await fireEvent.click(
+      await screen.findByRole("button", { name: "Toggle Example flag" }),
+    );
+
+    await waitFor(() => {
+      expect(updateSettings).toHaveBeenCalled();
+    });
+    const lastCall = vi.mocked(updateSettings).mock.calls.at(-1)!;
+    expect(lastCall[0].experiments?.exampleFlag).toBe(true);
+    // Sibling enum value must be preserved through the spread.
+    expect(lastCall[0].experiments?.exampleVariant).toBe("a");
+  });
+
+  it("changing an enum experiment persists the new variant", async () => {
+    render(SettingsPanel, { visible: true, onclose: vi.fn() });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Experiments" }));
+    const select = (await screen.findByText("Example variant"))
+      .closest("div.flex")!
+      .querySelector("select") as HTMLSelectElement;
+
+    await fireEvent.change(select, { target: { value: "c" } });
+
+    await waitFor(() => {
+      expect(updateSettings).toHaveBeenCalled();
+    });
+    const lastCall = vi.mocked(updateSettings).mock.calls.at(-1)!;
+    expect(lastCall[0].experiments?.exampleVariant).toBe("c");
+    expect(lastCall[0].experiments?.exampleFlag).toBe(false);
   });
 });

--- a/src/lib/components/__tests__/SettingsPanel.test.ts
+++ b/src/lib/components/__tests__/SettingsPanel.test.ts
@@ -111,12 +111,10 @@ describe("SettingsPanel Experiments tab", () => {
     const toggle = await screen.findByRole("button", { name: "Toggle Example flag" });
     expect(toggle).toBeDefined();
 
-    expect(await screen.findByText("Example variant")).toBeDefined();
-    const select = document.querySelector(
-      "select",
-    ) as HTMLSelectElement | null;
-    expect(select).not.toBeNull();
-    expect(select!.value).toBe("a");
+    const select = (await screen.findByRole("combobox", {
+      name: "Select Example variant",
+    })) as HTMLSelectElement;
+    expect(select.value).toBe("a");
   });
 
   it("toggling a boolean experiment persists the new value", async () => {
@@ -140,9 +138,9 @@ describe("SettingsPanel Experiments tab", () => {
     render(SettingsPanel, { visible: true, onclose: vi.fn() });
 
     await fireEvent.click(screen.getByRole("button", { name: "Experiments" }));
-    const select = (await screen.findByText("Example variant"))
-      .closest("div.flex")!
-      .querySelector("select") as HTMLSelectElement;
+    const select = (await screen.findByRole("combobox", {
+      name: "Select Example variant",
+    })) as HTMLSelectElement;
 
     await fireEvent.change(select, { target: { value: "c" } });
 

--- a/src/lib/experiments.ts
+++ b/src/lib/experiments.ts
@@ -1,11 +1,9 @@
 import { get } from "svelte/store";
 import { settings } from "$lib/stores/settings";
-import { DEFAULT_SETTINGS } from "$lib/types";
+import { EXPERIMENT_DEFAULTS } from "$lib/types";
 import type { ExperimentsConfig } from "$lib/bindings";
 
 type RequiredExperiments = Required<ExperimentsConfig>;
-
-const DEFAULTS = DEFAULT_SETTINGS.experiments as RequiredExperiments;
 
 type BoolExperimentId = {
   [K in keyof RequiredExperiments]: RequiredExperiments[K] extends boolean ? K : never;
@@ -13,34 +11,33 @@ type BoolExperimentId = {
 
 type EnumExperimentId = Exclude<keyof RequiredExperiments, BoolExperimentId>;
 
-type BoolExperimentDef = {
-  kind: "boolean";
-  id: BoolExperimentId;
-  label: string;
-  description: string;
-};
+type ExperimentDefFor<K extends keyof RequiredExperiments> =
+  RequiredExperiments[K] extends boolean
+    ? { kind: "boolean"; id: K; label: string; description: string }
+    : {
+        kind: "enum";
+        id: K;
+        label: string;
+        description: string;
+        options: ReadonlyArray<{ value: RequiredExperiments[K]; label: string }>;
+      };
 
-type EnumExperimentDef = {
-  [K in EnumExperimentId]: {
-    kind: "enum";
-    id: K;
-    label: string;
-    description: string;
-    options: ReadonlyArray<{ value: RequiredExperiments[K]; label: string }>;
-  };
-}[EnumExperimentId];
+export type ExperimentDef =
+  | ExperimentDefFor<BoolExperimentId>
+  | ExperimentDefFor<EnumExperimentId>;
 
-export type ExperimentDef = BoolExperimentDef | EnumExperimentDef;
-
-export const EXPERIMENTS: ReadonlyArray<ExperimentDef> = [
-  {
+// Indexed by id so adding a new flag to `ExperimentsConfig` (Rust side) without
+// adding a registry entry here is a TypeScript error — the UI can't silently
+// miss a flag.
+const EXPERIMENT_DEFS: { [K in keyof RequiredExperiments]: ExperimentDefFor<K> } = {
+  exampleFlag: {
     kind: "boolean",
     id: "exampleFlag",
     label: "Example flag",
     description:
       "No-op flag for verifying the boolean experiments pipeline. Safe to remove once a real experiment lands.",
   },
-  {
+  exampleVariant: {
     kind: "enum",
     id: "exampleVariant",
     label: "Example variant",
@@ -52,10 +49,16 @@ export const EXPERIMENTS: ReadonlyArray<ExperimentDef> = [
       { value: "c", label: "Variant C" },
     ],
   },
-];
+};
+
+export const EXPERIMENTS: ReadonlyArray<ExperimentDef> = Object.values(
+  EXPERIMENT_DEFS,
+) as ExperimentDef[];
+
+export { EXPERIMENT_DEFAULTS };
 
 function readExperiments(): RequiredExperiments {
-  return { ...DEFAULTS, ...(get(settings).experiments ?? {}) };
+  return { ...EXPERIMENT_DEFAULTS, ...(get(settings).experiments ?? {}) };
 }
 
 export function isExperimentEnabled(id: BoolExperimentId): boolean {

--- a/src/lib/experiments.ts
+++ b/src/lib/experiments.ts
@@ -1,0 +1,69 @@
+import { get } from "svelte/store";
+import { settings } from "$lib/stores/settings";
+import { DEFAULT_SETTINGS } from "$lib/types";
+import type { ExperimentsConfig } from "$lib/bindings";
+
+type RequiredExperiments = Required<ExperimentsConfig>;
+
+const DEFAULTS = DEFAULT_SETTINGS.experiments as RequiredExperiments;
+
+type BoolExperimentId = {
+  [K in keyof RequiredExperiments]: RequiredExperiments[K] extends boolean ? K : never;
+}[keyof RequiredExperiments];
+
+type EnumExperimentId = Exclude<keyof RequiredExperiments, BoolExperimentId>;
+
+type BoolExperimentDef = {
+  kind: "boolean";
+  id: BoolExperimentId;
+  label: string;
+  description: string;
+};
+
+type EnumExperimentDef = {
+  [K in EnumExperimentId]: {
+    kind: "enum";
+    id: K;
+    label: string;
+    description: string;
+    options: ReadonlyArray<{ value: RequiredExperiments[K]; label: string }>;
+  };
+}[EnumExperimentId];
+
+export type ExperimentDef = BoolExperimentDef | EnumExperimentDef;
+
+export const EXPERIMENTS: ReadonlyArray<ExperimentDef> = [
+  {
+    kind: "boolean",
+    id: "exampleFlag",
+    label: "Example flag",
+    description:
+      "No-op flag for verifying the boolean experiments pipeline. Safe to remove once a real experiment lands.",
+  },
+  {
+    kind: "enum",
+    id: "exampleVariant",
+    label: "Example variant",
+    description:
+      "No-op multi-choice flag for verifying the enum experiments pipeline. Safe to remove once a real experiment lands.",
+    options: [
+      { value: "a", label: "Variant A" },
+      { value: "b", label: "Variant B" },
+      { value: "c", label: "Variant C" },
+    ],
+  },
+];
+
+function readExperiments(): RequiredExperiments {
+  return { ...DEFAULTS, ...(get(settings).experiments ?? {}) };
+}
+
+export function isExperimentEnabled(id: BoolExperimentId): boolean {
+  return readExperiments()[id];
+}
+
+export function getExperimentValue<K extends keyof RequiredExperiments>(
+  id: K,
+): RequiredExperiments[K] {
+  return readExperiments()[id];
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,5 +1,14 @@
 // Import generated types from specta bindings
-import type { RouxSettings } from "./bindings";
+import type { ExperimentsConfig, RouxSettings } from "./bindings";
+
+// Typed defaults for every experiment flag. Adding a new optional field to
+// `ExperimentsConfig` will fail to compile here until a default is supplied,
+// keeping `RequiredExperiments` consumers (e.g. the SettingsPanel fallback,
+// `readExperiments()`) honest about what they can read.
+export const EXPERIMENT_DEFAULTS: Required<ExperimentsConfig> = {
+  exampleFlag: false,
+  exampleVariant: "a",
+};
 
 // Re-export generated types
 export type { RouxSettings };
@@ -121,10 +130,7 @@ export const DEFAULT_SETTINGS: RouxSettings = {
   mcpEnabled: false,
   mcpLastConfiguredHost: null,
   mcpLastConfiguredAtMs: null,
-  experiments: {
-    exampleFlag: false,
-    exampleVariant: "a",
-  },
+  experiments: EXPERIMENT_DEFAULTS,
 };
 
 // Re-export frontend-only task types

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -121,6 +121,10 @@ export const DEFAULT_SETTINGS: RouxSettings = {
   mcpEnabled: false,
   mcpLastConfiguredHost: null,
   mcpLastConfiguredAtMs: null,
+  experiments: {
+    exampleFlag: false,
+    exampleVariant: "a",
+  },
 };
 
 // Re-export frontend-only task types


### PR DESCRIPTION
## Summary
- New **Experiments** settings tab (flask icon) lets in-progress features land behind a default-off runtime toggle. No third-party flag service — just typed fields on `RouxSettings` reusing the existing settings persistence pipeline.
- Two flag kinds supported: **boolean** (renders as the existing pill toggle) and **enum** (renders as a `<select>` with named variants).
- Adding a new flag is one Rust struct field + one entry in the frontend `EXPERIMENTS` registry. Discriminated-union typing in `src/lib/experiments.ts` derives bool vs enum ids from the binding so kind-mismatches fail at compile time.
- Ships a no-op `exampleFlag` (bool) and `exampleVariant` (enum A/B/C) so the pipeline is exercised end-to-end. Safe to delete or repurpose when the first real experiment lands.

## Why no library
`flagged` (npm) is React-only and thinner than this. `unleash-client-rust` / LaunchDarkly SDK are SaaS clients (network, accounts, telemetry) — wrong shape for a local desktop toggle. The `feature-flags` Rust crate targets compile-time cargo features, not runtime user toggles.

## Backward compatibility
`experiments` field on `RouxSettings` is `#[serde(default)]`, and every inner flag is `#[serde(default)]` too. Existing `~/.config/roux/settings.json` files with no `experiments` key load cleanly with all flags off. Two new unit tests in `crates/roux-core/src/models/settings.rs` guard this.

## Test plan
- [x] `cargo test -p roux-core --lib settings` — 17/17 pass (incl. 2 new)
- [x] `npm run check` — 0 errors, 0 warnings
- [x] `npm run test` — 887 passed, 2 skipped
- [x] `cargo check` (src-tauri) — passes
- [x] Manual: Experiments tab renders, toggles, and selects work (verified by author)
- [ ] Manual: confirm `cat ~/.config/roux/settings.json | jq .experiments` shows persisted values after restart
- [ ] Manual: temporarily remove the `experiments` key from `settings.json` → restart → confirm app loads with flags at defaults, no error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Experiments settings category with toggles and selectable variants so users can view and manage experimental options.
  * Settings include sensible defaults and merge user overrides so missing experiment fields fall back to defaults.
* **Tests**
  * Added integration tests covering the Experiments tab UI and settings update behavior (toggle and variant changes preserve other experiment values).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->