### PR TITLE
fix(test): make branch-poller stop assertion non-trivial

### DIFF
--- a/src/lib/stores/__tests__/sessionBranchPoller.test.ts
+++ b/src/lib/stores/__tests__/sessionBranchPoller.test.ts
@@ -189,10 +189,31 @@ describe("sessionBranchPoller", () => {
   });
 
   it("installSessionBranchPoller returns a stop fn that cancels the timer", async () => {
+    // Seed an eligible session so the poller actually exercises
+    // `refreshSessionBranch` — otherwise the post-stop assertion
+    // passes trivially (0 === 0) even if cancellation is broken.
+    sessionState.set({
+      sessions: [
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        {
+          id: "s1",
+          repoRoot: "/repo",
+          branch: "main",
+          isGitRepo: true,
+          archived: false,
+        } as any,
+      ],
+      activeSessionId: "s1",
+    });
+    nextBranchByCall = ["feature/x", "feature/y", "feature/z"];
+
     const stop = installSessionBranchPoller(50);
     // First tick fires immediately; wait long enough that a second would
     // fire if we didn't stop.
     await new Promise((r) => setTimeout(r, 25));
+    // Sanity check: poller actually ran at least once before stop, so
+    // the post-stop comparison below is meaningful.
+    expect(refreshCalls.length).toBeGreaterThan(0);
     stop();
     const callsAtStop = refreshCalls.length;
     await new Promise((r) => setTimeout(r, 120));


### PR DESCRIPTION
## Summary

Follow-up to #147. CodeRabbit caught a real bug in the test I added there but the comment landed after the squash merge, so this is the small fix on its own branch.

The previous shape of the `installSessionBranchPoller returns a stop fn that cancels the timer` test ran the poller against an empty session list, so `refreshSessionBranch` was never called. The post-stop assertion (`refreshCalls.length === callsAtStop`) was always 0 === 0 regardless of whether `stop()` actually canceled the interval — the test would silently pass even if cancellation broke.

Fix:

- Seed an eligible session before installing the poller so the first tick actually exercises `refreshSessionBranch`.
- Sanity-check `refreshCalls.length > 0` before stopping, so the post-stop equality is meaningful.

## Test plan

- [x] `npm run test -- src/lib/stores/__tests__/sessionBranchPoller.test.ts` — 6/6 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced session branch poller test reliability to ensure proper refresh behavior validation and prevent trivial passing conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->