### PR TITLE
[codex] combine PR status details on hover

### DIFF
--- a/src-tauri/src/pr.rs
+++ b/src-tauri/src/pr.rs
@@ -22,6 +22,9 @@ pub(crate) struct PrInfo {
     /// Aggregate check status — feeds the status-bar checks icon.
     /// `None` when the lookup didn't (or couldn't) include the rollup.
     pub checks: Option<PrChecksSummary>,
+    /// Individual checks from GitHub's `statusCheckRollup` for the
+    /// status-bar hover popover.
+    pub check_runs: Vec<PrCheckDetails>,
     /// GitHub's `reviewDecision` enum — `"APPROVED"` |
     /// `"CHANGES_REQUESTED"` | `"REVIEW_REQUIRED"`. Mapped 1:1 from gh.
     pub review_decision: Option<String>,
@@ -50,6 +53,22 @@ pub(crate) enum PrChecksState {
     Failing,
     Pending,
     None,
+}
+
+#[derive(Debug, Clone, Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PrCheckDetails {
+    pub name: String,
+    pub status: PrCheckStatus,
+    pub url: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum PrCheckStatus {
+    Passing,
+    Failing,
+    Pending,
 }
 
 /// Parse either a full GitHub PR URL or a shortform `owner/repo#NNN`.
@@ -160,7 +179,7 @@ pub(crate) fn lookup_pr(repo_path: Option<&str>, input: &str) -> Result<PrInfo> 
 /// the two call sites stay in sync. `statusCheckRollup` and
 /// `reviewDecision` are the new additions; both are absent on older gh
 /// versions, but `serde(default)` on `RawPr` keeps the parse alive in
-/// that case (the chip just won't render the new icons).
+/// that case (the chip just won't render the new icons/details).
 const PR_JSON_FIELDS: &str = "number,title,headRefName,headRepositoryOwner,isCrossRepository,url,statusCheckRollup,reviewDecision";
 
 #[derive(Deserialize)]
@@ -187,17 +206,27 @@ struct RawOwner {
 }
 
 /// Subset of gh's check-rollup row we care about. gh emits two shapes
-/// here — workflow check-runs (with `status` + `conclusion`) and
-/// status-context rows (with `state`). Both fields are optional so the
-/// summary computation can fall back gracefully.
-#[derive(Deserialize)]
+/// here — workflow check-runs (with `name`, `status` + `conclusion`)
+/// and status-context rows (with `context` + `state`). All fields are
+/// optional so summary/detail computation can fall back gracefully.
+#[derive(Deserialize, Default)]
 struct RawCheckRun {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default, rename = "workflowName")]
+    workflow_name: Option<String>,
+    #[serde(default)]
+    context: Option<String>,
     #[serde(default)]
     status: Option<String>,
     #[serde(default)]
     conclusion: Option<String>,
     #[serde(default)]
     state: Option<String>,
+    #[serde(default, rename = "detailsUrl")]
+    details_url: Option<String>,
+    #[serde(default, rename = "targetUrl")]
+    target_url: Option<String>,
 }
 
 impl RawPr {
@@ -206,6 +235,11 @@ impl RawPr {
             .status_check_rollup
             .as_deref()
             .map(summarize_checks);
+        let check_runs = self
+            .status_check_rollup
+            .as_deref()
+            .map(check_details)
+            .unwrap_or_default();
         // gh returns "" when there's no decision; normalize to `None`
         // so the frontend doesn't have to special-case empty strings.
         let review_decision = self.review_decision.and_then(|s| {
@@ -221,6 +255,7 @@ impl RawPr {
             url: self.url,
             repo_slug: repo_slug.to_string(),
             checks,
+            check_runs,
             review_decision,
         }
     }
@@ -271,6 +306,46 @@ fn summarize_checks(rollup: &[RawCheckRun]) -> PrChecksSummary {
     PrChecksSummary { state, passing, failing, pending, total }
 }
 
+fn check_details(rollup: &[RawCheckRun]) -> Vec<PrCheckDetails> {
+    rollup
+        .iter()
+        .map(|row| PrCheckDetails {
+            name: check_name(row),
+            status: check_status(row),
+            url: check_url(row),
+        })
+        .collect()
+}
+
+fn check_name(row: &RawCheckRun) -> String {
+    row.name
+        .as_deref()
+        .or(row.context.as_deref())
+        .or(row.workflow_name.as_deref())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or("Unnamed check")
+        .to_string()
+}
+
+fn check_url(row: &RawCheckRun) -> Option<String> {
+    row.details_url
+        .as_deref()
+        .or(row.target_url.as_deref())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn check_status(row: &RawCheckRun) -> PrCheckStatus {
+    match classify_check(row) {
+        CheckClass::Pass => PrCheckStatus::Passing,
+        CheckClass::Fail => PrCheckStatus::Failing,
+        CheckClass::Pending => PrCheckStatus::Pending,
+    }
+}
+
+#[derive(Clone, Copy)]
 enum CheckClass {
     Pass,
     Fail,
@@ -615,18 +690,27 @@ mod tests {
 
     fn workflow_run(conclusion: &str) -> RawCheckRun {
         RawCheckRun {
+            name: Some("workflow".into()),
             status: Some("COMPLETED".into()),
             conclusion: Some(conclusion.into()),
-            state: None,
+            ..Default::default()
         }
     }
 
     fn workflow_pending() -> RawCheckRun {
-        RawCheckRun { status: Some("IN_PROGRESS".into()), conclusion: None, state: None }
+        RawCheckRun {
+            name: Some("workflow".into()),
+            status: Some("IN_PROGRESS".into()),
+            ..Default::default()
+        }
     }
 
     fn status_context(state: &str) -> RawCheckRun {
-        RawCheckRun { status: None, conclusion: None, state: Some(state.into()) }
+        RawCheckRun {
+            context: Some("context".into()),
+            state: Some(state.into()),
+            ..Default::default()
+        }
     }
 
     #[test]
@@ -669,5 +753,41 @@ mod tests {
         assert!(matches!(s.state, PrChecksState::Failing));
         assert_eq!(s.passing, 1);
         assert_eq!(s.failing, 1);
+    }
+
+    #[test]
+    fn check_details_normalizes_names_statuses_and_urls() {
+        let rows = [
+            RawCheckRun {
+                name: Some("cargo test".into()),
+                status: Some("COMPLETED".into()),
+                conclusion: Some("SUCCESS".into()),
+                details_url: Some("https://example.test/checks/1".into()),
+                ..Default::default()
+            },
+            RawCheckRun {
+                context: Some("lint".into()),
+                state: Some("FAILURE".into()),
+                target_url: Some("https://example.test/checks/2".into()),
+                ..Default::default()
+            },
+            RawCheckRun {
+                workflow_name: Some("preview".into()),
+                status: Some("IN_PROGRESS".into()),
+                ..Default::default()
+            },
+        ];
+
+        let details = check_details(&rows);
+
+        assert_eq!(details[0].name, "cargo test");
+        assert!(matches!(details[0].status, PrCheckStatus::Passing));
+        assert_eq!(details[0].url.as_deref(), Some("https://example.test/checks/1"));
+        assert_eq!(details[1].name, "lint");
+        assert!(matches!(details[1].status, PrCheckStatus::Failing));
+        assert_eq!(details[1].url.as_deref(), Some("https://example.test/checks/2"));
+        assert_eq!(details[2].name, "preview");
+        assert!(matches!(details[2].status, PrCheckStatus::Pending));
+        assert!(details[2].url.is_none());
     }
 }

--- a/src-tauri/src/pr.rs
+++ b/src-tauri/src/pr.rs
@@ -28,6 +28,9 @@ pub(crate) struct PrInfo {
     /// GitHub's `reviewDecision` enum — `"APPROVED"` |
     /// `"CHANGES_REQUESTED"` | `"REVIEW_REQUIRED"`. Mapped 1:1 from gh.
     pub review_decision: Option<String>,
+    /// Latest review per reviewer from GitHub's `latestReviews`; feeds the
+    /// status-bar review hover popover.
+    pub review_details: Vec<PrReviewDetails>,
 }
 
 /// Aggregate of a PR's check runs, derived from gh's
@@ -69,6 +72,14 @@ pub(crate) enum PrCheckStatus {
     Passing,
     Failing,
     Pending,
+}
+
+#[derive(Debug, Clone, Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PrReviewDetails {
+    pub reviewer: String,
+    pub state: String,
+    pub url: Option<String>,
 }
 
 /// Parse either a full GitHub PR URL or a shortform `owner/repo#NNN`.
@@ -177,10 +188,10 @@ pub(crate) fn lookup_pr(repo_path: Option<&str>, input: &str) -> Result<PrInfo> 
 
 /// JSON fields requested from `gh pr view` / `gh pr list`. Centralized so
 /// the two call sites stay in sync. `statusCheckRollup` and
-/// `reviewDecision` are the new additions; both are absent on older gh
+/// `reviewDecision`/`latestReviews` are the new additions; all are absent on older gh
 /// versions, but `serde(default)` on `RawPr` keeps the parse alive in
 /// that case (the chip just won't render the new icons/details).
-const PR_JSON_FIELDS: &str = "number,title,headRefName,headRepositoryOwner,isCrossRepository,url,statusCheckRollup,reviewDecision";
+const PR_JSON_FIELDS: &str = "number,title,headRefName,headRepositoryOwner,isCrossRepository,url,statusCheckRollup,reviewDecision,latestReviews";
 
 #[derive(Deserialize)]
 struct RawPr {
@@ -198,11 +209,23 @@ struct RawPr {
     status_check_rollup: Option<Vec<RawCheckRun>>,
     #[serde(default, rename = "reviewDecision")]
     review_decision: Option<String>,
+    #[serde(default, rename = "latestReviews")]
+    latest_reviews: Option<Vec<RawReview>>,
 }
 
 #[derive(Deserialize)]
 struct RawOwner {
     login: String,
+}
+
+#[derive(Deserialize, Default)]
+struct RawReview {
+    #[serde(default)]
+    author: Option<RawOwner>,
+    #[serde(default)]
+    state: Option<String>,
+    #[serde(default)]
+    url: Option<String>,
 }
 
 /// Subset of gh's check-rollup row we care about. gh emits two shapes
@@ -240,6 +263,11 @@ impl RawPr {
             .as_deref()
             .map(check_details)
             .unwrap_or_default();
+        let review_details = self
+            .latest_reviews
+            .as_deref()
+            .map(review_details)
+            .unwrap_or_default();
         // gh returns "" when there's no decision; normalize to `None`
         // so the frontend doesn't have to special-case empty strings.
         let review_decision = self.review_decision.and_then(|s| {
@@ -257,6 +285,7 @@ impl RawPr {
             checks,
             check_runs,
             review_decision,
+            review_details,
         }
     }
 }
@@ -343,6 +372,34 @@ fn check_status(row: &RawCheckRun) -> PrCheckStatus {
         CheckClass::Fail => PrCheckStatus::Failing,
         CheckClass::Pending => PrCheckStatus::Pending,
     }
+}
+
+fn review_details(reviews: &[RawReview]) -> Vec<PrReviewDetails> {
+    reviews
+        .iter()
+        .filter_map(|review| {
+            let state = review.state.as_deref().map(str::trim).unwrap_or("");
+            if state.is_empty() {
+                return None;
+            }
+            Some(PrReviewDetails {
+                reviewer: review
+                    .author
+                    .as_ref()
+                    .map(|a| a.login.trim())
+                    .filter(|s| !s.is_empty())
+                    .unwrap_or("unknown")
+                    .to_string(),
+                state: state.to_string(),
+                url: review
+                    .url
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(ToOwned::to_owned),
+            })
+        })
+        .collect()
 }
 
 #[derive(Clone, Copy)]
@@ -789,5 +846,36 @@ mod tests {
         assert_eq!(details[2].name, "preview");
         assert!(matches!(details[2].status, PrCheckStatus::Pending));
         assert!(details[2].url.is_none());
+    }
+
+    #[test]
+    fn review_details_normalizes_latest_reviews() {
+        let rows = [
+            RawReview {
+                author: Some(RawOwner { login: "alice".into() }),
+                state: Some("APPROVED".into()),
+                url: Some("https://example.test/reviews/1".into()),
+            },
+            RawReview {
+                author: Some(RawOwner { login: " ".into() }),
+                state: Some("CHANGES_REQUESTED".into()),
+                url: Some(" ".into()),
+            },
+            RawReview {
+                author: Some(RawOwner { login: "ignored".into() }),
+                state: Some(" ".into()),
+                url: None,
+            },
+        ];
+
+        let details = review_details(&rows);
+
+        assert_eq!(details.len(), 2);
+        assert_eq!(details[0].reviewer, "alice");
+        assert_eq!(details[0].state, "APPROVED");
+        assert_eq!(details[0].url.as_deref(), Some("https://example.test/reviews/1"));
+        assert_eq!(details[1].reviewer, "unknown");
+        assert_eq!(details[1].state, "CHANGES_REQUESTED");
+        assert!(details[1].url.is_none());
     }
 }

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -265,6 +265,11 @@ export const commands = {
 	 *  `"CHANGES_REQUESTED"` | `"REVIEW_REQUIRED"`. Mapped 1:1 from gh.
 	 */
 	reviewDecision: string | null,
+	/**
+	 *  Latest review per reviewer from GitHub's `latestReviews`; feeds the
+	 *  status-bar review hover popover.
+	 */
+	reviewDetails: PrReviewDetails[],
 } | null, string>(__TAURI_INVOKE("lookup_pr_for_branch", { repoPath, branch })),
 	cmdDiscoverTasks: (dir: string) => __TAURI_INVOKE<TaskGroup[]>("cmd_discover_tasks", { dir }),
 	cmdLoadTaskOverrides: () => __TAURI_INVOKE<{ [key in string]: { [key in string]: string } }>("cmd_load_task_overrides"),
@@ -861,9 +866,20 @@ export type PrInfo = {
 	 *  `"CHANGES_REQUESTED"` | `"REVIEW_REQUIRED"`. Mapped 1:1 from gh.
 	 */
 	reviewDecision: string | null,
+	/**
+	 *  Latest review per reviewer from GitHub's `latestReviews`; feeds the
+	 *  status-bar review hover popover.
+	 */
+	reviewDetails: PrReviewDetails[],
 };
 
 export type PrReview = {
+	reviewer: string,
+	state: string,
+	url: string | null,
+};
+
+export type PrReviewDetails = {
 	reviewer: string,
 	state: string,
 	url: string | null,

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -108,8 +108,10 @@ export const commands = {
 	 */
 	setSessionPinnedPrUrl: (sessionId: string, url: string | null) => typedError<null, string>(__TAURI_INVOKE("set_session_pinned_pr_url", { sessionId, url })),
 	/**
-	 *  Re-read the session's worktree branch via `git rev-parse` and update
-	 *  the stored value if it changed. Returns the current branch.
+	 *  Re-read the session's worktree branch via `git rev-parse` and update the
+	 *  stored value if it changed. Returns the current branch (whether or not it
+	 *  changed). The frontend calls this on a low-frequency tick so PR discovery
+	 *  re-runs after the user `git checkout`s inside a Roux pane.
 	 */
 	refreshSessionBranch: (sessionId: string) => typedError<string | null, string>(__TAURI_INVOKE("refresh_session_branch", { sessionId })),
 	getPtyGeneration: (id: string) => __TAURI_INVOKE<number | null>("get_pty_generation", { id }),
@@ -248,6 +250,21 @@ export const commands = {
 	isCrossRepository: boolean,
 	url: string,
 	repoSlug: string,
+	/**
+	 *  Aggregate check status — feeds the status-bar checks icon.
+	 *  `None` when the lookup didn't (or couldn't) include the rollup.
+	 */
+	checks: PrChecksSummary | null,
+	/**
+	 *  Individual checks from GitHub's `statusCheckRollup` for the
+	 *  status-bar hover popover.
+	 */
+	checkRuns: PrCheckDetails[],
+	/**
+	 *  GitHub's `reviewDecision` enum — `"APPROVED"` |
+	 *  `"CHANGES_REQUESTED"` | `"REVIEW_REQUIRED"`. Mapped 1:1 from gh.
+	 */
+	reviewDecision: string | null,
 } | null, string>(__TAURI_INVOKE("lookup_pr_for_branch", { repoPath, branch })),
 	cmdDiscoverTasks: (dir: string) => __TAURI_INVOKE<TaskGroup[]>("cmd_discover_tasks", { dir }),
 	cmdLoadTaskOverrides: () => __TAURI_INVOKE<{ [key in string]: { [key in string]: string } }>("cmd_load_task_overrides"),
@@ -787,10 +804,38 @@ export type ParsedKeymap = {
 	warnings: KeymapWarning[],
 };
 
+export type PrCheckDetails = {
+	name: string,
+	status: PrCheckStatus,
+	url: string | null,
+};
+
 export type PrCheckRun = {
 	name: string,
 	conclusion: string | null,
 	url: string | null,
+};
+
+export type PrCheckStatus = "passing" | "failing" | "pending";
+
+export type PrChecksState = "passing" | "failing" | "pending" | "none";
+
+/**
+ *  Aggregate of a PR's check runs, derived from gh's
+ *  `statusCheckRollup`. We collapse to a single "worst-of" state plus
+ *  counts so the status bar can render a tiny icon without re-deriving
+ *  the rollup on every render.
+ */
+export type PrChecksSummary = {
+	/**
+	 *  `"passing"` | `"failing"` | `"pending"` | `"none"`.
+	 *  `"none"` means there are no check runs at all (empty rollup).
+	 */
+	state: PrChecksState,
+	passing: number,
+	failing: number,
+	pending: number,
+	total: number,
 };
 
 export type PrInfo = {
@@ -801,22 +846,22 @@ export type PrInfo = {
 	isCrossRepository: boolean,
 	url: string,
 	repoSlug: string,
-	/** Aggregate check status — feeds the status-bar checks icon. */
+	/**
+	 *  Aggregate check status — feeds the status-bar checks icon.
+	 *  `None` when the lookup didn't (or couldn't) include the rollup.
+	 */
 	checks: PrChecksSummary | null,
-	/** GitHub's `reviewDecision`: `"APPROVED"` | `"CHANGES_REQUESTED"` |
-	 *  `"REVIEW_REQUIRED"`, or `null` when there's no decision yet. */
+	/**
+	 *  Individual checks from GitHub's `statusCheckRollup` for the
+	 *  status-bar hover popover.
+	 */
+	checkRuns: PrCheckDetails[],
+	/**
+	 *  GitHub's `reviewDecision` enum — `"APPROVED"` |
+	 *  `"CHANGES_REQUESTED"` | `"REVIEW_REQUIRED"`. Mapped 1:1 from gh.
+	 */
 	reviewDecision: string | null,
 };
-
-export type PrChecksSummary = {
-	state: PrChecksState,
-	passing: number,
-	failing: number,
-	pending: number,
-	total: number,
-};
-
-export type PrChecksState = "passing" | "failing" | "pending" | "none";
 
 export type PrReview = {
 	reviewer: string,

--- a/src/lib/commands/__tests__/ui.test.ts
+++ b/src/lib/commands/__tests__/ui.test.ts
@@ -1,0 +1,81 @@
+import { get, writable } from "svelte/store";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const queryMock = vi.hoisted(() => ({
+  activeSession: null as { id: string } | null,
+}));
+
+vi.mock("$lib/queries", () => ({
+  queries: {
+    activeSession: () => queryMock.activeSession,
+    activeSessionId: () => queryMock.activeSession?.id ?? null,
+  },
+}));
+
+vi.mock("$lib/bindings", () => ({
+  commands: {},
+}));
+
+vi.mock("$lib/tauri", () => ({
+  openInEditor: vi.fn(),
+  notificationsPush: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-opener", () => ({
+  openUrl: vi.fn(),
+}));
+
+vi.mock("$lib/logging", () => ({
+  logError: vi.fn(),
+}));
+
+vi.mock("$lib/themes", () => ({
+  THEME_DEFINITIONS: [],
+  MATCH_GUI_TERMINAL_THEME_ID: "auto",
+  getAllTerminalThemeDefinitions: vi.fn(() => []),
+}));
+
+vi.mock("$lib/stores/userTerminalThemes", () => ({
+  userTerminalThemes: writable([]),
+  loadUserTerminalThemes: vi.fn(),
+}));
+
+import { registry } from "../registry";
+import { registerUiCommands } from "../ui";
+import {
+  closePrStatusDetails,
+  prStatusDetailsOpen,
+} from "$lib/stores/prStatusDetails";
+
+describe("ui commands", () => {
+  beforeEach(() => {
+    registry.unregister("ui.toggle-pr-status-details");
+    queryMock.activeSession = null;
+    closePrStatusDetails();
+  });
+
+  it("registers a bindable PR status details toggle command", () => {
+    queryMock.activeSession = { id: "s1" };
+    registerUiCommands();
+
+    const command = registry.get("ui.toggle-pr-status-details");
+    expect(command?.label).toBe("Toggle PR Status Details");
+    expect(command?.category).toBe("Watches");
+    expect(command?.available?.()).toBe(true);
+
+    command?.execute?.();
+    expect(get(prStatusDetailsOpen)).toBe(true);
+
+    command?.execute?.();
+    expect(get(prStatusDetailsOpen)).toBe(false);
+  });
+
+  it("hides the PR status details toggle command without an active session", () => {
+    registerUiCommands();
+
+    expect(registry.get("ui.toggle-pr-status-details")?.available?.()).toBe(false);
+    expect(registry.getAvailable().map((cmd) => cmd.id)).not.toContain(
+      "ui.toggle-pr-status-details",
+    );
+  });
+});

--- a/src/lib/commands/ui.ts
+++ b/src/lib/commands/ui.ts
@@ -37,6 +37,7 @@ import {
   notesViewMode,
   type NotesScope,
 } from "$lib/stores/notesUi";
+import { togglePrStatusDetails } from "$lib/stores/prStatusDetails";
 
 const ISSUES_URL = "https://github.com/phin-tech/roux/issues";
 
@@ -134,6 +135,14 @@ export function registerUiCommands() {
     category: "App",
     available: () => !!queries.activeSession(),
     execute: () => toggleSidebar("notes"),
+  });
+
+  registry.register({
+    id: "ui.toggle-pr-status-details",
+    label: "Toggle PR Status Details",
+    category: "Watches",
+    available: () => !!queries.activeSession(),
+    execute: () => togglePrStatusDetails(),
   });
 
   registry.register({

--- a/src/lib/components/StatusBar.svelte
+++ b/src/lib/components/StatusBar.svelte
@@ -10,6 +10,7 @@
   import { ciChipFor } from "$lib/ciIcon";
   import { checksChipFor, reviewChipFor } from "$lib/prChips";
   import { safeHref } from "$lib/safeUrl";
+  import type { PrCheckStatus } from "$lib/tauri";
   import type { StatusBarPosition } from "$lib/types";
 
   interface Props {
@@ -57,6 +58,7 @@
   // decision. Both come from the gh-derived `PrInfo`, independent of
   // worktrunk, so they render in both the worktrunk and gh-only paths.
   let checksChip = $derived(checksChipFor(prInfo?.checks));
+  let checkRows = $derived(prInfo?.checkRuns ?? []);
   let reviewChip = $derived(reviewChipFor(prInfo?.reviewDecision));
 
   /** Extract a PR-style label from a GitHub/GitLab URL (e.g. "PR #42"). */
@@ -64,7 +66,77 @@
     const m = url.match(/\/(?:pull|pulls|merge_requests)\/(\d+)/);
     return m ? `PR #${m[1]}` : "PR";
   }
+
+  function checkStatusLabel(status: PrCheckStatus): string {
+    switch (status) {
+      case "passing":
+        return "passing";
+      case "failing":
+        return "failing";
+      case "pending":
+        return "pending";
+    }
+  }
+
+  function checkStatusDotClass(status: PrCheckStatus): string {
+    switch (status) {
+      case "passing":
+        return "bg-green";
+      case "failing":
+        return "bg-red";
+      case "pending":
+        return "bg-yellow";
+    }
+  }
+
+  function checkStatusTextClass(status: PrCheckStatus): string {
+    switch (status) {
+      case "passing":
+        return "text-green";
+      case "failing":
+        return "text-red";
+      case "pending":
+        return "text-yellow";
+    }
+  }
 </script>
+
+{#snippet prChecksChip()}
+  {#if checksChip}
+    {@const Icon = checksChip.icon}
+    <span class="group relative inline-flex items-center">
+      <span
+        data-testid="status-bar-pr-checks"
+        class={`inline-flex items-center ${checksChip.color}`}
+        aria-label={checksChip.label}
+        role="img"
+        title={checkRows.length > 0 ? undefined : checksChip.label}
+      >
+        <Icon size={12} class={checksChip.spin ? "animate-spin" : ""} />
+      </span>
+      {#if checkRows.length > 0}
+        <div
+          data-testid="status-bar-pr-checks-popover"
+          role="tooltip"
+          class={`pointer-events-none absolute left-1/2 z-50 hidden max-h-72 min-w-64 max-w-80 -translate-x-1/2 overflow-y-auto rounded border border-border bg-bg-elevated p-2 text-[11px] text-text-primary shadow-lg group-hover:block ${position === "top" ? "top-full mt-2" : "bottom-full mb-2"}`}
+        >
+          <div class="mb-1 text-[10px] font-semibold uppercase text-text-muted">Checks</div>
+          <div class="space-y-1">
+            {#each checkRows as check}
+              <div class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3">
+                <span class="truncate" title={check.name}>{check.name}</span>
+                <span class={`inline-flex items-center gap-1 ${checkStatusTextClass(check.status)}`}>
+                  <span class={`h-1.5 w-1.5 rounded-full ${checkStatusDotClass(check.status)}`}></span>
+                  <span>{checkStatusLabel(check.status)}</span>
+                </span>
+              </div>
+            {/each}
+          </div>
+        </div>
+      {/if}
+    </span>
+  {/if}
+{/snippet}
 
 <div
   class="flex h-8 items-center gap-3 bg-bg-base px-3 text-[12px] text-text-muted"
@@ -96,16 +168,7 @@
         <Icon size={12} class={running ? "animate-spin" : ""} />
         <span>{prLabel(ciHref)}</span>
       </a>
-      {#if checksChip}
-        {@const Icon = checksChip.icon}
-        <span
-          data-testid="status-bar-pr-checks"
-          class={`inline-flex items-center ${checksChip.color}`}
-          title={checksChip.label}
-        >
-          <Icon size={12} class={checksChip.spin ? "animate-spin" : ""} />
-        </span>
-      {/if}
+      {@render prChecksChip()}
       {#if reviewChip}
         {@const Icon = reviewChip.icon}
         <span
@@ -128,16 +191,7 @@
       >
         <span>{prLabel(ciHref)}</span>
       </a>
-      {#if checksChip}
-        {@const Icon = checksChip.icon}
-        <span
-          data-testid="status-bar-pr-checks"
-          class={`inline-flex items-center ${checksChip.color}`}
-          title={checksChip.label}
-        >
-          <Icon size={12} class={checksChip.spin ? "animate-spin" : ""} />
-        </span>
-      {/if}
+      {@render prChecksChip()}
       {#if reviewChip}
         {@const Icon = reviewChip.icon}
         <span

--- a/src/lib/components/StatusBar.svelte
+++ b/src/lib/components/StatusBar.svelte
@@ -163,41 +163,45 @@
 </script>
 
 {#snippet prStatusLink(href: string, stale: boolean = false, title: string = "Open PR for this branch")}
-  {#if prStatusChip}
-    {@const StatusIcon = prStatusChip.icon}
-    <a
-      data-testid="status-bar-pr-link"
-      href={href}
-      target="_blank"
-      rel="noopener noreferrer"
-      class={`group relative inline-flex items-center gap-1 underline ${prLinkColor} ${stale ? "opacity-60" : ""}`}
-      title={hasPrPopover ? undefined : title}
-    >
-      <StatusIcon size={12} class={prStatusChip.spin ? "animate-spin" : ""} />
-      <span>{prLabel(href)}</span>
-      {@render prPopover()}
-    </a>
-  {:else}
-    <a
-      data-testid="status-bar-pr-link"
-      href={href}
-      target="_blank"
-      rel="noopener noreferrer"
-      class={`group relative inline-flex items-center gap-1 underline ${prLinkColor} ${stale ? "opacity-60" : ""}`}
-      title={hasPrPopover ? undefined : title}
-    >
-      <span>{prLabel(href)}</span>
-      {@render prPopover()}
-    </a>
-  {/if}
+  <span class="group relative inline-flex items-center">
+    {#if prStatusChip}
+      {@const StatusIcon = prStatusChip.icon}
+      <a
+        data-testid="status-bar-pr-link"
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-describedby={hasPrPopover ? "status-bar-pr-popover" : undefined}
+        class={`inline-flex items-center gap-1 underline ${prLinkColor} ${stale ? "opacity-60" : ""}`}
+        title={hasPrPopover ? undefined : title}
+      >
+        <StatusIcon size={12} class={prStatusChip.spin ? "animate-spin" : ""} />
+        <span>{prLabel(href)}</span>
+      </a>
+    {:else}
+      <a
+        data-testid="status-bar-pr-link"
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-describedby={hasPrPopover ? "status-bar-pr-popover" : undefined}
+        class={`inline-flex items-center gap-1 underline ${prLinkColor} ${stale ? "opacity-60" : ""}`}
+        title={hasPrPopover ? undefined : title}
+      >
+        <span>{prLabel(href)}</span>
+      </a>
+    {/if}
+    {@render prPopover()}
+  </span>
 {/snippet}
 
 {#snippet prPopover()}
   {#if hasPrPopover}
     <div
+      id="status-bar-pr-popover"
       data-testid="status-bar-pr-popover"
       role="tooltip"
-      class={`pointer-events-none absolute left-1/2 z-50 max-h-80 min-w-72 max-w-96 -translate-x-1/2 overflow-y-auto rounded border border-border bg-bg-elevated p-2 text-[11px] text-text-primary shadow-lg ${$prStatusDetailsOpen ? "block" : "hidden group-hover:block"} ${position === "top" ? "top-full mt-2" : "bottom-full mb-2"}`}
+      class={`absolute left-1/2 z-50 max-h-80 min-w-72 max-w-96 -translate-x-1/2 overflow-y-auto rounded border border-border bg-bg-elevated p-2 text-[11px] text-text-primary shadow-lg ${$prStatusDetailsOpen ? "block" : "hidden group-hover:block group-focus-within:block"} ${position === "top" ? "top-full mt-2" : "bottom-full mb-2"}`}
     >
       {#if checkRows.length > 0}
         <div class="mb-1 text-[10px] font-semibold uppercase text-text-muted">Checks</div>

--- a/src/lib/components/StatusBar.svelte
+++ b/src/lib/components/StatusBar.svelte
@@ -10,6 +10,7 @@
   import { ciChipFor } from "$lib/ciIcon";
   import { checksChipFor, reviewChipFor } from "$lib/prChips";
   import { safeHref } from "$lib/safeUrl";
+  import { closePrStatusDetails, prStatusDetailsOpen } from "$lib/stores/prStatusDetails";
   import type { PrCheckStatus, PrReviewDetails } from "$lib/tauri";
   import type { StatusBarPosition } from "$lib/types";
 
@@ -77,6 +78,12 @@
   let approvalCount = $derived(
     reviewRows.filter((review) => normalizedReviewState(review.state) === "approved").length,
   );
+
+  $effect(() => {
+    if ((!$activeSession || !hasPrPopover) && $prStatusDetailsOpen) {
+      closePrStatusDetails();
+    }
+  });
 
   /** Extract a PR-style label from a GitHub/GitLab URL (e.g. "PR #42"). */
   function prLabel(url: string): string {
@@ -190,7 +197,7 @@
     <div
       data-testid="status-bar-pr-popover"
       role="tooltip"
-      class={`pointer-events-none absolute left-1/2 z-50 hidden max-h-80 min-w-72 max-w-96 -translate-x-1/2 overflow-y-auto rounded border border-border bg-bg-elevated p-2 text-[11px] text-text-primary shadow-lg group-hover:block ${position === "top" ? "top-full mt-2" : "bottom-full mb-2"}`}
+      class={`pointer-events-none absolute left-1/2 z-50 max-h-80 min-w-72 max-w-96 -translate-x-1/2 overflow-y-auto rounded border border-border bg-bg-elevated p-2 text-[11px] text-text-primary shadow-lg ${$prStatusDetailsOpen ? "block" : "hidden group-hover:block"} ${position === "top" ? "top-full mt-2" : "bottom-full mb-2"}`}
     >
       {#if checkRows.length > 0}
         <div class="mb-1 text-[10px] font-semibold uppercase text-text-muted">Checks</div>

--- a/src/lib/components/StatusBar.svelte
+++ b/src/lib/components/StatusBar.svelte
@@ -10,7 +10,7 @@
   import { ciChipFor } from "$lib/ciIcon";
   import { checksChipFor, reviewChipFor } from "$lib/prChips";
   import { safeHref } from "$lib/safeUrl";
-  import type { PrCheckStatus } from "$lib/tauri";
+  import type { PrCheckStatus, PrReviewDetails } from "$lib/tauri";
   import type { StatusBarPosition } from "$lib/types";
 
   interface Props {
@@ -60,6 +60,23 @@
   let checksChip = $derived(checksChipFor(prInfo?.checks));
   let checkRows = $derived(prInfo?.checkRuns ?? []);
   let reviewChip = $derived(reviewChipFor(prInfo?.reviewDecision));
+  let reviewRows = $derived(prInfo?.reviewDetails ?? []);
+  let prStatusChip = $derived(
+    checksChip ??
+      (ciChip
+        ? {
+            icon: ciChip.icon,
+            color: ciChip.color,
+            label: `CI: ${ciChip.label}`,
+            spin: wtMeta?.ciStatus === "running",
+          }
+        : reviewChip),
+  );
+  let prLinkColor = $derived(prStatusChip?.color ?? "text-text-muted hover:text-text-primary");
+  let hasPrPopover = $derived(checkRows.length > 0 || reviewRows.length > 0);
+  let approvalCount = $derived(
+    reviewRows.filter((review) => normalizedReviewState(review.state) === "approved").length,
+  );
 
   /** Extract a PR-style label from a GitHub/GitLab URL (e.g. "PR #42"). */
   function prLabel(url: string): string {
@@ -99,42 +116,116 @@
         return "text-yellow";
     }
   }
+
+  function normalizedReviewState(state: string): string {
+    return state.trim().toLowerCase().replace(/_/g, " ");
+  }
+
+  function reviewStatusLabel(review: PrReviewDetails): string {
+    const normalized = normalizedReviewState(review.state);
+    return normalized || "unknown";
+  }
+
+  function reviewStatusTextClass(review: PrReviewDetails): string {
+    switch (normalizedReviewState(review.state)) {
+      case "approved":
+        return "text-green";
+      case "changes requested":
+        return "text-red";
+      case "review requested":
+      case "pending":
+        return "text-yellow";
+      default:
+        return "text-text-muted";
+    }
+  }
+
+  function reviewStatusDotClass(review: PrReviewDetails): string {
+    switch (normalizedReviewState(review.state)) {
+      case "approved":
+        return "bg-green";
+      case "changes requested":
+        return "bg-red";
+      case "review requested":
+      case "pending":
+        return "bg-yellow";
+      default:
+        return "bg-text-muted";
+    }
+  }
 </script>
 
-{#snippet prChecksChip()}
-  {#if checksChip}
-    {@const Icon = checksChip.icon}
-    <span class="group relative inline-flex items-center">
-      <span
-        data-testid="status-bar-pr-checks"
-        class={`inline-flex items-center ${checksChip.color}`}
-        aria-label={checksChip.label}
-        role="img"
-        title={checkRows.length > 0 ? undefined : checksChip.label}
-      >
-        <Icon size={12} class={checksChip.spin ? "animate-spin" : ""} />
-      </span>
+{#snippet prStatusLink(href: string, stale: boolean = false, title: string = "Open PR for this branch")}
+  {#if prStatusChip}
+    {@const StatusIcon = prStatusChip.icon}
+    <a
+      data-testid="status-bar-pr-link"
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      class={`group relative inline-flex items-center gap-1 underline ${prLinkColor} ${stale ? "opacity-60" : ""}`}
+      title={hasPrPopover ? undefined : title}
+    >
+      <StatusIcon size={12} class={prStatusChip.spin ? "animate-spin" : ""} />
+      <span>{prLabel(href)}</span>
+      {@render prPopover()}
+    </a>
+  {:else}
+    <a
+      data-testid="status-bar-pr-link"
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      class={`group relative inline-flex items-center gap-1 underline ${prLinkColor} ${stale ? "opacity-60" : ""}`}
+      title={hasPrPopover ? undefined : title}
+    >
+      <span>{prLabel(href)}</span>
+      {@render prPopover()}
+    </a>
+  {/if}
+{/snippet}
+
+{#snippet prPopover()}
+  {#if hasPrPopover}
+    <div
+      data-testid="status-bar-pr-popover"
+      role="tooltip"
+      class={`pointer-events-none absolute left-1/2 z-50 hidden max-h-80 min-w-72 max-w-96 -translate-x-1/2 overflow-y-auto rounded border border-border bg-bg-elevated p-2 text-[11px] text-text-primary shadow-lg group-hover:block ${position === "top" ? "top-full mt-2" : "bottom-full mb-2"}`}
+    >
       {#if checkRows.length > 0}
-        <div
-          data-testid="status-bar-pr-checks-popover"
-          role="tooltip"
-          class={`pointer-events-none absolute left-1/2 z-50 hidden max-h-72 min-w-64 max-w-80 -translate-x-1/2 overflow-y-auto rounded border border-border bg-bg-elevated p-2 text-[11px] text-text-primary shadow-lg group-hover:block ${position === "top" ? "top-full mt-2" : "bottom-full mb-2"}`}
-        >
-          <div class="mb-1 text-[10px] font-semibold uppercase text-text-muted">Checks</div>
+        <div class="mb-1 text-[10px] font-semibold uppercase text-text-muted">Checks</div>
+        <div class="space-y-1">
+          {#each checkRows as check}
+            <div class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3">
+              <span class="truncate" title={check.name}>{check.name}</span>
+              <span class={`inline-flex items-center gap-1 ${checkStatusTextClass(check.status)}`}>
+                <span class={`h-1.5 w-1.5 rounded-full ${checkStatusDotClass(check.status)}`}></span>
+                <span>{checkStatusLabel(check.status)}</span>
+              </span>
+            </div>
+          {/each}
+        </div>
+      {/if}
+      {#if reviewRows.length > 0}
+        <div class={checkRows.length > 0 ? "mt-3" : ""}>
+          <div class="mb-1 flex items-center justify-between gap-3 text-[10px] font-semibold uppercase text-text-muted">
+            <span>Reviews</span>
+            <span>Approvals {approvalCount}/{reviewRows.length}</span>
+          </div>
           <div class="space-y-1">
-            {#each checkRows as check}
+            {#each reviewRows as review}
               <div class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3">
-                <span class="truncate" title={check.name}>{check.name}</span>
-                <span class={`inline-flex items-center gap-1 ${checkStatusTextClass(check.status)}`}>
-                  <span class={`h-1.5 w-1.5 rounded-full ${checkStatusDotClass(check.status)}`}></span>
-                  <span>{checkStatusLabel(check.status)}</span>
+                <span class="truncate" title={review.reviewer}>{review.reviewer}</span>
+                <span class={`inline-flex items-center gap-1 ${reviewStatusTextClass(review)}`}>
+                  <span class={`h-1.5 w-1.5 rounded-full ${reviewStatusDotClass(review)}`}></span>
+                  <span>{reviewStatusLabel(review)}</span>
                 </span>
               </div>
             {/each}
           </div>
         </div>
       {/if}
-    </span>
+    </div>
   {/if}
 {/snippet}
 
@@ -154,54 +245,19 @@
       <span class="text-text-muted">&#9095; {$activeSession.branch}</span>
     {/if}
     {#if ciHref && ciChip && wtMeta && !ghOnly}
-      {@const Icon = ciChip.icon}
-      {@const running = wtMeta.ciStatus === "running"}
       <span class="text-text-secondary">&bull;</span>
-      <a
-        data-testid="status-bar-pr-link"
-        href={ciHref}
-        target="_blank"
-        rel="noopener noreferrer"
-        class={`inline-flex items-center gap-1 underline ${ciChip.color} ${wtMeta.ciStale ? "opacity-60" : ""}`}
-        title={`CI: ${ciChip.label}${wtMeta.ciStale ? " (stale — unpushed changes)" : ""}`}
-      >
-        <Icon size={12} class={running ? "animate-spin" : ""} />
-        <span>{prLabel(ciHref)}</span>
-      </a>
-      {@render prChecksChip()}
-      {#if reviewChip}
-        {@const Icon = reviewChip.icon}
-        <span
-          data-testid="status-bar-pr-review"
-          class={`inline-flex items-center ${reviewChip.color}`}
-          title={reviewChip.label}
-        >
-          <Icon size={12} />
-        </span>
-      {/if}
+      {@render prStatusLink(
+        ciHref,
+        wtMeta.ciStale,
+        `CI: ${ciChip.label}${wtMeta.ciStale ? " (stale — unpushed changes)" : ""}`,
+      )}
     {:else if ciHref && ghOnly}
       <span class="text-text-secondary">&bull;</span>
-      <a
-        data-testid="status-bar-pr-link"
-        href={ciHref}
-        target="_blank"
-        rel="noopener noreferrer"
-        class="inline-flex items-center gap-1 underline text-text-muted hover:text-text-primary"
-        title={prInfo?.title ? `PR: ${prInfo.title}` : "Open PR for this branch"}
-      >
-        <span>{prLabel(ciHref)}</span>
-      </a>
-      {@render prChecksChip()}
-      {#if reviewChip}
-        {@const Icon = reviewChip.icon}
-        <span
-          data-testid="status-bar-pr-review"
-          class={`inline-flex items-center ${reviewChip.color}`}
-          title={reviewChip.label}
-        >
-          <Icon size={12} />
-        </span>
-      {/if}
+      {@render prStatusLink(
+        ciHref,
+        false,
+        prInfo?.title ? `PR: ${prInfo.title}` : "Open PR for this branch",
+      )}
     {:else if ciChip && wtMeta}
       {@const Icon = ciChip.icon}
       {@const running = wtMeta.ciStatus === "running"}

--- a/src/lib/components/__tests__/StatusBar.test.ts
+++ b/src/lib/components/__tests__/StatusBar.test.ts
@@ -257,8 +257,11 @@ describe("StatusBar worktrunk integration", () => {
     const popover = getByTestId("status-bar-pr-popover");
 
     expect(link.className).toContain("text-red");
+    expect(link.getAttribute("aria-describedby")).toBe("status-bar-pr-popover");
     expect(link.querySelectorAll("svg")).toHaveLength(1);
     expect(queryByTestId("status-bar-pr-checks")).toBeNull();
+    expect(popover.className).not.toContain("pointer-events-none");
+    expect(popover.className).toContain("group-focus-within:block");
     expect(popover.textContent).toContain("cargo test");
     expect(popover.textContent).toContain("passing");
     expect(popover.textContent).toContain("npm check");

--- a/src/lib/components/__tests__/StatusBar.test.ts
+++ b/src/lib/components/__tests__/StatusBar.test.ts
@@ -1,13 +1,25 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render } from "@testing-library/svelte";
 import type { Session, Worktree, WorktrunkMetadata } from "$lib/types";
+import type { PrInfo } from "$lib/tauri";
+
+const tauriMock = vi.hoisted(() => ({
+  nextPrLookupResult: null as unknown,
+}));
 
 vi.mock("$lib/tauri", () => ({
   listWorktrees: vi.fn(),
+  lookupPr: vi.fn(async () => tauriMock.nextPrLookupResult),
+  lookupPrForBranch: vi.fn(async () => tauriMock.nextPrLookupResult),
+  findOrCreateWatch: vi.fn(),
 }));
 
 import StatusBar from "../StatusBar.svelte";
 import { sessionState } from "$lib/stores/sessions";
+import {
+  _resetSessionPrLookupForTests,
+  lookupPrForSession,
+} from "$lib/stores/sessionPrLookup";
 import {
   _resetWorktreeMetadataForTests,
   upsertWorktreeMetadata,
@@ -55,6 +67,22 @@ function makeMeta(overrides: Partial<WorktrunkMetadata> = {}): WorktrunkMetadata
   };
 }
 
+function makePr(overrides: Partial<PrInfo> = {}): PrInfo {
+  return {
+    number: 42,
+    title: "Test PR",
+    headRef: "feature/x",
+    headOwner: "phin-tech",
+    isCrossRepository: false,
+    url: "https://github.com/phin-tech/roux/pull/42",
+    repoSlug: "phin-tech/roux",
+    checks: null,
+    checkRuns: [],
+    reviewDecision: null,
+    ...overrides,
+  };
+}
+
 function seed(path: string, meta: WorktrunkMetadata | null) {
   const wt: Worktree = {
     path,
@@ -69,11 +97,15 @@ describe("StatusBar worktrunk integration", () => {
   beforeEach(() => {
     sessionState.set({ sessions: [], activeSessionId: null });
     _resetWorktreeMetadataForTests();
+    _resetSessionPrLookupForTests();
+    tauriMock.nextPrLookupResult = null;
   });
 
   afterEach(() => {
     sessionState.set({ sessions: [], activeSessionId: null });
     _resetWorktreeMetadataForTests();
+    _resetSessionPrLookupForTests();
+    tauriMock.nextPrLookupResult = null;
   });
 
   it("renders no PR link when no session is active", () => {
@@ -180,5 +212,46 @@ describe("StatusBar worktrunk integration", () => {
     const { queryByTestId } = render(StatusBar);
     expect(queryByTestId("status-bar-pr-link")).toBeNull();
     expect(queryByTestId("status-bar-ci-chip")).toBeNull();
+  });
+
+  it("renders a hover popover with individual PR check statuses", async () => {
+    const s = makeSession({
+      repoRoot: "/repo",
+      worktreePath: "/wt/feat-checks",
+      branch: "feature/x",
+    });
+    sessionState.set({ sessions: [s], activeSessionId: s.id });
+    seed(
+      "/wt/feat-checks",
+      makeMeta({
+        ciStatus: "running",
+        ciUrl: "https://github.com/phin-tech/roux/pull/42",
+      }),
+    );
+    tauriMock.nextPrLookupResult = makePr({
+      checks: {
+        state: "failing",
+        passing: 1,
+        failing: 1,
+        pending: 1,
+        total: 3,
+      },
+      checkRuns: [
+        { name: "cargo test", status: "passing", url: null },
+        { name: "npm check", status: "failing", url: null },
+        { name: "publish preview", status: "pending", url: null },
+      ],
+    });
+    await lookupPrForSession(s, { force: true });
+
+    const { getByTestId } = render(StatusBar);
+    const popover = getByTestId("status-bar-pr-checks-popover");
+
+    expect(popover.textContent).toContain("cargo test");
+    expect(popover.textContent).toContain("passing");
+    expect(popover.textContent).toContain("npm check");
+    expect(popover.textContent).toContain("failing");
+    expect(popover.textContent).toContain("publish preview");
+    expect(popover.textContent).toContain("pending");
   });
 });

--- a/src/lib/components/__tests__/StatusBar.test.ts
+++ b/src/lib/components/__tests__/StatusBar.test.ts
@@ -78,6 +78,7 @@ function makePr(overrides: Partial<PrInfo> = {}): PrInfo {
     repoSlug: "phin-tech/roux",
     checks: null,
     checkRuns: [],
+    reviewDetails: [],
     reviewDecision: null,
     ...overrides,
   };
@@ -244,14 +245,53 @@ describe("StatusBar worktrunk integration", () => {
     });
     await lookupPrForSession(s, { force: true });
 
-    const { getByTestId } = render(StatusBar);
-    const popover = getByTestId("status-bar-pr-checks-popover");
+    const { getByTestId, queryByTestId } = render(StatusBar);
+    const link = getByTestId("status-bar-pr-link");
+    const popover = getByTestId("status-bar-pr-popover");
 
+    expect(link.className).toContain("text-red");
+    expect(link.querySelectorAll("svg")).toHaveLength(1);
+    expect(queryByTestId("status-bar-pr-checks")).toBeNull();
     expect(popover.textContent).toContain("cargo test");
     expect(popover.textContent).toContain("passing");
     expect(popover.textContent).toContain("npm check");
     expect(popover.textContent).toContain("failing");
     expect(popover.textContent).toContain("publish preview");
     expect(popover.textContent).toContain("pending");
+  });
+
+  it("renders a hover popover with individual PR review statuses", async () => {
+    const s = makeSession({
+      repoRoot: "/repo",
+      worktreePath: "/wt/feat-reviews",
+      branch: "feature/x",
+    });
+    sessionState.set({ sessions: [s], activeSessionId: s.id });
+    seed(
+      "/wt/feat-reviews",
+      makeMeta({
+        ciStatus: "passed",
+        ciUrl: "https://github.com/phin-tech/roux/pull/42",
+      }),
+    );
+    tauriMock.nextPrLookupResult = makePr({
+      reviewDecision: "CHANGES_REQUESTED",
+      reviewDetails: [
+        { reviewer: "alice", state: "APPROVED", url: null },
+        { reviewer: "bob", state: "CHANGES_REQUESTED", url: null },
+      ],
+    });
+    await lookupPrForSession(s, { force: true });
+
+    const { getByTestId, queryByTestId } = render(StatusBar);
+    const popover = getByTestId("status-bar-pr-popover");
+
+    expect(queryByTestId("status-bar-pr-review")).toBeNull();
+    expect(popover.textContent).toContain("Approvals");
+    expect(popover.textContent).toContain("1/2");
+    expect(popover.textContent).toContain("alice");
+    expect(popover.textContent).toContain("approved");
+    expect(popover.textContent).toContain("bob");
+    expect(popover.textContent).toContain("changes requested");
   });
 });

--- a/src/lib/components/__tests__/StatusBar.test.ts
+++ b/src/lib/components/__tests__/StatusBar.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
 import type { Session, Worktree, WorktrunkMetadata } from "$lib/types";
 import type { PrInfo } from "$lib/tauri";
 
@@ -24,6 +25,10 @@ import {
   _resetWorktreeMetadataForTests,
   upsertWorktreeMetadata,
 } from "$lib/stores/worktreeMetadata";
+import {
+  closePrStatusDetails,
+  togglePrStatusDetails,
+} from "$lib/stores/prStatusDetails";
 
 function makeSession(overrides: Partial<Session> = {}): Session {
   return {
@@ -100,6 +105,7 @@ describe("StatusBar worktrunk integration", () => {
     _resetWorktreeMetadataForTests();
     _resetSessionPrLookupForTests();
     tauriMock.nextPrLookupResult = null;
+    closePrStatusDetails();
   });
 
   afterEach(() => {
@@ -107,6 +113,7 @@ describe("StatusBar worktrunk integration", () => {
     _resetWorktreeMetadataForTests();
     _resetSessionPrLookupForTests();
     tauriMock.nextPrLookupResult = null;
+    closePrStatusDetails();
   });
 
   it("renders no PR link when no session is active", () => {
@@ -293,5 +300,42 @@ describe("StatusBar worktrunk integration", () => {
     expect(popover.textContent).toContain("approved");
     expect(popover.textContent).toContain("bob");
     expect(popover.textContent).toContain("changes requested");
+  });
+
+  it("can force the PR details popover open without hover", async () => {
+    const s = makeSession({
+      repoRoot: "/repo",
+      worktreePath: "/wt/feat-toggle",
+      branch: "feature/x",
+    });
+    sessionState.set({ sessions: [s], activeSessionId: s.id });
+    seed(
+      "/wt/feat-toggle",
+      makeMeta({
+        ciStatus: "running",
+        ciUrl: "https://github.com/phin-tech/roux/pull/42",
+      }),
+    );
+    tauriMock.nextPrLookupResult = makePr({
+      checks: {
+        state: "pending",
+        passing: 0,
+        failing: 0,
+        pending: 1,
+        total: 1,
+      },
+      checkRuns: [{ name: "npm check", status: "pending", url: null }],
+    });
+    await lookupPrForSession(s, { force: true });
+
+    const { getByTestId } = render(StatusBar);
+    const popover = getByTestId("status-bar-pr-popover");
+    expect(popover.className).toContain("hidden");
+
+    togglePrStatusDetails();
+    await tick();
+
+    expect(popover.className).toContain("block");
+    expect(popover.className).not.toContain("hidden");
   });
 });

--- a/src/lib/stores/__tests__/sessionPrLookup.test.ts
+++ b/src/lib/stores/__tests__/sessionPrLookup.test.ts
@@ -61,6 +61,7 @@ function makePr(overrides: Partial<PrInfo> = {}): PrInfo {
     checks: null,
     checkRuns: [],
     reviewDecision: null,
+    reviewDetails: [],
     ...overrides,
   };
 }

--- a/src/lib/stores/__tests__/sessionPrLookup.test.ts
+++ b/src/lib/stores/__tests__/sessionPrLookup.test.ts
@@ -59,6 +59,7 @@ function makePr(overrides: Partial<PrInfo> = {}): PrInfo {
     url: "https://github.com/phin-tech/roux/pull/42",
     repoSlug: "phin-tech/roux",
     checks: null,
+    checkRuns: [],
     reviewDecision: null,
     ...overrides,
   };

--- a/src/lib/stores/prStatusDetails.ts
+++ b/src/lib/stores/prStatusDetails.ts
@@ -1,0 +1,11 @@
+import { writable } from "svelte/store";
+
+export const prStatusDetailsOpen = writable(false);
+
+export function togglePrStatusDetails(): void {
+  prStatusDetailsOpen.update((open) => !open);
+}
+
+export function closePrStatusDetails(): void {
+  prStatusDetailsOpen.set(false);
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -592,6 +592,12 @@ export interface PrCheckDetails {
   url: string | null;
 }
 
+export interface PrReviewDetails {
+  reviewer: string;
+  state: string;
+  url: string | null;
+}
+
 export interface PrInfo {
   number: number;
   title: string;
@@ -605,6 +611,7 @@ export interface PrInfo {
   /** GitHub's `reviewDecision`: "APPROVED" | "CHANGES_REQUESTED" |
    *  "REVIEW_REQUIRED", or null when there's no decision yet. */
   reviewDecision: string | null;
+  reviewDetails: PrReviewDetails[];
 }
 
 export async function checkGhInstalled(): Promise<boolean> {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -576,6 +576,7 @@ export async function listNonoProfiles(): Promise<string[]> {
 
 // GitHub PR integration
 export type PrChecksState = "passing" | "failing" | "pending" | "none";
+export type PrCheckStatus = "passing" | "failing" | "pending";
 
 export interface PrChecksSummary {
   state: PrChecksState;
@@ -583,6 +584,12 @@ export interface PrChecksSummary {
   failing: number;
   pending: number;
   total: number;
+}
+
+export interface PrCheckDetails {
+  name: string;
+  status: PrCheckStatus;
+  url: string | null;
 }
 
 export interface PrInfo {
@@ -594,6 +601,7 @@ export interface PrInfo {
   url: string;
   repoSlug: string;
   checks: PrChecksSummary | null;
+  checkRuns: PrCheckDetails[];
   /** GitHub's `reviewDecision`: "APPROVED" | "CHANGES_REQUESTED" |
    *  "REVIEW_REQUIRED", or null when there's no decision yet. */
   reviewDecision: string | null;


### PR DESCRIPTION
## What changed

- Collapsed the status-bar PR area into a single PR link with one status icon.
- The status icon now uses gh check state when available, falling back to worktrunk CI state.
- Hovering the PR link opens one popover with individual checks, approvals count, and reviewer states.
- Added `ui.toggle-pr-status-details` so the same popover can be toggled from a keybinding.
- Added latest-review details to the gh-backed PR lookup payload and updated frontend bindings/types.

## Why

The previous layout could show duplicate status glyphs for the same PR: worktrunk CI on the link plus separate gh checks/review icons. The new layout combines worktrunk's PR/stale context with gh's granular details into one compact status surface, while still making the details accessible without hover.

## Validation

- `/usr/bin/env CI=true cargo test -p roux pr::tests`
- `npm run test -- src/lib/components/__tests__/StatusBar.test.ts src/lib/stores/__tests__/sessionPrLookup.test.ts src/lib/commands/__tests__/ui.test.ts`
- `npm run check`

Note: full `npm run test` was previously attempted locally and failed due to Vitest worker startup timeouts after reporting 70 files / 788 tests passed; no assertion failure was reported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed PR status popover displaying individual check run statuses and reviewer information
  * Introduced UI command to toggle PR status details visibility

* **Refactor**
  * Restructured PR information types to include granular check run details and review information

* **Tests**
  * Added tests for PR status popover rendering with checks and reviewer details
  * Added tests for PR status details toggle command functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->