### PR TITLE
feat(sidebar): simplify session tabs behind simplifiedSessionTabs experiment

### DIFF
--- a/crates/roux-core/src/models/settings.rs
+++ b/crates/roux-core/src/models/settings.rs
@@ -211,6 +211,8 @@ pub struct ExperimentsConfig {
     pub example_flag: bool,
     #[serde(default)]
     pub example_variant: ExampleVariant,
+    #[serde(default)]
+    pub simplified_session_tabs: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
@@ -902,6 +904,17 @@ mod tests {
         let exp: ExperimentsConfig = serde_json::from_str(json).unwrap();
         assert!(!exp.example_flag);
         assert_eq!(exp.example_variant, ExampleVariant::C);
+        assert!(!exp.simplified_session_tabs);
+    }
+
+    #[test]
+    fn experiments_default_simplified_session_tabs_off() {
+        // Legacy settings written before `simplifiedSessionTabs` existed must
+        // deserialize cleanly with the flag defaulting to `false`.
+        let json = r#"{ "exampleFlag": true }"#;
+        let exp: ExperimentsConfig = serde_json::from_str(json).unwrap();
+        assert!(exp.example_flag);
+        assert!(!exp.simplified_session_tabs);
     }
 
     #[test]

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -417,6 +417,7 @@ export type ExampleVariant = "a" | "b" | "c";
 export type ExperimentsConfig = {
 	exampleFlag?: boolean,
 	exampleVariant?: ExampleVariant,
+	simplifiedSessionTabs?: boolean,
 };
 
 export type GithubJob = {

--- a/src/lib/components/SessionCard.svelte
+++ b/src/lib/components/SessionCard.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
-  import type { Session } from "$lib/types";
+  import type { GroupBy, Session } from "$lib/types";
   import { renameSignal, sessionDisplayName } from "$lib/stores/sessions";
   import { projects } from "$lib/stores/projects";
   import { flashingSessions } from "$lib/stores/watches";
   import { unreadBySession } from "$lib/stores/notifications";
   import { showSessionHints } from "$lib/stores/ui";
   import { ptyInventoryBySession } from "$lib/stores/ptyInventory";
+  import { experimentValues } from "$lib/experiments";
   import {
     sessionAgentStatus,
     computeEffectiveSessionStatus,
@@ -18,8 +19,8 @@
   interface Props {
     session: Session;
     active: boolean;
+    groupBy: GroupBy;
     slotNumber?: number;
-    hideProjectTag?: boolean;
     onselect: () => void;
     onclose: () => void;
     onrename: (newName: string) => void;
@@ -30,14 +31,27 @@
   let {
     session,
     active,
+    groupBy,
     slotNumber,
-    hideProjectTag = false,
     onselect,
     onclose,
     onrename,
     onreconnect,
     oncontextmenu,
   }: Props = $props();
+
+  let simplified = $derived($experimentValues.simplifiedSessionTabs);
+  // Split on both separators so Windows paths (e.g. C:\src\repo\.worktrees\foo)
+  // resolve to the trailing component, not the entire absolute path.
+  let worktreeName = $derived(pathBasename(session.worktreePath));
+  let repoName = $derived(pathBasename(session.repoRoot));
+  let contextualSecondary = $derived(
+    groupBy === "project" ? repoName : worktreeName,
+  );
+
+  function pathBasename(path: string): string {
+    return path.split(/[\\/]+/).filter(Boolean).pop() ?? "";
+  }
 
   let slotLabel = $derived(
     slotNumber == null ? null : slotNumber === 10 ? "0" : String(slotNumber),
@@ -125,7 +139,7 @@
   let projectName = $derived(
     session.projectId ? $projects.find((p) => p.id === session.projectId)?.name ?? null : null
   );
-  let showProjectTag = $derived(!hideProjectTag && projectName != null);
+  let showProjectTag = $derived(groupBy !== "project" && projectName != null);
 
   let isFlashing = $derived($flashingSessions.has(session.id));
   let unreadCount = $derived($unreadBySession.get(session.id) ?? 0);
@@ -136,7 +150,9 @@
   );
 
   let showRow2 = $derived(
-    session.isWorktree || showProjectTag || session.cost != null
+    simplified
+      ? Boolean(secondaryBranch || contextualSecondary)
+      : session.isWorktree || showProjectTag || session.cost != null,
   );
 
   let detailLabel = $derived(
@@ -205,13 +221,13 @@
       </div>
 
       <div class="flex shrink-0 items-center gap-1">
-        {#if showPaneInventory}
+        {#if !simplified && showPaneInventory}
           <span
             class="inline-flex h-4 min-w-4 shrink-0 items-center justify-center rounded bg-bg-surface px-1 text-[9px] font-semibold tabular-nums text-text-muted"
             title={activePaneTitle}
           >{attachedCount}</span>
         {/if}
-        {#if detachedCount > 0}
+        {#if !simplified && detachedCount > 0}
           <span
             class="inline-flex h-4 min-w-4 shrink-0 items-center justify-center rounded px-1 text-[9px] font-semibold tabular-nums
               {detachedHasUnread
@@ -256,33 +272,58 @@
     </div>
 
     {#if showRow2}
-      <div class="mt-0.5 flex min-h-4 items-center gap-1.5 overflow-hidden text-[10px] text-text-muted">
-        {#if session.isWorktree}
-          <span
-            class="inline-flex h-4 shrink-0 items-center gap-1 rounded bg-bg-surface/70 px-1.5 font-medium text-text-secondary"
-            title={detailLabel}
-          >
-            <GitBranch size={10} />
-            <span>worktree</span>
-          </span>
-        {/if}
-        {#if secondaryBranch}
-          <span class="min-w-0 truncate font-mono text-[10px] text-text-muted" title={secondaryBranch}>
-            {secondaryBranch}
-          </span>
-        {/if}
-        {#if session.isWorktree}
-          <span class="inline-flex min-w-0 items-center gap-1">
-            <SessionWorktrunkChips worktreePath={session.worktreePath} />
-          </span>
-        {/if}
-        {#if showProjectTag}
-          <span class="inline-flex h-4 shrink-0 items-center rounded bg-accent-dim/15 px-1.5 font-semibold text-accent">{projectName}</span>
-        {/if}
-        {#if session.cost != null}
-          <span class="ml-auto shrink-0 font-semibold tabular-nums">${session.cost.toFixed(2)}</span>
-        {/if}
-      </div>
+      {#if simplified}
+        <div
+          data-testid="session-secondary"
+          class="mt-0.5 flex min-h-4 min-w-0 items-center gap-1.5 overflow-hidden text-[10px] text-text-muted"
+        >
+          {#if secondaryBranch}
+            <span
+              data-testid="session-secondary-branch"
+              class="min-w-0 truncate font-mono text-text-muted"
+              title={secondaryBranch}
+            >{secondaryBranch}</span>
+            {#if contextualSecondary}
+              <span class="shrink-0 text-text-muted">·</span>
+            {/if}
+          {/if}
+          {#if contextualSecondary}
+            <span
+              data-testid="session-secondary-context"
+              class="min-w-0 truncate"
+              title={contextualSecondary}
+            >{contextualSecondary}</span>
+          {/if}
+        </div>
+      {:else}
+        <div class="mt-0.5 flex min-h-4 items-center gap-1.5 overflow-hidden text-[10px] text-text-muted">
+          {#if session.isWorktree}
+            <span
+              class="inline-flex h-4 shrink-0 items-center gap-1 rounded bg-bg-surface/70 px-1.5 font-medium text-text-secondary"
+              title={detailLabel}
+            >
+              <GitBranch size={10} />
+              <span>worktree</span>
+            </span>
+          {/if}
+          {#if secondaryBranch}
+            <span class="min-w-0 truncate font-mono text-[10px] text-text-muted" title={secondaryBranch}>
+              {secondaryBranch}
+            </span>
+          {/if}
+          {#if session.isWorktree}
+            <span class="inline-flex min-w-0 items-center gap-1">
+              <SessionWorktrunkChips worktreePath={session.worktreePath} />
+            </span>
+          {/if}
+          {#if showProjectTag}
+            <span class="inline-flex h-4 shrink-0 items-center rounded bg-accent-dim/15 px-1.5 font-semibold text-accent">{projectName}</span>
+          {/if}
+          {#if session.cost != null}
+            <span class="ml-auto shrink-0 font-semibold tabular-nums">${session.cost.toFixed(2)}</span>
+          {/if}
+        </div>
+      {/if}
     {/if}
   </div>
 

--- a/src/lib/components/SessionTabs.svelte
+++ b/src/lib/components/SessionTabs.svelte
@@ -85,12 +85,9 @@
   let collapsedGroups = $state(loadStringSet(COLLAPSED_GROUPS_KEY));
   let seenProjects = $state(loadStringSet(SEEN_PROJECTS_KEY));
 
+  let groupByMode = $derived($settings.groupBy ?? "repo");
   let grouped = $derived(
-    getGroupedSessions(
-      $sessionList,
-      $projects,
-      $settings.groupBy ?? "repo",
-    ),
+    getGroupedSessions($sessionList, $projects, groupByMode),
   );
   // In "session" mode there is exactly one synthetic "Sessions" group — its
   // header would just take up space, so we hide it. In repo/project modes a
@@ -648,8 +645,8 @@
             <SessionCard
               {session}
               active={session.id === $activeSessionId}
+              groupBy={groupByMode}
               slotNumber={slotById.get(session.id)}
-              hideProjectTag={($settings.groupBy ?? "repo") === "project"}
               onselect={() => setActiveSession(session.id)}
               onclose={() => handleClose(session.id)}
               onrename={(newName) => renameSession(session.id, newName)}

--- a/src/lib/components/__tests__/SessionCard.test.ts
+++ b/src/lib/components/__tests__/SessionCard.test.ts
@@ -1,8 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/svelte";
-import type { Notification, Session, WorktrunkMetadata } from "$lib/types";
+import type {
+  GroupBy,
+  Notification,
+  RouxSettings,
+  Session,
+  WorktrunkMetadata,
+} from "$lib/types";
+import { DEFAULT_SETTINGS, EXPERIMENT_DEFAULTS } from "$lib/types";
 import { notifications } from "$lib/stores/notifications";
 import { projects } from "$lib/stores/projects";
+import { settings } from "$lib/stores/settings";
 import { flashingSessions } from "$lib/stores/watches";
 import { sessionLayouts } from "$lib/panes/layout";
 import { agentStates } from "$lib/panes/agentState";
@@ -74,25 +82,53 @@ function makeNotification(overrides: Partial<Notification> = {}): Notification {
   };
 }
 
-describe("SessionCard", () => {
+type RenderProps = {
+  session?: Session;
+  active?: boolean;
+  groupBy?: GroupBy;
+  onselect?: () => void;
+  onclose?: () => void;
+  onrename?: (newName: string) => void;
+  onreconnect?: () => void;
+};
+
+function renderCard(overrides: RenderProps = {}) {
+  return render(SessionCard, {
+    session: overrides.session ?? makeSession(),
+    active: overrides.active ?? false,
+    groupBy: overrides.groupBy ?? "repo",
+    onselect: overrides.onselect ?? (() => {}),
+    onclose: overrides.onclose ?? (() => {}),
+    onrename: overrides.onrename ?? (() => {}),
+    onreconnect: overrides.onreconnect ?? (() => {}),
+  });
+}
+
+function setSimplifiedFlag(enabled: boolean) {
+  settings.update((s: RouxSettings) => ({
+    ...s,
+    experiments: { ...EXPERIMENT_DEFAULTS, simplifiedSessionTabs: enabled },
+  }));
+}
+
+function resetStores() {
+  notifications.set([]);
+  projects.set([]);
+  flashingSessions.set(new Set());
+  sessionLayouts.set(new Map());
+  agentStates.set(new Map());
+  settings.set(DEFAULT_SETTINGS);
+  _resetWorktreeMetadataForTests();
+  _resetPtyInventoryForTests();
+}
+
+describe("SessionCard — legacy rendering (simplifiedSessionTabs off)", () => {
   beforeEach(() => {
-    notifications.set([]);
-    projects.set([]);
-    flashingSessions.set(new Set());
-    sessionLayouts.set(new Map());
-    agentStates.set(new Map());
-    _resetWorktreeMetadataForTests();
-    _resetPtyInventoryForTests();
+    resetStores();
   });
 
   afterEach(() => {
-    notifications.set([]);
-    projects.set([]);
-    flashingSessions.set(new Set());
-    sessionLayouts.set(new Map());
-    agentStates.set(new Map());
-    _resetWorktreeMetadataForTests();
-    _resetPtyInventoryForTests();
+    resetStores();
   });
 
   it("shows active and detached inventory separately when a session has detached terminals", () => {
@@ -100,14 +136,7 @@ describe("SessionCard", () => {
       ["session-1", { attachedCount: 2, detachedCount: 1, detachedHasUnread: true }],
     ]));
 
-    render(SessionCard, {
-      session: makeSession(),
-      active: false,
-      onselect: () => {},
-      onclose: () => {},
-      onrename: () => {},
-      onreconnect: () => {},
-    });
+    renderCard();
 
     const activeBadge = screen.getByTitle("2 active panes");
     expect(activeBadge.textContent).toBe("2");
@@ -121,14 +150,7 @@ describe("SessionCard", () => {
       ["session-1", { attachedCount: 1, detachedCount: 0, detachedHasUnread: false }],
     ]));
 
-    render(SessionCard, {
-      session: makeSession(),
-      active: false,
-      onselect: () => {},
-      onclose: () => {},
-      onrename: () => {},
-      onreconnect: () => {},
-    });
+    renderCard();
 
     expect(screen.queryByTitle("1 active pane")).toBeNull();
     expect(screen.queryByTitle(/detached terminal/)).toBeNull();
@@ -147,17 +169,13 @@ describe("SessionCard", () => {
       },
     ]);
 
-    const { container } = render(SessionCard, {
+    const { container } = renderCard({
       session: makeSession({
         worktreePath: "/repo/.worktrees/restore-closed-sessions",
         branch: "feature/restore-closed-sessions",
         isWorktree: true,
       }),
       active: true,
-      onselect: () => {},
-      onclose: () => {},
-      onrename: () => {},
-      onreconnect: () => {},
     });
 
     expect(container.textContent).toContain("feature/");
@@ -173,18 +191,13 @@ describe("SessionCard", () => {
       ["session-1", { attachedCount: 1, detachedCount: 0, detachedHasUnread: false }],
     ]));
 
-    render(SessionCard, {
+    renderCard({
       session: makeSession({
         worktreePath: "/repo/.worktrees/restore-closed-sessions",
         branch: "feature/restore-closed-sessions",
         isWorktree: true,
         nameOverride: "notes/design",
       }),
-      active: false,
-      onselect: () => {},
-      onclose: () => {},
-      onrename: () => {},
-      onreconnect: () => {},
     });
 
     expect(screen.getByTestId("session-primary-label").textContent).toBe("notes/design");
@@ -199,13 +212,10 @@ describe("SessionCard", () => {
     const onrename = vi.fn();
     const onclose = vi.fn();
 
-    render(SessionCard, {
+    renderCard({
       session: makeSession({ branch: "feature/restore-closed-sessions" }),
-      active: false,
-      onselect: () => {},
-      onclose,
       onrename,
-      onreconnect: () => {},
+      onclose,
     });
 
     await fireEvent.click(screen.getByLabelText("Rename session"));
@@ -227,14 +237,7 @@ describe("SessionCard", () => {
       makeNotification({ id: "notification-2", sessionId: "session-1" }),
     ]);
 
-    render(SessionCard, {
-      session: makeSession(),
-      active: false,
-      onselect: () => {},
-      onclose: () => {},
-      onrename: () => {},
-      onreconnect: () => {},
-    });
+    renderCard();
 
     expect(screen.getByTitle("2 active panes").textContent).toBe("2");
     expect(screen.getByTitle("2 unread notifications").textContent).toBe("2");
@@ -246,12 +249,8 @@ describe("SessionCard", () => {
     ]));
     const onreconnect = vi.fn();
 
-    render(SessionCard, {
+    renderCard({
       session: makeSession({ status: "disconnected" }),
-      active: false,
-      onselect: () => {},
-      onclose: () => {},
-      onrename: () => {},
       onreconnect,
     });
 
@@ -259,5 +258,147 @@ describe("SessionCard", () => {
     await fireEvent.click(button);
 
     expect(onreconnect).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("SessionCard — simplified rendering (simplifiedSessionTabs on)", () => {
+  beforeEach(() => {
+    resetStores();
+    setSimplifiedFlag(true);
+    ptyInventoryBySession.set(new Map([
+      ["session-1", { attachedCount: 2, detachedCount: 1, detachedHasUnread: true }],
+    ]));
+  });
+
+  afterEach(() => {
+    resetStores();
+  });
+
+  it("hides pane inventory badges and worktree metadata chips", () => {
+    upsertWorktreeMetadata([
+      {
+        path: "/repo/.worktrees/feature-x",
+        branch: "feature/x",
+        isMain: false,
+        worktrunk: makeMetadata({ dirty: true, ahead: 2, behind: 0 }),
+      },
+    ]);
+
+    renderCard({
+      session: makeSession({
+        worktreePath: "/repo/.worktrees/feature-x",
+        branch: "feature/x",
+        isWorktree: true,
+      }),
+    });
+
+    expect(screen.queryByTitle(/active pane/)).toBeNull();
+    expect(screen.queryByTitle(/detached terminal/)).toBeNull();
+    expect(screen.queryByText("worktree")).toBeNull();
+    expect(screen.queryByTestId("session-wt-dirty")).toBeNull();
+    expect(screen.queryByTestId("session-wt-ahead-behind")).toBeNull();
+  });
+
+  it("shows the worktree directory name as secondary when grouping by repo", () => {
+    renderCard({
+      session: makeSession({
+        worktreePath: "/repo/.worktrees/feature-x",
+        branch: "feature/x",
+        isWorktree: true,
+      }),
+      groupBy: "repo",
+    });
+
+    expect(screen.getByTestId("session-secondary-context").textContent).toBe("feature-x");
+  });
+
+  it("shows the worktree directory name as secondary when grouping by session", () => {
+    renderCard({
+      session: makeSession({
+        worktreePath: "/repo/.worktrees/feature-x",
+        branch: "feature/x",
+        isWorktree: true,
+      }),
+      groupBy: "session",
+    });
+
+    expect(screen.getByTestId("session-secondary-context").textContent).toBe("feature-x");
+  });
+
+  it("derives the basename from Windows-style paths", () => {
+    renderCard({
+      session: makeSession({
+        repoRoot: "C:\\src\\cool-repo",
+        worktreePath: "C:\\src\\cool-repo\\.worktrees\\feature-x",
+        branch: "feature/x",
+        isWorktree: true,
+      }),
+      groupBy: "repo",
+    });
+
+    expect(screen.getByTestId("session-secondary-context").textContent).toBe("feature-x");
+  });
+
+  it("shows the repo name as secondary when grouping by project", () => {
+    renderCard({
+      session: makeSession({
+        repoRoot: "/Users/me/code/cool-repo",
+        worktreePath: "/Users/me/code/cool-repo/.worktrees/feature-x",
+        branch: "feature/x",
+        isWorktree: true,
+      }),
+      groupBy: "project",
+    });
+
+    expect(screen.getByTestId("session-secondary-context").textContent).toBe("cool-repo");
+  });
+
+  it("renders branch and contextual name together when a custom name overrides the branch", () => {
+    renderCard({
+      session: makeSession({
+        worktreePath: "/repo/.worktrees/restore-closed-sessions",
+        branch: "feature/restore-closed-sessions",
+        isWorktree: true,
+        nameOverride: "notes/design",
+      }),
+      groupBy: "repo",
+    });
+
+    expect(screen.getByTestId("session-primary-label").textContent).toBe("notes/design");
+    expect(screen.getByTestId("session-secondary-branch").textContent).toBe(
+      "feature/restore-closed-sessions",
+    );
+    expect(screen.getByTestId("session-secondary-context").textContent).toBe(
+      "restore-closed-sessions",
+    );
+  });
+
+  it("keeps rename, close, and continue controls accessible", async () => {
+    const onrename = vi.fn();
+    const onclose = vi.fn();
+    const onreconnect = vi.fn();
+
+    renderCard({
+      session: makeSession({
+        branch: "feature/restore-closed-sessions",
+        status: "disconnected",
+      }),
+      onrename,
+      onclose,
+      onreconnect,
+    });
+
+    const continueButton = screen.getByRole("button", { name: "continue" });
+    await fireEvent.click(continueButton);
+    expect(onreconnect).toHaveBeenCalledTimes(1);
+
+    await fireEvent.click(screen.getByLabelText("Rename session"));
+    const input = screen.getByDisplayValue("feature/restore-closed-sessions");
+    await fireEvent.input(input, { target: { value: "Renamed session" } });
+    await fireEvent.blur(input);
+    expect(onrename).toHaveBeenCalledWith("Renamed session");
+
+    await fireEvent.click(screen.getByLabelText("Close session"));
+    expect(onclose).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/experiments.ts
+++ b/src/lib/experiments.ts
@@ -1,4 +1,4 @@
-import { get } from "svelte/store";
+import { derived, get, type Readable } from "svelte/store";
 import { settings } from "$lib/stores/settings";
 import { EXPERIMENT_DEFAULTS } from "$lib/types";
 import type { ExperimentsConfig } from "$lib/bindings";
@@ -49,6 +49,13 @@ const EXPERIMENT_DEFS: { [K in keyof RequiredExperiments]: ExperimentDefFor<K> }
       { value: "c", label: "Variant C" },
     ],
   },
+  simplifiedSessionTabs: {
+    kind: "boolean",
+    id: "simplifiedSessionTabs",
+    label: "Simplified session tabs",
+    description:
+      "Replace the session sidebar's per-tab metadata chips with a single contextual line (worktree or repo name, depending on the current grouping).",
+  },
 };
 
 export const EXPERIMENTS: ReadonlyArray<ExperimentDef> = Object.values(
@@ -60,6 +67,15 @@ export { EXPERIMENT_DEFAULTS };
 function readExperiments(): RequiredExperiments {
   return { ...EXPERIMENT_DEFAULTS, ...(get(settings).experiments ?? {}) };
 }
+
+// Reactive view of the resolved experiment values. Use this from Svelte
+// components when the UI should respond live to flag toggles in Settings →
+// Experiments. Non-reactive callers (event handlers, one-shot reads) should
+// keep using `isExperimentEnabled` / `getExperimentValue`.
+export const experimentValues: Readable<RequiredExperiments> = derived(
+  settings,
+  ($s) => ({ ...EXPERIMENT_DEFAULTS, ...($s.experiments ?? {}) }),
+);
 
 export function isExperimentEnabled(id: BoolExperimentId): boolean {
   return readExperiments()[id];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -8,6 +8,7 @@ import type { ExperimentsConfig, RouxSettings } from "./bindings";
 export const EXPERIMENT_DEFAULTS: Required<ExperimentsConfig> = {
   exampleFlag: false,
   exampleVariant: "a",
+  simplifiedSessionTabs: false,
 };
 
 // Re-export generated types


### PR DESCRIPTION
## Summary

- Adds a new boolean experiment, `simplifiedSessionTabs` (default off), wired through the existing experiments framework added in #144.
- When the flag is on, each session sidebar tab drops the dirty/CI/ahead-behind/cost/project chips and pane-count badges. In their place, a single contextual secondary line shows:
  - the worktree basename when grouping by repo or session,
  - the repo basename when grouping by project,
  - and `<branch> · <contextual>` when a custom name overrides the branch (so the branch is still surfaced).
- Status dot color/animation, pencil/close/continue, the unread-notifications badge, slot overlay, and rename flow are unchanged in both flag states.
- Path basename derivation splits on both `/` and `\\` so Windows paths resolve to the trailing component (Codex review finding addressed before opening this PR).

## Test plan

- [x] `cargo test -p roux-core --lib settings` — 18 pass, including a new test that legacy `experiments` JSON without `simplifiedSessionTabs` deserializes with the flag off.
- [x] `npm run check` — 0 errors, 0 warnings.
- [x] `npm run test` — full suite green (896 passing). SessionCard adds 14 tests covering both flag states and Windows-style paths.
- [ ] Manual UI: `task dev` → Settings → Experiments → toggle "Simplified session tabs". With the flag off, the sidebar renders as on `main`. With the flag on, cycle the "Group" button through `repo` → `project` → `session` and confirm the secondary line follows the spec for normal sessions, custom-named sessions, and disconnected sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added experimental simplified session tabs mode that provides a more compact display by hiding pane inventory badges and detailed metadata, showing only essential session information instead.

* **Refactor**
  * Updated session grouping mechanism and display logic to support the new simplified display mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->