### PR TITLE
fix(new-session): suppress repo autocomplete reopen after selection

### DIFF
--- a/src/lib/components/RepoAutoComplete.svelte
+++ b/src/lib/components/RepoAutoComplete.svelte
@@ -60,6 +60,9 @@
 
   let pickerOpen = $state(true);
   let closeT: ReturnType<typeof setTimeout> | null = null;
+  // One-shot guard: swallows the next focus event after a selection so a
+  // programmatic refocus by the caller doesn't immediately re-pop the dropdown.
+  let suppressNextFocusOpen = $state(false);
 
   function cancelDeferredClose() {
     if (closeT != null) {
@@ -78,6 +81,7 @@
   function handleSelect(path: string, label: string) {
     onselect(path, label);
     pickerOpen = false;
+    suppressNextFocusOpen = true;
   }
 
   function handleEnter() {
@@ -87,6 +91,7 @@
       return;
     }
     pickerOpen = false;
+    suppressNextFocusOpen = true;
     onenter?.(value);
   }
 
@@ -119,8 +124,17 @@
         bind:value
         {placeholder}
         class={pickerInputClass}
-        onfocus={() => { pickerOpen = true; }}
-        oninput={() => { pickerOpen = true; }}
+        onfocus={() => {
+          if (suppressNextFocusOpen) {
+            suppressNextFocusOpen = false;
+            return;
+          }
+          pickerOpen = true;
+        }}
+        oninput={() => {
+          suppressNextFocusOpen = false;
+          pickerOpen = true;
+        }}
         onkeydown={(e) => {
           if (e.key !== "Enter") return;
           e.preventDefault();

--- a/src/lib/components/__tests__/RepoAutoComplete.test.ts
+++ b/src/lib/components/__tests__/RepoAutoComplete.test.ts
@@ -1,0 +1,88 @@
+import { fireEvent, render, waitFor } from "@testing-library/svelte";
+import { describe, expect, it, vi } from "vitest";
+import RepoAutoComplete from "../RepoAutoComplete.svelte";
+
+const options = [
+  { path: "/repos/alpha", label: "alpha" },
+  { path: "/repos/beta", label: "beta" },
+];
+
+function getOptionItems(): HTMLElement[] {
+  return Array.from(document.querySelectorAll<HTMLElement>('[role="option"]'));
+}
+
+function getInput(): HTMLInputElement {
+  const input = document.querySelector<HTMLInputElement>("input");
+  if (!input) throw new Error("RepoAutoComplete input not rendered");
+  return input;
+}
+
+describe("RepoAutoComplete focus suppression after selection", () => {
+  it("does not reopen the dropdown when the caller programmatically refocuses the input after a selection", async () => {
+    const onselect = vi.fn();
+    render(RepoAutoComplete, {
+      props: {
+        value: "",
+        options,
+        hasConfiguredRoots: true,
+        onselect,
+      },
+    });
+
+    await waitFor(() => expect(getOptionItems().length).toBe(2));
+
+    await fireEvent.click(getOptionItems()[0]);
+    expect(onselect).toHaveBeenCalledWith("/repos/alpha", "alpha");
+    await waitFor(() => expect(getOptionItems().length).toBe(0));
+
+    // Reproduces NewSessionDialog.focusDirectoryInput() — programmatic focus
+    // returning to the input after selection. Pre-fix, this reopened the dropdown.
+    await fireEvent.focus(getInput());
+    expect(getOptionItems().length).toBe(0);
+  });
+
+  it("reopens the dropdown on a subsequent user-initiated refocus", async () => {
+    render(RepoAutoComplete, {
+      props: {
+        value: "",
+        options,
+        hasConfiguredRoots: true,
+        onselect: vi.fn(),
+      },
+    });
+
+    await waitFor(() => expect(getOptionItems().length).toBe(2));
+
+    await fireEvent.click(getOptionItems()[0]);
+    await waitFor(() => expect(getOptionItems().length).toBe(0));
+
+    const input = getInput();
+
+    // First focus consumes the one-shot guard.
+    await fireEvent.focus(input);
+    expect(getOptionItems().length).toBe(0);
+
+    // Second focus is a normal user re-focus and should reopen.
+    await fireEvent.focus(input);
+    await waitFor(() => expect(getOptionItems().length).toBeGreaterThan(0));
+  });
+
+  it("reopens the dropdown when the user types after a selection", async () => {
+    render(RepoAutoComplete, {
+      props: {
+        value: "",
+        options,
+        hasConfiguredRoots: true,
+        onselect: vi.fn(),
+      },
+    });
+
+    await waitFor(() => expect(getOptionItems().length).toBe(2));
+
+    await fireEvent.click(getOptionItems()[0]);
+    await waitFor(() => expect(getOptionItems().length).toBe(0));
+
+    await fireEvent.input(getInput(), { target: { value: "alp" } });
+    await waitFor(() => expect(getOptionItems().length).toBeGreaterThan(0));
+  });
+});


### PR DESCRIPTION
## Summary
- After picking a repository in the New Session dialog, the autocomplete dropdown immediately re-popped because `NewSessionDialog.selectQuickPick` calls `focusDirectoryInput()` post-selection — that programmatic `.focus()` triggered `RepoAutoComplete`'s `onfocus` handler, which unconditionally set `pickerOpen = true`.
- Added a one-shot `suppressNextFocusOpen` flag in `RepoAutoComplete.svelte` that's set by `handleSelect` and `handleEnter`'s no-match branch, and cleared by the next `onfocus` or `oninput`. Tabbing away and back still reopens the dropdown normally.
- Fix lives in the reusable component, so `NewProjectDialog` (the other consumer) gets the same protection without changes.

## Test plan
- [ ] `npm run check` passes (verified locally: 0 errors / 0 warnings)
- [ ] `npm run test` passes (verified locally: 945 passed, 2 skipped)
- [ ] Manual: open New Session, click a repo → dropdown closes and stays closed
- [ ] Manual: type a key in the repo field → dropdown reopens with filter
- [ ] Manual: tab away from the field and tab back → dropdown reopens
- [ ] Manual: type an exact-match path and press Enter → dropdown closes and stays closed
- [ ] Manual: type a non-matching path and press Enter → dropdown closes; `onenter` fires (no-match commit path)
- [ ] Manual: Settings → Projects → New Project — repo picker still works there

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the autocomplete dropdown from immediately reopening after selecting an item or pressing Enter.
* **Tests**
  * Added end-to-end tests verifying selection, programmatic refocus suppression, user-initiated refocus, and typing behavior to ensure consistent dropdown interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->