### PR TITLE
feat(worktrunk): bulk copy paths, reveal in Finder, open in terminal

### DIFF
--- a/crates/roux-core/src/worktree.rs
+++ b/crates/roux-core/src/worktree.rs
@@ -25,6 +25,12 @@ pub enum WorktreeError {
     /// to the user so they can unlock deliberately — see issue #101.
     #[error("worktree is locked (wt): {reason}")]
     WorktrunkLocked { reason: String },
+    /// Removal was refused because the worktree contains uncommitted or
+    /// untracked changes and the caller did not pass `force = true`.
+    /// Carries the underlying tool's stderr so the GUI can show the
+    /// user why and offer a force-delete follow-up.
+    #[error("worktree has uncommitted changes: {reason}")]
+    UncommittedChanges { reason: String },
 }
 
 fn sanitize_branch_for_path(branch: &str) -> String {
@@ -269,20 +275,29 @@ pub fn create_worktree(
 
 /// Remove a worktree using the requested provider.
 ///
-/// - `provider = Git` (or `Auto` + `wt = None`) → native `git worktree remove --force`.
+/// - `provider = Git` (or `Auto` + `wt = None`) → native `git worktree remove`,
+///   passing `--force` only when the caller asked for it.
 /// - `provider = Worktrunk` (or `Auto` + `wt = Some`) → `wt remove` via
-///   [`roux_worktrunk::remove_worktree`], which honors lock semantics:
-///   a locked worktree raises `WorktrunkLocked` instead of being silently forced.
+///   [`roux_worktrunk::remove_worktree`], which honors lock and dirty
+///   semantics: a locked or dirty worktree raises a typed error instead
+///   of being silently forced.
 ///
-/// Fallback: on non-lock wt failures, falls through to native git so
-/// removal doesn't get stuck when `wt` has a transient issue. Lock
-/// errors DO propagate — the caller is meant to surface them to the
-/// user per issue #101's "GUI cleanup defaults must be more
-/// conservative than terminal cleanup" principle.
+/// `force = false` is the conservative GUI default. When the underlying
+/// tool refuses because the worktree is locked or contains uncommitted
+/// changes, we surface that as `WorktrunkLocked` / `UncommittedChanges`
+/// so the caller can prompt the user. Other wt failures still fall
+/// through to native git (without `--force`) so transient `wt` glitches
+/// don't strand removal.
+///
+/// `force = true` is the explicit "I know what I'm doing" path used by
+/// callers that have already confirmed with the user. wt is invoked
+/// with `--force`; if it still fails we fall back to `git worktree
+/// remove --force`.
 pub fn remove_worktree_with_provider(
     repo_path: &str,
     worktree_path: &str,
     also_branch: bool,
+    force: bool,
     provider: WorktreeProvider,
     wt: Option<&roux_worktrunk::WtBinary>,
 ) -> Result<(), WorktreeError> {
@@ -295,7 +310,7 @@ pub fn remove_worktree_with_provider(
         if let Some(wt) = wt {
             let opts = roux_worktrunk::RemoveOpts {
                 also_branch,
-                force: false,
+                force,
                 env: Vec::new(),
             };
             match roux_worktrunk::remove_worktree(
@@ -308,6 +323,12 @@ pub fn remove_worktree_with_provider(
                 Err(roux_worktrunk::WtError::Locked { reason }) => {
                     // Locks are user-visible: do NOT silently fall back.
                     return Err(WorktreeError::WorktrunkLocked { reason });
+                }
+                Err(roux_worktrunk::WtError::Dirty { reason }) => {
+                    // Same reasoning — user has to opt into force-delete
+                    // explicitly. Falling back to git would silently
+                    // discard their uncommitted work.
+                    return Err(WorktreeError::UncommittedChanges { reason });
                 }
                 Err(err) => {
                     eprintln!(
@@ -324,7 +345,7 @@ pub fn remove_worktree_with_provider(
     // against.
     let branch = if also_branch { resolve_worktree_branch(worktree_path) } else { None };
 
-    remove_worktree(worktree_path)?;
+    git_worktree_remove(worktree_path, force)?;
 
     if let Some(branch) = branch {
         // Best-effort: if wt's fallback path already deleted the branch,
@@ -359,14 +380,40 @@ fn resolve_worktree_branch(worktree_path: &str) -> Option<String> {
 }
 
 pub fn remove_worktree(worktree_path: &str) -> Result<(), WorktreeError> {
-    let output = Command::new("git")
-        .args(["worktree", "remove", worktree_path, "--force"])
-        .output()
-        .map_err(|source| WorktreeError::RunGit { source })?;
+    // Existing in-tree callers (session cleanup, archived-session
+    // sweeps) want force semantics: the worktree was created by Roux
+    // and must go away even if `git` thinks it still has work in it.
+    // GUI removal goes through `remove_worktree_with_provider` with an
+    // explicit `force` parameter and uses `git_worktree_remove`
+    // directly.
+    git_worktree_remove(worktree_path, true)
+}
+
+/// Run `git worktree remove [--force]` and translate the failure modes
+/// the GUI cares about into typed errors. Caller decides whether to
+/// force; without it, the dirty-tree refusal becomes
+/// [`WorktreeError::UncommittedChanges`] so the GUI can offer a
+/// follow-up confirm.
+fn git_worktree_remove(worktree_path: &str, force: bool) -> Result<(), WorktreeError> {
+    let mut cmd = Command::new("git");
+    cmd.args(["worktree", "remove", worktree_path]);
+    if force {
+        cmd.arg("--force");
+    }
+    let output = cmd.output().map_err(|source| WorktreeError::RunGit { source })?;
 
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(WorktreeError::RemoveFailed { stderr: stderr.to_string() });
+        let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+        // git's stderr for a dirty worktree is e.g.
+        //   "fatal: '<path>' contains modified or untracked files,
+        //    use --force to delete it"
+        // and for a populated worktree:
+        //   "fatal: '<path>' is not empty, use --force to delete it"
+        let lower = stderr.to_lowercase();
+        if !force && (lower.contains("modified or untracked") || lower.contains("not empty")) {
+            return Err(WorktreeError::UncommittedChanges { reason: stderr });
+        }
+        return Err(WorktreeError::RemoveFailed { stderr });
     }
 
     Ok(())

--- a/crates/roux-core/src/worktree.rs
+++ b/crates/roux-core/src/worktree.rs
@@ -345,7 +345,7 @@ pub fn remove_worktree_with_provider(
     // against.
     let branch = if also_branch { resolve_worktree_branch(worktree_path) } else { None };
 
-    git_worktree_remove(worktree_path, force)?;
+    git_worktree_remove(repo_path, worktree_path, force)?;
 
     if let Some(branch) = branch {
         // Best-effort: if wt's fallback path already deleted the branch,
@@ -379,14 +379,14 @@ fn resolve_worktree_branch(worktree_path: &str) -> Option<String> {
     }
 }
 
-pub fn remove_worktree(worktree_path: &str) -> Result<(), WorktreeError> {
+pub fn remove_worktree(repo_path: &str, worktree_path: &str) -> Result<(), WorktreeError> {
     // Existing in-tree callers (session cleanup, archived-session
     // sweeps) want force semantics: the worktree was created by Roux
     // and must go away even if `git` thinks it still has work in it.
     // GUI removal goes through `remove_worktree_with_provider` with an
     // explicit `force` parameter and uses `git_worktree_remove`
     // directly.
-    git_worktree_remove(worktree_path, true)
+    git_worktree_remove(repo_path, worktree_path, true)
 }
 
 /// Run `git worktree remove [--force]` and translate the failure modes
@@ -394,9 +394,18 @@ pub fn remove_worktree(worktree_path: &str) -> Result<(), WorktreeError> {
 /// force; without it, the dirty-tree refusal becomes
 /// [`WorktreeError::UncommittedChanges`] so the GUI can offer a
 /// follow-up confirm.
-fn git_worktree_remove(worktree_path: &str, force: bool) -> Result<(), WorktreeError> {
+///
+/// `repo_path` is set as the spawned `git`'s `current_dir` so the
+/// invocation isn't sensitive to where Roux happens to be running
+/// from — the rest of this file's git calls do the same.
+fn git_worktree_remove(
+    repo_path: &str,
+    worktree_path: &str,
+    force: bool,
+) -> Result<(), WorktreeError> {
     let mut cmd = Command::new("git");
     cmd.args(["worktree", "remove", worktree_path]);
+    cmd.current_dir(repo_path);
     if force {
         cmd.arg("--force");
     }

--- a/crates/roux-worktrunk/src/exec.rs
+++ b/crates/roux-worktrunk/src/exec.rs
@@ -20,6 +20,11 @@ pub enum WtError {
     /// defaults must be more conservative than terminal cleanup".
     #[error("worktree is locked: {reason}")]
     Locked { reason: String },
+    /// `wt` refused to remove a worktree because it has uncommitted
+    /// changes. Same conservative-default reasoning as `Locked`: GUI
+    /// callers must opt into `force = true` to discard local work.
+    #[error("worktree has uncommitted changes: {reason}")]
+    Dirty { reason: String },
     /// The caller asked to operate on a path that `wt` does not
     /// consider a worktree (not in `wt list`).
     #[error("no worktree registered at {path}")]

--- a/crates/roux-worktrunk/src/remove.rs
+++ b/crates/roux-worktrunk/src/remove.rs
@@ -75,12 +75,17 @@ pub fn remove_worktree(
     }
 
     let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    // Heuristic: `wt remove` of a locked worktree emits stderr
-    // containing the word "locked". If that pattern changes upstream
-    // we fall through to `NonZeroExit`, which callers can still inspect.
+    // Heuristics for `wt remove` refusals. If these substrings change
+    // upstream we fall through to `NonZeroExit`, which callers can
+    // still inspect.
     let lower = stderr.to_lowercase();
-    if lower.contains("locked") && !opts.force {
-        return Err(WtError::Locked { reason: stderr });
+    if !opts.force {
+        if lower.contains("locked") {
+            return Err(WtError::Locked { reason: stderr });
+        }
+        if lower.contains("uncommitted changes") || lower.contains("uncommitted change") {
+            return Err(WtError::Dirty { reason: stderr });
+        }
     }
     Err(WtError::NonZeroExit {
         status: out.status.code().unwrap_or(-1),

--- a/src-tauri/src/commands/worktrees.rs
+++ b/src-tauri/src/commands/worktrees.rs
@@ -116,10 +116,12 @@ pub(crate) async fn cmd_remove_worktree(
     repo_path: String,
     worktree_path: String,
     also_branch: Option<bool>,
+    force: Option<bool>,
     state: tauri::State<'_, AppState>,
 ) -> Result<(), String> {
     let provider = state.settings.lock().unwrap().worktree_provider;
     let also_branch = also_branch.unwrap_or(false);
+    let force = force.unwrap_or(false);
     let wt = crate::services::setup::resolve_wt_binary();
     let wt_available = wt.is_some();
     let pre_context = HookContext {
@@ -141,6 +143,7 @@ pub(crate) async fn cmd_remove_worktree(
             &repo_path,
             &worktree_path,
             also_branch,
+            force,
             provider,
             wt.as_ref(),
         )

--- a/src-tauri/src/services/sessions.rs
+++ b/src-tauri/src/services/sessions.rs
@@ -283,7 +283,7 @@ pub(crate) async fn create_session_shell(
             // hook or a lock error here would leave the user with a
             // stranded worktree + no session. Cleanup-always-succeeds
             // trumps hooks-always-fire for error paths.
-            let _ = crate::worktree::remove_worktree(&work_dir);
+            let _ = crate::worktree::remove_worktree(repo_path, &work_dir);
         }
         return Err(anyhow!("{}", e));
     }
@@ -317,7 +317,7 @@ pub(crate) async fn create_session_shell(
         if is_wt {
             // Same rollback policy as the spawn-failure path above:
             // emergency cleanup stays native.
-            let _ = crate::worktree::remove_worktree(&session.worktree_path);
+            let _ = crate::worktree::remove_worktree(&session.repo_root, &session.worktree_path);
         }
         return Err(e.into());
     }

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -17,7 +17,7 @@ export const commands = {
 } | null, UpdaterError>(__TAURI_INVOKE("check_for_update", { channel })),
 	installUpdate: (channel: UpdateChannel) => typedError<null, UpdaterError>(__TAURI_INVOKE("install_update", { channel })),
 	cmdCreateWorktree: (repoPath: string, branch: string, startPoint: string | null, fetchFirst: boolean | null) => typedError<string, string>(__TAURI_INVOKE("cmd_create_worktree", { repoPath, branch, startPoint, fetchFirst })),
-	cmdRemoveWorktree: (repoPath: string, worktreePath: string, alsoBranch: boolean | null) => typedError<null, string>(__TAURI_INVOKE("cmd_remove_worktree", { repoPath, worktreePath, alsoBranch })),
+	cmdRemoveWorktree: (repoPath: string, worktreePath: string, alsoBranch: boolean | null, force: boolean | null) => typedError<null, string>(__TAURI_INVOKE("cmd_remove_worktree", { repoPath, worktreePath, alsoBranch, force })),
 	cmdListWorktrees: (repoPath: string) => typedError<Worktree[], string>(__TAURI_INVOKE("cmd_list_worktrees", { repoPath })),
 	/**
 	 *  Resolve a worktree-base-path template (`{project_dir}`, `{git_root}`,

--- a/src/lib/components/PrStatusPopover.svelte
+++ b/src/lib/components/PrStatusPopover.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+  import { tick } from "svelte";
   import type { PrCheckDetails, PrCheckStatus, PrReviewDetails } from "$lib/tauri";
+  import { portal } from "$lib/portal";
 
   interface Props {
     /** Per-check rows from the PR's `statusCheckRollup`. */
@@ -18,6 +20,19 @@
     forceOpen?: boolean;
     /** Optional testid for the popover root. */
     "data-testid"?: string;
+    /**
+     * When true, render the popover into `document.body` and position
+     * it `fixed` against `anchor`'s bounding rect. Use this for popovers
+     * inside scrollable containers — `overflow: hidden/auto` ancestors
+     * clip absolutely positioned children, and the popover would
+     * otherwise be partly cut off.
+     *
+     * `open` controls visibility in this mode (CSS-hover doesn't reach
+     * across the portal, so the caller drives it from JS).
+     */
+    portaled?: boolean;
+    anchor?: HTMLElement | null;
+    open?: boolean;
   }
 
   let {
@@ -27,7 +42,48 @@
     position = "bottom",
     forceOpen = false,
     "data-testid": testId,
+    portaled = false,
+    anchor = null,
+    open = false,
   }: Props = $props();
+
+  // Fixed-position coordinates derived from `anchor` whenever the
+  // popover is open. Recomputed each open so scroll/resize between
+  // renders doesn't leave the popover stranded.
+  let fixedLeft = $state(0);
+  let fixedTop = $state(0);
+  let fixedTransform = $state("translateX(-50%)");
+  let portalNode = $state<HTMLElement | null>(null);
+
+  $effect(() => {
+    if (!portaled) return;
+    if (!open || !anchor) return;
+    void tick().then(() => {
+      const rect = anchor.getBoundingClientRect();
+      const popHeight = portalNode?.offsetHeight ?? 0;
+      const popWidth = portalNode?.offsetWidth ?? 0;
+      // Center horizontally over the anchor; clamp into the viewport
+      // so a chip near the edge doesn't push the popover off-screen.
+      const centerX = rect.left + rect.width / 2;
+      const halfPop = popWidth / 2;
+      const maxLeft = window.innerWidth - halfPop - 8;
+      const minLeft = halfPop + 8;
+      fixedLeft = Math.max(minLeft, Math.min(centerX, maxLeft));
+      fixedTransform = "translateX(-50%)";
+      // Default: render above the anchor (matches the bottom status
+      // bar's vertical placement). Flip below if there's no room above.
+      const above = rect.top - popHeight - 8;
+      const below = rect.bottom + 8;
+      if (position === "top") {
+        // Caller wants below regardless.
+        fixedTop = below;
+      } else if (above >= 8) {
+        fixedTop = above;
+      } else {
+        fixedTop = below;
+      }
+    });
+  });
 
   let approvalCount = $derived(
     reviewDetails.filter(
@@ -108,14 +164,8 @@
   }
 </script>
 
-{#if hasContent}
-  <div
-    {id}
-    data-testid={testId}
-    role="tooltip"
-    class={`absolute left-1/2 z-50 max-h-80 min-w-72 max-w-96 -translate-x-1/2 overflow-y-auto rounded border border-border bg-bg-elevated p-2 text-[11px] text-text-primary shadow-lg ${forceOpen ? "block" : "hidden group-hover:block group-focus-within:block"} ${position === "top" ? "top-full mt-2" : "bottom-full mb-2"}`}
-  >
-    {#if checkRuns.length > 0}
+{#snippet body()}
+  {#if checkRuns.length > 0}
       <div class="mb-1 text-[10px] font-semibold uppercase text-text-muted">Checks</div>
       <div class="space-y-1">
         {#each checkRuns as check}
@@ -148,5 +198,33 @@
         </div>
       </div>
     {/if}
-  </div>
+{/snippet}
+
+{#if hasContent}
+  {#if portaled}
+    {#if open}
+      <div
+        bind:this={portalNode}
+        {id}
+        data-testid={testId}
+        role="tooltip"
+        use:portal
+        class="fixed z-50 max-h-80 min-w-72 max-w-96 overflow-y-auto rounded border border-border bg-bg-elevated p-2 text-[11px] text-text-primary shadow-lg"
+        style:left={`${fixedLeft}px`}
+        style:top={`${fixedTop}px`}
+        style:transform={fixedTransform}
+      >
+        {@render body()}
+      </div>
+    {/if}
+  {:else}
+    <div
+      {id}
+      data-testid={testId}
+      role="tooltip"
+      class={`absolute left-1/2 z-50 max-h-80 min-w-72 max-w-96 -translate-x-1/2 overflow-y-auto rounded border border-border bg-bg-elevated p-2 text-[11px] text-text-primary shadow-lg ${forceOpen ? "block" : "hidden group-hover:block group-focus-within:block"} ${position === "top" ? "top-full mt-2" : "bottom-full mb-2"}`}
+    >
+      {@render body()}
+    </div>
+  {/if}
 {/if}

--- a/src/lib/components/PrStatusPopover.svelte
+++ b/src/lib/components/PrStatusPopover.svelte
@@ -1,0 +1,152 @@
+<script lang="ts">
+  import type { PrCheckDetails, PrCheckStatus, PrReviewDetails } from "$lib/tauri";
+
+  interface Props {
+    /** Per-check rows from the PR's `statusCheckRollup`. */
+    checkRuns?: PrCheckDetails[];
+    /** Latest review per reviewer from `latestReviews`. */
+    reviewDetails?: PrReviewDetails[];
+    /** Optional id for `aria-describedby`. */
+    id?: string;
+    /** Anchor side; the popover sticks to the opposite edge. */
+    position?: "top" | "bottom";
+    /**
+     * When true, render the popover unconditionally. Defaults to the
+     * `group-hover:block group-focus-within:block` pattern used inside
+     * a `.group relative` parent.
+     */
+    forceOpen?: boolean;
+    /** Optional testid for the popover root. */
+    "data-testid"?: string;
+  }
+
+  let {
+    checkRuns = [],
+    reviewDetails = [],
+    id,
+    position = "bottom",
+    forceOpen = false,
+    "data-testid": testId,
+  }: Props = $props();
+
+  let approvalCount = $derived(
+    reviewDetails.filter(
+      (review) => normalizedReviewState(review.state) === "approved",
+    ).length,
+  );
+
+  let hasContent = $derived(checkRuns.length > 0 || reviewDetails.length > 0);
+
+  function checkStatusLabel(status: PrCheckStatus): string {
+    switch (status) {
+      case "passing":
+        return "passing";
+      case "failing":
+        return "failing";
+      case "pending":
+        return "pending";
+    }
+  }
+
+  function checkStatusDotClass(status: PrCheckStatus): string {
+    switch (status) {
+      case "passing":
+        return "bg-green";
+      case "failing":
+        return "bg-red";
+      case "pending":
+        return "bg-yellow";
+    }
+  }
+
+  function checkStatusTextClass(status: PrCheckStatus): string {
+    switch (status) {
+      case "passing":
+        return "text-green";
+      case "failing":
+        return "text-red";
+      case "pending":
+        return "text-yellow";
+    }
+  }
+
+  function normalizedReviewState(state: string): string {
+    return state.trim().toLowerCase().replace(/_/g, " ");
+  }
+
+  function reviewStatusLabel(review: PrReviewDetails): string {
+    const normalized = normalizedReviewState(review.state);
+    return normalized || "unknown";
+  }
+
+  function reviewStatusTextClass(review: PrReviewDetails): string {
+    switch (normalizedReviewState(review.state)) {
+      case "approved":
+        return "text-green";
+      case "changes requested":
+        return "text-red";
+      case "review requested":
+      case "pending":
+        return "text-yellow";
+      default:
+        return "text-text-muted";
+    }
+  }
+
+  function reviewStatusDotClass(review: PrReviewDetails): string {
+    switch (normalizedReviewState(review.state)) {
+      case "approved":
+        return "bg-green";
+      case "changes requested":
+        return "bg-red";
+      case "review requested":
+      case "pending":
+        return "bg-yellow";
+      default:
+        return "bg-text-muted";
+    }
+  }
+</script>
+
+{#if hasContent}
+  <div
+    {id}
+    data-testid={testId}
+    role="tooltip"
+    class={`absolute left-1/2 z-50 max-h-80 min-w-72 max-w-96 -translate-x-1/2 overflow-y-auto rounded border border-border bg-bg-elevated p-2 text-[11px] text-text-primary shadow-lg ${forceOpen ? "block" : "hidden group-hover:block group-focus-within:block"} ${position === "top" ? "top-full mt-2" : "bottom-full mb-2"}`}
+  >
+    {#if checkRuns.length > 0}
+      <div class="mb-1 text-[10px] font-semibold uppercase text-text-muted">Checks</div>
+      <div class="space-y-1">
+        {#each checkRuns as check}
+          <div class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3">
+            <span class="truncate" title={check.name}>{check.name}</span>
+            <span class={`inline-flex items-center gap-1 ${checkStatusTextClass(check.status)}`}>
+              <span class={`h-1.5 w-1.5 rounded-full ${checkStatusDotClass(check.status)}`}></span>
+              <span>{checkStatusLabel(check.status)}</span>
+            </span>
+          </div>
+        {/each}
+      </div>
+    {/if}
+    {#if reviewDetails.length > 0}
+      <div class={checkRuns.length > 0 ? "mt-3" : ""}>
+        <div class="mb-1 flex items-center justify-between gap-3 text-[10px] font-semibold uppercase text-text-muted">
+          <span>Reviews</span>
+          <span>Approvals {approvalCount}/{reviewDetails.length}</span>
+        </div>
+        <div class="space-y-1">
+          {#each reviewDetails as review}
+            <div class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3">
+              <span class="truncate" title={review.reviewer}>{review.reviewer}</span>
+              <span class={`inline-flex items-center gap-1 ${reviewStatusTextClass(review)}`}>
+                <span class={`h-1.5 w-1.5 rounded-full ${reviewStatusDotClass(review)}`}></span>
+                <span>{reviewStatusLabel(review)}</span>
+              </span>
+            </div>
+          {/each}
+        </div>
+      </div>
+    {/if}
+  </div>
+{/if}

--- a/src/lib/components/StatusBar.svelte
+++ b/src/lib/components/StatusBar.svelte
@@ -11,7 +11,7 @@
   import { checksChipFor, reviewChipFor } from "$lib/prChips";
   import { safeHref } from "$lib/safeUrl";
   import { closePrStatusDetails, prStatusDetailsOpen } from "$lib/stores/prStatusDetails";
-  import type { PrCheckStatus, PrReviewDetails } from "$lib/tauri";
+  import PrStatusPopover from "./PrStatusPopover.svelte";
   import type { StatusBarPosition } from "$lib/types";
 
   interface Props {
@@ -75,9 +75,6 @@
   );
   let prLinkColor = $derived(prStatusChip?.color ?? "text-text-muted hover:text-text-primary");
   let hasPrPopover = $derived(checkRows.length > 0 || reviewRows.length > 0);
-  let approvalCount = $derived(
-    reviewRows.filter((review) => normalizedReviewState(review.state) === "approved").length,
-  );
 
   $effect(() => {
     if ((!$activeSession || !hasPrPopover) && $prStatusDetailsOpen) {
@@ -89,76 +86,6 @@
   function prLabel(url: string): string {
     const m = url.match(/\/(?:pull|pulls|merge_requests)\/(\d+)/);
     return m ? `PR #${m[1]}` : "PR";
-  }
-
-  function checkStatusLabel(status: PrCheckStatus): string {
-    switch (status) {
-      case "passing":
-        return "passing";
-      case "failing":
-        return "failing";
-      case "pending":
-        return "pending";
-    }
-  }
-
-  function checkStatusDotClass(status: PrCheckStatus): string {
-    switch (status) {
-      case "passing":
-        return "bg-green";
-      case "failing":
-        return "bg-red";
-      case "pending":
-        return "bg-yellow";
-    }
-  }
-
-  function checkStatusTextClass(status: PrCheckStatus): string {
-    switch (status) {
-      case "passing":
-        return "text-green";
-      case "failing":
-        return "text-red";
-      case "pending":
-        return "text-yellow";
-    }
-  }
-
-  function normalizedReviewState(state: string): string {
-    return state.trim().toLowerCase().replace(/_/g, " ");
-  }
-
-  function reviewStatusLabel(review: PrReviewDetails): string {
-    const normalized = normalizedReviewState(review.state);
-    return normalized || "unknown";
-  }
-
-  function reviewStatusTextClass(review: PrReviewDetails): string {
-    switch (normalizedReviewState(review.state)) {
-      case "approved":
-        return "text-green";
-      case "changes requested":
-        return "text-red";
-      case "review requested":
-      case "pending":
-        return "text-yellow";
-      default:
-        return "text-text-muted";
-    }
-  }
-
-  function reviewStatusDotClass(review: PrReviewDetails): string {
-    switch (normalizedReviewState(review.state)) {
-      case "approved":
-        return "bg-green";
-      case "changes requested":
-        return "bg-red";
-      case "review requested":
-      case "pending":
-        return "bg-yellow";
-      default:
-        return "bg-text-muted";
-    }
   }
 </script>
 
@@ -191,53 +118,15 @@
         <span>{prLabel(href)}</span>
       </a>
     {/if}
-    {@render prPopover()}
-  </span>
-{/snippet}
-
-{#snippet prPopover()}
-  {#if hasPrPopover}
-    <div
+    <PrStatusPopover
       id="status-bar-pr-popover"
       data-testid="status-bar-pr-popover"
-      role="tooltip"
-      class={`absolute left-1/2 z-50 max-h-80 min-w-72 max-w-96 -translate-x-1/2 overflow-y-auto rounded border border-border bg-bg-elevated p-2 text-[11px] text-text-primary shadow-lg ${$prStatusDetailsOpen ? "block" : "hidden group-hover:block group-focus-within:block"} ${position === "top" ? "top-full mt-2" : "bottom-full mb-2"}`}
-    >
-      {#if checkRows.length > 0}
-        <div class="mb-1 text-[10px] font-semibold uppercase text-text-muted">Checks</div>
-        <div class="space-y-1">
-          {#each checkRows as check}
-            <div class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3">
-              <span class="truncate" title={check.name}>{check.name}</span>
-              <span class={`inline-flex items-center gap-1 ${checkStatusTextClass(check.status)}`}>
-                <span class={`h-1.5 w-1.5 rounded-full ${checkStatusDotClass(check.status)}`}></span>
-                <span>{checkStatusLabel(check.status)}</span>
-              </span>
-            </div>
-          {/each}
-        </div>
-      {/if}
-      {#if reviewRows.length > 0}
-        <div class={checkRows.length > 0 ? "mt-3" : ""}>
-          <div class="mb-1 flex items-center justify-between gap-3 text-[10px] font-semibold uppercase text-text-muted">
-            <span>Reviews</span>
-            <span>Approvals {approvalCount}/{reviewRows.length}</span>
-          </div>
-          <div class="space-y-1">
-            {#each reviewRows as review}
-              <div class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3">
-                <span class="truncate" title={review.reviewer}>{review.reviewer}</span>
-                <span class={`inline-flex items-center gap-1 ${reviewStatusTextClass(review)}`}>
-                  <span class={`h-1.5 w-1.5 rounded-full ${reviewStatusDotClass(review)}`}></span>
-                  <span>{reviewStatusLabel(review)}</span>
-                </span>
-              </div>
-            {/each}
-          </div>
-        </div>
-      {/if}
-    </div>
-  {/if}
+      checkRuns={checkRows}
+      reviewDetails={reviewRows}
+      position={position === "top" ? "top" : "bottom"}
+      forceOpen={$prStatusDetailsOpen}
+    />
+  </span>
 {/snippet}
 
 <div

--- a/src/lib/components/WorktreeRowContent.svelte
+++ b/src/lib/components/WorktreeRowContent.svelte
@@ -70,6 +70,20 @@
     lookupAttempted = true;
     void lookupPrForRepoBranch(repoRoot, wt.branch).catch(() => {});
   }
+
+  // Hover/focus state drives the popover open/close. We can't rely on
+  // CSS `group-hover:` here because the popover is portaled to
+  // document.body to escape the worktrunk panel's `overflow-y-auto`
+  // clip.
+  let chipAnchor = $state<HTMLElement | null>(null);
+  let popoverOpen = $state(false);
+  function onChipEnter() {
+    maybeLookup();
+    popoverOpen = true;
+  }
+  function onChipLeave() {
+    popoverOpen = false;
+  }
 </script>
 
 {#if wt.isMain}
@@ -152,9 +166,12 @@
   {@const Icon = ciChip.icon}
   {@const running = metadata.ciStatus === "running"}
   <span
-    class="group relative inline-flex items-center"
-    onmouseenter={maybeLookup}
-    onfocusin={maybeLookup}
+    bind:this={chipAnchor}
+    class="relative inline-flex items-center"
+    onmouseenter={onChipEnter}
+    onmouseleave={onChipLeave}
+    onfocusin={onChipEnter}
+    onfocusout={onChipLeave}
     role="presentation"
   >
     {#if ciHref}
@@ -184,13 +201,15 @@
         <span>ci</span>
       </span>
     {/if}
-    <PrStatusPopover
-      data-testid="wt-ci-popover"
-      {checkRuns}
-      {reviewDetails}
-      position="bottom"
-    />
   </span>
+  <PrStatusPopover
+    data-testid="wt-ci-popover"
+    {checkRuns}
+    {reviewDetails}
+    portaled
+    anchor={chipAnchor}
+    open={popoverOpen}
+  />
 {/if}
 
 {#if showPath}

--- a/src/lib/components/WorktreeRowContent.svelte
+++ b/src/lib/components/WorktreeRowContent.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
-  import type { Worktree } from "$lib/types";
+  import type { Session, Worktree } from "$lib/types";
   import { ciChipFor } from "$lib/ciIcon";
   import { safeHref } from "$lib/safeUrl";
   import {
     prLookupFor,
+    prLookupForSession,
     lookupPrForRepoBranch,
+    lookupPrForSession,
   } from "$lib/stores/sessionPrLookup";
   import PrStatusPopover from "./PrStatusPopover.svelte";
 
@@ -18,33 +20,55 @@
      * the bottom status bar uses.
      */
     repoRoot?: string | null;
+    /**
+     * Active session that owns this worktree, if any. When present we
+     * resolve PR data through `prLookupForSession` so a pinned PR URL
+     * resolves to the same cache entry the bottom status bar uses —
+     * otherwise the row would do a fresh branch-keyed lookup and miss
+     * the pinning.
+     */
+    session?: Session | null;
   }
 
-  let { wt, showPath = true, repoRoot = null }: Props = $props();
+  let {
+    wt,
+    showPath = true,
+    repoRoot = null,
+    session = null,
+  }: Props = $props();
 
   let metadata = $derived(wt.worktrunk);
   let ciChip = $derived(ciChipFor(metadata?.ciStatus ?? null));
   let ciHref = $derived(safeHref(metadata?.ciUrl));
   let devServerHref = $derived(safeHref(metadata?.devServerUrl));
 
-  let prStore = $derived(prLookupFor(repoRoot, wt.branch));
+  // Prefer the session-keyed lookup when this worktree owns one — that
+  // honors `pinnedPrUrl` and lines up exactly with what StatusBar shows
+  // for the active session. Fall back to the branch-keyed lookup for
+  // session-less worktrees so the popover still works.
+  let prStore = $derived(
+    session ? prLookupForSession(session) : prLookupFor(repoRoot, wt.branch),
+  );
   let prInfo = $derived($prStore ?? null);
   let checkRuns = $derived(prInfo?.checkRuns ?? []);
   let reviewDetails = $derived(prInfo?.reviewDetails ?? []);
   let hasPopover = $derived(checkRuns.length > 0 || reviewDetails.length > 0);
 
   // Lazy lookup: first hover on the chip triggers a PR fetch if the
-  // (repoRoot, branch) hasn't been resolved yet. Cached hits short-
+  // backing cache entry hasn't been resolved yet. Cached hits short-
   // circuit at the lookup layer, so re-hovers are free.
   let lookupAttempted = $state(false);
   function maybeLookup() {
     if (lookupAttempted) return;
-    if (!repoRoot || !wt.branch || wt.isMain) return;
+    if (wt.isMain) return;
+    if (session) {
+      lookupAttempted = true;
+      void lookupPrForSession(session).catch(() => {});
+      return;
+    }
+    if (!repoRoot || !wt.branch) return;
     lookupAttempted = true;
-    void lookupPrForRepoBranch(repoRoot, wt.branch).catch(() => {
-      // Errors are surfaced via prLookupErrorFor elsewhere; the popover
-      // simply stays empty.
-    });
+    void lookupPrForRepoBranch(repoRoot, wt.branch).catch(() => {});
   }
 </script>
 

--- a/src/lib/components/WorktreeRowContent.svelte
+++ b/src/lib/components/WorktreeRowContent.svelte
@@ -2,18 +2,50 @@
   import type { Worktree } from "$lib/types";
   import { ciChipFor } from "$lib/ciIcon";
   import { safeHref } from "$lib/safeUrl";
+  import {
+    prLookupFor,
+    lookupPrForRepoBranch,
+  } from "$lib/stores/sessionPrLookup";
+  import PrStatusPopover from "./PrStatusPopover.svelte";
 
   interface Props {
     wt: Worktree;
     showPath?: boolean;
+    /**
+     * Repo root for the worktree's parent repository. When supplied
+     * (and the worktree carries a branch), the row triggers a PR
+     * lookup on first hover and shows the same Checks/Reviews popover
+     * the bottom status bar uses.
+     */
+    repoRoot?: string | null;
   }
 
-  let { wt, showPath = true }: Props = $props();
+  let { wt, showPath = true, repoRoot = null }: Props = $props();
 
   let metadata = $derived(wt.worktrunk);
   let ciChip = $derived(ciChipFor(metadata?.ciStatus ?? null));
   let ciHref = $derived(safeHref(metadata?.ciUrl));
   let devServerHref = $derived(safeHref(metadata?.devServerUrl));
+
+  let prStore = $derived(prLookupFor(repoRoot, wt.branch));
+  let prInfo = $derived($prStore ?? null);
+  let checkRuns = $derived(prInfo?.checkRuns ?? []);
+  let reviewDetails = $derived(prInfo?.reviewDetails ?? []);
+  let hasPopover = $derived(checkRuns.length > 0 || reviewDetails.length > 0);
+
+  // Lazy lookup: first hover on the chip triggers a PR fetch if the
+  // (repoRoot, branch) hasn't been resolved yet. Cached hits short-
+  // circuit at the lookup layer, so re-hovers are free.
+  let lookupAttempted = $state(false);
+  function maybeLookup() {
+    if (lookupAttempted) return;
+    if (!repoRoot || !wt.branch || wt.isMain) return;
+    lookupAttempted = true;
+    void lookupPrForRepoBranch(repoRoot, wt.branch).catch(() => {
+      // Errors are surfaced via prLookupErrorFor elsewhere; the popover
+      // simply stays empty.
+    });
+  }
 </script>
 
 {#if wt.isMain}
@@ -95,29 +127,46 @@
   {@const stale = metadata.ciStale}
   {@const Icon = ciChip.icon}
   {@const running = metadata.ciStatus === "running"}
-  {#if ciHref}
-    <a
-      data-testid="wt-ci"
-      href={ciHref}
-      target="_blank"
-      rel="noopener noreferrer"
-      class={`inline-flex items-center gap-0.5 text-[10px] ${ciChip.color} ${stale ? "opacity-60" : ""}`}
-      onclick={(e) => e.stopPropagation()}
-      title={`CI: ${ciChip.label}${stale ? " (stale — unpushed changes)" : ""}`}
-    >
-      <Icon size={11} class={running ? "animate-spin" : ""} />
-      <span>ci</span>
-    </a>
-  {:else}
-    <span
-      data-testid="wt-ci"
-      class={`inline-flex items-center gap-0.5 text-[10px] ${ciChip.color} ${stale ? "opacity-60" : ""}`}
-      title={`CI: ${ciChip.label}${stale ? " (stale — unpushed changes)" : ""}`}
-    >
-      <Icon size={11} class={running ? "animate-spin" : ""} />
-      <span>ci</span>
-    </span>
-  {/if}
+  <span
+    class="group relative inline-flex items-center"
+    onmouseenter={maybeLookup}
+    onfocusin={maybeLookup}
+    role="presentation"
+  >
+    {#if ciHref}
+      <a
+        data-testid="wt-ci"
+        href={ciHref}
+        target="_blank"
+        rel="noopener noreferrer"
+        class={`inline-flex items-center gap-0.5 text-[10px] ${ciChip.color} ${stale ? "opacity-60" : ""}`}
+        onclick={(e) => e.stopPropagation()}
+        title={hasPopover
+          ? undefined
+          : `CI: ${ciChip.label}${stale ? " (stale — unpushed changes)" : ""}`}
+      >
+        <Icon size={11} class={running ? "animate-spin" : ""} />
+        <span>ci</span>
+      </a>
+    {:else}
+      <span
+        data-testid="wt-ci"
+        class={`inline-flex items-center gap-0.5 text-[10px] ${ciChip.color} ${stale ? "opacity-60" : ""}`}
+        title={hasPopover
+          ? undefined
+          : `CI: ${ciChip.label}${stale ? " (stale — unpushed changes)" : ""}`}
+      >
+        <Icon size={11} class={running ? "animate-spin" : ""} />
+        <span>ci</span>
+      </span>
+    {/if}
+    <PrStatusPopover
+      data-testid="wt-ci-popover"
+      {checkRuns}
+      {reviewDetails}
+      position="bottom"
+    />
+  </span>
 {/if}
 
 {#if showPath}

--- a/src/lib/components/WorktreeRowContent.svelte
+++ b/src/lib/components/WorktreeRowContent.svelte
@@ -57,7 +57,19 @@
   // Lazy lookup: first hover on the chip triggers a PR fetch if the
   // backing cache entry hasn't been resolved yet. Cached hits short-
   // circuit at the lookup layer, so re-hovers are free.
+  // The latch resets when the lookup target changes — without that, a
+  // row reused for a different (session, repoRoot, branch) tuple
+  // would never re-fetch.
+  let lookupKey = $derived(
+    session
+      ? `session:${session.id}|${session.pinnedPrUrl ?? ""}`
+      : `branch:${repoRoot ?? ""}::${wt.branch ?? ""}`,
+  );
   let lookupAttempted = $state(false);
+  $effect(() => {
+    void lookupKey;
+    lookupAttempted = false;
+  });
   function maybeLookup() {
     if (lookupAttempted) return;
     if (wt.isMain) return;

--- a/src/lib/components/WorktrunkPanel.svelte
+++ b/src/lib/components/WorktrunkPanel.svelte
@@ -53,11 +53,18 @@
   let removing = $state<string | null>(null); // path currently being removed
   let menuOpenFor = $state<string | null>(null); // kebab menu target
   let headerMenuOpen = $state(false);
+  let bulkMenuOpen = $state(false);
+  let bulkCopiedFlash = $state(false);
   let filterText = $state("");
   let selected = $state(new Set<string>());
   let selectAllCheckbox = $state<HTMLInputElement | null>(null);
   let bulkPending = $state(false);
   let bulkError = $state<string | null>(null);
+
+  // Above this many selected items, "Reveal in Finder" / "Open in
+  // terminal" prompt for confirmation — they spawn one external window
+  // per worktree, and a stray select-all could carpet the desktop.
+  const BULK_WINDOW_CONFIRM_THRESHOLD = 5;
 
   // Close the kebab menu on any click that isn't inside the currently
   // open row. `pointerdown` fires before `onclick`, so toggling the
@@ -85,6 +92,19 @@
       if (!(target instanceof Element)) return;
       if (!target.closest("[data-worktrunk-header-menu]")) {
         headerMenuOpen = false;
+      }
+    };
+    window.addEventListener("pointerdown", onPointerDown, true);
+    return () => window.removeEventListener("pointerdown", onPointerDown, true);
+  });
+
+  $effect(() => {
+    if (!bulkMenuOpen) return;
+    const onPointerDown = (ev: PointerEvent) => {
+      const target = ev.target;
+      if (!(target instanceof Element)) return;
+      if (!target.closest("[data-worktrunk-bulk-menu]")) {
+        bulkMenuOpen = false;
       }
     };
     window.addEventListener("pointerdown", onPointerDown, true);
@@ -194,6 +214,8 @@
     readerLoading = false;
     menuOpenFor = null;
     headerMenuOpen = false;
+    bulkMenuOpen = false;
+    bulkCopiedFlash = false;
     filterText = "";
     selected = new Set();
     bulkPending = false;
@@ -540,6 +562,93 @@
     }
   }
 
+  async function handleBulkCopyPaths() {
+    if (selectedWorktrees.length === 0 || bulkPending) return;
+    const text = selectedWorktrees.map((wt) => wt.path).join("\n");
+    bulkError = null;
+    try {
+      await navigator.clipboard.writeText(text);
+      bulkMenuOpen = false;
+      bulkCopiedFlash = true;
+      setTimeout(() => {
+        bulkCopiedFlash = false;
+      }, 1500);
+    } catch (err) {
+      const msg = typeof err === "string" ? err : String(err);
+      bulkError = `Copy failed: ${msg}`;
+    }
+  }
+
+  async function handleBulkRevealInFinder() {
+    if (selectedWorktrees.length === 0 || bulkPending) return;
+    const targets = [...selectedWorktrees];
+    const count = targets.length;
+    if (count > BULK_WINDOW_CONFIRM_THRESHOLD) {
+      const confirmed = window.confirm(
+        `Reveal ${count} worktrees in Finder?\n\nEach one opens a separate Finder window.`,
+      );
+      if (!confirmed) return;
+    }
+    bulkError = null;
+    bulkMenuOpen = false;
+    bulkPending = true;
+    const failures: { branch: string; error: string }[] = [];
+    let succeeded = 0;
+    try {
+      for (const wt of targets) {
+        try {
+          await revealItemInDir(wt.path);
+          succeeded += 1;
+        } catch (err) {
+          failures.push({
+            branch: wt.branch,
+            error: typeof err === "string" ? err : String(err),
+          });
+        }
+      }
+      bulkError = describeBulkResult("reveal", succeeded, failures);
+    } finally {
+      bulkPending = false;
+    }
+  }
+
+  async function handleBulkOpenTerminal() {
+    if (selectedWorktrees.length === 0 || bulkPending) return;
+    const targets = [...selectedWorktrees];
+    const count = targets.length;
+    if (count > BULK_WINDOW_CONFIRM_THRESHOLD) {
+      const confirmed = window.confirm(
+        `Open ${count} worktrees in terminal?\n\nEach one opens a separate terminal window.`,
+      );
+      if (!confirmed) return;
+    }
+    bulkError = null;
+    bulkMenuOpen = false;
+    bulkPending = true;
+    const failures: { branch: string; error: string }[] = [];
+    let succeeded = 0;
+    try {
+      for (const wt of targets) {
+        try {
+          const res = await commands.cmdOpenTerminalAt(wt.path);
+          if (res.status === "error") {
+            failures.push({ branch: wt.branch, error: res.error });
+          } else {
+            succeeded += 1;
+          }
+        } catch (err) {
+          failures.push({
+            branch: wt.branch,
+            error: typeof err === "string" ? err : String(err),
+          });
+        }
+      }
+      bulkError = describeBulkResult("open in terminal", succeeded, failures);
+    } finally {
+      bulkPending = false;
+    }
+  }
+
   async function handleRemove(wt: Worktree, alsoBranch: boolean) {
     if (!currentRepo) return;
     // Belt-and-suspenders: the Remove buttons set `disabled` when these
@@ -880,14 +989,79 @@
 
         {#if hasSelection}
           <div
-            class="mx-2 mb-1 flex flex-wrap items-center gap-1 rounded border border-accent-dim/40 bg-accent-dim/10 px-2 py-1 text-[10px] text-text-secondary"
+            class="relative mx-2 mb-1 flex flex-wrap items-center gap-1 rounded border border-accent-dim/40 bg-accent-dim/10 px-2 py-1 text-[10px] text-text-secondary"
             data-testid="worktrunk-bulk-toolbar"
+            data-worktrunk-bulk-menu
           >
             <span class="text-text-primary">{selected.size} selected</span>
+            {#if bulkCopiedFlash}
+              <span
+                class="text-accent"
+                data-testid="worktrunk-bulk-copied-flash"
+                aria-live="polite"
+              >Copied</span>
+            {/if}
+            <button
+              type="button"
+              data-testid="worktrunk-bulk-more"
+              class="ml-auto inline-flex h-5 w-5 cursor-pointer items-center justify-center rounded text-text-secondary transition-colors duration-150 hover:bg-bg-hover hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-40"
+              title="More bulk actions"
+              aria-label="More bulk actions"
+              disabled={bulkPending}
+              onclick={() => (bulkMenuOpen = !bulkMenuOpen)}
+            >
+              <MoreHorizontal size={11} />
+            </button>
+            {#if bulkMenuOpen}
+              <div
+                class="absolute right-2 top-7 z-20 flex min-w-44 flex-col rounded border border-border bg-bg-elevated p-1 shadow-lg"
+                data-testid="worktrunk-bulk-menu-content"
+              >
+                <button
+                  type="button"
+                  data-testid="worktrunk-bulk-copy-paths"
+                  class="flex items-center gap-2 rounded px-2 py-1 text-left text-[11px] text-text-primary enabled:cursor-pointer enabled:hover:bg-bg-hover disabled:opacity-40"
+                  disabled={bulkPending}
+                  onclick={handleBulkCopyPaths}
+                  title={`Copy ${selected.size} path${selected.size === 1 ? "" : "s"} to clipboard`}
+                >
+                  <span>Copy paths</span>
+                  <span class="ml-auto text-[10px] text-text-muted"
+                    >{selected.size}</span
+                  >
+                </button>
+                <button
+                  type="button"
+                  data-testid="worktrunk-bulk-reveal"
+                  class="flex items-center gap-2 rounded px-2 py-1 text-left text-[11px] text-text-primary enabled:cursor-pointer enabled:hover:bg-bg-hover disabled:opacity-40"
+                  disabled={bulkPending}
+                  onclick={handleBulkRevealInFinder}
+                  title={`Reveal ${selected.size} worktree${selected.size === 1 ? "" : "s"} in Finder`}
+                >
+                  <span>Reveal in Finder</span>
+                  <span class="ml-auto text-[10px] text-text-muted"
+                    >{selected.size}</span
+                  >
+                </button>
+                <button
+                  type="button"
+                  data-testid="worktrunk-bulk-open-terminal"
+                  class="flex items-center gap-2 rounded px-2 py-1 text-left text-[11px] text-text-primary enabled:cursor-pointer enabled:hover:bg-bg-hover disabled:opacity-40"
+                  disabled={bulkPending}
+                  onclick={handleBulkOpenTerminal}
+                  title={`Open ${selected.size} worktree${selected.size === 1 ? "" : "s"} in terminal`}
+                >
+                  <span>Open in terminal</span>
+                  <span class="ml-auto text-[10px] text-text-muted"
+                    >{selected.size}</span
+                  >
+                </button>
+              </div>
+            {/if}
             <button
               type="button"
               data-testid="worktrunk-bulk-remove"
-              class="ml-auto inline-flex h-5 cursor-pointer items-center gap-1 rounded border border-border-subtle bg-bg-elevated px-1.5 text-[10px] text-text-secondary transition-colors duration-150 hover:bg-amber/20 hover:text-amber disabled:cursor-not-allowed disabled:opacity-40"
+              class="inline-flex h-5 cursor-pointer items-center gap-1 rounded border border-border-subtle bg-bg-elevated px-1.5 text-[10px] text-text-secondary transition-colors duration-150 hover:bg-amber/20 hover:text-amber disabled:cursor-not-allowed disabled:opacity-40"
               disabled={removableSelectedWorktrees.length === 0 || bulkPending}
               title={removableSelectedWorktrees.length === 0
                 ? "No selected worktrees can be removed"

--- a/src/lib/components/WorktrunkPanel.svelte
+++ b/src/lib/components/WorktrunkPanel.svelte
@@ -1069,7 +1069,7 @@
               onclick={() => handleBulkRemove(false)}
             >
               <Trash size={10} />
-              <span>Worktrees</span>
+              <span>Delete</span>
             </button>
             <button
               type="button"
@@ -1082,7 +1082,7 @@
               onclick={() => handleBulkRemove(true)}
             >
               <GitBranch size={10} />
-              <span>Worktree + branch</span>
+              <span>Delete + branch</span>
             </button>
             <button
               type="button"

--- a/src/lib/components/WorktrunkPanel.svelte
+++ b/src/lib/components/WorktrunkPanel.svelte
@@ -55,6 +55,10 @@
   let headerMenuOpen = $state(false);
   let bulkMenuOpen = $state(false);
   let bulkCopiedFlash = $state(false);
+  // Pending timer handle for the "Copied" flash. We clear and replace
+  // it on each copy so a slow second click doesn't hide the new flash
+  // because an earlier timer is still racing to fire.
+  let bulkCopiedFlashTimer: ReturnType<typeof setTimeout> | null = null;
   let filterText = $state("");
   let selected = $state(new Set<string>());
   let selectAllCheckbox = $state<HTMLInputElement | null>(null);
@@ -216,6 +220,10 @@
     headerMenuOpen = false;
     bulkMenuOpen = false;
     bulkCopiedFlash = false;
+    if (bulkCopiedFlashTimer != null) {
+      clearTimeout(bulkCopiedFlashTimer);
+      bulkCopiedFlashTimer = null;
+    }
     filterText = "";
     selected = new Set();
     bulkPending = false;
@@ -285,6 +293,18 @@
   $effect(() => {
     if (selectAllCheckbox) {
       selectAllCheckbox.indeterminate = someVisibleSelected;
+    }
+  });
+
+  // The bulk toolbar (and its More menu) only render while
+  // `hasSelection` is true. If the user clears the selection while the
+  // menu is open, the toolbar unmounts but `bulkMenuOpen` stays true —
+  // the next time a selection appears, the dropdown would render
+  // already-open. Reset the menu/flash state alongside the selection.
+  $effect(() => {
+    if (selected.size === 0) {
+      bulkMenuOpen = false;
+      bulkCopiedFlash = false;
     }
   });
 
@@ -535,6 +555,14 @@
     const repo = currentRepo;
     const targets = [...removableSelectedWorktrees];
     const count = targets.length;
+    // Close transient menus BEFORE the confirm so the dropdown isn't
+    // left dangling behind the modal prompt (or after the user
+    // cancels). The dropdown is non-interactive while the native
+    // confirm is up, but visually it's still rendered and gets
+    // dismissed only on next pointerdown — feels janky.
+    menuOpenFor = null;
+    headerMenuOpen = false;
+    bulkMenuOpen = false;
     const confirmed = window.confirm(
       alsoBranch
         ? `Delete ${count} worktree${count === 1 ? "" : "s"} AND ${count} local branch${count === 1 ? "" : "es"}?\n\nBoth the on-disk worktrees and local branches will be deleted.`
@@ -543,9 +571,6 @@
     if (!confirmed) return;
     bulkError = null;
     worktreesError = null;
-    menuOpenFor = null;
-    headerMenuOpen = false;
-    bulkMenuOpen = false;
     bulkPending = true;
     const succeeded: string[] = [];
     const dirty: Worktree[] = [];
@@ -646,8 +671,10 @@
       await navigator.clipboard.writeText(text);
       bulkMenuOpen = false;
       bulkCopiedFlash = true;
-      setTimeout(() => {
+      if (bulkCopiedFlashTimer != null) clearTimeout(bulkCopiedFlashTimer);
+      bulkCopiedFlashTimer = setTimeout(() => {
         bulkCopiedFlash = false;
+        bulkCopiedFlashTimer = null;
       }, 1500);
     } catch (err) {
       const msg = typeof err === "string" ? err : String(err);
@@ -657,6 +684,8 @@
 
   async function handleBulkRevealInFinder() {
     if (selectedWorktrees.length === 0 || bulkPending) return;
+    const repo = currentRepo;
+    if (!repo) return;
     const targets = [...selectedWorktrees];
     const count = targets.length;
     if (count > BULK_WINDOW_CONFIRM_THRESHOLD) {
@@ -682,6 +711,7 @@
           });
         }
       }
+      if (!isCurrentRepoRequest(repo)) return;
       bulkError = describeBulkResult("reveal", succeeded, failures);
     } finally {
       bulkPending = false;
@@ -690,6 +720,8 @@
 
   async function handleBulkOpenTerminal() {
     if (selectedWorktrees.length === 0 || bulkPending) return;
+    const repo = currentRepo;
+    if (!repo) return;
     const targets = [...selectedWorktrees];
     const count = targets.length;
     if (count > BULK_WINDOW_CONFIRM_THRESHOLD) {
@@ -719,6 +751,7 @@
           });
         }
       }
+      if (!isCurrentRepoRequest(repo)) return;
       bulkError = describeBulkResult("open in terminal", succeeded, failures);
     } finally {
       bulkPending = false;
@@ -763,16 +796,19 @@
           `"${wt.branch}" has uncommitted changes.\n\nForce-delete and DISCARD local changes?`,
         );
         if (!force) {
+          if (!isCurrentRepoRequest(repo)) return;
           worktreesError = `Skipped ${wt.branch}: uncommitted changes`;
           return;
         }
         await removeWorktree(repo, wt.path, alsoBranch, true);
       }
+      if (!isCurrentRepoRequest(repo)) return;
       const next = new Set(selected);
       next.delete(wt.path);
       selected = next;
       await loadWorktrees(repo);
     } catch (err) {
+      if (!isCurrentRepoRequest(repo)) return;
       const msg = typeof err === "string" ? err : String(err);
       worktreesError = `Failed to remove ${wt.branch}: ${msg}`;
     } finally {

--- a/src/lib/components/WorktrunkPanel.svelte
+++ b/src/lib/components/WorktrunkPanel.svelte
@@ -512,6 +512,22 @@
     return `${verb}: ${succeeded} succeeded, ${failures.length} failed (e.g. ${sample.branch}: ${sample.error})`;
   }
 
+  // Backend reports dirty worktrees as `WorktreeError::UncommittedChanges`,
+  // whose Display impl starts with "worktree has uncommitted changes".
+  // We match the substring so a wt-vs-git phrasing drift doesn't silently
+  // re-enable the data-loss footgun (fall through to git --force).
+  function isDirtyError(err: unknown): boolean {
+    const msg = typeof err === "string" ? err : String(err);
+    return /uncommitted changes/i.test(msg);
+  }
+
+  function formatDirtyBranchList(dirty: Worktree[]): string {
+    const preview = dirty.slice(0, 5).map((wt) => `  • ${wt.branch}`);
+    const more =
+      dirty.length > 5 ? `\n  …and ${dirty.length - 5} more` : "";
+    return `${preview.join("\n")}${more}`;
+  }
+
   async function handleBulkRemove(alsoBranch: boolean) {
     if (!currentRepo || bulkPending || removableSelectedWorktrees.length === 0) {
       return;
@@ -521,41 +537,101 @@
     const count = targets.length;
     const confirmed = window.confirm(
       alsoBranch
-        ? `Remove ${count} worktree${count === 1 ? "" : "s"} AND delete ${count} local branch${count === 1 ? "" : "es"}?\n\nBoth the on-disk worktrees and local branches will be deleted.`
-        : `Remove ${count} worktree${count === 1 ? "" : "s"} on disk?\n\nThe branches stay in the repo.`,
+        ? `Delete ${count} worktree${count === 1 ? "" : "s"} AND ${count} local branch${count === 1 ? "" : "es"}?\n\nBoth the on-disk worktrees and local branches will be deleted.`
+        : `Delete ${count} worktree${count === 1 ? "" : "s"} on disk?\n\nThe branches stay in the repo.`,
     );
     if (!confirmed) return;
     bulkError = null;
     worktreesError = null;
     menuOpenFor = null;
     headerMenuOpen = false;
+    bulkMenuOpen = false;
     bulkPending = true;
     const succeeded: string[] = [];
+    const dirty: Worktree[] = [];
     const failures: { branch: string; error: string }[] = [];
     try {
       for (const wt of targets) {
         try {
-          await removeWorktree(repo, wt.path, alsoBranch);
+          await removeWorktree(repo, wt.path, alsoBranch, false);
           succeeded.push(wt.path);
         } catch (err) {
-          failures.push({
-            branch: wt.branch,
-            error: typeof err === "string" ? err : String(err),
-          });
+          if (isDirtyError(err)) {
+            dirty.push(wt);
+          } else {
+            failures.push({
+              branch: wt.branch,
+              error: typeof err === "string" ? err : String(err),
+            });
+          }
         }
       }
       if (succeeded.length > 0 && isCurrentRepoRequest(repo)) {
         await loadWorktrees(repo);
       }
-      if (isCurrentRepoRequest(repo)) {
+      if (!isCurrentRepoRequest(repo)) return;
+
+      // Trim selection to what's left undeleted so the toolbar still
+      // makes sense if the user dismisses the dirty prompt.
+      {
         const remaining = new Set(selected);
         for (const path of succeeded) remaining.delete(path);
         selected = remaining;
-        bulkError = describeBulkResult(
-          alsoBranch ? "remove worktrees + branches" : "remove worktrees",
-          succeeded.length,
-          failures,
-        );
+      }
+      bulkError = describeBulkResult(
+        alsoBranch ? "remove worktrees + branches" : "remove worktrees",
+        succeeded.length,
+        failures,
+      );
+
+      if (dirty.length === 0) return;
+
+      // Phase 2: review dirty worktrees and ask whether to force-delete.
+      const forceConfirmed = window.confirm(
+        `${dirty.length} worktree${dirty.length === 1 ? "" : "s"} ${dirty.length === 1 ? "has" : "have"} uncommitted changes:\n\n${formatDirtyBranchList(dirty)}\n\nForce-delete and DISCARD local changes?`,
+      );
+      if (!forceConfirmed) {
+        const branches = dirty.map((wt) => wt.branch).join(", ");
+        const skippedMsg = `${dirty.length} skipped (uncommitted changes): ${branches}`;
+        bulkError = bulkError ? `${bulkError}. ${skippedMsg}` : skippedMsg;
+        return;
+      }
+
+      const forceSucceeded: string[] = [];
+      const forceFailures: { branch: string; error: string }[] = [];
+      for (const wt of dirty) {
+        try {
+          await removeWorktree(repo, wt.path, alsoBranch, true);
+          forceSucceeded.push(wt.path);
+        } catch (err) {
+          forceFailures.push({
+            branch: wt.branch,
+            error: typeof err === "string" ? err : String(err),
+          });
+        }
+      }
+      if (forceSucceeded.length > 0 && isCurrentRepoRequest(repo)) {
+        await loadWorktrees(repo);
+      }
+      if (!isCurrentRepoRequest(repo)) return;
+      {
+        const remaining = new Set(selected);
+        for (const path of forceSucceeded) remaining.delete(path);
+        selected = remaining;
+      }
+      const forceBanner = describeBulkResult(
+        "force-delete",
+        forceSucceeded.length,
+        forceFailures,
+      );
+      // Combine the two phases' banners so the user sees both outcomes.
+      if (bulkError && forceBanner) {
+        bulkError = `${bulkError}. ${forceBanner}`;
+      } else if (forceBanner) {
+        bulkError = forceBanner;
+      } else if (failures.length === 0) {
+        // Everything ultimately succeeded — clear the banner.
+        bulkError = null;
       }
     } finally {
       bulkPending = false;
@@ -676,13 +752,26 @@
           : "The worktree is removed from disk; the branch stays in the repo."),
     );
     if (!confirmed) return;
+    const repo = currentRepo;
     removing = wt.path;
     try {
-      await removeWorktree(currentRepo, wt.path, alsoBranch);
+      try {
+        await removeWorktree(repo, wt.path, alsoBranch, false);
+      } catch (err) {
+        if (!isDirtyError(err)) throw err;
+        const force = window.confirm(
+          `"${wt.branch}" has uncommitted changes.\n\nForce-delete and DISCARD local changes?`,
+        );
+        if (!force) {
+          worktreesError = `Skipped ${wt.branch}: uncommitted changes`;
+          return;
+        }
+        await removeWorktree(repo, wt.path, alsoBranch, true);
+      }
       const next = new Set(selected);
       next.delete(wt.path);
       selected = next;
-      await loadWorktrees(currentRepo);
+      await loadWorktrees(repo);
     } catch (err) {
       const msg = typeof err === "string" ? err : String(err);
       worktreesError = `Failed to remove ${wt.branch}: ${msg}`;

--- a/src/lib/components/WorktrunkPanel.svelte
+++ b/src/lib/components/WorktrunkPanel.svelte
@@ -1287,7 +1287,12 @@
                     data-testid="worktrunk-row-checkbox"
                   />
                   <div class="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
-                    <WorktreeRowContent {wt} showPath={false} repoRoot={currentRepo} />
+                    <WorktreeRowContent
+                      {wt}
+                      showPath={false}
+                      repoRoot={currentRepo}
+                      session={session ?? null}
+                    />
                   </div>
                   <div class="flex shrink-0 items-center gap-1">
                     {#if hasSession}

--- a/src/lib/components/WorktrunkPanel.svelte
+++ b/src/lib/components/WorktrunkPanel.svelte
@@ -1287,7 +1287,7 @@
                     data-testid="worktrunk-row-checkbox"
                   />
                   <div class="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
-                    <WorktreeRowContent {wt} showPath={false} />
+                    <WorktreeRowContent {wt} showPath={false} repoRoot={currentRepo} />
                   </div>
                   <div class="flex shrink-0 items-center gap-1">
                     {#if hasSession}

--- a/src/lib/components/__tests__/WorktreeRowContent.test.ts
+++ b/src/lib/components/__tests__/WorktreeRowContent.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import WorktreeRowContent from "../WorktreeRowContent.svelte";
-import type { Worktree, WorktrunkMetadata } from "$lib/types";
+import type { Session, Worktree, WorktrunkMetadata } from "$lib/types";
 
 vi.mock("$lib/tauri", async () => {
   const actual =
@@ -9,11 +9,34 @@ vi.mock("$lib/tauri", async () => {
   return {
     ...actual,
     lookupPrForBranch: vi.fn(),
+    lookupPr: vi.fn(),
   };
 });
 
-import { lookupPrForBranch } from "$lib/tauri";
+import { lookupPr, lookupPrForBranch } from "$lib/tauri";
 import { _resetSessionPrLookupForTests } from "$lib/stores/sessionPrLookup";
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "s1",
+    name: "sess",
+    repoRoot: "/repo",
+    worktreePath: "/repo",
+    branch: "main",
+    isWorktree: false,
+    status: "idle",
+    model: null,
+    cost: null,
+    createdAt: Date.now() / 1000,
+    projectId: null,
+    isGitRepo: true,
+    nameOverride: null,
+    primaryPtyId: "s1",
+    archived: false,
+    endedAt: null,
+    ...overrides,
+  };
+}
 
 function makeMetadata(overrides: Partial<WorktrunkMetadata> = {}): WorktrunkMetadata {
   return {
@@ -48,6 +71,7 @@ function makeWorktree(overrides: Partial<Worktree> = {}): Worktree {
 describe("WorktreeRowContent", () => {
   beforeEach(() => {
     vi.mocked(lookupPrForBranch).mockReset();
+    vi.mocked(lookupPr).mockReset();
     _resetSessionPrLookupForTests();
   });
   afterEach(() => {
@@ -309,6 +333,57 @@ describe("WorktreeRowContent", () => {
     expect(popover.textContent).toContain("passing");
     expect(popover.textContent).toContain("alice");
     expect(popover.textContent).toContain("approved");
+  });
+
+  it("routes through the session lookup when a session is supplied (so pinned PRs match the status bar)", async () => {
+    vi.mocked(lookupPr).mockResolvedValue({
+      number: 7,
+      title: "Pinned",
+      headRef: "feat-x",
+      headOwner: "user",
+      isCrossRepository: false,
+      url: "https://example.com/pr/7",
+      repoSlug: "user/repo",
+      checks: null,
+      checkRuns: [{ name: "lint", status: "passing", url: null }],
+      reviewDecision: null,
+      reviewDetails: [],
+    });
+
+    const session = makeSession({
+      id: "s2",
+      repoRoot: "/repo",
+      branch: "feat-x",
+      worktreePath: "/repo-feat-x",
+      pinnedPrUrl: "https://example.com/pr/7",
+    });
+
+    const { getByTestId, findByTestId } = render(WorktreeRowContent, {
+      props: {
+        wt: makeWorktree({
+          path: "/repo-feat-x",
+          branch: "feat-x",
+          worktrunk: makeMetadata({
+            ciStatus: "passed",
+            ciUrl: "https://example.com",
+          }),
+        }),
+        repoRoot: "/repo",
+        session,
+      },
+    });
+    const chipWrap = getByTestId("wt-ci").parentElement as HTMLElement;
+    await fireEvent.mouseEnter(chipWrap);
+    // Session-aware path uses lookupPr (pin URL), not lookupPrForBranch.
+    await waitFor(() =>
+      expect(lookupPr).toHaveBeenCalledWith(
+        "/repo",
+        "https://example.com/pr/7",
+      ),
+    );
+    expect(lookupPrForBranch).not.toHaveBeenCalled();
+    const popover = await findByTestId("wt-ci-popover");
+    expect(popover.textContent).toContain("lint");
   });
 
   it("renders dev-server link when devServerUrl is set", () => {

--- a/src/lib/components/__tests__/WorktreeRowContent.test.ts
+++ b/src/lib/components/__tests__/WorktreeRowContent.test.ts
@@ -1,7 +1,19 @@
-import { describe, expect, it } from "vitest";
-import { render } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import WorktreeRowContent from "../WorktreeRowContent.svelte";
 import type { Worktree, WorktrunkMetadata } from "$lib/types";
+
+vi.mock("$lib/tauri", async () => {
+  const actual =
+    await vi.importActual<typeof import("$lib/tauri")>("$lib/tauri");
+  return {
+    ...actual,
+    lookupPrForBranch: vi.fn(),
+  };
+});
+
+import { lookupPrForBranch } from "$lib/tauri";
+import { _resetSessionPrLookupForTests } from "$lib/stores/sessionPrLookup";
 
 function makeMetadata(overrides: Partial<WorktrunkMetadata> = {}): WorktrunkMetadata {
   return {
@@ -34,6 +46,14 @@ function makeWorktree(overrides: Partial<Worktree> = {}): Worktree {
 }
 
 describe("WorktreeRowContent", () => {
+  beforeEach(() => {
+    vi.mocked(lookupPrForBranch).mockReset();
+    _resetSessionPrLookupForTests();
+  });
+  afterEach(() => {
+    _resetSessionPrLookupForTests();
+  });
+
   it("renders branch + path when no worktrunk metadata is present", () => {
     const { queryByTestId, container } = render(WorktreeRowContent, {
       props: { wt: makeWorktree({ branch: "feat", path: "/tmp/repo-feat" }) },
@@ -207,6 +227,88 @@ describe("WorktreeRowContent", () => {
     const a = getByTestId("wt-ci");
     expect(a.className).toContain("opacity-60");
     expect(a.getAttribute("title")).toContain("stale");
+  });
+
+  it("triggers a PR lookup once on first hover when repoRoot is set", async () => {
+    vi.mocked(lookupPrForBranch).mockResolvedValue(null);
+    const { getByTestId } = render(WorktreeRowContent, {
+      props: {
+        wt: makeWorktree({
+          branch: "feat-x",
+          worktrunk: makeMetadata({
+            ciStatus: "passed",
+            ciUrl: "https://example.com",
+          }),
+        }),
+        repoRoot: "/repo",
+      },
+    });
+    const chipWrap = getByTestId("wt-ci").parentElement as HTMLElement;
+    await fireEvent.mouseEnter(chipWrap);
+    await waitFor(() =>
+      expect(lookupPrForBranch).toHaveBeenCalledWith("/repo", "feat-x"),
+    );
+    // Re-hover doesn't refire; the first attempt is sticky.
+    await fireEvent.mouseEnter(chipWrap);
+    await fireEvent.mouseEnter(chipWrap);
+    expect(lookupPrForBranch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not look up when repoRoot is missing or branch is main", async () => {
+    vi.mocked(lookupPrForBranch).mockResolvedValue(null);
+    const { getByTestId } = render(WorktreeRowContent, {
+      props: {
+        wt: makeWorktree({
+          branch: "main",
+          isMain: true,
+          worktrunk: makeMetadata({
+            ciStatus: "passed",
+            ciUrl: "https://example.com",
+          }),
+        }),
+        repoRoot: "/repo",
+      },
+    });
+    const chipWrap = getByTestId("wt-ci").parentElement as HTMLElement;
+    await fireEvent.mouseEnter(chipWrap);
+    expect(lookupPrForBranch).not.toHaveBeenCalled();
+  });
+
+  it("renders the popover content once PR data lands", async () => {
+    vi.mocked(lookupPrForBranch).mockResolvedValue({
+      number: 42,
+      title: "Fix things",
+      headRef: "feat-x",
+      headOwner: "user",
+      isCrossRepository: false,
+      url: "https://example.com/pr/42",
+      repoSlug: "user/repo",
+      checks: null,
+      checkRuns: [{ name: "build", status: "passing", url: null }],
+      reviewDecision: null,
+      reviewDetails: [
+        { reviewer: "alice", state: "APPROVED", url: null },
+      ],
+    });
+    const { getByTestId, findByTestId } = render(WorktreeRowContent, {
+      props: {
+        wt: makeWorktree({
+          branch: "feat-x",
+          worktrunk: makeMetadata({
+            ciStatus: "passed",
+            ciUrl: "https://example.com",
+          }),
+        }),
+        repoRoot: "/repo",
+      },
+    });
+    const chipWrap = getByTestId("wt-ci").parentElement as HTMLElement;
+    await fireEvent.mouseEnter(chipWrap);
+    const popover = await findByTestId("wt-ci-popover");
+    expect(popover.textContent).toContain("build");
+    expect(popover.textContent).toContain("passing");
+    expect(popover.textContent).toContain("alice");
+    expect(popover.textContent).toContain("approved");
   });
 
   it("renders dev-server link when devServerUrl is set", () => {

--- a/src/lib/components/__tests__/WorktrunkPanel.test.ts
+++ b/src/lib/components/__tests__/WorktrunkPanel.test.ts
@@ -337,8 +337,10 @@ describe("WorktrunkPanel Worktrees tab", () => {
   beforeEach(() => {
     vi.mocked(commands.cmdWorktrunkDiagnostics).mockReset();
     vi.mocked(commands.cmdWorktrunkReadLog).mockReset();
+    vi.mocked(commands.cmdOpenTerminalAt).mockReset();
     vi.mocked(listWorktrees).mockReset();
     vi.mocked(removeWorktree).mockReset();
+    vi.mocked(revealItemInDir).mockReset();
     sessionState.set({ sessions: [], activeSessionId: null });
     _resetWorktreeMetadataForTests();
     _setWorktrunkDetectionForTests({
@@ -815,6 +817,196 @@ describe("WorktrunkPanel Worktrees tab", () => {
         .mock.calls.filter(([repo]) => repo === "/project");
       expect(projectCalls.length).toBe(1);
     });
+  });
+
+  it("bulk-copies selected worktree paths newline-separated to the clipboard", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    const s = makeSession({ repoRoot: "/project", isWorktree: false });
+    sessionState.set({ sessions: [s], activeSessionId: s.id });
+    vi.mocked(commands.cmdWorktrunkDiagnostics).mockResolvedValue(
+      okDiagnostics(makeDiagnostics()),
+    );
+    vi.mocked(listWorktrees).mockResolvedValueOnce([
+      makeWorktree({ path: "/project", branch: "main", isMain: true }),
+      makeWorktree({
+        path: "/project-feat-a",
+        branch: "feat-a",
+        isMain: false,
+      }),
+      makeWorktree({
+        path: "/project-feat-b",
+        branch: "feat-b",
+        isMain: false,
+      }),
+    ]);
+
+    const { findAllByTestId, findByTestId } = render(WorktrunkPanel, {
+      props: { visible: true, onclose: () => {} },
+    });
+    await findAllByTestId("worktrunk-worktree-row");
+    await fireEvent.click(await findByTestId("worktrunk-select-all"));
+    await fireEvent.click(await findByTestId("worktrunk-bulk-more"));
+    await fireEvent.click(await findByTestId("worktrunk-bulk-copy-paths"));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    expect(writeText).toHaveBeenCalledWith("/project-feat-a\n/project-feat-b");
+    expect(await findByTestId("worktrunk-bulk-copied-flash")).toBeDefined();
+  });
+
+  it("bulk-reveals selected worktrees in Finder without confirm under the threshold", async () => {
+    const s = makeSession({ repoRoot: "/project", isWorktree: false });
+    sessionState.set({ sessions: [s], activeSessionId: s.id });
+    vi.mocked(commands.cmdWorktrunkDiagnostics).mockResolvedValue(
+      okDiagnostics(makeDiagnostics()),
+    );
+    vi.mocked(listWorktrees).mockResolvedValueOnce([
+      makeWorktree({ path: "/project", branch: "main", isMain: true }),
+      makeWorktree({
+        path: "/project-feat-a",
+        branch: "feat-a",
+        isMain: false,
+      }),
+      makeWorktree({
+        path: "/project-feat-b",
+        branch: "feat-b",
+        isMain: false,
+      }),
+    ]);
+    vi.mocked(revealItemInDir).mockResolvedValue(undefined);
+
+    const { findAllByTestId, findByTestId } = render(WorktrunkPanel, {
+      props: { visible: true, onclose: () => {} },
+    });
+    await findAllByTestId("worktrunk-worktree-row");
+    await fireEvent.click(await findByTestId("worktrunk-select-all"));
+    await fireEvent.click(await findByTestId("worktrunk-bulk-more"));
+    await fireEvent.click(await findByTestId("worktrunk-bulk-reveal"));
+
+    await waitFor(() => expect(revealItemInDir).toHaveBeenCalledTimes(2));
+    expect(revealItemInDir).toHaveBeenNthCalledWith(1, "/project-feat-a");
+    expect(revealItemInDir).toHaveBeenNthCalledWith(2, "/project-feat-b");
+    // Threshold is 5, so two items must not have prompted.
+    expect(confirmSpy).not.toHaveBeenCalled();
+  });
+
+  it("prompts before bulk-revealing more than the threshold of worktrees", async () => {
+    confirmSpy.mockReturnValueOnce(false);
+    const s = makeSession({ repoRoot: "/project", isWorktree: false });
+    sessionState.set({ sessions: [s], activeSessionId: s.id });
+    vi.mocked(commands.cmdWorktrunkDiagnostics).mockResolvedValue(
+      okDiagnostics(makeDiagnostics()),
+    );
+    vi.mocked(listWorktrees).mockResolvedValueOnce([
+      makeWorktree({ path: "/project", branch: "main", isMain: true }),
+      ...Array.from({ length: 6 }, (_, i) =>
+        makeWorktree({
+          path: `/project-feat-${i}`,
+          branch: `feat-${i}`,
+          isMain: false,
+        }),
+      ),
+    ]);
+    vi.mocked(revealItemInDir).mockResolvedValue(undefined);
+
+    const { findAllByTestId, findByTestId } = render(WorktrunkPanel, {
+      props: { visible: true, onclose: () => {} },
+    });
+    await findAllByTestId("worktrunk-worktree-row");
+    await fireEvent.click(await findByTestId("worktrunk-select-all"));
+    await fireEvent.click(await findByTestId("worktrunk-bulk-more"));
+    await fireEvent.click(await findByTestId("worktrunk-bulk-reveal"));
+
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(confirmSpy.mock.calls[0]?.[0]).toContain("Reveal 6 worktrees");
+    expect(revealItemInDir).not.toHaveBeenCalled();
+  });
+
+  it("bulk-opens selected worktrees in terminal under the threshold", async () => {
+    const s = makeSession({ repoRoot: "/project", isWorktree: false });
+    sessionState.set({ sessions: [s], activeSessionId: s.id });
+    vi.mocked(commands.cmdWorktrunkDiagnostics).mockResolvedValue(
+      okDiagnostics(makeDiagnostics()),
+    );
+    vi.mocked(listWorktrees).mockResolvedValueOnce([
+      makeWorktree({ path: "/project", branch: "main", isMain: true }),
+      makeWorktree({
+        path: "/project-feat-a",
+        branch: "feat-a",
+        isMain: false,
+      }),
+      makeWorktree({
+        path: "/project-feat-b",
+        branch: "feat-b",
+        isMain: false,
+      }),
+    ]);
+    vi.mocked(commands.cmdOpenTerminalAt).mockResolvedValue({
+      status: "ok",
+      data: null,
+    });
+
+    const { findAllByTestId, findByTestId } = render(WorktrunkPanel, {
+      props: { visible: true, onclose: () => {} },
+    });
+    await findAllByTestId("worktrunk-worktree-row");
+    await fireEvent.click(await findByTestId("worktrunk-select-all"));
+    await fireEvent.click(await findByTestId("worktrunk-bulk-more"));
+    await fireEvent.click(await findByTestId("worktrunk-bulk-open-terminal"));
+
+    await waitFor(() =>
+      expect(commands.cmdOpenTerminalAt).toHaveBeenCalledTimes(2),
+    );
+    expect(commands.cmdOpenTerminalAt).toHaveBeenNthCalledWith(
+      1,
+      "/project-feat-a",
+    );
+    expect(commands.cmdOpenTerminalAt).toHaveBeenNthCalledWith(
+      2,
+      "/project-feat-b",
+    );
+    expect(confirmSpy).not.toHaveBeenCalled();
+  });
+
+  it("surfaces partial failures from bulk open-in-terminal", async () => {
+    const s = makeSession({ repoRoot: "/project", isWorktree: false });
+    sessionState.set({ sessions: [s], activeSessionId: s.id });
+    vi.mocked(commands.cmdWorktrunkDiagnostics).mockResolvedValue(
+      okDiagnostics(makeDiagnostics()),
+    );
+    vi.mocked(listWorktrees).mockResolvedValueOnce([
+      makeWorktree({ path: "/project", branch: "main", isMain: true }),
+      makeWorktree({
+        path: "/project-feat-a",
+        branch: "feat-a",
+        isMain: false,
+      }),
+      makeWorktree({
+        path: "/project-feat-b",
+        branch: "feat-b",
+        isMain: false,
+      }),
+    ]);
+    vi.mocked(commands.cmdOpenTerminalAt).mockImplementation(async (path) => {
+      if (path === "/project-feat-b") {
+        return { status: "error", error: "no terminal" };
+      }
+      return { status: "ok", data: null };
+    });
+
+    const { findAllByTestId, findByTestId } = render(WorktrunkPanel, {
+      props: { visible: true, onclose: () => {} },
+    });
+    await findAllByTestId("worktrunk-worktree-row");
+    await fireEvent.click(await findByTestId("worktrunk-select-all"));
+    await fireEvent.click(await findByTestId("worktrunk-bulk-more"));
+    await fireEvent.click(await findByTestId("worktrunk-bulk-open-terminal"));
+
+    const err = await findByTestId("worktrunk-bulk-error");
+    expect(err.textContent).toContain("1 succeeded, 1 failed");
+    expect(err.textContent).toContain("feat-b");
+    expect(err.textContent).toContain("no terminal");
   });
 
   it("disables Remove for the main worktree (inside the kebab menu)", async () => {

--- a/src/lib/components/__tests__/WorktrunkPanel.test.ts
+++ b/src/lib/components/__tests__/WorktrunkPanel.test.ts
@@ -660,11 +660,13 @@ describe("WorktrunkPanel Worktrees tab", () => {
       "/project",
       "/project-feat-a",
       false,
+      false,
     );
     expect(removeWorktree).toHaveBeenNthCalledWith(
       2,
       "/project",
       "/project-feat-b",
+      false,
       false,
     );
   });
@@ -696,6 +698,7 @@ describe("WorktrunkPanel Worktrees tab", () => {
       "/project",
       "/project-feat-a",
       true,
+      false,
     );
   });
 
@@ -767,6 +770,183 @@ describe("WorktrunkPanel Worktrees tab", () => {
     expect(err.textContent).toContain("1 succeeded, 1 failed");
     expect(err.textContent).toContain("feat-b");
     expect(err.textContent).toContain("locked");
+  });
+
+  it("offers to force-delete dirty worktrees after bulk remove leaves them behind", async () => {
+    const s = makeSession({ repoRoot: "/project", isWorktree: false });
+    sessionState.set({ sessions: [s], activeSessionId: s.id });
+    vi.mocked(commands.cmdWorktrunkDiagnostics).mockResolvedValue(
+      okDiagnostics(makeDiagnostics()),
+    );
+    vi.mocked(listWorktrees)
+      .mockResolvedValueOnce([
+        makeWorktree({ path: "/project", branch: "main", isMain: true }),
+        makeWorktree({
+          path: "/project-clean",
+          branch: "clean",
+          isMain: false,
+        }),
+        makeWorktree({
+          path: "/project-dirty",
+          branch: "dirty",
+          isMain: false,
+        }),
+      ])
+      // After phase 1: only the dirty one remains.
+      .mockResolvedValueOnce([
+        makeWorktree({ path: "/project", branch: "main", isMain: true }),
+        makeWorktree({
+          path: "/project-dirty",
+          branch: "dirty",
+          isMain: false,
+        }),
+      ])
+      // After phase 2 force: dirty also gone.
+      .mockResolvedValueOnce([
+        makeWorktree({ path: "/project", branch: "main", isMain: true }),
+      ]);
+    vi.mocked(removeWorktree).mockImplementation(
+      async (_repo, path, _alsoBranch, force) => {
+        if (path === "/project-dirty" && !force) {
+          throw new Error(
+            "worktree has uncommitted changes: ✗ Cannot remove worktree: dirty has uncommitted changes",
+          );
+        }
+      },
+    );
+
+    const { findAllByTestId, findByTestId } = render(WorktrunkPanel, {
+      props: { visible: true, onclose: () => {} },
+    });
+    await findAllByTestId("worktrunk-worktree-row");
+    await fireEvent.click(await findByTestId("worktrunk-select-all"));
+    await fireEvent.click(await findByTestId("worktrunk-bulk-remove"));
+
+    await waitFor(() => expect(removeWorktree).toHaveBeenCalledTimes(3));
+    // Phase 1: both targets attempted with force=false.
+    expect(removeWorktree).toHaveBeenNthCalledWith(
+      1,
+      "/project",
+      "/project-clean",
+      false,
+      false,
+    );
+    expect(removeWorktree).toHaveBeenNthCalledWith(
+      2,
+      "/project",
+      "/project-dirty",
+      false,
+      false,
+    );
+    // Phase 2: dirty re-attempted with force=true after the second confirm.
+    expect(removeWorktree).toHaveBeenNthCalledWith(
+      3,
+      "/project",
+      "/project-dirty",
+      false,
+      true,
+    );
+    // Two confirms: initial bulk delete + force-delete prompt.
+    expect(confirmSpy).toHaveBeenCalledTimes(2);
+    expect(confirmSpy.mock.calls[1]?.[0]).toContain("uncommitted changes");
+    expect(confirmSpy.mock.calls[1]?.[0]).toContain("dirty");
+  });
+
+  it("skips force-delete when the user declines the dirty prompt", async () => {
+    const s = makeSession({ repoRoot: "/project", isWorktree: false });
+    sessionState.set({ sessions: [s], activeSessionId: s.id });
+    vi.mocked(commands.cmdWorktrunkDiagnostics).mockResolvedValue(
+      okDiagnostics(makeDiagnostics()),
+    );
+    vi.mocked(listWorktrees).mockResolvedValueOnce([
+      makeWorktree({ path: "/project", branch: "main", isMain: true }),
+      makeWorktree({
+        path: "/project-dirty",
+        branch: "dirty",
+        isMain: false,
+      }),
+    ]);
+    vi.mocked(removeWorktree).mockImplementation(async () => {
+      throw new Error("worktree has uncommitted changes: dirty");
+    });
+    // First confirm = initial bulk delete (allow); second = force prompt (deny).
+    confirmSpy.mockReturnValueOnce(true).mockReturnValueOnce(false);
+
+    const { findAllByTestId, findByTestId } = render(WorktrunkPanel, {
+      props: { visible: true, onclose: () => {} },
+    });
+    await findAllByTestId("worktrunk-worktree-row");
+    await fireEvent.click(await findByTestId("worktrunk-select-all"));
+    await fireEvent.click(await findByTestId("worktrunk-bulk-remove"));
+
+    await waitFor(() => expect(removeWorktree).toHaveBeenCalledTimes(1));
+    expect(removeWorktree).toHaveBeenCalledWith(
+      "/project",
+      "/project-dirty",
+      false,
+      false,
+    );
+    const err = await findByTestId("worktrunk-bulk-error");
+    expect(err.textContent).toContain("skipped (uncommitted changes)");
+    expect(err.textContent).toContain("dirty");
+  });
+
+  it("offers to force-delete a single worktree from the kebab menu when it's dirty", async () => {
+    const s = makeSession({ repoRoot: "/project", isWorktree: false });
+    sessionState.set({ sessions: [s], activeSessionId: s.id });
+    vi.mocked(commands.cmdWorktrunkDiagnostics).mockResolvedValue(
+      okDiagnostics(makeDiagnostics()),
+    );
+    vi.mocked(listWorktrees).mockResolvedValue([
+      makeWorktree({ path: "/project", branch: "main", isMain: true }),
+      makeWorktree({
+        path: "/project-dirty",
+        branch: "dirty",
+        isMain: false,
+      }),
+    ]);
+    vi.mocked(removeWorktree).mockImplementation(
+      async (_repo, _path, _alsoBranch, force) => {
+        if (!force) {
+          throw new Error("worktree has uncommitted changes: dirty");
+        }
+      },
+    );
+
+    const { findAllByTestId } = render(WorktrunkPanel, {
+      props: { visible: true, onclose: () => {} },
+    });
+    const rows = await findAllByTestId("worktrunk-worktree-row");
+    const featRow = rows[1];
+    await fireEvent.click(
+      featRow.querySelector(
+        '[data-testid="worktrunk-worktree-menu"]',
+      ) as HTMLButtonElement,
+    );
+    await fireEvent.click(
+      featRow.querySelector(
+        '[data-testid="worktrunk-worktree-remove"]',
+      ) as HTMLButtonElement,
+    );
+
+    await waitFor(() => expect(removeWorktree).toHaveBeenCalledTimes(2));
+    expect(removeWorktree).toHaveBeenNthCalledWith(
+      1,
+      "/project",
+      "/project-dirty",
+      false,
+      false,
+    );
+    expect(removeWorktree).toHaveBeenNthCalledWith(
+      2,
+      "/project",
+      "/project-dirty",
+      false,
+      true,
+    );
+    // Initial confirm + force-delete confirm.
+    expect(confirmSpy).toHaveBeenCalledTimes(2);
+    expect(confirmSpy.mock.calls[1]?.[0]).toContain("uncommitted changes");
   });
 
   it("does not refresh the stale repo after bulk remove if the active repo changes", async () => {
@@ -1116,6 +1296,7 @@ describe("WorktrunkPanel Worktrees tab", () => {
       "/project",
       "/project-feat-a",
       false,
+      false,
     );
   });
 
@@ -1197,6 +1378,7 @@ describe("WorktrunkPanel Worktrees tab", () => {
       "/project",
       "/project-feat-a",
       true,
+      false,
     );
   });
 

--- a/src/lib/components/__tests__/WorktrunkPanel.test.ts
+++ b/src/lib/components/__tests__/WorktrunkPanel.test.ts
@@ -333,6 +333,10 @@ describe("WorktrunkPanel", () => {
 
 describe("WorktrunkPanel Worktrees tab", () => {
   let confirmSpy: ReturnType<typeof vi.spyOn>;
+  // Snapshot the real `navigator.clipboard` so the bulk-copy test
+  // (which swaps in a vi.fn for `writeText`) doesn't leak the stub
+  // into later tests.
+  let originalClipboard: typeof navigator.clipboard | undefined;
 
   beforeEach(() => {
     vi.mocked(commands.cmdWorktrunkDiagnostics).mockReset();
@@ -349,12 +353,16 @@ describe("WorktrunkPanel Worktrees tab", () => {
       probed: true,
     });
     confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    originalClipboard = navigator.clipboard;
   });
 
   afterEach(() => {
     confirmSpy.mockRestore();
     sessionState.set({ sessions: [], activeSessionId: null });
     _resetWorktreeMetadataForTests();
+    if (originalClipboard !== undefined) {
+      Object.assign(navigator, { clipboard: originalClipboard });
+    }
   });
 
   it("fetches and renders the worktree list for the session's repo", async () => {

--- a/src/lib/portal.ts
+++ b/src/lib/portal.ts
@@ -1,0 +1,31 @@
+import type { Action } from "svelte/action";
+
+/**
+ * Move a node into a target element (default: `document.body`) on mount,
+ * remove it on destroy. Useful for popovers/tooltips inside scroll
+ * containers — `overflow: hidden/auto` ancestors clip absolutely
+ * positioned children, but `position: fixed` descendants of
+ * `document.body` are anchored to the viewport and escape that clipping.
+ *
+ * Callers are responsible for positioning the portaled node themselves
+ * (typically via `position: fixed` with coordinates derived from an
+ * anchor element's bounding rect).
+ */
+export const portal: Action<HTMLElement, HTMLElement | undefined | null> = (
+  node,
+  target,
+) => {
+  const dest = target ?? document.body;
+  dest.appendChild(node);
+  return {
+    update(next) {
+      const nextDest = next ?? document.body;
+      if (nextDest !== node.parentElement) {
+        nextDest.appendChild(node);
+      }
+    },
+    destroy() {
+      node.remove();
+    },
+  };
+};

--- a/src/lib/stores/sessionPrLookup.ts
+++ b/src/lib/stores/sessionPrLookup.ts
@@ -150,6 +150,25 @@ export function getPrLookupSnapshot(
  * manual `Refresh PR for active session` command and by the
  * window-focus refresh path).
  */
+/**
+ * Trigger a PR lookup for an arbitrary `(repoRoot, branch)` pair —
+ * used by surfaces (worktrunk panel rows, project PR overview) that
+ * aren't tied to a specific `Session` and just need the branch's PR
+ * info. Shares the cache, TTL, and in-flight dedupe with
+ * `lookupPrForSession`.
+ */
+export async function lookupPrForRepoBranch(
+  repoRoot: string,
+  branch: string,
+  opts: { force?: boolean } = {},
+): Promise<PrInfo | null> {
+  return lookupForKey(
+    keyFor(repoRoot, branch),
+    () => lookupPrForBranch(repoRoot, branch),
+    opts,
+  );
+}
+
 export async function lookupPrForSession(
   session: Pick<Session, "repoRoot" | "branch" | "isGitRepo" | "pinnedPrUrl">,
   opts: { force?: boolean } = {},

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -252,12 +252,14 @@ export async function createWorktree(
 export async function removeWorktree(
   repoPath: string,
   worktreePath: string,
-  alsoBranch: boolean = false
+  alsoBranch: boolean = false,
+  force: boolean = false
 ): Promise<void> {
   return invoke("cmd_remove_worktree", {
     repoPath,
     worktreePath,
     alsoBranch,
+    force,
   });
 }
 


### PR DESCRIPTION
## Summary

- Add a "More" kebab to the worktrunk bulk toolbar exposing three non-destructive bulk actions: **Copy paths**, **Reveal in Finder**, **Open in terminal**.
- The two "open external window" actions prompt for confirmation when the selection exceeds 5, so a stray select-all can't carpet the desktop.
- Reuses the existing `describeBulkResult` partial-failure pattern, so failures land in the same `worktrunk-bulk-error` banner as the bulk remove flows.

The existing destructive buttons ("Worktrees", "Worktree + branch") are unchanged.

## Test plan

- [x] `npm run check` clean
- [x] `npx vitest run src/lib/components/__tests__/WorktrunkPanel.test.ts` — 43/43 passing (38 prior + 5 new)
- [ ] Manual: select multiple worktrees in the panel, click ⋯, verify Copy / Reveal / Open-in-terminal each behave correctly
- [ ] Manual: select >5 worktrees, click Reveal — verify the confirmation prompt fires
- [ ] Manual: trigger a partial failure (e.g. select a worktree on a path that's been moved) and verify the error banner shows "N succeeded, M failed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk actions: copy paths (shows “Copied”), reveal in file explorer, open in terminal via a “More bulk actions” dropdown; separate Delete / Delete+branch buttons.
  * PR status popover on CI chips with lazy, session-aware PR lookups; Status bar delegates to the new popover.
  * Confirmation gating when bulk operations exceed a threshold.

* **Bug Fixes**
  * Detects dirty/uncommitted worktrees and prompts to force-delete for single and bulk deletes; unified reporting and selection cleanup.

* **Tests**
  * Expanded tests for bulk actions, dirty-delete flows, and PR lookup/CI interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->