### PR TITLE
fix(sidebar): hide empty project groups when grouping by project

### DIFF
--- a/src/lib/sessions/__tests__/order.test.ts
+++ b/src/lib/sessions/__tests__/order.test.ts
@@ -65,10 +65,10 @@ describe("getGroupedSessions (project)", () => {
     expect(groups[0].name).toBe("Untagged");
   });
 
-  it("includes projects that have blueprints but no live sessions", () => {
-    // Without this, a freshly-created project never renders in the sidebar
-    // (no group → no header → no dimmed blueprint rows), so the user can't
-    // spawn from it or edit it from the sidebar.
+  it("hides projects with no live sessions, even when they have blueprints", () => {
+    // Empty project groups crowd the sidebar without an obvious way to
+    // dismiss them. Blueprint-only projects remain addressable via the
+    // command palette and project header menu.
     const projects: Project[] = [
       {
         id: "p-empty",
@@ -85,23 +85,16 @@ describe("getGroupedSessions (project)", () => {
       },
     ];
     const groups = getGroupedSessions([], projects, "project");
-    expect(groups.map((g) => g.key)).toEqual(["p-empty"]);
-    expect(groups[0].sessions).toEqual([]);
-    expect(groups[0].name).toBe("Empty");
+    expect(groups).toEqual([]);
   });
 
-  it("seeds an empty group for every project, even ones with no blueprints", () => {
-    // With auto-spawn-on-create, a project may have neither blueprints nor
-    // live sessions — sessions were spawned without "save as template" and
-    // then closed. Seeding the group keeps the project addressable in the
-    // sidebar; the consumer's auto-collapse-on-first-sight handles noise.
+  it("hides projects that have neither blueprints nor live sessions", () => {
     const projects: Project[] = [{ id: "p-nothing", name: "Nothing" }];
     const groups = getGroupedSessions([], projects, "project");
-    expect(groups.map((g) => g.key)).toEqual(["p-nothing"]);
-    expect(groups[0].sessions).toEqual([]);
+    expect(groups).toEqual([]);
   });
 
-  it("sorts a blueprint-only project below groups that have live sessions", () => {
+  it("only renders project groups that have live sessions", () => {
     const projects: Project[] = [
       { id: "p-active", name: "Active" },
       {
@@ -120,7 +113,7 @@ describe("getGroupedSessions (project)", () => {
     ];
     const sessions = [makeSession({ id: "a", projectId: "p-active", createdAt: 50 })];
     const groups = getGroupedSessions(sessions, projects, "project");
-    expect(groups.map((g) => g.key)).toEqual(["p-active", "p-empty"]);
+    expect(groups.map((g) => g.key)).toEqual(["p-active"]);
   });
 });
 

--- a/src/lib/sessions/order.ts
+++ b/src/lib/sessions/order.ts
@@ -49,18 +49,6 @@ function groupByProject(
     group.sessions.push(s);
     if (s.createdAt > group.latest) group.latest = s.createdAt;
   }
-  // Seed an empty group for every known project, regardless of whether it
-  // has blueprints or live sessions. Projects with auto-spawned-but-closed
-  // sessions and no templates would otherwise vanish from the sidebar once
-  // their last session ends, leaving no way to rediscover or edit them
-  // outside the command palette. `latest = 0` keeps these below any group
-  // with real activity, just above the Untagged tail. The sidebar's
-  // auto-collapse-on-first-sight keeps quiet projects from crowding the
-  // view.
-  for (const p of projects) {
-    if (map.has(p.id)) continue;
-    map.set(p.id, { name: p.name, key: p.id, sessions: [], latest: 0 });
-  }
   const groups = [...map.values()].sort((a, b) => b.latest - a.latest);
   const untaggedIdx = groups.findIndex((g) => g.key === UNTAGGED_KEY);
   if (untaggedIdx > 0) {


### PR DESCRIPTION
## Summary
- Drop the loop in `groupByProject` that seeded an empty group for every known project, so project groups only render when they have at least one live session.
- Blueprint-only projects remain reachable via the command palette and project header menu — they just no longer crowd the sidebar.
- Update `order.test.ts` to assert the new behavior (empty / blueprint-only projects produce no group).

## Test plan
- [x] `npm run test` — 897 pass
- [x] `npm run check` — clean
- [ ] Manual: create a project with no sessions, switch to "group by project", confirm it does not appear; spawn a session, confirm it appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved session grouping to display only projects with active sessions, removing empty projects from the grouped results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->