### PR TITLE
feat(notifications): rework agent completion notifications

### DIFF
--- a/crates/roux-core/src/models/settings.rs
+++ b/crates/roux-core/src/models/settings.rs
@@ -303,6 +303,11 @@ pub struct RouxSettings {
     /// `tauri-plugin-notification` is never invoked. Defaults to true.
     #[serde(default = "default_true")]
     pub notifications_enabled: bool,
+    /// Per-pane agent completion notifications. When false, the
+    /// generating→idle transition never produces a notification card or OS
+    /// fan-out. Error notifications are unaffected. Defaults to true.
+    #[serde(default = "default_true")]
+    pub agent_completion_notifications_enabled: bool,
     /// When a background agent leaves the "attention" (waiting-for-answer)
     /// state, also clear the pane's `permissionInfo` so the Claude
     /// Allow/Deny affordance disappears alongside the notification.
@@ -459,6 +464,7 @@ impl Default for RouxSettings {
             group_by: GroupBy::Repo,
             confirm_on_quit: true,
             notifications_enabled: true,
+            agent_completion_notifications_enabled: true,
             auto_clear_attention_state: true,
             update_check_on_launch: true,
             notes_include_web_anchors: true,
@@ -769,6 +775,32 @@ mod tests {
 
         let normalized = settings.normalized();
         assert_eq!(normalized.repo_roots, vec!["/tmp/src", "/tmp/other"]);
+    }
+
+    #[test]
+    fn settings_without_agent_completion_field_defaults_to_true() {
+        let legacy = r#"{
+            "tabPosition": "left",
+            "tabWidth": 260,
+            "fontSize": 14,
+            "fontFamily": "monospace",
+            "lineHeight": 1.2,
+            "scrollback": 5000,
+            "cursorStyle": "block",
+            "cursorBlink": true,
+            "defaultProjectPath": null,
+            "confirmOnClose": true,
+            "restoreSessionsOnLaunch": true,
+            "worktreeBasePath": null,
+            "cleanupWorktreesOnClose": false,
+            "theme": "deep-blue",
+            "defaultModel": null,
+            "additionalFlags": [],
+            "taskPanelSplit": 0.5,
+            "taskPanelCollapsed": true
+        }"#;
+        let parsed: RouxSettings = serde_json::from_str(legacy).unwrap();
+        assert!(parsed.agent_completion_notifications_enabled);
     }
 
     #[test]

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -1075,6 +1075,12 @@ export type RouxSettings = {
 	 */
 	notificationsEnabled?: boolean,
 	/**
+	 *  Per-pane agent completion notifications. When false, the
+	 *  generating→idle transition never produces a notification card or OS
+	 *  fan-out. Error notifications are unaffected. Defaults to true.
+	 */
+	agentCompletionNotificationsEnabled?: boolean,
+	/**
 	 *  When a background agent leaves the "attention" (waiting-for-answer)
 	 *  state, also clear the pane's `permissionInfo` so the Claude
 	 *  Allow/Deny affordance disappears alongside the notification.

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -1343,6 +1343,22 @@
               </button>
             </div>
 
+            <div class="flex items-center justify-between py-2">
+              <div>
+                <div class="text-[13px]">Agent completion notifications</div>
+                <div class="text-[11px] text-text-muted mt-0.5">Notify when an off-screen agent finishes generating. Errors notify regardless.</div>
+              </div>
+              <button
+                aria-label="Toggle agent completion notifications"
+                class="w-9 h-5 rounded-full relative cursor-pointer transition-all border
+                  {($settings.agentCompletionNotificationsEnabled ?? true) ? 'bg-accent-dim border-accent' : 'bg-bg-deep border-border'}"
+                onclick={() => updateSetting("agentCompletionNotificationsEnabled", !($settings.agentCompletionNotificationsEnabled ?? true))}
+              >
+                <div class="w-3.5 h-3.5 rounded-full absolute top-0.5 transition-all
+                  {($settings.agentCompletionNotificationsEnabled ?? true) ? 'left-[18px] bg-accent' : 'left-0.5 bg-text-secondary'}"></div>
+              </button>
+            </div>
+
             <div class="mt-3 rounded-xl border border-border-subtle bg-bg-surface/35 p-3">
               <div class="flex items-center justify-between gap-2">
                 <div>

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -1346,7 +1346,7 @@
             <div class="flex items-center justify-between py-2">
               <div>
                 <div class="text-[13px]">Agent completion notifications</div>
-                <div class="text-[11px] text-text-muted mt-0.5">Notify when an off-screen agent finishes generating. Errors notify regardless.</div>
+                <div class="text-[11px] text-text-muted mt-0.5">Notify when an agent finishes in a pane other than the one you're focused on. Errors notify regardless.</div>
               </div>
               <button
                 aria-label="Toggle agent completion notifications"

--- a/src/lib/notifications/__tests__/autoRead.test.ts
+++ b/src/lib/notifications/__tests__/autoRead.test.ts
@@ -14,7 +14,7 @@ import { focusedPaneId, resetFocus } from "$lib/panes/focus";
 import { resetLayouts, sessionLayouts } from "$lib/panes/layout";
 import { sessionState } from "$lib/stores/sessions";
 import type { Notification } from "$lib/types";
-import { notificationsMarkRead } from "$lib/tauri";
+import { notificationsMarkRead, notificationsRemove } from "$lib/tauri";
 import {
   initNotificationAutoRead,
   stopNotificationAutoRead,
@@ -67,6 +67,8 @@ describe("notification auto-read", () => {
     sessionState.set({ sessions: [], activeSessionId: null });
     vi.mocked(notificationsMarkRead).mockReset();
     vi.mocked(notificationsMarkRead).mockResolvedValue(true);
+    vi.mocked(notificationsRemove).mockReset();
+    vi.mocked(notificationsRemove).mockResolvedValue(true);
   });
 
   afterEach(() => {
@@ -144,6 +146,90 @@ describe("notification auto-read", () => {
     await waitTick();
 
     expect(notificationsMarkRead).not.toHaveBeenCalled();
+  });
+
+  it("auto-removes completion-session notifications when the matching session becomes active", async () => {
+    const completion = makeNotification({
+      id: "completion-1",
+      sessionId: "s1",
+      dedupKey: "completion:session:s1",
+      level: "success",
+    });
+    notifications.set([completion]);
+
+    initNotificationAutoRead();
+    sessionState.set({ sessions: [], activeSessionId: "s1" });
+    await waitTick();
+
+    expect(notificationsRemove).toHaveBeenCalledWith("completion-1");
+    expect(notificationsMarkRead).not.toHaveBeenCalled();
+  });
+
+  it("does not auto-remove completion-session notifications for other sessions", async () => {
+    const completion = makeNotification({
+      id: "completion-2",
+      sessionId: "s2",
+      dedupKey: "completion:session:s2",
+      level: "success",
+    });
+    notifications.set([completion]);
+
+    initNotificationAutoRead();
+    sessionState.set({ sessions: [], activeSessionId: "s1" });
+    await waitTick();
+
+    expect(notificationsRemove).not.toHaveBeenCalled();
+  });
+
+  it("does not auto-remove completion:pane fallback notifications", async () => {
+    const fallback = makeNotification({
+      id: "fallback-pane",
+      sessionId: "s1",
+      dedupKey: "completion:pane:pane-1",
+      level: "success",
+    });
+    notifications.set([fallback]);
+
+    initNotificationAutoRead();
+    sessionState.set({ sessions: [], activeSessionId: "s1" });
+    await waitTick();
+
+    expect(notificationsRemove).not.toHaveBeenCalled();
+    // It still gets marked read via the normal path.
+    expect(notificationsMarkRead).toHaveBeenCalledWith("fallback-pane");
+  });
+
+  it("limits concurrent auto-remove requests and drains remaining matches", async () => {
+    const blockers: Array<ReturnType<typeof deferred<boolean>>> = [];
+    vi.mocked(notificationsRemove).mockImplementation(() => {
+      const blocker = deferred<boolean>();
+      blockers.push(blocker);
+      return blocker.promise;
+    });
+    notifications.set(
+      Array.from({ length: 10 }, (_, index) =>
+        makeNotification({
+          id: `completion-${index}`,
+          sessionId: "s1",
+          dedupKey: "completion:session:s1",
+          level: "success",
+        }),
+      ),
+    );
+
+    initNotificationAutoRead();
+    sessionState.set({ sessions: [], activeSessionId: "s1" });
+    await waitTick();
+
+    expect(notificationsRemove).toHaveBeenCalledTimes(8);
+
+    for (const blocker of blockers.slice(0, 8)) {
+      blocker.resolve(true);
+    }
+    await waitTick();
+    await waitTick();
+
+    expect(notificationsRemove).toHaveBeenCalledTimes(10);
   });
 
   it("limits concurrent auto-read requests and drains remaining matches", async () => {

--- a/src/lib/notifications/autoRead.ts
+++ b/src/lib/notifications/autoRead.ts
@@ -1,10 +1,11 @@
 import { get } from "svelte/store";
 import { activeSessionId } from "$lib/stores/sessions";
 import { focusedPaneId } from "$lib/panes/focus";
-import { collectLeafIds, sessionLayouts } from "$lib/panes/layout";
+import { findSessionForPane, sessionLayouts } from "$lib/panes/layout";
 import {
   markNotificationRead,
   notifications,
+  removeNotification,
 } from "$lib/stores/notifications";
 import type { Notification } from "$lib/types";
 import { logError } from "$lib/logging";
@@ -16,6 +17,10 @@ let unsubscribeLayouts: (() => void) | null = null;
 const pendingReadIds = new Set<string>();
 const MAX_AUTO_READ_CONCURRENCY = 8;
 let inFlightAutoReads = 0;
+const pendingRemoveIds = new Set<string>();
+const MAX_AUTO_REMOVE_CONCURRENCY = 8;
+let inFlightAutoRemoves = 0;
+const COMPLETION_SESSION_DEDUP_PREFIX = "completion:session:";
 
 export function initNotificationAutoRead(): void {
   if (unsubscribeActiveSession) return;
@@ -41,6 +46,8 @@ export function stopNotificationAutoRead(): void {
   unsubscribeLayouts = null;
   pendingReadIds.clear();
   inFlightAutoReads = 0;
+  pendingRemoveIds.clear();
+  inFlightAutoRemoves = 0;
 }
 
 function markRelevantNotificationsRead(): void {
@@ -49,15 +56,44 @@ function markRelevantNotificationsRead(): void {
   const focusedPaneSession = focusedPane ? findSessionForPane(focusedPane) : null;
   const snapshot = get(notifications);
   const unreadIds = new Set(snapshot.filter((n) => !n.read).map((n) => n.id));
+  const liveIds = new Set(snapshot.map((n) => n.id));
   for (const id of pendingReadIds) {
     if (!unreadIds.has(id)) pendingReadIds.delete(id);
   }
+  for (const id of pendingRemoveIds) {
+    if (!liveIds.has(id)) pendingRemoveIds.delete(id);
+  }
 
   for (const notification of snapshot) {
-    if (notification.read || pendingReadIds.has(notification.id)) continue;
+    if (pendingRemoveIds.has(notification.id)) continue;
     if (!matchesNavigationTarget(notification, activeSession, focusedPaneSession, focusedPane)) {
       continue;
     }
+
+    // Completion-session notifications get auto-*removed* on session visit
+    // rather than just marked read — they exist to alert the user that an
+    // off-screen agent finished, so once the user returns the card is noise.
+    if (notification.dedupKey?.startsWith(COMPLETION_SESSION_DEDUP_PREFIX)) {
+      if (inFlightAutoRemoves >= MAX_AUTO_REMOVE_CONCURRENCY) break;
+      pendingRemoveIds.add(notification.id);
+      inFlightAutoRemoves += 1;
+      let failed = false;
+      void removeNotification(notification.id)
+        .catch((e) => {
+          failed = true;
+          pendingRemoveIds.delete(notification.id);
+          logError("notification auto-remove failed", e);
+        })
+        .finally(() => {
+          inFlightAutoRemoves = Math.max(0, inFlightAutoRemoves - 1);
+          if (!failed && unsubscribeActiveSession) {
+            queueMicrotask(markRelevantNotificationsRead);
+          }
+        });
+      continue;
+    }
+
+    if (notification.read || pendingReadIds.has(notification.id)) continue;
     if (inFlightAutoReads >= MAX_AUTO_READ_CONCURRENCY) break;
     pendingReadIds.add(notification.id);
     inFlightAutoReads += 1;
@@ -102,9 +138,3 @@ function matchesNavigationTarget(
   });
 }
 
-function findSessionForPane(paneId: string): string | null {
-  for (const [sessionId, layout] of get(sessionLayouts)) {
-    if (collectLeafIds(layout).includes(paneId)) return sessionId;
-  }
-  return null;
-}

--- a/src/lib/notifications/dispatchAction.ts
+++ b/src/lib/notifications/dispatchAction.ts
@@ -3,7 +3,7 @@ import { openPathInFinder } from "$lib/tauri";
 import { setActiveSession, sessionState } from "$lib/stores/sessions";
 import { setLogicalFocus } from "$lib/panes/focus";
 import { paneInstances } from "$lib/panes/instances";
-import { sessionLayouts, collectLeafIds } from "$lib/panes/layout";
+import { findSessionForPane } from "$lib/panes/layout";
 import { get } from "svelte/store";
 import { log } from "$lib/logging";
 import {
@@ -25,16 +25,6 @@ function normalizeOpenPath(path: string): string {
   } catch {
     return path.slice("file://".length);
   }
-}
-
-/** Find which session owns a pane by walking layouts. Returns null if none. */
-function findSessionForPane(paneId: string): string | null {
-  for (const [sessionId, layout] of get(sessionLayouts)) {
-    for (const leafId of collectLeafIds(layout)) {
-      if (leafId === paneId) return sessionId;
-    }
-  }
-  return null;
 }
 
 /**

--- a/src/lib/panes/__tests__/agentNotifications.test.ts
+++ b/src/lib/panes/__tests__/agentNotifications.test.ts
@@ -19,6 +19,11 @@ import {
 import { updateAgentState, resetAgentStates } from "../agentState";
 import { resetInstances, createPane } from "../instances";
 import { resetProfileRegistry } from "../profiles";
+import { resetLayouts, sessionLayouts } from "../layout";
+import { focusedPaneId, resetFocus } from "../focus";
+import { sessionState } from "$lib/stores/sessions";
+import { settings } from "$lib/stores/settings";
+import { DEFAULT_SETTINGS } from "$lib/types";
 import { notificationsPush } from "$lib/tauri";
 
 function waitTick(): Promise<void> {
@@ -32,6 +37,10 @@ describe("agentNotifications", () => {
     resetInstances();
     resetAgentStates();
     resetProfileRegistry();
+    resetLayouts();
+    resetFocus();
+    sessionState.set({ sessions: [], activeSessionId: null });
+    settings.set({ ...DEFAULT_SETTINGS });
     vi.mocked(notificationsPush).mockClear();
     initAgentNotifications();
   });
@@ -158,7 +167,8 @@ describe("agentNotifications", () => {
     );
   });
 
-  it("fires once per pane — two panes finishing in the same session produces two notifications", async () => {
+  it("fires once per pane when no session layout owns either pane", async () => {
+    // Without sessionLayouts, both panes fall back to per-pane dedup keys.
     updateAgentState("pane-a", {
       provider: "claude",
       status: "generating",
@@ -185,8 +195,119 @@ describe("agentNotifications", () => {
     expect(notificationsPush).toHaveBeenCalledTimes(2);
     const titles = vi.mocked(notificationsPush).mock.calls.map(([req]) => req.title);
     // Default title is provider-based when no pane name/profile is set.
-    expect(titles).toContain("Claude is idle");
-    expect(titles).toContain("Codex is idle");
+    expect(titles).toContain("Claude finished");
+    expect(titles).toContain("Codex finished");
+    const dedupKeys = vi.mocked(notificationsPush).mock.calls.map(([req]) => req.dedupKey);
+    expect(dedupKeys).toContain("completion:pane:pane-a");
+    expect(dedupKeys).toContain("completion:pane:pane-b");
+  });
+
+  it("collapses two panes in the same session into one completion:session dedup key", async () => {
+    sessionLayouts.set(
+      new Map([
+        [
+          "s1",
+          {
+            kind: "split",
+            direction: "h",
+            children: [
+              { kind: "leaf", paneId: "pane-a" },
+              { kind: "leaf", paneId: "pane-b" },
+            ],
+          },
+        ],
+      ]),
+    );
+
+    updateAgentState("pane-a", { provider: "claude", status: "generating", source: "hook" });
+    updateAgentState("pane-b", { provider: "claude", status: "generating", source: "hook" });
+    updateAgentState("pane-a", { provider: "claude", status: "idle", source: "hook" });
+    updateAgentState("pane-b", { provider: "claude", status: "idle", source: "hook" });
+    await waitTick();
+
+    expect(notificationsPush).toHaveBeenCalledTimes(2);
+    const requests = vi.mocked(notificationsPush).mock.calls.map(([req]) => req);
+    expect(requests.every((req) => req.sessionId === "s1")).toBe(true);
+    expect(requests.every((req) => req.dedupKey === "completion:session:s1")).toBe(true);
+  });
+
+  it("does not fire when the setting is disabled", async () => {
+    settings.set({ ...DEFAULT_SETTINGS, agentCompletionNotificationsEnabled: false });
+
+    updateAgentState("pane-1", { provider: "claude", status: "generating", source: "hook" });
+    updateAgentState("pane-1", { provider: "claude", status: "idle", source: "hook" });
+    await waitTick();
+
+    expect(notificationsPush).not.toHaveBeenCalled();
+  });
+
+  it("still fires error notifications when completion notifications are disabled", async () => {
+    settings.set({ ...DEFAULT_SETTINGS, agentCompletionNotificationsEnabled: false });
+    createPane({ id: "pane-1", type: "shell", ptyId: "pty-1", name: "Work pane" });
+
+    updateAgentState("pane-1", { provider: "claude", status: "generating", source: "hook" });
+    updateAgentState("pane-1", { provider: "claude", status: "error", source: "hook" });
+    await waitTick();
+
+    expect(notificationsPush).toHaveBeenCalledTimes(1);
+    const request = vi.mocked(notificationsPush).mock.calls[0][0];
+    expect(request.level).toBe("error");
+  });
+
+  it("does not fire when the pane is currently visible (active session + focused)", async () => {
+    sessionLayouts.set(new Map([["s1", { kind: "leaf", paneId: "pane-1" }]]));
+    sessionState.set({ sessions: [], activeSessionId: "s1" });
+    focusedPaneId.set("pane-1");
+
+    updateAgentState("pane-1", { provider: "claude", status: "generating", source: "hook" });
+    updateAgentState("pane-1", { provider: "claude", status: "idle", source: "hook" });
+    await waitTick();
+
+    expect(notificationsPush).not.toHaveBeenCalled();
+  });
+
+  it("fires when the pane is in a non-active session", async () => {
+    sessionLayouts.set(new Map([["s1", { kind: "leaf", paneId: "pane-1" }]]));
+    sessionState.set({ sessions: [], activeSessionId: "s2" });
+    focusedPaneId.set("pane-1");
+
+    updateAgentState("pane-1", { provider: "claude", status: "generating", source: "hook" });
+    updateAgentState("pane-1", { provider: "claude", status: "idle", source: "hook" });
+    await waitTick();
+
+    expect(notificationsPush).toHaveBeenCalledTimes(1);
+    const request = vi.mocked(notificationsPush).mock.calls[0][0];
+    expect(request.sessionId).toBe("s1");
+    expect(request.dedupKey).toBe("completion:session:s1");
+  });
+
+  it("fires when the pane is in the active session but not focused", async () => {
+    sessionLayouts.set(
+      new Map([
+        [
+          "s1",
+          {
+            kind: "split",
+            direction: "h",
+            children: [
+              { kind: "leaf", paneId: "pane-1" },
+              { kind: "leaf", paneId: "pane-2" },
+            ],
+          },
+        ],
+      ]),
+    );
+    sessionState.set({ sessions: [], activeSessionId: "s1" });
+    focusedPaneId.set("pane-2");
+
+    updateAgentState("pane-1", { provider: "claude", status: "generating", source: "hook" });
+    updateAgentState("pane-1", { provider: "claude", status: "idle", source: "hook" });
+    await waitTick();
+
+    expect(notificationsPush).toHaveBeenCalledTimes(1);
+    const request = vi.mocked(notificationsPush).mock.calls[0][0];
+    expect(request.sessionId).toBe("s1");
+    expect(request.dedupKey).toBe("completion:session:s1");
   });
 
   it("forgetLastStatus lets a reused pane id re-fire the first transition", async () => {

--- a/src/lib/panes/agentNotifications.ts
+++ b/src/lib/panes/agentNotifications.ts
@@ -2,6 +2,10 @@ import { get } from "svelte/store";
 import { agentStates, type AgentState } from "./agentState";
 import { paneInstances } from "./instances";
 import { resolveProfileRef } from "./profiles";
+import { findSessionForPane } from "./layout";
+import { focusedPaneId } from "./focus";
+import { activeSessionId } from "$lib/stores/sessions";
+import { settings } from "$lib/stores/settings";
 import { notificationsPush } from "$lib/tauri";
 import { log, logError } from "$lib/logging";
 
@@ -88,10 +92,23 @@ async function fireCompletionNotification(
   paneId: string,
   state: AgentState,
 ): Promise<void> {
+  const enabled = get(settings).agentCompletionNotificationsEnabled ?? true;
+  if (!enabled) return;
+
+  const sessionId = findSessionForPane(paneId);
+  const paneIsVisible =
+    sessionId !== null
+    && get(activeSessionId) === sessionId
+    && get(focusedPaneId) === paneId;
+  if (paneIsVisible) return;
+
   const instance = get(paneInstances).get(paneId);
   const profile = resolveProfileRef(instance?.spawnProfileRef);
   const title = deriveTitle(instance?.name, profile?.name, state.provider);
   const body = deriveBody(state);
+  const dedupKey = sessionId
+    ? `completion:session:${sessionId}`
+    : `completion:pane:${paneId}`;
 
   try {
     await notificationsPush({
@@ -100,7 +117,7 @@ async function fireCompletionNotification(
       title,
       subtitle: null,
       body,
-      sessionId: null,
+      sessionId,
       actions: [
         {
           id: "focus",
@@ -115,7 +132,7 @@ async function fireCompletionNotification(
           primary: false,
         },
       ],
-      dedupKey: `completion:pane:${paneId}`,
+      dedupKey,
     });
     log(`agentNotifications: fired generating→idle notification for pane ${paneId}`);
   } catch (e) {
@@ -166,9 +183,9 @@ function deriveTitle(
   profileName: string | undefined,
   provider: string,
 ): string {
-  if (paneName) return `${paneName} is idle`;
-  if (profileName) return `${profileName} is idle`;
-  return `${capitalize(provider)} is idle`;
+  if (paneName) return `${paneName} finished`;
+  if (profileName) return `${profileName} finished`;
+  return `${capitalize(provider)} finished`;
 }
 
 function deriveErrorTitle(

--- a/src/lib/panes/layout.ts
+++ b/src/lib/panes/layout.ts
@@ -188,11 +188,12 @@ export function collectLeafIds(node: LayoutNode): string[] {
 
 /**
  * Returns the sessionId whose layout currently contains paneId, or null
- * if no session owns it. Walks all layouts (O(panes)).
+ * if no session owns it. Walks all layouts; per-session traversal
+ * short-circuits at the first match via `containsPaneId`.
  */
 export function findSessionForPane(paneId: string): string | null {
   for (const [sessionId, layout] of get(sessionLayouts)) {
-    if (collectLeafIds(layout).includes(paneId)) return sessionId;
+    if (containsPaneId(layout, paneId)) return sessionId;
   }
   return null;
 }

--- a/src/lib/panes/layout.ts
+++ b/src/lib/panes/layout.ts
@@ -187,6 +187,17 @@ export function collectLeafIds(node: LayoutNode): string[] {
 }
 
 /**
+ * Returns the sessionId whose layout currently contains paneId, or null
+ * if no session owns it. Walks all layouts (O(panes)).
+ */
+export function findSessionForPane(paneId: string): string | null {
+  for (const [sessionId, layout] of get(sessionLayouts)) {
+    if (collectLeafIds(layout).includes(paneId)) return sessionId;
+  }
+  return null;
+}
+
+/**
  * Collects leaf paneIds in DFS order, visiting only the currently-visible
  * branch of stacked splits. Hidden stack tabs are skipped because the
  * session-switch / pane-jump overlay can only draw a badge on a rendered

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -117,6 +117,7 @@ export const DEFAULT_SETTINGS: RouxSettings = {
   groupBy: "repo",
   confirmOnQuit: true,
   notificationsEnabled: true,
+  agentCompletionNotificationsEnabled: true,
   updateCheckOnLaunch: true,
   spawnProfiles: [],
   trustedWorkspaces: [],


### PR DESCRIPTION
## Summary

The "Claude is idle" notifications fired on every `generating → idle` transition for every pane — including the one the user was actively watching — with a title that read like a warning instead of "done". The in-app pane filled up with noise.

This change makes completion notifications actually useful:

- **New setting** `agentCompletionNotificationsEnabled` (default `true`) with a toggle in Settings → Notifications.
- **Suppress when visible**: skip the push when the pane is in the active session AND is the focused pane. The user already saw the result.
- **Group under session**: pass `sessionId` to the push so cards render under their session in `NotificationsPane`.
- **One card per session**: dedup key changed from `completion:pane:<id>` to `completion:session:<id>`. Two panes finishing back-to-back update one card instead of stacking. Falls back to per-pane key when no session owns the pane.
- **Reworded title**: `"X is idle"` → `"X finished"`.
- **Auto-remove on session visit**: when the user navigates back to the owning session, completion-session cards are removed (not just marked read). Extended `autoRead.ts` with a parallel remove queue + concurrency limit.
- **Errors unchanged**: no gate, no visibility check, no dedup-key change.

Drive-by: extracted the duplicated `findSessionForPane` helper from `autoRead.ts` and `dispatchAction.ts` into `src/lib/panes/layout.ts`.

## Test plan

- [x] `cargo test -p roux-core models::settings` (19/19 incl. new defaults test)
- [x] `npm run check` (937 files, 0 errors / 0 warnings)
- [x] `npm test` (79 files, 969 pass / 2 skipped, 11 new cases)
- [ ] Manual: pane finishes in active session while focused → no card
- [ ] Manual: pane in inactive session finishes → card appears under that session
- [ ] Manual: switch to that session → card auto-removes
- [ ] Manual: two panes in same session both finish → one card, "Focus pane" targets the most recent
- [ ] Manual: toggle the new setting off → no card on next finish
- [ ] Manual: agent enters error state → error card still appears regardless of toggle / visibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Agent completion notifications" toggle in Settings (enabled by default).

* **Improvements**
  * Auto-removal of certain completion notifications for cleaner inbox.
  * Session-aware deduplication to avoid duplicate completion alerts.
  * Suppresses completion notifications when the active pane is focused.
  * Clarified completion notification wording.

* **Tests**
  * Expanded tests covering completion notification behavior, auto-remove, and session deduplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->