### PR TITLE
[codex] Improve agent notification parity

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -57,6 +57,7 @@
   import NewProjectDialog from "$lib/components/NewProjectDialog.svelte";
   import { routeStatusUpdate, applyStatusRouting } from "$lib/panes/statusRouting";
   import { initAgentNotifications } from "$lib/panes/agentNotifications";
+  import { initNotificationAutoRead } from "$lib/notifications/autoRead";
   import {
     installSessionPrEffect,
     refreshActiveSessionPr,
@@ -765,6 +766,7 @@
     await onNotificationEvent((payload) => {
       applyNotificationEvent(payload);
     });
+    initNotificationAutoRead();
 
     // Listen for global status updates from hooks. Tier-1 routing (with a
     // `rouxPaneId` in the payload) updates the pane's runtime agentState so

--- a/src/lib/notifications/__tests__/autoRead.test.ts
+++ b/src/lib/notifications/__tests__/autoRead.test.ts
@@ -104,14 +104,17 @@ describe("notification auto-read", () => {
   it("uses the active session even when focus still points at a previous pane", async () => {
     const activeSession = makeNotification({ id: "active-session", sessionId: "s2" });
     const previousSession = makeNotification({ id: "previous-session", sessionId: "s1" });
+    const previousPane = makeNotification({
+      id: "previous-pane",
+      actions: [focusPaneAction("pane-a")],
+    });
 
     sessionLayouts.set(new Map([["s1", { kind: "leaf", paneId: "pane-a" }]]));
     focusedPaneId.set("pane-a");
-    notifications.set([activeSession, previousSession]);
+    notifications.set([activeSession, previousSession, previousPane]);
+    sessionState.set({ sessions: [], activeSessionId: "s2" });
 
     initNotificationAutoRead();
-    vi.mocked(notificationsMarkRead).mockClear();
-    sessionState.set({ sessions: [], activeSessionId: "s2" });
     await waitTick();
 
     expect(vi.mocked(notificationsMarkRead).mock.calls.map(([id]) => id)).toEqual([

--- a/src/lib/notifications/__tests__/autoRead.test.ts
+++ b/src/lib/notifications/__tests__/autoRead.test.ts
@@ -121,4 +121,19 @@ describe("notification auto-read", () => {
       "active-session",
     ]);
   });
+
+  it("does not mark pane-targeted notifications read before pane layouts hydrate", async () => {
+    const paneTargeted = makeNotification({
+      id: "pane-targeted",
+      actions: [focusPaneAction("pane-a")],
+    });
+
+    focusedPaneId.set("pane-a");
+    notifications.set([paneTargeted]);
+
+    initNotificationAutoRead();
+    await waitTick();
+
+    expect(notificationsMarkRead).not.toHaveBeenCalled();
+  });
 });

--- a/src/lib/notifications/__tests__/autoRead.test.ts
+++ b/src/lib/notifications/__tests__/autoRead.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("$lib/tauri", () => ({
+  listNotifications: vi.fn().mockResolvedValue([]),
+  notificationsMarkRead: vi.fn().mockResolvedValue(true),
+  notificationsMarkAllRead: vi.fn().mockResolvedValue(0),
+  notificationsRemove: vi.fn().mockResolvedValue(true),
+  notificationsClear: vi.fn().mockResolvedValue(0),
+  notificationsDismissSource: vi.fn().mockResolvedValue(0),
+}));
+
+import { notifications } from "$lib/stores/notifications";
+import { focusedPaneId, resetFocus } from "$lib/panes/focus";
+import { resetLayouts, sessionLayouts } from "$lib/panes/layout";
+import { sessionState } from "$lib/stores/sessions";
+import type { Notification } from "$lib/types";
+import { notificationsMarkRead } from "$lib/tauri";
+import {
+  initNotificationAutoRead,
+  stopNotificationAutoRead,
+} from "../autoRead";
+
+function waitTick(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function makeNotification(overrides: Partial<Notification> = {}): Notification {
+  return {
+    id: crypto.randomUUID(),
+    createdAt: Date.now(),
+    level: "info",
+    source: { type: "hook", provider: "claude" },
+    title: "test",
+    subtitle: null,
+    body: null,
+    sessionId: null,
+    read: false,
+    actions: [],
+    dedupKey: null,
+    ...overrides,
+  };
+}
+
+function focusPaneAction(paneId: string): Notification["actions"][number] {
+  return {
+    id: "focus",
+    label: "Focus pane",
+    kind: { type: "focusPane", paneId },
+    primary: true,
+  };
+}
+
+describe("notification auto-read", () => {
+  beforeEach(() => {
+    stopNotificationAutoRead();
+    notifications.set([]);
+    resetFocus();
+    resetLayouts();
+    sessionState.set({ sessions: [], activeSessionId: null });
+    vi.mocked(notificationsMarkRead).mockClear();
+  });
+
+  afterEach(() => {
+    stopNotificationAutoRead();
+  });
+
+  it("marks session-scoped and pane-targeted notifications read when focusing a pane", async () => {
+    const sessionScoped = makeNotification({ id: "session-scoped", sessionId: "s1" });
+    const paneTargeted = makeNotification({
+      id: "pane-targeted",
+      actions: [focusPaneAction("pane-a")],
+    });
+    const otherSession = makeNotification({ id: "other-session", sessionId: "s2" });
+    const global = makeNotification({ id: "global", sessionId: null });
+
+    sessionLayouts.set(new Map([["s1", { kind: "leaf", paneId: "pane-a" }]]));
+    notifications.set([sessionScoped, paneTargeted, otherSession, global]);
+
+    initNotificationAutoRead();
+    focusedPaneId.set("pane-a");
+    await waitTick();
+
+    expect(vi.mocked(notificationsMarkRead).mock.calls.map(([id]) => id).sort()).toEqual([
+      "pane-targeted",
+      "session-scoped",
+    ]);
+  });
+
+  it("marks session-scoped notifications read when selecting a session", async () => {
+    const activeSession = makeNotification({ id: "active-session", sessionId: "s1" });
+    const otherSession = makeNotification({ id: "other-session", sessionId: "s2" });
+    const global = makeNotification({ id: "global", sessionId: null });
+    notifications.set([activeSession, otherSession, global]);
+
+    initNotificationAutoRead();
+    sessionState.set({ sessions: [], activeSessionId: "s1" });
+    await waitTick();
+
+    expect(vi.mocked(notificationsMarkRead).mock.calls.map(([id]) => id)).toEqual([
+      "active-session",
+    ]);
+  });
+
+  it("uses the active session even when focus still points at a previous pane", async () => {
+    const activeSession = makeNotification({ id: "active-session", sessionId: "s2" });
+    const previousSession = makeNotification({ id: "previous-session", sessionId: "s1" });
+
+    sessionLayouts.set(new Map([["s1", { kind: "leaf", paneId: "pane-a" }]]));
+    focusedPaneId.set("pane-a");
+    notifications.set([activeSession, previousSession]);
+
+    initNotificationAutoRead();
+    vi.mocked(notificationsMarkRead).mockClear();
+    sessionState.set({ sessions: [], activeSessionId: "s2" });
+    await waitTick();
+
+    expect(vi.mocked(notificationsMarkRead).mock.calls.map(([id]) => id)).toEqual([
+      "active-session",
+    ]);
+  });
+});

--- a/src/lib/notifications/autoRead.ts
+++ b/src/lib/notifications/autoRead.ts
@@ -79,8 +79,9 @@ function matchesNavigationTarget(
   ) {
     return true;
   }
-  if (!focusedPaneMatchesActiveSession) return false;
-  if (!paneId) return false;
+  if (!focusedPaneMatchesActiveSession || !focusedPaneSession || !paneId) {
+    return false;
+  }
   return notification.actions.some((action) => {
     const kind = action.kind;
     return kind.type === "focusPane" && kind.paneId === paneId;

--- a/src/lib/notifications/autoRead.ts
+++ b/src/lib/notifications/autoRead.ts
@@ -1,0 +1,86 @@
+import { get } from "svelte/store";
+import { activeSessionId } from "$lib/stores/sessions";
+import { focusedPaneId } from "$lib/panes/focus";
+import { collectLeafIds, sessionLayouts } from "$lib/panes/layout";
+import {
+  markNotificationRead,
+  notifications,
+} from "$lib/stores/notifications";
+import type { Notification } from "$lib/types";
+import { logError } from "$lib/logging";
+
+let unsubscribeActiveSession: (() => void) | null = null;
+let unsubscribeFocusedPane: (() => void) | null = null;
+let unsubscribeNotifications: (() => void) | null = null;
+let unsubscribeLayouts: (() => void) | null = null;
+const pendingReadIds = new Set<string>();
+
+export function initNotificationAutoRead(): void {
+  if (unsubscribeActiveSession) return;
+
+  const refresh = () => {
+    markRelevantNotificationsRead();
+  };
+
+  unsubscribeActiveSession = activeSessionId.subscribe(refresh);
+  unsubscribeFocusedPane = focusedPaneId.subscribe(refresh);
+  unsubscribeNotifications = notifications.subscribe(refresh);
+  unsubscribeLayouts = sessionLayouts.subscribe(refresh);
+}
+
+export function stopNotificationAutoRead(): void {
+  unsubscribeActiveSession?.();
+  unsubscribeFocusedPane?.();
+  unsubscribeNotifications?.();
+  unsubscribeLayouts?.();
+  unsubscribeActiveSession = null;
+  unsubscribeFocusedPane = null;
+  unsubscribeNotifications = null;
+  unsubscribeLayouts = null;
+  pendingReadIds.clear();
+}
+
+function markRelevantNotificationsRead(): void {
+  const focusedPane = get(focusedPaneId);
+  const activeSession = get(activeSessionId);
+  const focusedPaneSession = focusedPane ? findSessionForPane(focusedPane) : null;
+  const snapshot = get(notifications);
+  const unreadIds = new Set(snapshot.filter((n) => !n.read).map((n) => n.id));
+  for (const id of pendingReadIds) {
+    if (!unreadIds.has(id)) pendingReadIds.delete(id);
+  }
+
+  for (const notification of snapshot) {
+    if (notification.read || pendingReadIds.has(notification.id)) continue;
+    if (!matchesNavigationTarget(notification, activeSession, focusedPaneSession, focusedPane)) {
+      continue;
+    }
+    pendingReadIds.add(notification.id);
+    void markNotificationRead(notification.id).catch((e) => {
+      pendingReadIds.delete(notification.id);
+      logError("notification auto-read failed", e);
+    });
+  }
+}
+
+function matchesNavigationTarget(
+  notification: Notification,
+  activeSession: string | null,
+  focusedPaneSession: string | null,
+  paneId: string | null,
+): boolean {
+  if (activeSession && notification.sessionId === activeSession) return true;
+  if (focusedPaneSession && notification.sessionId === focusedPaneSession) return true;
+  if (!paneId) return false;
+  return notification.actions.some((action) => {
+    const kind = action.kind;
+    return kind.type === "focusPane" && kind.paneId === paneId;
+  });
+}
+
+function findSessionForPane(paneId: string): string | null {
+  for (const [sessionId, layout] of get(sessionLayouts)) {
+    if (collectLeafIds(layout).includes(paneId)) return sessionId;
+  }
+  return null;
+}

--- a/src/lib/notifications/autoRead.ts
+++ b/src/lib/notifications/autoRead.ts
@@ -70,7 +70,16 @@ function matchesNavigationTarget(
   paneId: string | null,
 ): boolean {
   if (activeSession && notification.sessionId === activeSession) return true;
-  if (focusedPaneSession && notification.sessionId === focusedPaneSession) return true;
+  const focusedPaneMatchesActiveSession =
+    !activeSession || focusedPaneSession === activeSession;
+  if (
+    focusedPaneMatchesActiveSession &&
+    focusedPaneSession &&
+    notification.sessionId === focusedPaneSession
+  ) {
+    return true;
+  }
+  if (!focusedPaneMatchesActiveSession) return false;
   if (!paneId) return false;
   return notification.actions.some((action) => {
     const kind = action.kind;

--- a/src/lib/panes/__tests__/agentNotifications.test.ts
+++ b/src/lib/panes/__tests__/agentNotifications.test.ts
@@ -88,6 +88,52 @@ describe("agentNotifications", () => {
     expect(request.actions[0].kind).toEqual({ type: "focusPane", paneId: "pane-1" });
   });
 
+  it("does not fire completion for blocked → idle", async () => {
+    updateAgentState("pane-1", {
+      provider: "claude",
+      status: "blocked",
+      permissionInfo: { toolName: "Edit" },
+      source: "hook",
+    });
+    updateAgentState("pane-1", {
+      provider: "claude",
+      status: "idle",
+      source: "hook",
+    });
+    await waitTick();
+
+    expect(notificationsPush).not.toHaveBeenCalled();
+  });
+
+  it("fires a deduped error notification when an agent enters error", async () => {
+    createPane({ id: "pane-1", type: "shell", ptyId: "pty-1", name: "Work pane" });
+
+    updateAgentState("pane-1", {
+      provider: "claude",
+      status: "generating",
+      source: "hook",
+    });
+    updateAgentState("pane-1", {
+      provider: "claude",
+      status: "error",
+      source: "hook",
+    });
+    updateAgentState("pane-1", {
+      provider: "claude",
+      status: "error",
+      source: "hook",
+    });
+    await waitTick();
+
+    expect(notificationsPush).toHaveBeenCalledTimes(1);
+    const request = vi.mocked(notificationsPush).mock.calls[0][0];
+    expect(request.level).toBe("error");
+    expect(request.source).toEqual({ type: "hook", provider: "claude" });
+    expect(request.title).toContain("Work pane");
+    expect(request.actions[0].kind).toEqual({ type: "focusPane", paneId: "pane-1" });
+    expect(request.dedupKey).toBe("error:pane:pane-1");
+  });
+
   it("includes Claude Stop transcript summaries when present", async () => {
     updateAgentState("pane-1", {
       provider: "claude",

--- a/src/lib/panes/__tests__/agentState.test.ts
+++ b/src/lib/panes/__tests__/agentState.test.ts
@@ -216,6 +216,21 @@ describe("agentState store", () => {
       expect(getSessionAgentStatus("sess-1")).toBe("generating");
     });
 
+    it("prefers blocked over generating", () => {
+      setSplitLayout("sess-1", ["pane-a", "pane-b"]);
+      updateAgentState("pane-a", { provider: "claude", status: "generating", source: "hook" });
+      updateAgentState("pane-b", { provider: "claude", status: "blocked", source: "hook" });
+      expect(getSessionAgentStatus("sess-1")).toBe("blocked");
+    });
+
+    it("prefers error over blocked and generating", () => {
+      setSplitLayout("sess-1", ["pane-a", "pane-b", "pane-c"]);
+      updateAgentState("pane-a", { provider: "claude", status: "generating", source: "hook" });
+      updateAgentState("pane-b", { provider: "claude", status: "blocked", source: "hook" });
+      updateAgentState("pane-c", { provider: "claude", status: "error", source: "hook" });
+      expect(getSessionAgentStatus("sess-1")).toBe("error");
+    });
+
     it("is idle when at least one pane is idle and none are generating", () => {
       setSplitLayout("sess-1", ["pane-a", "pane-b"]);
       updateAgentState("pane-a", { provider: "claude", status: "idle", source: "hook" });
@@ -267,6 +282,8 @@ describe("agentState store", () => {
         "generating",
       );
       expect(computeEffectiveSessionStatus("generating", "idle")).toBe("idle");
+      expect(computeEffectiveSessionStatus("idle", "blocked")).toBe("attention");
+      expect(computeEffectiveSessionStatus("idle", "error")).toBe("error");
     });
 
     it("legacy field passes through when no agent aggregate is present", () => {

--- a/src/lib/panes/__tests__/statusRouting.test.ts
+++ b/src/lib/panes/__tests__/statusRouting.test.ts
@@ -55,7 +55,7 @@ describe("routeStatusUpdate", () => {
     expect(routing.event.source).toBe("hook");
   });
 
-  it("maps thinking / attention to generating", () => {
+  it("maps thinking to generating and attention to blocked", () => {
     expect(
       (routeStatusUpdate(ev({ status: "thinking" }), trustAll) as {
         event: { status: string };
@@ -65,12 +65,15 @@ describe("routeStatusUpdate", () => {
       (routeStatusUpdate(ev({ status: "attention" }), trustAll) as {
         event: { status: string };
       }).event.status,
-    ).toBe("generating");
+    ).toBe("blocked");
   });
 
-  it("drops non-routable pane statuses (error/disconnected)", () => {
+  it("routes error to the pane tier and drops disconnected", () => {
     const err = routeStatusUpdate(ev({ status: "error" }), trustAll);
-    expect(err.kind).toBe("dropped");
+    expect(err.kind).toBe("pane");
+    if (err.kind !== "pane") throw new Error("unreachable");
+    expect(err.event.status).toBe("error");
+
     const disc = routeStatusUpdate(ev({ status: "disconnected" }), trustAll);
     expect(disc.kind).toBe("dropped");
   });
@@ -154,6 +157,7 @@ describe("routeStatusUpdate", () => {
     );
     expect(routing.kind).toBe("pane");
     if (routing.kind !== "pane") throw new Error("unreachable");
+    expect(routing.event.status).toBe("blocked");
     expect(routing.event.permissionInfo).toEqual({
       toolName: "Edit",
       toolInput: { file: "README.md" },
@@ -254,7 +258,7 @@ describe("applyStatusRouting", () => {
 
   it("leaves agentStates untouched for dropped events", () => {
     applyStatusRouting(
-      routeStatusUpdate(ev({ status: "error" }), trustAll),
+      routeStatusUpdate(ev({ status: "disconnected" }), trustAll),
     );
     expect(get(agentStates).size).toBe(0);
   });

--- a/src/lib/panes/agentNotifications.ts
+++ b/src/lib/panes/agentNotifications.ts
@@ -61,6 +61,10 @@ export function initAgentNotifications(): void {
       if (prev === "generating" && state.status === "idle") {
         void fireCompletionNotification(paneId, state);
       }
+
+      if (prev !== "error" && state.status === "error") {
+        void fireErrorNotification(paneId, state);
+      }
     }
 
     // Drop entries for panes that no longer have an agentState — keeps
@@ -119,6 +123,44 @@ async function fireCompletionNotification(
   }
 }
 
+async function fireErrorNotification(
+  paneId: string,
+  state: AgentState,
+): Promise<void> {
+  const instance = get(paneInstances).get(paneId);
+  const profile = resolveProfileRef(instance?.spawnProfileRef);
+  const title = deriveErrorTitle(instance?.name, profile?.name, state.provider);
+
+  try {
+    await notificationsPush({
+      level: "error",
+      source: { type: "hook", provider: state.provider },
+      title,
+      subtitle: null,
+      body: `${capitalize(state.provider)} reported an error.`,
+      sessionId: null,
+      actions: [
+        {
+          id: "focus",
+          label: "Focus pane",
+          kind: { type: "focusPane", paneId },
+          primary: true,
+        },
+        {
+          id: "dismiss",
+          label: "Dismiss",
+          kind: { type: "dismiss" },
+          primary: false,
+        },
+      ],
+      dedupKey: `error:pane:${paneId}`,
+    });
+    log(`agentNotifications: fired error notification for pane ${paneId}`);
+  } catch (e) {
+    logError("agentNotifications: error notificationsPush failed", e);
+  }
+}
+
 function deriveTitle(
   paneName: string | undefined,
   profileName: string | undefined,
@@ -127,6 +169,16 @@ function deriveTitle(
   if (paneName) return `${paneName} is idle`;
   if (profileName) return `${profileName} is idle`;
   return `${capitalize(provider)} is idle`;
+}
+
+function deriveErrorTitle(
+  paneName: string | undefined,
+  profileName: string | undefined,
+  provider: string,
+): string {
+  if (paneName) return `${paneName} has an error`;
+  if (profileName) return `${profileName} has an error`;
+  return `${capitalize(provider)} has an error`;
 }
 
 function deriveBody(state: AgentState): string {

--- a/src/lib/panes/agentState.ts
+++ b/src/lib/panes/agentState.ts
@@ -12,7 +12,7 @@ import { sessionLayouts, collectLeafIds, type LayoutNode } from "./layout";
  * 133 prompt-marker detection to auto-clear stale state on the next shell
  * prompt.
  */
-export type AgentStatus = "idle" | "generating";
+export type AgentStatus = "idle" | "generating" | "blocked" | "error";
 
 /**
  * Structural info from an attention-level hook payload. Used by the
@@ -129,11 +129,13 @@ export function disposeAgentState(paneId: string): void {
 /**
  * Aggregate status for a session's sidebar card, derived from its shell
  * panes' agent states:
- * - `generating` when any pane is generating
- * - `idle` when at least one pane has an entry and none are generating
+ * - `error` when any pane errored
+ * - `blocked` when any pane is waiting for user input
+ * - `generating` when any pane is generating and none are blocked/errored
+ * - `idle` when at least one pane has an entry and none are active
  * - `null` when no pane in the session has an agent-state entry
  */
-export type AggregateStatus = "idle" | "generating";
+export type AggregateStatus = "idle" | "generating" | "blocked" | "error";
 
 function aggregateFor(
   layout: LayoutNode | undefined,
@@ -141,12 +143,18 @@ function aggregateFor(
 ): AggregateStatus | null {
   if (!layout) return null;
   let sawIdle = false;
+  let sawGenerating = false;
+  let sawBlocked = false;
   for (const paneId of collectLeafIds(layout)) {
     const s = states.get(paneId);
     if (!s) continue;
-    if (s.status === "generating") return "generating";
+    if (s.status === "error") return "error";
+    if (s.status === "blocked") sawBlocked = true;
+    if (s.status === "generating") sawGenerating = true;
     if (s.status === "idle") sawIdle = true;
   }
+  if (sawBlocked) return "blocked";
+  if (sawGenerating) return "generating";
   return sawIdle ? "idle" : null;
 }
 
@@ -187,9 +195,9 @@ export function getSessionAgentStatus(
  *    record and win unconditionally — if the primary PTY is gone
  *    there is nothing generating, and an agent-state entry that
  *    predates the disconnect must not silently repaint the card.
- * 2. A live agent aggregate (`"generating"` / `"idle"`) overrides the
- *    legacy field, so a pane actively generating always pulses even
- *    when `Session.status` is stuck at a stale "idle" from an earlier
+ * 2. A live agent aggregate (`"error"` / `"blocked"` / `"generating"` /
+ *    `"idle"`) overrides the legacy field, so a pane actively generating
+ *    always pulses even when `Session.status` is stuck at a stale "idle" from an earlier
  *    event we never bothered to clear.
  * 3. Otherwise the legacy field passes through.
  *
@@ -205,6 +213,8 @@ export function computeEffectiveSessionStatus(
 ): SessionStatus {
   if (rawSessionStatus === "disconnected") return "disconnected";
   if (rawSessionStatus === "error") return "error";
+  if (agentAggregate === "error") return "error";
+  if (agentAggregate === "blocked") return "attention";
   if (agentAggregate === "generating") return "generating";
   if (agentAggregate === "idle") return "idle";
   return rawSessionStatus;

--- a/src/lib/panes/statusRouting.ts
+++ b/src/lib/panes/statusRouting.ts
@@ -98,9 +98,8 @@ export function routeStatusUpdate(
 
   const routed = mapStatus(update.status);
   if (!routed) {
-    // Non-routable statuses ("error", "disconnected") still fan out to
-    // notifications via the legacy path; they don't move the pane's
-    // agentState dot.
+    // Disconnected is backend/session liveness, not pane agent activity,
+    // so it does not move the pane's agentState dot.
     return { kind: "dropped", reason: `non-routable status "${update.status}"` };
   }
 
@@ -162,14 +161,18 @@ function inferProvider(update: StatusUpdate): Provider | null {
   return null;
 }
 
-function mapStatus(raw: string): "idle" | "generating" | null {
+function mapStatus(raw: string): AgentStateEvent["status"] | null {
   switch (raw) {
     case "generating":
     case "thinking":
-    case "attention":
+    case "working":
       return "generating";
+    case "attention":
+      return "blocked";
     case "idle":
       return "idle";
+    case "error":
+      return "error";
     default:
       return null;
   }


### PR DESCRIPTION
## Summary

Adds phase-1 Warp-style agent notification parity for Roux:

- normalizes agent runtime states with `blocked` and `error`
- routes Claude/Codex-style status updates into working, blocked, completed, and errored indicators
- emits deduped agent error notifications with pane focus actions
- keeps completion notifications limited to `generating -> idle`
- auto-marks relevant notifications read when navigating to the session or pane

## Why

Warp's agent notification model centers on Complete, Request, and Error events, plus tab/session indicators and auto-read on navigation. Roux already had the notification store and completion path, but attention/error states were not first-class in pane/session status, and read state required explicit action.

Claude/Codex setup/config is intentionally left for a follow-up PR because it writes user-level config and needs preview/confirm behavior.

## Validation

- `npm run test -- src/lib/panes/__tests__/statusRouting.test.ts src/lib/panes/__tests__/agentState.test.ts src/lib/panes/__tests__/agentNotifications.test.ts src/lib/notifications/__tests__/autoRead.test.ts src/lib/stores/__tests__/notifications.test.ts`
- `npm run check`

Note: Vitest prints the existing jsdom canvas `getContext()` warning, but the targeted tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic marking of notifications as read based on navigation/context (auto-read initializes on app startup)
  * New error-state handling with descriptive, deduplicated error notifications for agent failures
  * Richer agent status handling (added "blocked" and "error" states, updated routing)

* **Tests**
  * Expanded coverage for auto-read behavior, error notification deduplication, status routing, and session/agent state prioritization
<!-- end of auto-generated comment: release notes by coderabbit.ai -->