### PR TITLE
feat(mailbox): agent message bus + per-pane mailboxes

### DIFF
--- a/crates/roux-core/src/models/alias.rs
+++ b/crates/roux-core/src/models/alias.rs
@@ -50,7 +50,7 @@ pub fn validate_alias_name(input: &str) -> Result<String, AliasNameError> {
 }
 
 pub fn is_reserved_alias(canonical: &str) -> bool {
-    RESERVED_ALIASES.iter().any(|r| *r == canonical)
+    RESERVED_ALIASES.contains(&canonical)
 }
 
 /// Format-validate AND reject reserved names. Use for the public CLI/socket

--- a/crates/roux-core/src/models/alias.rs
+++ b/crates/roux-core/src/models/alias.rs
@@ -1,0 +1,229 @@
+use serde::{Deserialize, Serialize};
+
+const MAX_ALIAS_LEN: usize = 64;
+
+/// Reserved alias names. `me` is the human-user mailbox; `human` canonicalizes
+/// to `me`. The remaining names are held back for future system use and
+/// rejected by `validate_user_alias_name` so user-facing CLI/socket commands
+/// can't claim them.
+pub const RESERVED_ALIASES: &[&str] = &["me", "human", "system", "audit", "roux"];
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum AliasNameError {
+    #[error("alias name is empty")]
+    Empty,
+    #[error("alias name '{0}' is too long (max 64 chars)")]
+    TooLong(String),
+    #[error("alias name '{0}' has invalid characters; expected lowercase letters, digits, hyphens, starting with a letter")]
+    InvalidChars(String),
+    #[error("alias name '{0}' is reserved")]
+    Reserved(String),
+}
+
+/// Lowercase, trim, and map `human` → `me`. The store always uses canonical
+/// names; lookups are case-insensitive because they go through this function.
+pub fn canonical_alias_name(input: &str) -> String {
+    let lower = input.trim().to_ascii_lowercase();
+    if lower == "human" { "me".to_string() } else { lower }
+}
+
+/// Validate format only. Does not check reservation. Returns the canonical form.
+pub fn validate_alias_name(input: &str) -> Result<String, AliasNameError> {
+    let canonical = canonical_alias_name(input);
+    if canonical.is_empty() {
+        return Err(AliasNameError::Empty);
+    }
+    if canonical.len() > MAX_ALIAS_LEN {
+        return Err(AliasNameError::TooLong(canonical));
+    }
+    let mut chars = canonical.chars();
+    let first = chars.next().expect("non-empty after empty check");
+    if !first.is_ascii_lowercase() {
+        return Err(AliasNameError::InvalidChars(canonical));
+    }
+    for ch in chars {
+        if !(ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-') {
+            return Err(AliasNameError::InvalidChars(canonical));
+        }
+    }
+    Ok(canonical)
+}
+
+pub fn is_reserved_alias(canonical: &str) -> bool {
+    RESERVED_ALIASES.iter().any(|r| *r == canonical)
+}
+
+/// Format-validate AND reject reserved names. Use for the public CLI/socket
+/// surface where user-supplied aliases shouldn't shadow system-reserved ones.
+pub fn validate_user_alias_name(input: &str) -> Result<String, AliasNameError> {
+    let canonical = validate_alias_name(input)?;
+    if is_reserved_alias(&canonical) {
+        return Err(AliasNameError::Reserved(canonical));
+    }
+    Ok(canonical)
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentAlias {
+    /// Canonical (lowercase, normalized) alias name.
+    pub alias: String,
+    /// Cached parent session id for grouping/filtering. Derived from the
+    /// pane on bind. `None` when the alias is unbound or when bound via
+    /// the legacy session-only path (Phase 1).
+    #[serde(default)]
+    pub session_id: Option<String>,
+    /// Canonical binding: which pane currently holds this alias.
+    /// `None` for unbound aliases or for legacy entries from Phase 1
+    /// (those resolve to the session's primary pane at delivery time).
+    #[serde(default)]
+    pub pane_id: Option<String>,
+    /// Optional project scope. Used for disambiguation when the same
+    /// alias name exists in multiple projects.
+    #[serde(default)]
+    pub project_id: Option<String>,
+    /// True when the alias was auto-claimed from a pane name (vs explicit
+    /// `roux alias claim`). Auto-claimed bindings release on pane rename
+    /// or close; manual bindings persist for queued mail.
+    #[serde(default)]
+    pub auto_claimed: bool,
+    /// Unix epoch milliseconds.
+    pub created_at: u64,
+    /// Unix epoch milliseconds. Updated on every binding change.
+    pub updated_at: u64,
+}
+
+/// Tauri event emitted on every alias mutation so the frontend can update
+/// without polling. Mirrors `NotificationEvent` shape.
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+pub enum AliasEvent {
+    /// Alias was created or rebound (any binding change).
+    Set { alias: AgentAlias },
+    /// Alias's session binding was cleared (entry remains for queued mail).
+    Unset {
+        canonical: String,
+        #[serde(default)]
+        project_id: Option<String>,
+    },
+}
+
+impl AgentAlias {
+    pub fn new(alias: impl Into<String>, project_id: Option<String>) -> Self {
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+        Self {
+            alias: alias.into(),
+            session_id: None,
+            pane_id: None,
+            project_id,
+            auto_claimed: false,
+            created_at: now_ms,
+            updated_at: now_ms,
+        }
+    }
+
+    /// True when this alias has any active binding (pane-level or legacy
+    /// session-level).
+    pub fn is_bound(&self) -> bool {
+        self.pane_id.is_some() || self.session_id.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_accepts_simple_lowercase() {
+        assert_eq!(validate_alias_name("reviewer"), Ok("reviewer".to_string()));
+        assert_eq!(validate_alias_name("frontend-team"), Ok("frontend-team".to_string()));
+        assert_eq!(validate_alias_name("agent-1"), Ok("agent-1".to_string()));
+    }
+
+    #[test]
+    fn validate_lowercases_uppercase_input() {
+        assert_eq!(validate_alias_name("Reviewer"), Ok("reviewer".to_string()));
+        assert_eq!(validate_alias_name("FRONTEND"), Ok("frontend".to_string()));
+    }
+
+    #[test]
+    fn validate_trims_whitespace() {
+        assert_eq!(validate_alias_name("  reviewer  "), Ok("reviewer".to_string()));
+    }
+
+    #[test]
+    fn validate_rejects_empty() {
+        assert_eq!(validate_alias_name(""), Err(AliasNameError::Empty));
+        assert_eq!(validate_alias_name("   "), Err(AliasNameError::Empty));
+    }
+
+    #[test]
+    fn validate_rejects_too_long() {
+        let too_long = "a".repeat(65);
+        match validate_alias_name(&too_long) {
+            Err(AliasNameError::TooLong(_)) => {}
+            other => panic!("expected TooLong, got {other:?}"),
+        }
+        let just_right = "a".repeat(64);
+        assert!(validate_alias_name(&just_right).is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_invalid_chars() {
+        for bad in ["agent_one", "agent.one", "agent one", "agent/one", "agent!"] {
+            match validate_alias_name(bad) {
+                Err(AliasNameError::InvalidChars(_)) => {}
+                other => panic!("expected InvalidChars for {bad:?}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn validate_rejects_leading_digit_or_hyphen() {
+        assert!(matches!(validate_alias_name("1agent"), Err(AliasNameError::InvalidChars(_))));
+        assert!(matches!(validate_alias_name("-agent"), Err(AliasNameError::InvalidChars(_))));
+    }
+
+    #[test]
+    fn human_canonicalizes_to_me() {
+        assert_eq!(canonical_alias_name("human"), "me");
+        assert_eq!(canonical_alias_name("Human"), "me");
+        assert_eq!(canonical_alias_name("HUMAN"), "me");
+    }
+
+    #[test]
+    fn is_reserved_covers_expected_names() {
+        for name in ["me", "human", "system", "audit", "roux"] {
+            assert!(
+                is_reserved_alias(&canonical_alias_name(name)),
+                "{name} should be reserved"
+            );
+        }
+        assert!(!is_reserved_alias("reviewer"));
+    }
+
+    #[test]
+    fn validate_user_alias_rejects_reserved() {
+        assert!(matches!(validate_user_alias_name("me"), Err(AliasNameError::Reserved(_))));
+        assert!(matches!(validate_user_alias_name("Human"), Err(AliasNameError::Reserved(_))));
+        assert!(matches!(validate_user_alias_name("audit"), Err(AliasNameError::Reserved(_))));
+    }
+
+    #[test]
+    fn validate_user_alias_accepts_normal_names() {
+        assert_eq!(validate_user_alias_name("reviewer"), Ok("reviewer".to_string()));
+        assert_eq!(validate_user_alias_name("Reviewer"), Ok("reviewer".to_string()));
+    }
+
+    #[test]
+    fn agent_alias_new_sets_timestamps() {
+        let a = AgentAlias::new("reviewer", None);
+        assert_eq!(a.alias, "reviewer");
+        assert!(a.session_id.is_none());
+        assert!(a.created_at > 0);
+        assert_eq!(a.created_at, a.updated_at);
+    }
+}

--- a/crates/roux-core/src/models/event.rs
+++ b/crates/roux-core/src/models/event.rs
@@ -1,0 +1,361 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Categorical event kind. Lets the UI default-filter the main inbox to
+/// human-actionable items (`Task`, `Question`) and route `Fyi` / `Signal`
+/// noise to the firehose tab. Senders pick the kind; storage is the same
+/// for all of them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, specta::Type, Default)]
+#[serde(rename_all = "camelCase")]
+pub enum EventKind {
+    /// Direct task handoff: "please do X."
+    #[default]
+    Task,
+    /// Reply to a Task with the outcome.
+    Result,
+    /// Asks for input. Surfaces in the human's main inbox by default.
+    Question,
+    /// Passive notification, no reply expected.
+    Fyi,
+    /// Bus-style ambient signal (e.g. `build.completed`).
+    Signal,
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum EventValidationError {
+    #[error("event must address at least one of `to` or `topic`")]
+    NoAddressing,
+    #[error("event body is empty")]
+    EmptyBody,
+}
+
+/// Append-only event in the unified store. Both mailbox-style direct
+/// addressing (`to=<alias>`) and bus-style topic addressing (`topic=...`)
+/// live in the same row; an event may use either, both, or only `topic`.
+///
+/// Per-recipient read/ack state is split into `ReadState` so the same
+/// event can serve N subscribers without copying.
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Event {
+    /// Unique id (uuid v4 in current implementation; ordering is by
+    /// `created_at`, not id).
+    pub id: String,
+    /// Unix epoch milliseconds.
+    pub created_at: u64,
+
+    // ── Addressing axes ─────────────────────────────────────────────
+    /// Recipient alias. `Some` for mailbox-style direct addressing,
+    /// `None` for pure-topic broadcast events.
+    #[serde(default)]
+    pub to: Option<String>,
+    /// Dotted topic name (e.g. `repo-a.build.completed`). `Some` to
+    /// participate in bus-style fan-out; `None` for pure direct mail.
+    #[serde(default)]
+    pub topic: Option<String>,
+    /// Sender alias or session id.
+    #[serde(default)]
+    pub from: Option<String>,
+
+    // ── Categorical axes ────────────────────────────────────────────
+    pub kind: EventKind,
+    /// Thread key. New events copy from the event they're replying to;
+    /// originals leave it `None`.
+    #[serde(default)]
+    pub correlation_id: Option<String>,
+    /// Project scope for filtering. `None` = global.
+    #[serde(default)]
+    pub project_id: Option<String>,
+
+    // ── Payload ─────────────────────────────────────────────────────
+    /// Optional short subject line for inbox display.
+    #[serde(default)]
+    pub subject: Option<String>,
+    /// Free-form body text.
+    pub body: String,
+    /// Optional structured JSON payload. Convention encourages
+    /// `{ task, context, expectsReply }` but nothing is enforced.
+    #[serde(default)]
+    pub structured: Option<Value>,
+}
+
+/// Per-recipient mutable state for an event. Split from `Event` so a
+/// single broadcast event can have N independent cursors without
+/// duplicating the payload.
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ReadState {
+    pub event_id: String,
+    /// Alias (or session id) that owns this state row.
+    pub recipient: String,
+    /// First time the recipient saw the event. Set automatically on
+    /// `mailbox read`. `Some` is weaker than acked.
+    #[serde(default)]
+    pub read_at: Option<u64>,
+    /// Time the recipient acked. `Some` means processed/done.
+    #[serde(default)]
+    pub acked_at: Option<u64>,
+    /// Optional short result string returned with the ack
+    /// (`mailbox ack <id> --result "PR merged"`).
+    #[serde(default)]
+    pub ack_result: Option<String>,
+}
+
+impl ReadState {
+    pub fn new(event_id: impl Into<String>, recipient: impl Into<String>) -> Self {
+        Self {
+            event_id: event_id.into(),
+            recipient: recipient.into(),
+            read_at: None,
+            acked_at: None,
+            ack_result: None,
+        }
+    }
+
+    pub fn is_read(&self) -> bool {
+        self.read_at.is_some()
+    }
+
+    pub fn is_acked(&self) -> bool {
+        self.acked_at.is_some()
+    }
+}
+
+/// Tauri event emitted on every store mutation so the frontend can update
+/// without polling. Mirrors the NotificationEvent / AliasEvent shape.
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+pub enum MailboxEvent {
+    /// New event was appended.
+    Posted { event: Event },
+    /// Recipient marked an event read (or read an unread event for the first time).
+    Read { event_id: String, recipient: String },
+    /// Recipient acked an event with optional result.
+    Acked {
+        event_id: String,
+        recipient: String,
+        #[serde(default)]
+        result: Option<String>,
+    },
+    /// Recipient cleared their inbox (or a project-scoped slice of it).
+    Cleared { recipient: String, count: u32 },
+}
+
+/// Builder for new events. Validates at construction so callers get a
+/// typed error rather than a silently malformed row in the store.
+#[derive(Debug, Clone, Default)]
+pub struct EventBuilder {
+    pub to: Option<String>,
+    pub topic: Option<String>,
+    pub from: Option<String>,
+    pub kind: EventKind,
+    pub correlation_id: Option<String>,
+    pub project_id: Option<String>,
+    pub subject: Option<String>,
+    pub body: String,
+    pub structured: Option<Value>,
+}
+
+impl EventBuilder {
+    pub fn new(body: impl Into<String>) -> Self {
+        Self { body: body.into(), ..Default::default() }
+    }
+
+    pub fn to(mut self, alias: impl Into<String>) -> Self {
+        self.to = Some(alias.into());
+        self
+    }
+    pub fn topic(mut self, topic: impl Into<String>) -> Self {
+        self.topic = Some(topic.into());
+        self
+    }
+    pub fn from(mut self, sender: impl Into<String>) -> Self {
+        self.from = Some(sender.into());
+        self
+    }
+    pub fn kind(mut self, kind: EventKind) -> Self {
+        self.kind = kind;
+        self
+    }
+    pub fn correlation_id(mut self, cid: impl Into<String>) -> Self {
+        self.correlation_id = Some(cid.into());
+        self
+    }
+    pub fn project_id(mut self, pid: impl Into<String>) -> Self {
+        self.project_id = Some(pid.into());
+        self
+    }
+    pub fn subject(mut self, s: impl Into<String>) -> Self {
+        self.subject = Some(s.into());
+        self
+    }
+    pub fn structured(mut self, v: Value) -> Self {
+        self.structured = Some(v);
+        self
+    }
+
+    /// Validate addressing/body invariants but do NOT assign `id` /
+    /// `created_at` — those come from the store on insert.
+    pub fn validate(&self) -> Result<(), EventValidationError> {
+        if self.to.is_none() && self.topic.is_none() {
+            return Err(EventValidationError::NoAddressing);
+        }
+        if self.body.trim().is_empty() && self.structured.is_none() {
+            return Err(EventValidationError::EmptyBody);
+        }
+        Ok(())
+    }
+
+    /// Build the Event with caller-supplied id and timestamp. Used by the
+    /// store, which owns id assignment so the same uuid library doesn't
+    /// have to be available in `roux-core`.
+    pub fn build_with(
+        self,
+        id: impl Into<String>,
+        created_at: u64,
+    ) -> Result<Event, EventValidationError> {
+        self.validate()?;
+        Ok(Event {
+            id: id.into(),
+            created_at,
+            to: self.to,
+            topic: self.topic,
+            from: self.from,
+            kind: self.kind,
+            correlation_id: self.correlation_id,
+            project_id: self.project_id,
+            subject: self.subject,
+            body: self.body,
+            structured: self.structured,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builder_validate_requires_addressing() {
+        let e = EventBuilder::new("hello");
+        assert_eq!(e.validate(), Err(EventValidationError::NoAddressing));
+    }
+
+    #[test]
+    fn builder_validate_accepts_to_only() {
+        let e = EventBuilder::new("hello").to("reviewer");
+        assert!(e.validate().is_ok());
+    }
+
+    #[test]
+    fn builder_validate_accepts_topic_only() {
+        let e = EventBuilder::new("hello").topic("build.completed");
+        assert!(e.validate().is_ok());
+    }
+
+    #[test]
+    fn builder_validate_accepts_both() {
+        let e = EventBuilder::new("hello").to("reviewer").topic("review.requested");
+        assert!(e.validate().is_ok());
+    }
+
+    #[test]
+    fn builder_validate_rejects_empty_body_without_structured() {
+        let e = EventBuilder::new("   ").to("reviewer");
+        assert_eq!(e.validate(), Err(EventValidationError::EmptyBody));
+    }
+
+    #[test]
+    fn builder_validate_accepts_empty_body_with_structured_payload() {
+        let e = EventBuilder::new("")
+            .to("reviewer")
+            .structured(serde_json::json!({"task": "review"}));
+        assert!(e.validate().is_ok());
+    }
+
+    #[test]
+    fn build_with_assigns_id_and_timestamp() {
+        let event = EventBuilder::new("hello")
+            .to("reviewer")
+            .from("me")
+            .kind(EventKind::Task)
+            .build_with("evt-1", 12345)
+            .unwrap();
+        assert_eq!(event.id, "evt-1");
+        assert_eq!(event.created_at, 12345);
+        assert_eq!(event.to.as_deref(), Some("reviewer"));
+        assert_eq!(event.from.as_deref(), Some("me"));
+        assert_eq!(event.kind, EventKind::Task);
+    }
+
+    #[test]
+    fn build_with_propagates_validation_failure() {
+        let result = EventBuilder::new("hi").build_with("evt-1", 0);
+        assert!(matches!(result, Err(EventValidationError::NoAddressing)));
+    }
+
+    #[test]
+    fn builder_chains_correlation_and_project() {
+        let event = EventBuilder::new("reply")
+            .to("reviewer")
+            .from("builder")
+            .kind(EventKind::Result)
+            .correlation_id("thread-1")
+            .project_id("repo-a")
+            .subject("done")
+            .build_with("evt-2", 1)
+            .unwrap();
+        assert_eq!(event.correlation_id.as_deref(), Some("thread-1"));
+        assert_eq!(event.project_id.as_deref(), Some("repo-a"));
+        assert_eq!(event.subject.as_deref(), Some("done"));
+    }
+
+    #[test]
+    fn read_state_starts_unread_unacked() {
+        let state = ReadState::new("evt-1", "reviewer");
+        assert!(!state.is_read());
+        assert!(!state.is_acked());
+    }
+
+    #[test]
+    fn read_state_serde_round_trip() {
+        let mut state = ReadState::new("evt-1", "reviewer");
+        state.read_at = Some(1000);
+        state.acked_at = Some(1500);
+        state.ack_result = Some("PR merged".to_string());
+        let json = serde_json::to_string(&state).unwrap();
+        let parsed: ReadState = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, state);
+    }
+
+    #[test]
+    fn event_kind_default_is_task() {
+        assert_eq!(EventKind::default(), EventKind::Task);
+    }
+
+    #[test]
+    fn event_serde_round_trip_preserves_all_fields() {
+        let original = EventBuilder::new("hello")
+            .to("reviewer")
+            .topic("review.requested")
+            .from("builder")
+            .kind(EventKind::Question)
+            .correlation_id("thread-1")
+            .project_id("repo-a")
+            .subject("PR needs review")
+            .structured(serde_json::json!({"pr_url": "https://example.com"}))
+            .build_with("evt-1", 42)
+            .unwrap();
+        let json = serde_json::to_string(&original).unwrap();
+        let parsed: Event = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, original);
+    }
+
+    #[test]
+    fn event_kind_serializes_camel_case() {
+        let v = serde_json::to_string(&EventKind::Fyi).unwrap();
+        assert_eq!(v, "\"fyi\"");
+        let v = serde_json::to_string(&EventKind::Task).unwrap();
+        assert_eq!(v, "\"task\"");
+    }
+}

--- a/crates/roux-core/src/models/event.rs
+++ b/crates/roux-core/src/models/event.rs
@@ -99,6 +99,15 @@ pub struct ReadState {
     /// (`mailbox ack <id> --result "PR merged"`).
     #[serde(default)]
     pub ack_result: Option<String>,
+    /// Set when the recipient has cleared this event from their inbox
+    /// view via `mailbox clear`. The underlying event is preserved
+    /// (other recipients can still see it); cleared events drop from
+    /// `list_for_recipient` and don't count as unread for this
+    /// recipient. Distinct from `read_at` so the prior read state isn't
+    /// lost — without this marker, "clear read" would delete `read_at`
+    /// and the event would re-surface as unread on the next list call.
+    #[serde(default)]
+    pub cleared_at: Option<u64>,
 }
 
 impl ReadState {
@@ -109,6 +118,7 @@ impl ReadState {
             read_at: None,
             acked_at: None,
             ack_result: None,
+            cleared_at: None,
         }
     }
 
@@ -118,6 +128,13 @@ impl ReadState {
 
     pub fn is_acked(&self) -> bool {
         self.acked_at.is_some()
+    }
+
+    /// True when the recipient has cleared this event from their view.
+    /// Cleared events are filtered out of `list_for_recipient` and don't
+    /// count as unread.
+    pub fn is_cleared(&self) -> bool {
+        self.cleared_at.is_some()
     }
 }
 

--- a/crates/roux-core/src/models/mod.rs
+++ b/crates/roux-core/src/models/mod.rs
@@ -1,3 +1,5 @@
+mod alias;
+mod event;
 mod events;
 mod keymap;
 mod layout;
@@ -11,6 +13,13 @@ mod user_terminal_themes;
 mod watch;
 mod worktree;
 
+pub use alias::{
+    canonical_alias_name, is_reserved_alias, validate_alias_name, validate_user_alias_name,
+    AgentAlias, AliasEvent, AliasNameError, RESERVED_ALIASES,
+};
+pub use event::{
+    Event, EventBuilder, EventKind, EventValidationError, MailboxEvent, ReadState,
+};
 pub use events::{RouxCommand, SessionExitPayload, SessionExitReason};
 pub use keymap::{
     merge_keymaps, parse_keymap_kdl, Bind, HudMode, KeyRef, KeymapAction, KeymapParseError,

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -21,6 +21,7 @@ Roux is a terminal-first workspace for running agent sessions, shells, notes, wa
 ## Automation
 
 - [Notifications](notifications.md) — in-app inbox, unread badges, OS notification fan-out, and agent setup.
+- [Mailbox & Bus](mailbox.md) — addressable mail between agents and the human, plus topic-based broadcasts. Aliases bind to panes; auto-claim from pane name.
 - [Watches](watches.md) — track long-running checks, HTTP endpoints, and GitHub PRs.
 - [CLI](cli.md) — drive sessions, panes, notes, notifications, and automation from `roux-cli`.
 - [Keymap](keymap.md) — customize direct shortcuts, leader chords, and command bindings.

--- a/docs/features/mailbox.md
+++ b/docs/features/mailbox.md
@@ -1,0 +1,330 @@
+# Mailbox
+
+Roux gives every agent a stable, addressable inbox so humans and other agents
+can send durable messages to a session without typing into its terminal at the
+wrong moment. The same store also powers a topic-based bus for ambient
+broadcasts (build done, tests went red, deploy started).
+
+!!! info "Why not just `roux send`?"
+    `roux send` types raw bytes into a target session's PTY. Useful, but it
+    jams whatever the receiver was doing — there's no queueing, no acking,
+    no addressing by role, no audit trail. The mailbox keeps the same
+    "across-pane communication" intent but adds: durable queueing,
+    per-recipient read/ack state, alias-based addressing that survives
+    session restart, and a backend the UI and MCP can plug into.
+
+## The three layers
+
+| Layer | What it is | Used for |
+|---|---|---|
+| **Aliases** | Stable, restart-durable names bound to panes (`reviewer`, `builder`, `me`) | Addressing |
+| **Mailbox** | Queue of events addressed `to=<alias>` with per-recipient read/ack state | Direct mail |
+| **Bus** | Same store, addressed by `topic` (e.g. `repo-a.build.completed`) | Broadcasts |
+
+All three live in one append-only event log. "Mailbox" and "bus" are usage
+patterns over the same store, not separate systems.
+
+## Aliases
+
+An **alias** is a human-meaningful name (lowercase letters, digits, hyphens;
+1–64 chars) that resolves to whichever pane currently holds it. Aliases
+survive session restart; pane IDs do not.
+
+### How aliases get bound
+
+1. **Auto-claim from pane name** *(easiest)*. Rename a pane to something that
+   matches the alias format and Roux auto-claims that name as the pane's
+   alias. Look for the `@<alias>` chip in the pane's title bar.
+2. **`roux alias claim <name>`** *(manual)*. Run from inside the pane.
+   Defaults to `$ROUX_PANE_ID`.
+3. **`roux alias set <name> --session <id>` or `--pane <id>`** *(third-party)*.
+   Bind from the outside, useful for scripts/MCP.
+
+If the pane's name doesn't match the alias format (capitals, spaces,
+parens) Roux skips auto-claim — the user can still bind manually. Reserved
+names that can't be claimed: `me`, `human` (alias of `me`), `system`,
+`audit`, `roux`.
+
+### Inspecting aliases
+
+```sh
+roux alias whoami                       # what aliases is my pane holding?
+roux alias list                         # all aliases (JSON)
+roux alias list --only-unbound          # aliases with no current pane
+roux alias get reviewer                 # resolve one alias
+roux alias get reviewer --project foo   # project-scoped lookup
+```
+
+### Releasing
+
+Auto-claimed aliases release when:
+
+- the pane is renamed to a non-conformant name
+- the pane is closed
+- the user runs `roux alias unset <name>`
+
+Manual claims persist across pane close — queued mail keeps for whoever
+re-claims the alias next.
+
+### The `me` alias
+
+`me` (and its synonym `human`) is reserved for **you, the human at the
+keyboard**. Agents post to `me` when they need your attention; mail
+addressed to `me` shows up in the Mailbox panel's main inbox and fires a
+Roux notification. Agents can't claim `me`.
+
+### Project scoping
+
+The same alias name can exist independently in different projects:
+
+- `reviewer@frontend-app` and `reviewer@mobile-app` are different aliases.
+- Bare `roux alias get reviewer` looks up in your current project's scope
+  first (via `$ROUX_PROJECT_ID`), falling back to the global scope.
+- Cross-project addressing uses `<alias>@<project>` syntax.
+
+## Mailbox
+
+Direct addressed mail with per-recipient read/ack state.
+
+### Posting
+
+```sh
+roux mailbox post --to reviewer "PR ready: https://github.com/..."
+roux mailbox post --to me "I need a decision on X" --kind question
+roux mailbox post --to reviewer --subject "Hot fix" --kind task "<long body>"
+```
+
+Kinds: `task` (default), `result`, `question`, `fyi`, `signal`. The Mailbox
+panel surfaces `me`-addressed mail and questions in the main inbox; agent-
+to-agent `fyi` traffic shows in the Firehose tab only.
+
+### Reading
+
+```sh
+roux mailbox count                    # how many unread? (JSON)
+roux mailbox peek --unread            # see them without consuming
+roux mailbox read --ack               # drain + mark processed (recommended)
+```
+
+`read` returns each event as JSON. `--ack` also flips `acked_at` on each so
+the sender's `mailbox sent` view shows the work was processed.
+
+### Acking with results
+
+```sh
+roux mailbox ack <event_id> --result "PR merged"
+```
+
+The result string is visible to the sender. Use it for short status updates
+the original poster cares about.
+
+### Threaded replies
+
+Reply to an event by id; the new event copies the original's `correlation_id`
+(or seeds one from the original event id if absent), so the conversation
+threads:
+
+```sh
+roux mailbox reply <event_id> "looking now, will get back in 10"
+```
+
+### Sender's view
+
+```sh
+roux mailbox sent                     # everything I've sent
+roux mailbox sent --to reviewer       # only stuff I sent to reviewer
+```
+
+Each row pairs the event with the recipient's read/ack state, so you can
+tell whether the reviewer saw your mail and what they did with it.
+
+## Bus
+
+When you want to publish "this happened" without addressing a specific
+recipient:
+
+```sh
+roux bus publish repo-a.build.completed "main is green"
+roux bus tail --topic repo-a.build.completed   # filter
+roux bus tail                                   # firehose, newest first
+```
+
+Topics live in the same store as mailbox events. An event can have *both*
+`--to` and `--topic` — it lands in the recipient's inbox AND fires for
+anyone tailing that topic.
+
+Default `kind` for `bus publish` is `signal`.
+
+## The Mailbox panel (UI)
+
+Click the inbox icon in the activity rail (or use the keybinding for
+"mailbox"). The panel has two views:
+
+- **Inbox** — alias selector strip + the selected alias's events, oldest
+  first. Mark-read / ack / clear-read buttons per event. Compose form at
+  the top sends to any alias (with autocomplete).
+- **All / Firehose** — every event newest-first, no per-recipient state.
+  Read-only; for awareness across recipients.
+
+The pane title bar shows an `@<alias>` chip when an alias is bound. Auto-
+claimed bindings get a lighter outline; manually-claimed bindings are
+filled. An unread badge appears next to the chip when mail is waiting.
+
+### The Deliver button
+
+In the Inbox view, each event has a `deliver →` button **iff the
+recipient alias is bound to a live pane**. Clicking it types the message
+body (plus a CR) into the recipient's pane via the existing PTY write
+path, then auto-acks. This is the "send to my friend" UX — combines
+mailbox addressing with PTY delivery for the last mile, useful when the
+recipient agent isn't running a hook to drain mail automatically.
+
+## Environment variables
+
+When a pane is hosting an agent, Roux injects these:
+
+| Var | Meaning |
+|---|---|
+| `ROUX_AGENT_ALIAS` | Alias bound to this pane at PTY spawn time. Snapshot — does not update mid-session. Use `roux alias whoami` for live state. |
+| `ROUX_PANE_ID` | The pane's id; pass to `roux alias claim`. |
+| `ROUX_SESSION_ID` | The session's id. |
+| `ROUX_PROJECT_ID` | Project scope, if any. Used for current-project alias resolution. |
+
+## How agents discover the mailbox
+
+Roux ships a Claude Code [skill](../sessions.md#skills) (auto-installed at
+`~/.claude/skills/roux/SKILL.md`) that teaches agents:
+
+- `$ROUX_SESSION=1` ⇒ they're in Roux
+- The `mailbox`, `alias`, and `bus` CLI surfaces and when to use them
+- That "mail" / "inbox" / "messages" mean **Roux mailbox**, NOT Gmail (this
+  prevents Claude from reaching for the Gmail MCP when you ask "any new
+  mail?" inside a Roux pane)
+
+For deterministic auto-drain (without relying on the model remembering),
+add a `UserPromptSubmit` hook in your project's `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [{
+      "command": "roux mailbox read --ack"
+    }]
+  }
+}
+```
+
+Output of `mailbox read` will be prepended to whatever you type, so the
+agent picks up pending mail at the start of every turn.
+
+## MCP
+
+The Roux MCP server exposes the mailbox tools natively to MCP-aware
+clients. To wire it up:
+
+1. Open Roux → Settings → **Integrations** → **Model Context Protocol**.
+2. Click **Add to Claude Code**, **Add to Claude Desktop**, or **Add to
+   Codex** depending on which client you use. Roux writes the right config
+   shape (JSON `mcpServers` for Claude clients, TOML `[mcp_servers.roux]`
+   for Codex) and prints the diff in the preview pane.
+3. Restart the client. The next session sees `roux_mailbox_*`,
+   `roux_alias_*`, `roux_bus_*` tools natively — no shell-out cost, no
+   permission prompts per call.
+
+Behind the scenes the MCP tools just wrap the same socket commands the
+CLI uses; you get parity with the CLI surface, just typed.
+
+## Persistence
+
+| File | Format | Notes |
+|---|---|---|
+| `aliases.json` | Versioned envelope (`{version: 1, data: [...]}`) | Full rewrite on mutation |
+| `events.jsonl` | Append-only NDJSON, one event per line, with `schemaVersion: 1` | Audit log; never compacted |
+| `read_state.json` | Versioned envelope | Full rewrite on mark-read / ack / clear-read |
+
+All three live under `roux_config_dir()` (`~/.config/roux/` on
+macOS/Linux). Future-version rows are preserved on disk but skipped at
+load time, so a downgrade doesn't lose data.
+
+## Retention
+
+The in-memory event store caps at the most recent 5,000 events. Events
+past the cap are evicted from RAM but stay in `events.jsonl` for audit.
+Restarts rebuild the in-memory view from the on-disk log, applying the
+cap.
+
+## Discipline
+
+- **Don't drain mail mid-tool-call.** Mail is durable — it's there at the
+  start of your next turn. Draining mid-task fragments your context.
+- **Don't flood.** A soft per-sender rate cap (~60 events/min) folds
+  identical bodies posted to the same recipient within 5 seconds.
+- **Treat `me` mail with priority.** It's the human asking — surface it,
+  don't silently sit on it.
+
+## Common workflows
+
+### "Tell my reviewer I'm ready"
+
+From the implementer's pane:
+
+```sh
+roux mailbox post --to reviewer "PR ready, /Users/me/branch-foo, please look"
+```
+
+The reviewer's pane shows the unread badge. The reviewer (a person or an
+agent) drains via `roux mailbox read --ack` or by clicking through the
+Mailbox panel.
+
+### "Coordinate two agents on a worktree"
+
+```sh
+# Open a worktree session, name two panes "frontend" and "backend"
+# (auto-claim picks them up)
+roux session create --worktree-branch feature-x
+
+# From the frontend pane:
+roux mailbox post --to backend "API contract for /reviews: {fields...}"
+
+# From the backend pane:
+roux mailbox read --ack       # sees the contract
+# ...does the work...
+roux mailbox post --to frontend --kind result "/reviews implemented in commit abc123"
+```
+
+### "Broadcast that the build went green"
+
+```sh
+roux bus publish repo-a.build.completed "main is green at sha abc123"
+```
+
+Anyone tailing `repo-a.*` (or a wildcard subscriber, once subscriptions
+land) sees it.
+
+### "Send me a note from a script"
+
+```sh
+roux mailbox post --to me "deploy finished, took 4m12s" --kind fyi
+```
+
+Roux fires a notification on your screen.
+
+## Troubleshooting
+
+**`alias 'reviewer' is already bound to pane 'pane-XYZ'`**: another pane
+holds the alias. Either rename the conflicting pane (auto-release), use
+`roux alias claim reviewer --steal` to take it over, or pick a different
+name.
+
+**My pane name auto-claimed but other pane has the same name**: only the
+first auto-claim wins; the second pane keeps its name but no alias.
+Manually `roux alias claim <some-other-name>` for the second pane.
+
+**Mail isn't arriving even though I posted**: check `roux alias list` to
+confirm the recipient alias exists and has a `paneId` set. Posts to
+unbound aliases queue durably — mail is there, just no live recipient.
+Bind a pane (or use the Deliver button) to see it.
+
+**Agent ignores mail**: install the `UserPromptSubmit` hook (see above)
+or run `roux mailbox read` manually. The skill teaches agents about the
+mailbox, but doesn't compel them to drain on every turn — hooks do.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
       - Smol Machines: features/smol-machines.md
       - Library: features/library.md
       - Notifications: features/notifications.md
+      - Mailbox & Bus: features/mailbox.md
       - Watches: features/watches.md
       - Automation hooks: features/hooks.md
       - CLI: features/cli.md

--- a/src-tauri/src/aliases/manager.rs
+++ b/src-tauri/src/aliases/manager.rs
@@ -1,0 +1,572 @@
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use roux_core::{AgentAlias, AliasEvent};
+use tauri::{AppHandle, Emitter};
+
+use super::persistence::{self, load_from_path, save_to_path};
+use super::store::{AliasStore, BindError, BindRequest, ProjectFilter};
+
+/// Tauri event name emitted on every alias mutation.
+pub const ALIAS_EVENT: &str = "alias-event";
+
+/// Clonable handle over the alias store. Wraps `Arc<Mutex<_>>` so all clones
+/// share state. Mirrors the `NotificationManager` shape.
+///
+/// Persistence runs synchronously on every mutation. The on-disk file is
+/// small (a few entries × ~150 bytes each) so the cost is negligible and
+/// the simpler "save on every change" model avoids stale-state recovery
+/// after a crash.
+#[derive(Clone)]
+pub struct AliasManager {
+    inner: Arc<Mutex<AliasStore>>,
+    /// `None` = in-memory only (test mode); `Some(path)` = persisted.
+    persistence_path: Option<Arc<PathBuf>>,
+}
+
+impl AliasManager {
+    /// Production constructor: loads from the default config-dir path,
+    /// seeds the reserved `me` alias, and writes the seeded state back.
+    pub fn load() -> Self {
+        Self::load_from(persistence::persistence_path())
+    }
+
+    /// Load from an explicit path. Used by tests to redirect to a temp dir.
+    /// Always seeds `me` if absent (the reserved human-user mailbox alias).
+    pub fn load_from(path: PathBuf) -> Self {
+        let entries = load_from_path(&path);
+        let had_me = entries.iter().any(|a| a.alias == "me" && a.project_id.is_none());
+        let mut store = AliasStore::from_entries(entries);
+        if !had_me {
+            store.ensure("me", None);
+        }
+        let mgr = Self {
+            inner: Arc::new(Mutex::new(store)),
+            persistence_path: Some(Arc::new(path)),
+        };
+        if !had_me {
+            mgr.persist();
+        }
+        mgr
+    }
+
+    /// In-memory variant. No load, no persist on mutations. For tests that
+    /// don't care about disk state.
+    #[cfg(test)]
+    pub fn in_memory() -> Self {
+        let mut store = AliasStore::new();
+        store.ensure("me", None);
+        Self { inner: Arc::new(Mutex::new(store)), persistence_path: None }
+    }
+
+    pub fn bind(
+        &self,
+        canonical: &str,
+        req: BindRequest,
+        app: Option<&AppHandle>,
+    ) -> Result<AgentAlias, BindError> {
+        let alias = {
+            let mut store = self.inner.lock().expect("alias store poisoned");
+            store.bind(canonical, req)?
+        };
+        self.persist();
+        if let Some(app) = app {
+            let _ = app.emit(ALIAS_EVENT, &AliasEvent::Set { alias: alias.clone() });
+        }
+        Ok(alias)
+    }
+
+    /// Release every binding tied to `pane_id`. Used on pane close /
+    /// rename. `only_auto_claimed=true` preserves manual `roux alias claim`
+    /// bindings. Returns the names of released aliases so the caller can
+    /// emit per-alias `Unset` events for the UI.
+    pub fn unbind_for_pane(
+        &self,
+        pane_id: &str,
+        only_auto_claimed: bool,
+        app: Option<&AppHandle>,
+    ) -> Vec<String> {
+        let released = {
+            let mut store = self.inner.lock().expect("alias store poisoned");
+            store.unbind_for_pane(pane_id, only_auto_claimed)
+        };
+        if !released.is_empty() {
+            self.persist();
+            if let Some(app) = app {
+                for canonical in &released {
+                    // We don't know the project_id post-release without
+                    // re-querying, but the store treats project_id as the
+                    // disambiguator only at lookup time — UI listeners
+                    // re-query via the store for the full alias state.
+                    let _ = app.emit(
+                        ALIAS_EVENT,
+                        &AliasEvent::Unset {
+                            canonical: canonical.clone(),
+                            project_id: None,
+                        },
+                    );
+                }
+            }
+        }
+        released
+    }
+
+    pub fn find_for_pane(&self, pane_id: &str) -> Vec<AgentAlias> {
+        let store = self.inner.lock().expect("alias store poisoned");
+        store.find_for_pane(pane_id).into_iter().cloned().collect()
+    }
+
+    /// Try to auto-claim an alias for `pane_id` from `pane_name`.
+    ///
+    /// Behavior:
+    /// - If `pane_name` is `None` or empty → release any auto-claim
+    ///   currently held by this pane and return `None`.
+    /// - If `pane_name` doesn't pass `validate_user_alias_name` (capitals,
+    ///   spaces, reserved) → release auto-claims, return `None`.
+    /// - If the canonical alias is already bound to a *different* pane →
+    ///   release auto-claims for THIS pane, return `None` (no steal).
+    /// - Otherwise: release any prior auto-claim, then bind under the new
+    ///   name with `auto_claimed=true`.
+    ///
+    /// Idempotent: calling repeatedly with the same name is a no-op (after
+    /// the first claim succeeds). Pane rename = call with the new name and
+    /// the helper handles the old-name release.
+    pub fn try_auto_claim_from_pane_name(
+        &self,
+        pane_id: &str,
+        pane_name: Option<&str>,
+        project_id: Option<String>,
+        app: Option<&AppHandle>,
+    ) -> Option<AgentAlias> {
+        let trimmed = pane_name.map(str::trim).filter(|s| !s.is_empty());
+
+        // Validate first; if the name doesn't fit the alias format, we
+        // still need to release any prior auto-claim (e.g. user renamed
+        // a pane from "reviewer" to "Reviewer (v2)").
+        let canonical = match trimmed.and_then(|n| roux_core::validate_user_alias_name(n).ok()) {
+            Some(c) => c,
+            None => {
+                self.unbind_for_pane(pane_id, true, app);
+                return None;
+            }
+        };
+
+        // If THIS pane already holds this exact alias, no-op.
+        let already_held = {
+            let store = self.inner.lock().expect("alias store poisoned");
+            store
+                .get(&canonical, project_id.as_deref())
+                .map(|a| a.pane_id.as_deref() == Some(pane_id))
+                .unwrap_or(false)
+        };
+        if already_held {
+            return self.get(&canonical, project_id.as_deref());
+        }
+
+        // If the alias is bound elsewhere (different pane), don't steal —
+        // but DO release any prior auto-claim this pane held under a
+        // different name.
+        let bound_elsewhere = {
+            let store = self.inner.lock().expect("alias store poisoned");
+            match store.get(&canonical, project_id.as_deref()) {
+                Some(a) => match a.pane_id.as_deref() {
+                    Some(other) => other != pane_id,
+                    None => false,
+                },
+                None => false,
+            }
+        };
+        if bound_elsewhere {
+            self.unbind_for_pane(pane_id, true, app);
+            return None;
+        }
+
+        // Safe to claim. Release prior auto-claims first so the rename
+        // case (oldname→newname) doesn't leave a stale binding.
+        self.unbind_for_pane(pane_id, true, app);
+
+        match self.bind(
+            &canonical,
+            BindRequest {
+                project_id,
+                session_id: None,
+                pane_id: Some(pane_id.to_string()),
+                auto_claimed: true,
+                force: false,
+            },
+            app,
+        ) {
+            Ok(alias) => Some(alias),
+            Err(_) => None,
+        }
+    }
+
+    pub fn unbind(
+        &self,
+        canonical: &str,
+        project_id: Option<&str>,
+        app: Option<&AppHandle>,
+    ) -> bool {
+        let changed = {
+            let mut store = self.inner.lock().expect("alias store poisoned");
+            store.unbind(canonical, project_id)
+        };
+        if changed {
+            self.persist();
+            if let Some(app) = app {
+                let _ = app.emit(
+                    ALIAS_EVENT,
+                    &AliasEvent::Unset {
+                        canonical: canonical.to_string(),
+                        project_id: project_id.map(String::from),
+                    },
+                );
+            }
+        }
+        changed
+    }
+
+    /// Idempotent ensure — creates an unbound entry if missing, returns
+    /// the existing entry otherwise. Persists only when a new entry was
+    /// actually inserted.
+    pub fn ensure(&self, canonical: &str, project_id: Option<String>) -> AgentAlias {
+        let (alias, was_new) = {
+            let mut store = self.inner.lock().expect("alias store poisoned");
+            let before_len = store.entries().len();
+            let alias = store.ensure(canonical, project_id);
+            let was_new = store.entries().len() > before_len;
+            (alias, was_new)
+        };
+        if was_new {
+            self.persist();
+        }
+        alias
+    }
+
+    pub fn get(&self, canonical: &str, project_id: Option<&str>) -> Option<AgentAlias> {
+        let store = self.inner.lock().expect("alias store poisoned");
+        store.get(canonical, project_id).cloned()
+    }
+
+    pub fn find_all_by_name(&self, canonical: &str) -> Vec<AgentAlias> {
+        let store = self.inner.lock().expect("alias store poisoned");
+        store.find_all_by_name(canonical).into_iter().cloned().collect()
+    }
+
+    pub fn list(&self, project_filter: ProjectFilter<'_>, only_unbound: bool) -> Vec<AgentAlias> {
+        let store = self.inner.lock().expect("alias store poisoned");
+        store.list(project_filter, only_unbound)
+    }
+
+    pub fn whoami(&self, session_id: &str) -> Vec<AgentAlias> {
+        let store = self.inner.lock().expect("alias store poisoned");
+        store.whoami(session_id)
+    }
+
+    fn persist(&self) {
+        let Some(path) = self.persistence_path.as_ref() else {
+            return;
+        };
+        let store = self.inner.lock().expect("alias store poisoned");
+        if let Err(e) = save_to_path(store.entries(), path.as_path()) {
+            eprintln!("[roux] alias persistence failed at {}: {e}", path.display());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn load_seeds_me_alias_when_absent() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("aliases.json");
+        let mgr = AliasManager::load_from(path.clone());
+        assert!(mgr.get("me", None).is_some(), "me alias must be seeded");
+        // And persisted back so the seed survives next load.
+        assert!(path.exists(), "load_from must write the seeded state");
+    }
+
+    #[test]
+    fn load_preserves_existing_me_alias() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("aliases.json");
+        // First load creates `me`.
+        let mgr = AliasManager::load_from(path.clone());
+        // Bind some other alias and verify it persists.
+        mgr.bind("reviewer", BindRequest { session_id: Some("sess-1".into()), ..Default::default() }, None).unwrap();
+        // Reload from same path.
+        let mgr2 = AliasManager::load_from(path);
+        assert!(mgr2.get("me", None).is_some());
+        assert_eq!(mgr2.get("reviewer", None).unwrap().session_id.as_deref(), Some("sess-1"));
+    }
+
+    #[test]
+    fn bind_persists_to_disk() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("aliases.json");
+        let mgr = AliasManager::load_from(path.clone());
+        mgr.bind("reviewer", BindRequest { session_id: Some("sess-1".into()), ..Default::default() }, None).unwrap();
+
+        let raw = std::fs::read_to_string(&path).unwrap();
+        let envelope: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        let aliases = envelope["data"].as_array().unwrap();
+        assert!(aliases.iter().any(|a| a["alias"] == "reviewer"));
+    }
+
+    #[test]
+    fn unbind_persists_when_changed() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("aliases.json");
+        let mgr = AliasManager::load_from(path.clone());
+        mgr.bind("reviewer", BindRequest { session_id: Some("sess-1".into()), ..Default::default() }, None).unwrap();
+        assert!(mgr.unbind("reviewer", None, None));
+
+        let mgr2 = AliasManager::load_from(path);
+        assert!(mgr2.get("reviewer", None).unwrap().session_id.is_none());
+    }
+
+    #[test]
+    fn unbind_returns_false_when_nothing_changes() {
+        let mgr = AliasManager::in_memory();
+        // `me` is unbound by default; unbinding it again should report no change.
+        assert!(!mgr.unbind("me", None, None));
+    }
+
+    #[test]
+    fn bind_force_overrides_existing_binding() {
+        let mgr = AliasManager::in_memory();
+        mgr.bind(
+            "reviewer",
+            BindRequest { session_id: Some("sess-1".into()), ..Default::default() },
+            None,
+        )
+        .unwrap();
+        let err = mgr
+            .bind(
+                "reviewer",
+                BindRequest { session_id: Some("sess-2".into()), ..Default::default() },
+                None,
+            )
+            .unwrap_err();
+        assert!(matches!(err, BindError::AlreadyBoundElsewhere { .. }));
+        let stolen = mgr
+            .bind(
+                "reviewer",
+                BindRequest { session_id: Some("sess-2".into()), force: true, ..Default::default() },
+                None,
+            )
+            .unwrap();
+        assert_eq!(stolen.session_id.as_deref(), Some("sess-2"));
+    }
+
+    fn rs(session: &str) -> BindRequest {
+        BindRequest { session_id: Some(session.into()), ..Default::default() }
+    }
+
+    #[test]
+    fn whoami_finds_aliases_held_by_session() {
+        let mgr = AliasManager::in_memory();
+        mgr.bind("alpha", rs("sess-1"), None).unwrap();
+        mgr.bind("beta", rs("sess-1"), None).unwrap();
+        mgr.bind("gamma", rs("sess-2"), None).unwrap();
+
+        let mine = mgr.whoami("sess-1");
+        let mut names: Vec<_> = mine.into_iter().map(|a| a.alias).collect();
+        names.sort();
+        assert_eq!(names, vec!["alpha", "beta"]);
+    }
+
+    #[test]
+    fn list_filters_correctly() {
+        let mgr = AliasManager::in_memory();
+        mgr.bind("a", rs("s"), None).unwrap();
+        mgr.bind(
+            "b",
+            BindRequest {
+                project_id: Some("p1".into()),
+                session_id: Some("s".into()),
+                ..Default::default()
+            },
+            None,
+        )
+        .unwrap();
+
+        let all = mgr.list(ProjectFilter::Any, false);
+        // me + a + b
+        assert_eq!(all.len(), 3);
+
+        let global_only = mgr.list(ProjectFilter::Exact(None), false);
+        // me + a
+        assert_eq!(global_only.len(), 2);
+
+        let p1_only = mgr.list(ProjectFilter::Exact(Some("p1")), false);
+        assert_eq!(p1_only.len(), 1);
+        assert_eq!(p1_only[0].alias, "b");
+    }
+
+    #[test]
+    fn ensure_is_idempotent_on_disk() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("aliases.json");
+        let mgr = AliasManager::load_from(path.clone());
+        let before = std::fs::metadata(&path).unwrap().modified().unwrap();
+        // Sleep a tick so mtime would change if a write happened.
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        mgr.ensure("me", None); // already exists
+        let after = std::fs::metadata(&path).unwrap().modified().unwrap();
+        assert_eq!(before, after, "ensure on existing entry must not rewrite the file");
+    }
+
+    #[test]
+    fn ensure_writes_when_new_entry_added() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("aliases.json");
+        let mgr = AliasManager::load_from(path.clone());
+        mgr.ensure("freshly-created", None);
+        let raw = std::fs::read_to_string(&path).unwrap();
+        assert!(raw.contains("freshly-created"));
+    }
+
+    // ── Phase 1.5: pane-name auto-claim ─────────────────────────────────
+
+    #[test]
+    fn auto_claim_binds_when_pane_name_is_valid_alias() {
+        let mgr = AliasManager::in_memory();
+        let alias = mgr
+            .try_auto_claim_from_pane_name("pane-A", Some("reviewer"), None, None)
+            .expect("should claim");
+        assert_eq!(alias.alias, "reviewer");
+        assert_eq!(alias.pane_id.as_deref(), Some("pane-A"));
+        assert!(alias.auto_claimed);
+    }
+
+    #[test]
+    fn auto_claim_skips_when_name_has_invalid_chars() {
+        let mgr = AliasManager::in_memory();
+        // Capitals, spaces, parens — all rejected by validate_user_alias_name.
+        assert!(mgr
+            .try_auto_claim_from_pane_name("pane-A", Some("Reviewer (v2)"), None, None)
+            .is_none());
+        assert!(mgr.find_for_pane("pane-A").is_empty());
+    }
+
+    #[test]
+    fn auto_claim_skips_reserved_name() {
+        let mgr = AliasManager::in_memory();
+        assert!(mgr.try_auto_claim_from_pane_name("pane-A", Some("me"), None, None).is_none());
+    }
+
+    #[test]
+    fn auto_claim_idempotent_for_same_pane_and_name() {
+        let mgr = AliasManager::in_memory();
+        let first = mgr
+            .try_auto_claim_from_pane_name("pane-A", Some("reviewer"), None, None)
+            .expect("first claim");
+        let second = mgr
+            .try_auto_claim_from_pane_name("pane-A", Some("reviewer"), None, None)
+            .expect("re-claim");
+        assert_eq!(first.created_at, second.created_at);
+    }
+
+    #[test]
+    fn auto_claim_does_not_steal_from_other_pane() {
+        let mgr = AliasManager::in_memory();
+        mgr.try_auto_claim_from_pane_name("pane-A", Some("reviewer"), None, None);
+        // A second pane named "reviewer" can't auto-claim — pane-A holds it.
+        assert!(mgr.try_auto_claim_from_pane_name("pane-B", Some("reviewer"), None, None).is_none());
+        // pane-A still holds it.
+        let held = mgr.find_for_pane("pane-A");
+        assert_eq!(held[0].alias, "reviewer");
+    }
+
+    #[test]
+    fn auto_claim_releases_prior_auto_claim_on_rename() {
+        let mgr = AliasManager::in_memory();
+        // Pane starts as "reviewer".
+        mgr.try_auto_claim_from_pane_name("pane-A", Some("reviewer"), None, None);
+        // Renamed to "builder".
+        let after = mgr
+            .try_auto_claim_from_pane_name("pane-A", Some("builder"), None, None)
+            .expect("rename should re-claim");
+        assert_eq!(after.alias, "builder");
+        // The old "reviewer" alias is now unbound (pane_id cleared).
+        let held = mgr.find_for_pane("pane-A");
+        assert_eq!(held.len(), 1);
+        assert_eq!(held[0].alias, "builder");
+    }
+
+    #[test]
+    fn auto_claim_invalid_rename_releases_old_binding() {
+        let mgr = AliasManager::in_memory();
+        mgr.try_auto_claim_from_pane_name("pane-A", Some("reviewer"), None, None);
+        // Rename to something that can't be canonicalized to a valid
+        // alias (space + parens).
+        let result =
+            mgr.try_auto_claim_from_pane_name("pane-A", Some("Reviewer (v2)"), None, None);
+        assert!(result.is_none(), "invalid name should not claim");
+        // The pane has no auto-claimed binding anymore.
+        assert!(mgr.find_for_pane("pane-A").is_empty());
+    }
+
+    #[test]
+    fn auto_claim_preserves_manual_claim_on_pane() {
+        let mgr = AliasManager::in_memory();
+        // Manual claim binds with auto_claimed=false.
+        mgr.bind(
+            "manual-name",
+            BindRequest {
+                session_id: Some("sess-1".into()),
+                pane_id: Some("pane-A".into()),
+                auto_claimed: false,
+                ..Default::default()
+            },
+            None,
+        )
+        .unwrap();
+        // Now pane gets renamed to a valid alias name.
+        let auto = mgr
+            .try_auto_claim_from_pane_name("pane-A", Some("auto-name"), None, None)
+            .expect("auto-claim still works alongside manual");
+        assert!(auto.auto_claimed);
+        // Both bindings exist.
+        let held = mgr.find_for_pane("pane-A");
+        assert_eq!(held.len(), 2);
+    }
+
+    #[test]
+    fn auto_claim_with_empty_name_releases_existing_auto_claim() {
+        let mgr = AliasManager::in_memory();
+        mgr.try_auto_claim_from_pane_name("pane-A", Some("reviewer"), None, None);
+        let result =
+            mgr.try_auto_claim_from_pane_name("pane-A", Some(""), None, None);
+        assert!(result.is_none());
+        assert!(mgr.find_for_pane("pane-A").is_empty());
+    }
+
+    #[test]
+    fn unbind_for_pane_releases_only_auto_when_only_auto_claimed_true() {
+        let mgr = AliasManager::in_memory();
+        mgr.bind(
+            "manual",
+            BindRequest {
+                session_id: Some("sess-1".into()),
+                pane_id: Some("pane-A".into()),
+                auto_claimed: false,
+                ..Default::default()
+            },
+            None,
+        )
+        .unwrap();
+        mgr.try_auto_claim_from_pane_name("pane-A", Some("auto"), None, None);
+
+        let released = mgr.unbind_for_pane("pane-A", true, None);
+        assert_eq!(released, vec!["auto".to_string()]);
+        // Manual binding is still in place.
+        let held = mgr.find_for_pane("pane-A");
+        assert_eq!(held.len(), 1);
+        assert_eq!(held[0].alias, "manual");
+    }
+}

--- a/src-tauri/src/aliases/manager.rs
+++ b/src-tauri/src/aliases/manager.rs
@@ -78,14 +78,14 @@ impl AliasManager {
 
     /// Release every binding tied to `pane_id`. Used on pane close /
     /// rename. `only_auto_claimed=true` preserves manual `roux alias claim`
-    /// bindings. Returns the names of released aliases so the caller can
-    /// emit per-alias `Unset` events for the UI.
+    /// bindings. Returns `(canonical, project_id)` pairs so the caller
+    /// can emit per-scope `Unset` events for the UI.
     pub fn unbind_for_pane(
         &self,
         pane_id: &str,
         only_auto_claimed: bool,
         app: Option<&AppHandle>,
-    ) -> Vec<String> {
+    ) -> Vec<(String, Option<String>)> {
         let released = {
             let mut store = self.inner.lock().expect("alias store poisoned");
             store.unbind_for_pane(pane_id, only_auto_claimed)
@@ -93,16 +93,12 @@ impl AliasManager {
         if !released.is_empty() {
             self.persist();
             if let Some(app) = app {
-                for canonical in &released {
-                    // We don't know the project_id post-release without
-                    // re-querying, but the store treats project_id as the
-                    // disambiguator only at lookup time — UI listeners
-                    // re-query via the store for the full alias state.
+                for (canonical, project_id) in &released {
                     let _ = app.emit(
                         ALIAS_EVENT,
                         &AliasEvent::Unset {
                             canonical: canonical.clone(),
-                            project_id: None,
+                            project_id: project_id.clone(),
                         },
                     );
                 }
@@ -227,9 +223,16 @@ impl AliasManager {
     }
 
     /// Idempotent ensure — creates an unbound entry if missing, returns
-    /// the existing entry otherwise. Persists only when a new entry was
-    /// actually inserted.
-    pub fn ensure(&self, canonical: &str, project_id: Option<String>) -> AgentAlias {
+    /// the existing entry otherwise. Persists and fires an `AliasEvent::Set`
+    /// only when a new entry was actually inserted, so the frontend store
+    /// picks up implicit aliases (e.g. `mailbox-post` to a not-yet-claimed
+    /// name) without needing a re-hydrate.
+    pub fn ensure(
+        &self,
+        canonical: &str,
+        project_id: Option<String>,
+        app: Option<&AppHandle>,
+    ) -> AgentAlias {
         let (alias, was_new) = {
             let mut store = self.inner.lock().expect("alias store poisoned");
             let before_len = store.entries().len();
@@ -239,6 +242,9 @@ impl AliasManager {
         };
         if was_new {
             self.persist();
+            if let Some(app) = app {
+                let _ = app.emit(ALIAS_EVENT, &AliasEvent::Set { alias: alias.clone() });
+            }
         }
         alias
     }
@@ -415,7 +421,7 @@ mod tests {
         let before = std::fs::metadata(&path).unwrap().modified().unwrap();
         // Sleep a tick so mtime would change if a write happened.
         std::thread::sleep(std::time::Duration::from_millis(10));
-        mgr.ensure("me", None); // already exists
+        mgr.ensure("me", None, None); // already exists
         let after = std::fs::metadata(&path).unwrap().modified().unwrap();
         assert_eq!(before, after, "ensure on existing entry must not rewrite the file");
     }
@@ -425,7 +431,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let path = dir.path().join("aliases.json");
         let mgr = AliasManager::load_from(path.clone());
-        mgr.ensure("freshly-created", None);
+        mgr.ensure("freshly-created", None, None);
         let raw = std::fs::read_to_string(&path).unwrap();
         assert!(raw.contains("freshly-created"));
     }
@@ -563,7 +569,7 @@ mod tests {
         mgr.try_auto_claim_from_pane_name("pane-A", Some("auto"), None, None);
 
         let released = mgr.unbind_for_pane("pane-A", true, None);
-        assert_eq!(released, vec!["auto".to_string()]);
+        assert_eq!(released, vec![("auto".to_string(), None)]);
         // Manual binding is still in place.
         let held = mgr.find_for_pane("pane-A");
         assert_eq!(held.len(), 1);

--- a/src-tauri/src/aliases/manager.rs
+++ b/src-tauri/src/aliases/manager.rs
@@ -181,7 +181,7 @@ impl AliasManager {
         // case (oldname→newname) doesn't leave a stale binding.
         self.unbind_for_pane(pane_id, true, app);
 
-        match self.bind(
+        self.bind(
             &canonical,
             BindRequest {
                 project_id,
@@ -191,10 +191,8 @@ impl AliasManager {
                 force: false,
             },
             app,
-        ) {
-            Ok(alias) => Some(alias),
-            Err(_) => None,
-        }
+        )
+        .ok()
     }
 
     pub fn unbind(

--- a/src-tauri/src/aliases/mod.rs
+++ b/src-tauri/src/aliases/mod.rs
@@ -1,0 +1,17 @@
+//! Agent alias service — stable, restart-durable identity for sessions.
+//!
+//! Aliases are human-meaningful labels (e.g. `reviewer`, `frontend`) that
+//! resolve to whichever session currently holds them. They survive session
+//! restart so cross-session references don't rot when UUIDs change.
+//!
+//! Mirrors the `notifications` module split: `store` holds the in-memory
+//! state and is persistence/Tauri-free; `manager` (added next) owns the
+//! `Arc<Mutex<Store>>`, JSON persistence, and event emission.
+
+pub mod manager;
+pub mod persistence;
+pub mod store;
+
+pub use manager::{AliasManager, ALIAS_EVENT};
+pub use persistence::{load_aliases, persistence_path, save_aliases};
+pub use store::{AliasStore, BindError, BindRequest, ProjectFilter};

--- a/src-tauri/src/aliases/persistence.rs
+++ b/src-tauri/src/aliases/persistence.rs
@@ -1,0 +1,138 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use roux_core::AgentAlias;
+use serde::{Deserialize, Serialize};
+
+const SCHEMA_VERSION: u32 = 1;
+
+/// Versioned envelope wrapping the alias array. Versioning is baked in
+/// from day one so future shape changes can migrate or coexist without
+/// silently corrupting on-disk state.
+#[derive(Debug, Serialize, Deserialize)]
+struct AliasesFile {
+    version: u32,
+    data: Vec<AgentAlias>,
+}
+
+pub fn persistence_path() -> PathBuf {
+    crate::paths::roux_config_dir().join("aliases.json")
+}
+
+pub fn load_aliases() -> Vec<AgentAlias> {
+    load_from_path(&persistence_path())
+}
+
+pub fn save_aliases(entries: &[AgentAlias]) -> std::io::Result<()> {
+    save_to_path(entries, &persistence_path())
+}
+
+pub(crate) fn load_from_path(path: &Path) -> Vec<AgentAlias> {
+    if !path.exists() {
+        return Vec::new();
+    }
+    let content = match fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(_) => return Vec::new(),
+    };
+
+    if let Ok(file) = serde_json::from_str::<AliasesFile>(&content) {
+        return file.data;
+    }
+
+    // Defensive fallback: pre-versioning files (or hand-edited bare
+    // arrays) parse as a plain Vec.
+    serde_json::from_str::<Vec<AgentAlias>>(&content).unwrap_or_default()
+}
+
+pub(crate) fn save_to_path(entries: &[AgentAlias], path: &Path) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let envelope = AliasesFile { version: SCHEMA_VERSION, data: entries.to_vec() };
+    let json = serde_json::to_string_pretty(&envelope)?;
+    fs::write(path, json)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn save_then_load_round_trips() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("aliases.json");
+        let mut a = AgentAlias::new("reviewer", None);
+        a.session_id = Some("sess-1".into());
+        let mut b = AgentAlias::new("frontend", Some("proj-x".into()));
+        b.session_id = Some("sess-2".into());
+        let entries = vec![a.clone(), b.clone()];
+
+        save_to_path(&entries, &path).unwrap();
+        let loaded = load_from_path(&path);
+        assert_eq!(loaded.len(), 2);
+        assert_eq!(loaded[0], a);
+        assert_eq!(loaded[1], b);
+    }
+
+    #[test]
+    fn load_returns_empty_when_file_missing() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("aliases.json");
+        assert!(load_from_path(&path).is_empty());
+    }
+
+    #[test]
+    fn load_returns_empty_when_file_is_malformed() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("aliases.json");
+        fs::write(&path, "not json at all").unwrap();
+        assert!(load_from_path(&path).is_empty());
+    }
+
+    #[test]
+    fn load_accepts_bare_array_for_back_compat() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("aliases.json");
+        let entries = vec![AgentAlias::new("reviewer", None)];
+        let bare_array = serde_json::to_string(&entries).unwrap();
+        fs::write(&path, bare_array).unwrap();
+        let loaded = load_from_path(&path);
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].alias, "reviewer");
+    }
+
+    #[test]
+    fn load_envelope_with_unknown_version_still_parses_data() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("aliases.json");
+        let entries = vec![AgentAlias::new("reviewer", None)];
+        let envelope = serde_json::json!({
+            "version": 999,
+            "data": entries,
+        });
+        fs::write(&path, envelope.to_string()).unwrap();
+        let loaded = load_from_path(&path);
+        assert_eq!(loaded.len(), 1, "unknown future version should still load data");
+    }
+
+    #[test]
+    fn save_writes_versioned_envelope() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("aliases.json");
+        save_to_path(&[AgentAlias::new("reviewer", None)], &path).unwrap();
+        let content = fs::read_to_string(&path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert_eq!(parsed["version"], SCHEMA_VERSION);
+        assert!(parsed["data"].is_array());
+    }
+
+    #[test]
+    fn save_creates_parent_directory() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("nested").join("dir").join("aliases.json");
+        save_to_path(&[], &path).unwrap();
+        assert!(path.exists());
+    }
+}

--- a/src-tauri/src/aliases/store.rs
+++ b/src-tauri/src/aliases/store.rs
@@ -1,0 +1,632 @@
+use roux_core::AgentAlias;
+
+/// Filter helper for list operations. `Any` matches every project; `Exact`
+/// matches one specific project (or global, when the inner value is `None`).
+#[derive(Debug, Clone, Copy)]
+pub enum ProjectFilter<'a> {
+    Any,
+    Exact(Option<&'a str>),
+}
+
+impl<'a> ProjectFilter<'a> {
+    pub fn matches(&self, candidate: Option<&str>) -> bool {
+        match self {
+            ProjectFilter::Any => true,
+            ProjectFilter::Exact(target) => candidate == *target,
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum BindError {
+    #[error(
+        "alias '{canonical}' is already bound to {current}; pass force=true to override"
+    )]
+    AlreadyBoundElsewhere { canonical: String, current: String },
+}
+
+/// Bind request bag. Use `BindRequest::default()` then set the fields you
+/// care about; reduces multi-positional-arg call ergonomics to one struct
+/// literal per call site.
+#[derive(Debug, Clone, Default)]
+pub struct BindRequest {
+    /// Project scope. `None` means global (typically the human-user `me`).
+    pub project_id: Option<String>,
+    /// Optional cached session parent. Auto-claim from pane name leaves
+    /// this `None` when the session linkage isn't known. Required by the
+    /// explicit `roux alias claim` flow, which is rejected upstream when
+    /// the caller isn't inside a session.
+    pub session_id: Option<String>,
+    /// Canonical addressable target. When `None`, the alias falls back
+    /// to the session's primary pane at delivery time (Phase-1 compat).
+    pub pane_id: Option<String>,
+    /// `true` when the alias was derived from the pane's name. Released
+    /// on pane rename or close.
+    pub auto_claimed: bool,
+    /// Override an existing bound-elsewhere binding. Manual claims with
+    /// `--steal`, or auto-claim races, set this.
+    pub force: bool,
+}
+
+/// In-memory alias store. Entries are keyed by `(canonical_alias, project_id)`,
+/// so the same name may exist in multiple project scopes.
+///
+/// Persistence and event emission live in `AliasManager` (mirrors the
+/// `NotificationStore` / `NotificationManager` split).
+pub struct AliasStore {
+    entries: Vec<AgentAlias>,
+}
+
+impl AliasStore {
+    pub fn new() -> Self {
+        Self { entries: Vec::new() }
+    }
+
+    pub fn from_entries(entries: Vec<AgentAlias>) -> Self {
+        Self { entries }
+    }
+
+    pub fn entries(&self) -> &[AgentAlias] {
+        &self.entries
+    }
+
+    /// Bind `canonical` (within `req.project_id` scope) to the
+    /// `(session_id, pane_id)` pair from `req`.
+    ///
+    /// Conflict rules:
+    /// - If the alias is already bound to a *different* pane, conflict
+    ///   unless `req.force`.
+    /// - If the alias is bound only at session-level (legacy Phase 1)
+    ///   and the new session differs, conflict unless `req.force`.
+    pub fn bind(
+        &mut self,
+        canonical: &str,
+        req: BindRequest,
+    ) -> Result<AgentAlias, BindError> {
+        let now = now_ms();
+        if let Some(entry) = self.find_mut(canonical, req.project_id.as_deref()) {
+            if let Some(conflict) =
+                current_binding_conflict(entry, req.session_id.as_deref(), req.pane_id.as_deref())
+            {
+                if !req.force {
+                    return Err(BindError::AlreadyBoundElsewhere {
+                        canonical: canonical.to_string(),
+                        current: conflict,
+                    });
+                }
+            }
+            entry.session_id = req.session_id;
+            entry.pane_id = req.pane_id;
+            entry.auto_claimed = req.auto_claimed;
+            entry.updated_at = now;
+            return Ok(entry.clone());
+        }
+        let mut entry = AgentAlias::new(canonical, req.project_id);
+        entry.session_id = req.session_id;
+        entry.pane_id = req.pane_id;
+        entry.auto_claimed = req.auto_claimed;
+        self.entries.push(entry.clone());
+        Ok(entry)
+    }
+
+    /// Clear `canonical`'s binding (within `project_id` scope). Entry is
+    /// retained so addressed mail still has a valid target. Returns true
+    /// when a binding was actually cleared.
+    pub fn unbind(&mut self, canonical: &str, project_id: Option<&str>) -> bool {
+        let now = now_ms();
+        if let Some(entry) = self.find_mut(canonical, project_id) {
+            if entry.is_bound() {
+                entry.session_id = None;
+                entry.pane_id = None;
+                entry.auto_claimed = false;
+                entry.updated_at = now;
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Release every binding currently tied to `pane_id`. Used when a
+    /// pane is destroyed or renamed. `only_auto_claimed=true` limits the
+    /// release to bindings the system created automatically from the
+    /// pane's name; manual `roux alias claim` bindings are preserved.
+    /// Returns the names of the released aliases (in canonical form) so
+    /// the caller can fan out events.
+    pub fn unbind_for_pane(&mut self, pane_id: &str, only_auto_claimed: bool) -> Vec<String> {
+        let now = now_ms();
+        let mut released = Vec::new();
+        for entry in self.entries.iter_mut() {
+            if entry.pane_id.as_deref() != Some(pane_id) {
+                continue;
+            }
+            if only_auto_claimed && !entry.auto_claimed {
+                continue;
+            }
+            entry.session_id = None;
+            entry.pane_id = None;
+            entry.auto_claimed = false;
+            entry.updated_at = now;
+            released.push(entry.alias.clone());
+        }
+        released
+    }
+
+    /// Aliases currently bound to the given pane. Typically zero or one
+    /// in practice (auto-claim binds a single name from the pane's name),
+    /// but the API returns a Vec because manual claims can stack.
+    pub fn find_for_pane(&self, pane_id: &str) -> Vec<&AgentAlias> {
+        self.entries
+            .iter()
+            .filter(|a| a.pane_id.as_deref() == Some(pane_id))
+            .collect()
+    }
+
+    /// Ensure `(canonical, project_id)` exists. If already present, returns
+    /// it unchanged. If absent, creates it as an unbound entry. Used both
+    /// to seed system aliases (`me`) and to materialize implicit alias
+    /// records when posting to a never-claimed name.
+    pub fn ensure(&mut self, canonical: &str, project_id: Option<String>) -> AgentAlias {
+        if let Some(entry) = self.find_mut(canonical, project_id.as_deref()) {
+            return entry.clone();
+        }
+        let entry = AgentAlias::new(canonical, project_id);
+        self.entries.push(entry.clone());
+        entry
+    }
+
+    pub fn get(&self, canonical: &str, project_id: Option<&str>) -> Option<&AgentAlias> {
+        self.entries
+            .iter()
+            .find(|a| a.alias == canonical && a.project_id.as_deref() == project_id)
+    }
+
+    /// All entries matching `canonical` regardless of project scope. Used
+    /// for bare-alias resolution: caller checks for ambiguity (>1 result)
+    /// and demands a project qualification when needed.
+    pub fn find_all_by_name(&self, canonical: &str) -> Vec<&AgentAlias> {
+        self.entries.iter().filter(|a| a.alias == canonical).collect()
+    }
+
+    pub fn list(&self, project_filter: ProjectFilter<'_>, only_unbound: bool) -> Vec<AgentAlias> {
+        self.entries
+            .iter()
+            .filter(|a| project_filter.matches(a.project_id.as_deref()))
+            .filter(|a| !only_unbound || a.session_id.is_none())
+            .cloned()
+            .collect()
+    }
+
+    /// Aliases currently bound to the given session.
+    pub fn whoami(&self, session_id: &str) -> Vec<AgentAlias> {
+        self.entries
+            .iter()
+            .filter(|a| a.session_id.as_deref() == Some(session_id))
+            .cloned()
+            .collect()
+    }
+
+    fn find_mut(
+        &mut self,
+        canonical: &str,
+        project_id: Option<&str>,
+    ) -> Option<&mut AgentAlias> {
+        self.entries
+            .iter_mut()
+            .find(|a| a.alias == canonical && a.project_id.as_deref() == project_id)
+    }
+
+    #[cfg(test)]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+impl Default for AliasStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Returns a human-readable description of an existing binding when the
+/// requested new binding would conflict, or `None` when there is no
+/// conflict. Pane-level conflicts win over session-level (a Phase-1.5
+/// pane-bound alias is more specific than a Phase-1 session-bound one).
+fn current_binding_conflict(
+    existing: &AgentAlias,
+    new_session: Option<&str>,
+    new_pane: Option<&str>,
+) -> Option<String> {
+    match (existing.pane_id.as_deref(), new_pane) {
+        (Some(eid), Some(nid)) if eid != nid => Some(format!("pane '{eid}'")),
+        (Some(eid), None) => Some(format!("pane '{eid}'")),
+        _ => match (existing.session_id.as_deref(), new_session, new_pane) {
+            (Some(esid), Some(ns), None) if esid != ns => Some(format!("session '{esid}'")),
+            _ => None,
+        },
+    }
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Test-only convenience: build a session-only `BindRequest`, mirroring
+    /// the Phase-1 default of "no pane, manual bind."
+    fn req(session: &str) -> BindRequest {
+        BindRequest { session_id: Some(session.into()), ..Default::default() }
+    }
+
+    #[test]
+    fn bind_creates_unknown_alias() {
+        let mut store = AliasStore::new();
+        let a = store.bind("reviewer", req("sess-1")).unwrap();
+        assert_eq!(a.alias, "reviewer");
+        assert_eq!(a.session_id.as_deref(), Some("sess-1"));
+        assert_eq!(store.len(), 1);
+    }
+
+    #[test]
+    fn bind_rebinds_when_same_session() {
+        let mut store = AliasStore::new();
+        store.bind("reviewer", req("sess-1")).unwrap();
+        let again = store.bind("reviewer", req("sess-1")).unwrap();
+        assert_eq!(again.session_id.as_deref(), Some("sess-1"));
+        assert_eq!(store.len(), 1);
+    }
+
+    #[test]
+    fn bind_rejects_when_bound_elsewhere() {
+        let mut store = AliasStore::new();
+        store.bind("reviewer", req("sess-1")).unwrap();
+        let err = store.bind("reviewer", req("sess-2")).unwrap_err();
+        assert_eq!(
+            err,
+            BindError::AlreadyBoundElsewhere {
+                canonical: "reviewer".into(),
+                current: "session 'sess-1'".into(),
+            }
+        );
+        assert_eq!(store.get("reviewer", None).unwrap().session_id.as_deref(), Some("sess-1"));
+    }
+
+    #[test]
+    fn bind_force_overrides_existing() {
+        let mut store = AliasStore::new();
+        store.bind("reviewer", req("sess-1")).unwrap();
+        let stolen = store
+            .bind(
+                "reviewer",
+                BindRequest { session_id: Some("sess-2".into()), force: true, ..Default::default() },
+            )
+            .unwrap();
+        assert_eq!(stolen.session_id.as_deref(), Some("sess-2"));
+    }
+
+    #[test]
+    fn bind_after_unbind_succeeds_without_force() {
+        let mut store = AliasStore::new();
+        store.bind("reviewer", req("sess-1")).unwrap();
+        assert!(store.unbind("reviewer", None));
+        let rebind = store.bind("reviewer", req("sess-2")).unwrap();
+        assert_eq!(rebind.session_id.as_deref(), Some("sess-2"));
+    }
+
+    #[test]
+    fn unbind_clears_session_but_keeps_entry() {
+        let mut store = AliasStore::new();
+        store.bind("reviewer", req("sess-1")).unwrap();
+        assert!(store.unbind("reviewer", None));
+        let entry = store.get("reviewer", None).unwrap();
+        assert!(entry.session_id.is_none());
+        assert!(entry.pane_id.is_none());
+        assert_eq!(store.len(), 1, "entry must persist for queued mail");
+    }
+
+    #[test]
+    fn unbind_returns_false_when_already_unbound() {
+        let mut store = AliasStore::new();
+        store.ensure("reviewer", None);
+        assert!(!store.unbind("reviewer", None));
+    }
+
+    #[test]
+    fn unbind_returns_false_for_missing_alias() {
+        let mut store = AliasStore::new();
+        assert!(!store.unbind("ghost", None));
+    }
+
+    #[test]
+    fn ensure_creates_unbound_when_missing() {
+        let mut store = AliasStore::new();
+        let a = store.ensure("reviewer", None);
+        assert_eq!(a.alias, "reviewer");
+        assert!(a.session_id.is_none());
+        assert_eq!(store.len(), 1);
+    }
+
+    #[test]
+    fn ensure_is_idempotent() {
+        let mut store = AliasStore::new();
+        let first = store.ensure("reviewer", None);
+        let second = store.ensure("reviewer", None);
+        assert_eq!(first.created_at, second.created_at);
+        assert_eq!(store.len(), 1);
+    }
+
+    #[test]
+    fn project_scoped_aliases_are_independent() {
+        let mut store = AliasStore::new();
+        store
+            .bind(
+                "reviewer",
+                BindRequest {
+                    project_id: Some("proj-a".into()),
+                    session_id: Some("sess-a".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        store
+            .bind(
+                "reviewer",
+                BindRequest {
+                    project_id: Some("proj-b".into()),
+                    session_id: Some("sess-b".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        store.bind("reviewer", req("sess-global")).unwrap();
+        assert_eq!(store.len(), 3);
+
+        assert_eq!(
+            store.get("reviewer", Some("proj-a")).unwrap().session_id.as_deref(),
+            Some("sess-a")
+        );
+        assert_eq!(
+            store.get("reviewer", Some("proj-b")).unwrap().session_id.as_deref(),
+            Some("sess-b")
+        );
+        assert_eq!(
+            store.get("reviewer", None).unwrap().session_id.as_deref(),
+            Some("sess-global")
+        );
+    }
+
+    #[test]
+    fn find_all_by_name_returns_every_scope() {
+        let mut store = AliasStore::new();
+        for (proj, sess) in [(Some("proj-a"), "s1"), (Some("proj-b"), "s2")] {
+            store
+                .bind(
+                    "reviewer",
+                    BindRequest {
+                        project_id: proj.map(String::from),
+                        session_id: Some(sess.into()),
+                        ..Default::default()
+                    },
+                )
+                .unwrap();
+        }
+        store.bind("other", req("s3")).unwrap();
+        let matches = store.find_all_by_name("reviewer");
+        assert_eq!(matches.len(), 2);
+    }
+
+    #[test]
+    fn list_filters_by_project_scope() {
+        let mut store = AliasStore::new();
+        store.bind("a", req("s")).unwrap();
+        store
+            .bind(
+                "b",
+                BindRequest {
+                    project_id: Some("p1".into()),
+                    session_id: Some("s".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        store
+            .bind(
+                "c",
+                BindRequest {
+                    project_id: Some("p2".into()),
+                    session_id: Some("s".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        assert_eq!(store.list(ProjectFilter::Any, false).len(), 3);
+        assert_eq!(store.list(ProjectFilter::Exact(None), false).len(), 1);
+        assert_eq!(store.list(ProjectFilter::Exact(Some("p1")), false).len(), 1);
+        assert_eq!(store.list(ProjectFilter::Exact(Some("missing")), false).len(), 0);
+    }
+
+    #[test]
+    fn list_only_unbound_filters_correctly() {
+        let mut store = AliasStore::new();
+        store.bind("bound", req("sess")).unwrap();
+        store.ensure("unbound", None);
+        let only_unbound = store.list(ProjectFilter::Any, true);
+        assert_eq!(only_unbound.len(), 1);
+        assert_eq!(only_unbound[0].alias, "unbound");
+    }
+
+    #[test]
+    fn whoami_lists_aliases_for_session() {
+        let mut store = AliasStore::new();
+        store.bind("alpha", req("sess-1")).unwrap();
+        store.bind("beta", req("sess-1")).unwrap();
+        store.bind("gamma", req("sess-2")).unwrap();
+        store.ensure("orphan", None);
+
+        let names: Vec<_> = store.whoami("sess-1").iter().map(|a| a.alias.clone()).collect();
+        assert_eq!(names, vec!["alpha", "beta"]);
+        assert_eq!(store.whoami("sess-2").len(), 1);
+        assert_eq!(store.whoami("missing").len(), 0);
+    }
+
+    #[test]
+    fn from_entries_round_trip() {
+        let mut store = AliasStore::new();
+        store.bind("alpha", req("sess-1")).unwrap();
+        store
+            .bind(
+                "beta",
+                BindRequest {
+                    project_id: Some("proj".into()),
+                    session_id: Some("sess-2".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let snapshot: Vec<_> = store.entries().to_vec();
+
+        let restored = AliasStore::from_entries(snapshot);
+        assert_eq!(restored.len(), 2);
+        assert_eq!(restored.get("alpha", None).unwrap().session_id.as_deref(), Some("sess-1"));
+        assert_eq!(
+            restored.get("beta", Some("proj")).unwrap().session_id.as_deref(),
+            Some("sess-2")
+        );
+    }
+
+    // ── Phase 1.5: pane-level binding ─────────────────────────────────────
+
+    fn req_pane(session: &str, pane: &str) -> BindRequest {
+        BindRequest {
+            session_id: Some(session.into()),
+            pane_id: Some(pane.into()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn bind_with_pane_records_pane_id() {
+        let mut store = AliasStore::new();
+        let a = store.bind("reviewer", req_pane("sess-1", "pane-A")).unwrap();
+        assert_eq!(a.pane_id.as_deref(), Some("pane-A"));
+        assert_eq!(a.session_id.as_deref(), Some("sess-1"));
+        assert!(!a.auto_claimed);
+    }
+
+    #[test]
+    fn bind_pane_conflicts_with_other_pane() {
+        let mut store = AliasStore::new();
+        store.bind("reviewer", req_pane("sess-1", "pane-A")).unwrap();
+        let err = store.bind("reviewer", req_pane("sess-1", "pane-B")).unwrap_err();
+        match err {
+            BindError::AlreadyBoundElsewhere { current, .. } => {
+                assert!(current.contains("pane 'pane-A'"));
+            }
+        }
+    }
+
+    #[test]
+    fn bind_force_overrides_pane() {
+        let mut store = AliasStore::new();
+        store.bind("reviewer", req_pane("sess-1", "pane-A")).unwrap();
+        let stolen = store
+            .bind(
+                "reviewer",
+                BindRequest {
+                    session_id: Some("sess-1".into()),
+                    pane_id: Some("pane-B".into()),
+                    force: true,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert_eq!(stolen.pane_id.as_deref(), Some("pane-B"));
+    }
+
+    #[test]
+    fn auto_claimed_flag_round_trips() {
+        let mut store = AliasStore::new();
+        let a = store
+            .bind(
+                "reviewer",
+                BindRequest {
+                    session_id: Some("sess-1".into()),
+                    pane_id: Some("pane-A".into()),
+                    auto_claimed: true,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert!(a.auto_claimed);
+    }
+
+    #[test]
+    fn unbind_for_pane_releases_only_matching_pane() {
+        let mut store = AliasStore::new();
+        store
+            .bind(
+                "reviewer",
+                BindRequest {
+                    session_id: Some("sess-1".into()),
+                    pane_id: Some("pane-A".into()),
+                    auto_claimed: true,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        store.bind("other", req_pane("sess-1", "pane-B")).unwrap();
+        let released = store.unbind_for_pane("pane-A", false);
+        assert_eq!(released, vec!["reviewer".to_string()]);
+        assert!(store.get("reviewer", None).unwrap().pane_id.is_none());
+        assert_eq!(store.get("other", None).unwrap().pane_id.as_deref(), Some("pane-B"));
+    }
+
+    #[test]
+    fn unbind_for_pane_skips_manual_when_only_auto() {
+        let mut store = AliasStore::new();
+        store
+            .bind(
+                "manual",
+                BindRequest {
+                    session_id: Some("sess-1".into()),
+                    pane_id: Some("pane-A".into()),
+                    auto_claimed: false,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        store
+            .bind(
+                "auto",
+                BindRequest {
+                    session_id: Some("sess-1".into()),
+                    pane_id: Some("pane-A".into()),
+                    auto_claimed: true,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let released = store.unbind_for_pane("pane-A", true);
+        assert_eq!(released, vec!["auto".to_string()]);
+        // manual binding survived
+        assert_eq!(
+            store.get("manual", None).unwrap().pane_id.as_deref(),
+            Some("pane-A")
+        );
+    }
+
+    #[test]
+    fn find_for_pane_returns_only_that_panes_aliases() {
+        let mut store = AliasStore::new();
+        store.bind("reviewer", req_pane("s", "pane-A")).unwrap();
+        store.bind("builder", req_pane("s", "pane-B")).unwrap();
+        let mine: Vec<_> = store.find_for_pane("pane-A").iter().map(|a| a.alias.clone()).collect();
+        assert_eq!(mine, vec!["reviewer"]);
+    }
+}

--- a/src-tauri/src/aliases/store.rs
+++ b/src-tauri/src/aliases/store.rs
@@ -228,6 +228,11 @@ impl AliasStore {
     pub fn len(&self) -> usize {
         self.entries.len()
     }
+
+    #[cfg(test)]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
 }
 
 impl Default for AliasStore {

--- a/src-tauri/src/aliases/store.rs
+++ b/src-tauri/src/aliases/store.rs
@@ -130,9 +130,15 @@ impl AliasStore {
     /// pane is destroyed or renamed. `only_auto_claimed=true` limits the
     /// release to bindings the system created automatically from the
     /// pane's name; manual `roux alias claim` bindings are preserved.
-    /// Returns the names of the released aliases (in canonical form) so
-    /// the caller can fan out events.
-    pub fn unbind_for_pane(&mut self, pane_id: &str, only_auto_claimed: bool) -> Vec<String> {
+    ///
+    /// Returns `(canonical, project_id)` pairs for each released alias
+    /// so the caller can emit per-scope events. Without `project_id`,
+    /// project-scoped aliases couldn't be unbound on the frontend.
+    pub fn unbind_for_pane(
+        &mut self,
+        pane_id: &str,
+        only_auto_claimed: bool,
+    ) -> Vec<(String, Option<String>)> {
         let now = now_ms();
         let mut released = Vec::new();
         for entry in self.entries.iter_mut() {
@@ -146,7 +152,7 @@ impl AliasStore {
             entry.pane_id = None;
             entry.auto_claimed = false;
             entry.updated_at = now;
-            released.push(entry.alias.clone());
+            released.push((entry.alias.clone(), entry.project_id.clone()));
         }
         released
     }
@@ -582,7 +588,7 @@ mod tests {
             .unwrap();
         store.bind("other", req_pane("sess-1", "pane-B")).unwrap();
         let released = store.unbind_for_pane("pane-A", false);
-        assert_eq!(released, vec!["reviewer".to_string()]);
+        assert_eq!(released, vec![("reviewer".to_string(), None)]);
         assert!(store.get("reviewer", None).unwrap().pane_id.is_none());
         assert_eq!(store.get("other", None).unwrap().pane_id.as_deref(), Some("pane-B"));
     }
@@ -613,7 +619,7 @@ mod tests {
             )
             .unwrap();
         let released = store.unbind_for_pane("pane-A", true);
-        assert_eq!(released, vec!["auto".to_string()]);
+        assert_eq!(released, vec![("auto".to_string(), None)]);
         // manual binding survived
         assert_eq!(
             store.get("manual", None).unwrap().pane_id.as_deref(),

--- a/src-tauri/src/aliases/store.rs
+++ b/src-tauri/src/aliases/store.rs
@@ -197,7 +197,10 @@ impl AliasStore {
         self.entries
             .iter()
             .filter(|a| project_filter.matches(a.project_id.as_deref()))
-            .filter(|a| !only_unbound || a.session_id.is_none())
+            // Phase 1.5: an alias bound only at the pane level still
+            // counts as bound. Earlier we only checked session_id, which
+            // mis-classified pane-bound aliases as unbound.
+            .filter(|a| !only_unbound || !a.is_bound())
             .cloned()
             .collect()
     }
@@ -245,8 +248,12 @@ fn current_binding_conflict(
     match (existing.pane_id.as_deref(), new_pane) {
         (Some(eid), Some(nid)) if eid != nid => Some(format!("pane '{eid}'")),
         (Some(eid), None) => Some(format!("pane '{eid}'")),
-        _ => match (existing.session_id.as_deref(), new_session, new_pane) {
-            (Some(esid), Some(ns), None) if esid != ns => Some(format!("session '{esid}'")),
+        _ => match (existing.session_id.as_deref(), new_session) {
+            // Session-level conflict applies regardless of whether the
+            // new bind specifies a pane: a Phase-1 session-only alias
+            // bound to `sess-1` shouldn't get silently rebound to
+            // `pane-B` in `sess-2` without `force`.
+            (Some(esid), Some(ns)) if esid != ns => Some(format!("session '{esid}'")),
             _ => None,
         },
     }

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -1025,6 +1025,12 @@ fn main() {
                 correlation_id,
                 from,
             } => {
+                // Fail fast locally rather than burning a socket round-trip
+                // on a malformed post.
+                if to.is_none() && topic.is_none() {
+                    eprintln!("Error: mailbox post requires at least one of --to or --topic");
+                    std::process::exit(2);
+                }
                 let mut args = serde_json::Map::new();
                 args.insert("body".into(), Value::String(body));
                 if let Some(v) = to {

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -208,6 +208,10 @@ enum MailboxAction {
     Clear {
         #[arg(short = 'a', long)]
         alias: Option<String>,
+        #[arg(short = 'p', long)]
+        project: Option<String>,
+        #[arg(long, conflicts_with = "project")]
+        global: bool,
     },
     /// Reply to an event, preserving its correlation_id for threading
     Reply {
@@ -1104,16 +1108,12 @@ fn main() {
                     "args": build_mailbox_recv_args(alias, project, global, None, None),
                 }));
             }
-            MailboxAction::Clear { alias } => {
-                let mut args = serde_json::Map::new();
-                if let Some(a) = alias {
-                    args.insert("alias".into(), Value::String(a));
-                }
+            MailboxAction::Clear { alias, project, global } => {
                 run_socket_command(serde_json::json!({
                     "command": "mailbox-clear",
                     "session_id": get_session_id(),
                     "pane_id": get_pane_id(),
-                    "args": Value::Object(args),
+                    "args": build_mailbox_recv_args(alias, project, global, None, None),
                 }));
             }
             MailboxAction::Reply { event_id, body, subject, kind } => {

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -112,6 +112,208 @@ enum Commands {
     },
     /// Start the Roux MCP stdio server
     Mcp,
+    /// Manage agent aliases — stable, restart-durable identity for sessions
+    Alias {
+        #[command(subcommand)]
+        action: AliasAction,
+    },
+    /// Direct, ack-able mail addressed to an alias
+    Mailbox {
+        #[command(subcommand)]
+        action: MailboxAction,
+    },
+    /// Topic-based broadcast over the same event store
+    Bus {
+        #[command(subcommand)]
+        action: BusAction,
+    },
+}
+
+#[derive(Subcommand)]
+enum MailboxAction {
+    /// Post a message to a recipient alias and/or topic
+    Post {
+        /// Body text
+        body: String,
+        /// Recipient alias (at least one of --to or --topic required)
+        #[arg(short = 't', long)]
+        to: Option<String>,
+        /// Topic name for broadcast (mailbox + bus addressing combine)
+        #[arg(long)]
+        topic: Option<String>,
+        /// Optional subject line
+        #[arg(long)]
+        subject: Option<String>,
+        /// Kind: task | result | question | fyi | signal (default: task)
+        #[arg(long)]
+        kind: Option<String>,
+        /// Project scope
+        #[arg(short = 'p', long)]
+        project: Option<String>,
+        /// Thread key — copy from a previous event id to thread replies
+        #[arg(long)]
+        correlation_id: Option<String>,
+        /// Override sender (default: calling session's primary alias)
+        #[arg(long)]
+        from: Option<String>,
+    },
+    /// Peek at unread mail (does not change read state)
+    Peek {
+        /// Recipient alias (default: calling session's primary alias)
+        #[arg(short = 'a', long)]
+        alias: Option<String>,
+        /// Only show unread events
+        #[arg(short = 'u', long)]
+        unread: bool,
+        #[arg(short = 'p', long)]
+        project: Option<String>,
+        #[arg(long, conflicts_with = "project")]
+        global: bool,
+        #[arg(short = 'l', long)]
+        limit: Option<u32>,
+    },
+    /// Drain unread mail and mark it read
+    Read {
+        #[arg(short = 'a', long)]
+        alias: Option<String>,
+        /// Also ack each drained event
+        #[arg(long)]
+        ack: bool,
+        #[arg(short = 'p', long)]
+        project: Option<String>,
+        #[arg(long, conflicts_with = "project")]
+        global: bool,
+        #[arg(short = 'l', long)]
+        limit: Option<u32>,
+    },
+    /// Ack a specific event (terminal "I've handled this" state)
+    Ack {
+        event_id: String,
+        /// Optional short result string visible to the sender
+        #[arg(short = 'r', long)]
+        result: Option<String>,
+        #[arg(short = 'a', long)]
+        alias: Option<String>,
+    },
+    /// Count unread mail
+    Count {
+        #[arg(short = 'a', long)]
+        alias: Option<String>,
+        #[arg(short = 'p', long)]
+        project: Option<String>,
+        #[arg(long, conflicts_with = "project")]
+        global: bool,
+    },
+    /// Clear read mail (read events drop from your view; unread persist)
+    Clear {
+        #[arg(short = 'a', long)]
+        alias: Option<String>,
+    },
+    /// Reply to an event, preserving its correlation_id for threading
+    Reply {
+        event_id: String,
+        body: String,
+        #[arg(long)]
+        subject: Option<String>,
+        /// Kind (default: result)
+        #[arg(long)]
+        kind: Option<String>,
+    },
+    /// List events I've sent with their per-recipient state
+    Sent {
+        /// Filter to a single recipient alias
+        #[arg(long)]
+        to: Option<String>,
+        /// Override sender lookup (default: calling session's primary alias)
+        #[arg(long)]
+        sender: Option<String>,
+        #[arg(short = 'l', long)]
+        limit: Option<u32>,
+    },
+}
+
+#[derive(Subcommand)]
+enum BusAction {
+    /// Publish an event to a topic (no specific recipient)
+    Publish {
+        topic: String,
+        /// Body text (or empty when only `--structured` is meaningful)
+        body: String,
+        /// Kind (default: signal)
+        #[arg(long)]
+        kind: Option<String>,
+        #[arg(short = 'p', long)]
+        project: Option<String>,
+        #[arg(long)]
+        subject: Option<String>,
+    },
+    /// Tail events. With --topic filters by topic; otherwise firehose
+    Tail {
+        #[arg(short = 't', long)]
+        topic: Option<String>,
+        #[arg(short = 'p', long)]
+        project: Option<String>,
+        #[arg(long, conflicts_with = "project")]
+        global: bool,
+        #[arg(short = 'l', long)]
+        limit: Option<u32>,
+    },
+}
+
+#[derive(Subcommand)]
+enum AliasAction {
+    /// Bind an alias to a session (defaults to the current session)
+    Set {
+        /// Alias name (lowercase, hyphens allowed; reserved names rejected)
+        alias: String,
+        /// Target session id; defaults to $ROUX_SESSION_ID
+        #[arg(short, long)]
+        session: Option<String>,
+        /// Project scope; aliases with the same name in different projects are independent
+        #[arg(short, long)]
+        project: Option<String>,
+        /// Override an existing binding to a different session
+        #[arg(short, long)]
+        force: bool,
+    },
+    /// Release an alias's binding (queued mail persists for the next claim)
+    Unset {
+        alias: String,
+        #[arg(short, long)]
+        project: Option<String>,
+    },
+    /// Current session claims the alias
+    Claim {
+        alias: String,
+        #[arg(short, long)]
+        project: Option<String>,
+        /// Override existing binding
+        #[arg(long)]
+        steal: bool,
+    },
+    /// List aliases
+    List {
+        /// Filter to a specific project scope
+        #[arg(short, long)]
+        project: Option<String>,
+        /// Only list global (project-less) aliases
+        #[arg(long, conflicts_with = "project")]
+        global: bool,
+        /// Only list aliases that are currently unbound
+        #[arg(long)]
+        only_unbound: bool,
+    },
+    /// Resolve an alias to its current binding
+    Get {
+        alias: String,
+        #[arg(short, long)]
+        project: Option<String>,
+    },
+    /// List aliases bound to a session (defaults to the current session)
+    Whoami {
+        #[arg(short, long)]
+        session: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -326,6 +528,35 @@ enum NotesScopeVerb {
 
 fn status_dir() -> PathBuf {
     platform::status_dir()
+}
+
+/// Build the shared `args` map for receive-side mailbox commands
+/// (peek/read/count/clear). Keeps the dispatch arms focused on their
+/// command-specific extras.
+fn build_mailbox_recv_args(
+    alias: Option<String>,
+    project: Option<String>,
+    global: bool,
+    unread: Option<bool>,
+    limit: Option<u32>,
+) -> Value {
+    let mut args = serde_json::Map::new();
+    if let Some(a) = alias {
+        args.insert("alias".into(), Value::String(a));
+    }
+    if let Some(p) = project {
+        args.insert("project_id".into(), Value::String(p));
+    }
+    if global {
+        args.insert("global".into(), Value::Bool(true));
+    }
+    if let Some(true) = unread {
+        args.insert("unread".into(), Value::Bool(true));
+    }
+    if let Some(n) = limit {
+        args.insert("limit".into(), Value::Number(n.into()));
+    }
+    Value::Object(args)
 }
 
 fn resolve_path(path: &str) -> String {
@@ -696,6 +927,269 @@ fn main() {
                 "args": { "path": resolved },
             }));
         }
+
+        Commands::Alias { action } => match action {
+            AliasAction::Set { alias, session, project, force } => {
+                let mut args = serde_json::Map::new();
+                args.insert("alias".into(), Value::String(alias));
+                if let Some(s) = session {
+                    args.insert("session_id".into(), Value::String(s));
+                }
+                if let Some(p) = project {
+                    args.insert("project_id".into(), Value::String(p));
+                }
+                if force {
+                    args.insert("force".into(), Value::Bool(true));
+                }
+                run_socket_command(serde_json::json!({
+                    "command": "alias-set",
+                    "session_id": get_session_id(),
+                    "pane_id": get_pane_id(),
+                    "args": Value::Object(args),
+                }));
+            }
+            AliasAction::Unset { alias, project } => {
+                let mut args = serde_json::Map::new();
+                args.insert("alias".into(), Value::String(alias));
+                if let Some(p) = project {
+                    args.insert("project_id".into(), Value::String(p));
+                }
+                run_socket_command(serde_json::json!({
+                    "command": "alias-unset",
+                    "session_id": get_session_id(),
+                    "pane_id": get_pane_id(),
+                    "args": Value::Object(args),
+                }));
+            }
+            AliasAction::Claim { alias, project, steal } => {
+                let mut args = serde_json::Map::new();
+                args.insert("alias".into(), Value::String(alias));
+                if let Some(p) = project {
+                    args.insert("project_id".into(), Value::String(p));
+                }
+                if steal {
+                    args.insert("steal".into(), Value::Bool(true));
+                }
+                run_socket_command(serde_json::json!({
+                    "command": "alias-claim",
+                    "session_id": get_session_id(),
+                    "pane_id": get_pane_id(),
+                    "args": Value::Object(args),
+                }));
+            }
+            AliasAction::List { project, global, only_unbound } => {
+                let mut args = serde_json::Map::new();
+                if let Some(p) = project {
+                    args.insert("project_id".into(), Value::String(p));
+                }
+                if global {
+                    args.insert("global".into(), Value::Bool(true));
+                }
+                if only_unbound {
+                    args.insert("only_unbound".into(), Value::Bool(true));
+                }
+                run_socket_command(serde_json::json!({
+                    "command": "alias-list",
+                    "args": Value::Object(args),
+                }));
+            }
+            AliasAction::Get { alias, project } => {
+                let mut args = serde_json::Map::new();
+                args.insert("alias".into(), Value::String(alias));
+                if let Some(p) = project {
+                    args.insert("project_id".into(), Value::String(p));
+                }
+                run_socket_command(serde_json::json!({
+                    "command": "alias-get",
+                    "args": Value::Object(args),
+                }));
+            }
+            AliasAction::Whoami { session } => {
+                let effective_session = session.or_else(get_session_id);
+                run_socket_command(serde_json::json!({
+                    "command": "alias-whoami",
+                    "session_id": effective_session,
+                    "args": {},
+                }));
+            }
+        },
+
+        Commands::Mailbox { action } => match action {
+            MailboxAction::Post {
+                body,
+                to,
+                topic,
+                subject,
+                kind,
+                project,
+                correlation_id,
+                from,
+            } => {
+                let mut args = serde_json::Map::new();
+                args.insert("body".into(), Value::String(body));
+                if let Some(v) = to {
+                    args.insert("to".into(), Value::String(v));
+                }
+                if let Some(v) = topic {
+                    args.insert("topic".into(), Value::String(v));
+                }
+                if let Some(v) = subject {
+                    args.insert("subject".into(), Value::String(v));
+                }
+                if let Some(v) = kind {
+                    args.insert("kind".into(), Value::String(v));
+                }
+                if let Some(v) = project {
+                    args.insert("project_id".into(), Value::String(v));
+                }
+                if let Some(v) = correlation_id {
+                    args.insert("correlation_id".into(), Value::String(v));
+                }
+                if let Some(v) = from {
+                    args.insert("from".into(), Value::String(v));
+                }
+                run_socket_command(serde_json::json!({
+                    "command": "mailbox-post",
+                    "session_id": get_session_id(),
+                    "pane_id": get_pane_id(),
+                    "args": Value::Object(args),
+                }));
+            }
+            MailboxAction::Peek { alias, unread, project, global, limit } => {
+                run_socket_command(serde_json::json!({
+                    "command": "mailbox-peek",
+                    "session_id": get_session_id(),
+                    "args": build_mailbox_recv_args(alias, project, global, Some(unread), limit),
+                }));
+            }
+            MailboxAction::Read { alias, ack, project, global, limit } => {
+                let mut args =
+                    build_mailbox_recv_args(alias, project, global, None, limit);
+                if ack {
+                    args["ack"] = Value::Bool(true);
+                }
+                run_socket_command(serde_json::json!({
+                    "command": "mailbox-read",
+                    "session_id": get_session_id(),
+                    "pane_id": get_pane_id(),
+                    "args": args,
+                }));
+            }
+            MailboxAction::Ack { event_id, result, alias } => {
+                let mut args = serde_json::Map::new();
+                args.insert("event_id".into(), Value::String(event_id));
+                if let Some(r) = result {
+                    args.insert("result".into(), Value::String(r));
+                }
+                if let Some(a) = alias {
+                    args.insert("alias".into(), Value::String(a));
+                }
+                run_socket_command(serde_json::json!({
+                    "command": "mailbox-ack",
+                    "session_id": get_session_id(),
+                    "pane_id": get_pane_id(),
+                    "args": Value::Object(args),
+                }));
+            }
+            MailboxAction::Count { alias, project, global } => {
+                run_socket_command(serde_json::json!({
+                    "command": "mailbox-count",
+                    "session_id": get_session_id(),
+                    "args": build_mailbox_recv_args(alias, project, global, None, None),
+                }));
+            }
+            MailboxAction::Clear { alias } => {
+                let mut args = serde_json::Map::new();
+                if let Some(a) = alias {
+                    args.insert("alias".into(), Value::String(a));
+                }
+                run_socket_command(serde_json::json!({
+                    "command": "mailbox-clear",
+                    "session_id": get_session_id(),
+                    "pane_id": get_pane_id(),
+                    "args": Value::Object(args),
+                }));
+            }
+            MailboxAction::Reply { event_id, body, subject, kind } => {
+                let mut args = serde_json::Map::new();
+                args.insert("event_id".into(), Value::String(event_id));
+                args.insert("body".into(), Value::String(body));
+                if let Some(s) = subject {
+                    args.insert("subject".into(), Value::String(s));
+                }
+                if let Some(k) = kind {
+                    args.insert("kind".into(), Value::String(k));
+                }
+                run_socket_command(serde_json::json!({
+                    "command": "mailbox-reply",
+                    "session_id": get_session_id(),
+                    "pane_id": get_pane_id(),
+                    "args": Value::Object(args),
+                }));
+            }
+            MailboxAction::Sent { to, sender, limit } => {
+                let mut args = serde_json::Map::new();
+                if let Some(t) = to {
+                    args.insert("to".into(), Value::String(t));
+                }
+                if let Some(s) = sender {
+                    args.insert("sender".into(), Value::String(s));
+                }
+                if let Some(n) = limit {
+                    args.insert("limit".into(), Value::Number(n.into()));
+                }
+                run_socket_command(serde_json::json!({
+                    "command": "mailbox-sent",
+                    "session_id": get_session_id(),
+                    "pane_id": get_pane_id(),
+                    "args": Value::Object(args),
+                }));
+            }
+        },
+
+        Commands::Bus { action } => match action {
+            BusAction::Publish { topic, body, kind, project, subject } => {
+                let mut args = serde_json::Map::new();
+                args.insert("topic".into(), Value::String(topic));
+                args.insert("body".into(), Value::String(body));
+                if let Some(k) = kind {
+                    args.insert("kind".into(), Value::String(k));
+                }
+                if let Some(p) = project {
+                    args.insert("project_id".into(), Value::String(p));
+                }
+                if let Some(s) = subject {
+                    args.insert("subject".into(), Value::String(s));
+                }
+                run_socket_command(serde_json::json!({
+                    "command": "bus-publish",
+                    "session_id": get_session_id(),
+                    "pane_id": get_pane_id(),
+                    "args": Value::Object(args),
+                }));
+            }
+            BusAction::Tail { topic, project, global, limit } => {
+                let mut args = serde_json::Map::new();
+                if let Some(t) = topic {
+                    args.insert("topic".into(), Value::String(t));
+                }
+                if let Some(p) = project {
+                    args.insert("project_id".into(), Value::String(p));
+                }
+                if global {
+                    args.insert("global".into(), Value::Bool(true));
+                }
+                if let Some(n) = limit {
+                    args.insert("limit".into(), Value::Number(n.into()));
+                }
+                run_socket_command(serde_json::json!({
+                    "command": "bus-tail",
+                    "session_id": get_session_id(),
+                    "pane_id": get_pane_id(),
+                    "args": Value::Object(args),
+                }));
+            }
+        },
 
         Commands::Split { direction } => {
             run_socket_command(serde_json::json!({

--- a/src-tauri/src/commands/aliases.rs
+++ b/src-tauri/src/commands/aliases.rs
@@ -1,0 +1,49 @@
+//! Tauri commands exposing the alias surface to the frontend.
+//!
+//! Read-only here for Phase 3 — the UI lists aliases, gets one by name,
+//! and runs `whoami`. Mutations (set/unset/claim) keep flowing through
+//! the CLI / socket so settings-style UI work can land later without
+//! re-shaping the surface.
+
+use roux_core::AgentAlias;
+use roux_lib::aliases::ProjectFilter;
+
+use crate::state::AppState;
+
+fn project_filter<'a>(project_id: Option<&'a str>, global: bool) -> ProjectFilter<'a> {
+    match (project_id, global) {
+        (Some(p), _) => ProjectFilter::Exact(Some(p)),
+        (None, true) => ProjectFilter::Exact(None),
+        (None, false) => ProjectFilter::Any,
+    }
+}
+
+#[tauri::command]
+pub async fn aliases_list(
+    project_id: Option<String>,
+    global: Option<bool>,
+    only_unbound: Option<bool>,
+    state: tauri::State<'_, AppState>,
+) -> Result<Vec<AgentAlias>, String> {
+    Ok(state.alias_manager.list(
+        project_filter(project_id.as_deref(), global.unwrap_or(false)),
+        only_unbound.unwrap_or(false),
+    ))
+}
+
+#[tauri::command]
+pub async fn aliases_get(
+    alias: String,
+    project_id: Option<String>,
+    state: tauri::State<'_, AppState>,
+) -> Result<Option<AgentAlias>, String> {
+    Ok(state.alias_manager.get(&alias, project_id.as_deref()))
+}
+
+#[tauri::command]
+pub async fn aliases_whoami(
+    session_id: String,
+    state: tauri::State<'_, AppState>,
+) -> Result<Vec<AgentAlias>, String> {
+    Ok(state.alias_manager.whoami(&session_id))
+}

--- a/src-tauri/src/commands/mailbox.rs
+++ b/src-tauri/src/commands/mailbox.rs
@@ -1,0 +1,260 @@
+//! Tauri commands for the mailbox UI.
+//!
+//! These commands are intentionally NOT typed via `#[specta::specta]` —
+//! `Event::structured` is `serde_json::Value`, which specta can't render
+//! as valid TypeScript. The frontend hand-writes its types in
+//! `src/lib/types/mailbox.ts` and calls `invoke()` directly, mirroring
+//! how `pane_state` commands work.
+
+use roux_core::{Event, EventBuilder, EventKind, ReadState};
+use roux_lib::aliases::ProjectFilter;
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::state::AppState;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MailboxPostInput {
+    pub to: Option<String>,
+    pub topic: Option<String>,
+    pub body: String,
+    pub subject: Option<String>,
+    pub kind: Option<String>,
+    pub project_id: Option<String>,
+    pub correlation_id: Option<String>,
+    pub structured: Option<Value>,
+    pub from: Option<String>,
+}
+
+fn parse_kind(s: &str) -> Result<EventKind, String> {
+    match s {
+        "task" => Ok(EventKind::Task),
+        "result" => Ok(EventKind::Result),
+        "question" => Ok(EventKind::Question),
+        "fyi" => Ok(EventKind::Fyi),
+        "signal" => Ok(EventKind::Signal),
+        other => Err(format!("invalid kind: {other}")),
+    }
+}
+
+fn project_filter<'a>(project_id: Option<&'a str>, global: bool) -> ProjectFilter<'a> {
+    match (project_id, global) {
+        (Some(p), _) => ProjectFilter::Exact(Some(p)),
+        (None, true) => ProjectFilter::Exact(None),
+        (None, false) => ProjectFilter::Any,
+    }
+}
+
+#[tauri::command]
+pub async fn mailbox_list_for_recipient(
+    alias: String,
+    unread_only: Option<bool>,
+    project_id: Option<String>,
+    global: Option<bool>,
+    state: tauri::State<'_, AppState>,
+) -> Result<Vec<Event>, String> {
+    Ok(state.mailbox_manager.list_for_recipient(
+        &alias,
+        unread_only.unwrap_or(false),
+        project_filter(project_id.as_deref(), global.unwrap_or(false)),
+    ))
+}
+
+#[tauri::command]
+pub async fn mailbox_list_for_topic(
+    topic: String,
+    project_id: Option<String>,
+    global: Option<bool>,
+    state: tauri::State<'_, AppState>,
+) -> Result<Vec<Event>, String> {
+    Ok(state.mailbox_manager.list_for_topic(
+        &topic,
+        project_filter(project_id.as_deref(), global.unwrap_or(false)),
+    ))
+}
+
+#[tauri::command]
+pub async fn mailbox_list_all(
+    project_id: Option<String>,
+    global: Option<bool>,
+    limit: Option<u32>,
+    state: tauri::State<'_, AppState>,
+) -> Result<Vec<Event>, String> {
+    Ok(state.mailbox_manager.list_all(
+        project_filter(project_id.as_deref(), global.unwrap_or(false)),
+        limit.map(|n| n as usize),
+    ))
+}
+
+#[tauri::command]
+pub async fn mailbox_unread_count(
+    alias: String,
+    project_id: Option<String>,
+    global: Option<bool>,
+    state: tauri::State<'_, AppState>,
+) -> Result<u32, String> {
+    Ok(state.mailbox_manager.unread_count(
+        &alias,
+        project_filter(project_id.as_deref(), global.unwrap_or(false)),
+    ) as u32)
+}
+
+#[tauri::command]
+pub async fn mailbox_get_event(
+    event_id: String,
+    state: tauri::State<'_, AppState>,
+) -> Result<Option<Event>, String> {
+    Ok(state.mailbox_manager.get(&event_id))
+}
+
+#[tauri::command]
+pub async fn mailbox_read_state(
+    event_id: String,
+    recipient: String,
+    state: tauri::State<'_, AppState>,
+) -> Result<Option<ReadState>, String> {
+    Ok(state.mailbox_manager.read_state(&event_id, &recipient))
+}
+
+#[tauri::command]
+pub async fn mailbox_post(
+    input: MailboxPostInput,
+    state: tauri::State<'_, AppState>,
+    app: tauri::AppHandle,
+) -> Result<Event, String> {
+    if input.to.is_none() && input.topic.is_none() {
+        return Err("at least one of `to` or `topic` required".into());
+    }
+
+    let canonical_to = match input.to.as_deref() {
+        Some(s) => Some(roux_core::validate_alias_name(s).map_err(|e| e.to_string())?),
+        None => None,
+    };
+    if let Some(c) = &canonical_to {
+        state.alias_manager.ensure(c, input.project_id.clone());
+    }
+
+    let kind = match input.kind.as_deref() {
+        Some(s) => parse_kind(s)?,
+        None => EventKind::Task,
+    };
+
+    let mut builder = EventBuilder::new(input.body).kind(kind);
+    if let Some(c) = canonical_to {
+        builder = builder.to(c);
+    }
+    if let Some(t) = input.topic {
+        builder = builder.topic(t);
+    }
+    if let Some(f) = input.from {
+        builder = builder.from(f);
+    }
+    if let Some(p) = input.project_id {
+        builder = builder.project_id(p);
+    }
+    if let Some(s) = input.subject {
+        builder = builder.subject(s);
+    }
+    if let Some(c) = input.correlation_id {
+        builder = builder.correlation_id(c);
+    }
+    if let Some(v) = input.structured {
+        if !v.is_null() {
+            builder = builder.structured(v);
+        }
+    }
+
+    state.mailbox_manager.post(builder, Some(&app)).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn mailbox_mark_read(
+    event_id: String,
+    recipient: String,
+    state: tauri::State<'_, AppState>,
+    app: tauri::AppHandle,
+) -> Result<bool, String> {
+    Ok(state.mailbox_manager.mark_read(&event_id, &recipient, Some(&app)))
+}
+
+#[tauri::command]
+pub async fn mailbox_ack(
+    event_id: String,
+    recipient: String,
+    result: Option<String>,
+    state: tauri::State<'_, AppState>,
+    app: tauri::AppHandle,
+) -> Result<bool, String> {
+    Ok(state.mailbox_manager.ack(&event_id, &recipient, result, Some(&app)))
+}
+
+#[tauri::command]
+pub async fn mailbox_clear_read(
+    recipient: String,
+    state: tauri::State<'_, AppState>,
+    app: tauri::AppHandle,
+) -> Result<u32, String> {
+    Ok(state.mailbox_manager.clear_read(&recipient, Some(&app)) as u32)
+}
+
+/// Deliver a mailbox event to the recipient's pane by writing the body
+/// (plus a trailing CR) into its PTY. Acks the event with a "delivered
+/// via UI" marker so the sender's `mailbox sent` view shows it landed.
+///
+/// Requires the recipient alias to be currently bound to a pane —
+/// "deliver" is a last-mile PTY-typing operation, distinct from posting
+/// (which queues durably regardless of binding).
+#[tauri::command]
+pub async fn mailbox_deliver_to_pane(
+    event_id: String,
+    state: tauri::State<'_, AppState>,
+    app: tauri::AppHandle,
+) -> Result<(), String> {
+    let event = state
+        .mailbox_manager
+        .get(&event_id)
+        .ok_or_else(|| format!("event '{event_id}' not found"))?;
+
+    let recipient = event
+        .to
+        .as_deref()
+        .ok_or_else(|| "event has no `to` recipient — nothing to deliver".to_string())?;
+
+    let alias = state
+        .alias_manager
+        .get(recipient, event.project_id.as_deref())
+        .ok_or_else(|| format!("alias '{recipient}' not found"))?;
+
+    let pane_id = alias.pane_id.clone().ok_or_else(|| {
+        format!(
+            "alias '{recipient}' has no pane bound; claim from inside a pane or use `roux send` directly"
+        )
+    })?;
+
+    // Resolve pty_id via the pane handle.
+    let pane_records =
+        state.pane_handle.list_by_ids(vec![pane_id.clone()]).await.map_err(|e| e.to_string())?;
+    let pane = pane_records
+        .first()
+        .ok_or_else(|| format!("pane '{pane_id}' not found"))?;
+    let pty_id = pane.pty_id.clone();
+
+    // Type the body into the pane. Append CR so Claude/Codex see it as
+    // submitted input rather than a half-typed line.
+    let mut bytes = event.body.clone().into_bytes();
+    bytes.push(b'\r');
+    state
+        .pty_manager
+        .write(&pty_id, &bytes)
+        .map_err(|e| format!("failed to write to pane: {e}"))?;
+
+    // Ack so the sender's `sent` view shows the delivery.
+    state.mailbox_manager.ack(
+        &event_id,
+        recipient,
+        Some(format!("delivered to pane {pane_id}")),
+        Some(&app),
+    );
+    Ok(())
+}

--- a/src-tauri/src/commands/mailbox.rs
+++ b/src-tauri/src/commands/mailbox.rs
@@ -192,10 +192,16 @@ pub async fn mailbox_ack(
 #[tauri::command]
 pub async fn mailbox_clear_read(
     recipient: String,
+    project_id: Option<String>,
+    global: Option<bool>,
     state: tauri::State<'_, AppState>,
     app: tauri::AppHandle,
 ) -> Result<u32, String> {
-    Ok(state.mailbox_manager.clear_read(&recipient, Some(&app)) as u32)
+    Ok(state.mailbox_manager.clear_read(
+        &recipient,
+        project_filter(project_id.as_deref(), global.unwrap_or(false)),
+        Some(&app),
+    ) as u32)
 }
 
 /// Deliver a mailbox event to the recipient's pane by writing the body

--- a/src-tauri/src/commands/mailbox.rs
+++ b/src-tauri/src/commands/mailbox.rs
@@ -132,7 +132,7 @@ pub async fn mailbox_post(
         None => None,
     };
     if let Some(c) = &canonical_to {
-        state.alias_manager.ensure(c, input.project_id.clone());
+        state.alias_manager.ensure(c, input.project_id.clone(), Some(&app));
     }
 
     let kind = match input.kind.as_deref() {

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -7,25 +7,39 @@ use tauri::Emitter;
 #[serde(rename_all = "camelCase")]
 pub(crate) enum McpHostId {
     ClaudeDesktop,
+    ClaudeCode,
+    Codex,
 }
 
 impl McpHostId {
     fn as_str(self) -> &'static str {
         match self {
             McpHostId::ClaudeDesktop => "claudeDesktop",
+            McpHostId::ClaudeCode => "claudeCode",
+            McpHostId::Codex => "codex",
         }
     }
 
     fn label(self) -> &'static str {
         match self {
             McpHostId::ClaudeDesktop => "Claude Desktop",
+            McpHostId::ClaudeCode => "Claude Code",
+            McpHostId::Codex => "Codex",
         }
     }
 
     fn config_path(self) -> Option<std::path::PathBuf> {
         match self {
             McpHostId::ClaudeDesktop => svc::claude_desktop_config_path(),
+            McpHostId::ClaudeCode => svc::claude_code_config_path(),
+            McpHostId::Codex => svc::codex_config_path(),
         }
+    }
+
+    /// All hosts known to this build, in the order users see them in
+    /// the Settings UI (most-likely-to-want first).
+    fn all() -> &'static [McpHostId] {
+        &[McpHostId::ClaudeCode, McpHostId::ClaudeDesktop, McpHostId::Codex]
     }
 }
 
@@ -77,7 +91,11 @@ pub(crate) fn cmd_mcp_status(state: tauri::State<AppState>) -> McpStatus {
         cli_path: cli_path.to_string_lossy().to_string(),
         last_configured_host: settings.mcp_last_configured_host,
         last_configured_at_ms: settings.mcp_last_configured_at_ms,
-        hosts: vec![host_status(McpHostId::ClaudeDesktop, &cli_path.to_string_lossy())],
+        hosts: McpHostId::all()
+            .iter()
+            .copied()
+            .map(|host| host_status(host, &cli_path.to_string_lossy()))
+            .collect(),
     }
 }
 
@@ -98,7 +116,17 @@ pub(crate) fn cmd_configure_mcp_host(
         .config_path()
         .ok_or_else(|| format!("{} config path is unavailable on this platform", host.label()))?;
     let cli_path = svc::roux_cli_command_path().to_string_lossy().to_string();
-    let plan = svc::write_config_file(&path, &cli_path).map_err(|e| e.to_string())?;
+    let plan = match host {
+        // JSON `mcpServers` format — Claude Desktop, Claude Code, and any
+        // other downstream tool that follows the same convention.
+        McpHostId::ClaudeDesktop | McpHostId::ClaudeCode => {
+            svc::write_config_file(&path, &cli_path).map_err(|e| e.to_string())?
+        }
+        // TOML `[mcp_servers.<id>]` table — OpenAI Codex CLI's config.toml.
+        McpHostId::Codex => {
+            svc::write_codex_config_file(&path, &cli_path).map_err(|e| e.to_string())?
+        }
+    };
     if let Err(error) = record_configured_host(host, state, app) {
         eprintln!("roux: failed to record MCP host configuration metadata: {error}");
     }
@@ -140,7 +168,13 @@ fn host_status(host: McpHostId, cli_path: &str) -> McpHostStatus {
     };
 
     let config_exists = path.exists();
-    match svc::plan_config_file(&path, cli_path) {
+    let plan_result = match host {
+        McpHostId::ClaudeDesktop | McpHostId::ClaudeCode => {
+            svc::plan_config_file(&path, cli_path)
+        }
+        McpHostId::Codex => svc::plan_codex_config_file(&path, cli_path),
+    };
+    match plan_result {
         Ok(plan) => McpHostStatus {
             id: host,
             label: host.label().to_string(),
@@ -165,7 +199,14 @@ fn preview_host(host: McpHostId) -> Result<McpHostConfigPreview, String> {
         .config_path()
         .ok_or_else(|| format!("{} config path is unavailable on this platform", host.label()))?;
     let cli_path = svc::roux_cli_command_path().to_string_lossy().to_string();
-    let plan = svc::plan_config_file(&path, &cli_path).map_err(|e| e.to_string())?;
+    let plan = match host {
+        McpHostId::ClaudeDesktop | McpHostId::ClaudeCode => {
+            svc::plan_config_file(&path, &cli_path).map_err(|e| e.to_string())?
+        }
+        McpHostId::Codex => {
+            svc::plan_codex_config_file(&path, &cli_path).map_err(|e| e.to_string())?
+        }
+    };
     Ok(preview_from_plan(host, path, plan))
 }
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,5 +1,7 @@
+pub(crate) mod aliases;
 pub(crate) mod docs;
 pub(crate) mod layouts;
+pub(crate) mod mailbox;
 pub(crate) mod library;
 pub(crate) mod library_sync;
 pub(crate) mod mcp;

--- a/src-tauri/src/commands/panes.rs
+++ b/src-tauri/src/commands/panes.rs
@@ -5,14 +5,37 @@ use crate::state::AppState;
 pub(crate) async fn upsert_pane_record(
     record: PaneRecord,
     state: tauri::State<'_, AppState>,
+    app: tauri::AppHandle,
 ) -> Result<(), String> {
-    state.pane_handle.upsert(record).await.map_err(|e| e.to_string())
+    let pane_id = record.id.clone();
+    let pane_name = record.name.clone();
+    state.pane_handle.upsert(record).await.map_err(|e| e.to_string())?;
+
+    // Try to auto-claim an alias from the pane's name. No-op if the
+    // name doesn't match the alias format (capitals, spaces, reserved)
+    // or if the canonical alias is already held by another pane.
+    // Project scope is `None` for the MVP — pane→session→project lookup
+    // is a follow-up.
+    state.alias_manager.try_auto_claim_from_pane_name(
+        &pane_id,
+        pane_name.as_deref(),
+        None,
+        Some(&app),
+    );
+    Ok(())
 }
 
 #[tauri::command]
 pub(crate) async fn remove_pane_record(
     id: String,
     state: tauri::State<'_, AppState>,
+    app: tauri::AppHandle,
 ) -> Result<(), String> {
-    state.pane_handle.remove(&id).await.map_err(|e| e.to_string())
+    state.pane_handle.remove(&id).await.map_err(|e| e.to_string())?;
+
+    // Release auto-claimed aliases held by this pane. Manual `roux alias
+    // claim` bindings persist — queued mail addressed to them survives
+    // for the next session that claims them.
+    state.alias_manager.unbind_for_pane(&id, true, Some(&app));
+    Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod aliases;
+pub mod mailbox;
 pub mod paths;
 
 pub fn run() {

--- a/src-tauri/src/mailbox/manager.rs
+++ b/src-tauri/src/mailbox/manager.rs
@@ -142,23 +142,24 @@ impl MailboxManager {
     }
 
     pub fn clear_read(&self, recipient: &str, app: Option<&AppHandle>) -> usize {
-        let removed = {
+        let now = now_ms();
+        let cleared = {
             let mut store = self.inner.lock().expect("event store poisoned");
-            store.clear_read(recipient)
+            store.clear_read(recipient, now)
         };
-        if removed > 0 {
+        if cleared > 0 {
             self.persist_read_state();
             if let Some(app) = app {
                 let _ = app.emit(
                     MAILBOX_EVENT,
                     &MailboxEvent::Cleared {
                         recipient: recipient.to_string(),
-                        count: removed as u32,
+                        count: cleared as u32,
                     },
                 );
             }
         }
-        removed
+        cleared
     }
 
     pub fn list_for_recipient(
@@ -306,7 +307,7 @@ mod tests {
     }
 
     #[test]
-    fn clear_read_returns_count_and_persists() {
+    fn clear_read_marks_cleared_and_persists() {
         let dir = tempdir().unwrap();
         let (e, r) = paths(dir.path());
         let mgr = MailboxManager::load_from(e, r);
@@ -315,10 +316,12 @@ mod tests {
         mgr.mark_read(&e1.id, "reviewer", None);
         mgr.mark_read(&e2.id, "reviewer", None);
 
-        let removed = mgr.clear_read("reviewer", None);
-        assert_eq!(removed, 2);
-        assert!(mgr.read_state(&e1.id, "reviewer").is_none());
-        assert!(mgr.read_state(&e2.id, "reviewer").is_none());
+        let cleared = mgr.clear_read("reviewer", None);
+        assert_eq!(cleared, 2);
+        // Cleared events keep their ReadState (with cleared_at set) so
+        // they don't re-surface as unread on the next list call.
+        assert!(mgr.read_state(&e1.id, "reviewer").unwrap().is_cleared());
+        assert!(mgr.read_state(&e2.id, "reviewer").unwrap().is_cleared());
     }
 
     #[test]

--- a/src-tauri/src/mailbox/manager.rs
+++ b/src-tauri/src/mailbox/manager.rs
@@ -1,0 +1,357 @@
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use roux_core::{Event, EventBuilder, MailboxEvent, ReadState};
+use tauri::{AppHandle, Emitter};
+
+use crate::aliases::ProjectFilter;
+
+use super::persistence::{
+    self, append_event_to, load_events_from, load_read_state_from, save_read_state_to,
+};
+use super::store::{EventStore, PostError};
+
+/// Tauri event name emitted on every mailbox mutation. Frontend listens
+/// here to update the inbox / firehose without polling.
+pub const MAILBOX_EVENT: &str = "mailbox-event";
+
+struct MailboxPaths {
+    events: PathBuf,
+    read_state: PathBuf,
+}
+
+/// Clonable handle over the categorical event store. Persistence layout:
+///
+/// - On `post`: append a single row to `events.jsonl` (cheap, ordered).
+/// - On `mark_read` / `ack` / `clear_read`: full rewrite of
+///   `read_state.json`. The state file stays small even at developer-tool
+///   scale (a few thousand rows max).
+///
+/// The events file grows monotonically — the in-memory store applies
+/// retention caps at load time, but the on-disk audit log is preserved.
+#[derive(Clone)]
+pub struct MailboxManager {
+    inner: Arc<Mutex<EventStore>>,
+    paths: Option<Arc<MailboxPaths>>,
+}
+
+impl MailboxManager {
+    /// Production constructor: loads from the default config-dir paths.
+    pub fn load() -> Self {
+        Self::load_from(persistence::events_path(), persistence::read_state_path())
+    }
+
+    /// Load from explicit paths. Used by tests with a tempdir.
+    pub fn load_from(events_path: PathBuf, read_state_path: PathBuf) -> Self {
+        let events = load_events_from(&events_path);
+        let read_state = load_read_state_from(&read_state_path);
+        let store = EventStore::from_entries(events, read_state);
+        Self {
+            inner: Arc::new(Mutex::new(store)),
+            paths: Some(Arc::new(MailboxPaths {
+                events: events_path,
+                read_state: read_state_path,
+            })),
+        }
+    }
+
+    /// In-memory only. No load, no persist on mutation. For tests that
+    /// don't care about disk IO.
+    #[cfg(test)]
+    pub fn in_memory() -> Self {
+        Self { inner: Arc::new(Mutex::new(EventStore::new())), paths: None }
+    }
+
+    pub fn post(
+        &self,
+        builder: EventBuilder,
+        app: Option<&AppHandle>,
+    ) -> Result<Event, PostError> {
+        let id = uuid::Uuid::new_v4().to_string();
+        let now = now_ms();
+        let event = {
+            let mut store = self.inner.lock().expect("event store poisoned");
+            store.post(builder, id, now)?
+        };
+        if let Some(paths) = self.paths.as_ref() {
+            if let Err(e) = append_event_to(&paths.events, &event) {
+                eprintln!(
+                    "[roux] mailbox events.jsonl append failed at {}: {e}",
+                    paths.events.display()
+                );
+            }
+        }
+        if let Some(app) = app {
+            let _ = app.emit(MAILBOX_EVENT, &MailboxEvent::Posted { event: event.clone() });
+        }
+        Ok(event)
+    }
+
+    pub fn mark_read(
+        &self,
+        event_id: &str,
+        recipient: &str,
+        app: Option<&AppHandle>,
+    ) -> bool {
+        let now = now_ms();
+        let changed = {
+            let mut store = self.inner.lock().expect("event store poisoned");
+            store.mark_read(event_id, recipient, now)
+        };
+        if changed {
+            self.persist_read_state();
+            if let Some(app) = app {
+                let _ = app.emit(
+                    MAILBOX_EVENT,
+                    &MailboxEvent::Read {
+                        event_id: event_id.to_string(),
+                        recipient: recipient.to_string(),
+                    },
+                );
+            }
+        }
+        changed
+    }
+
+    pub fn ack(
+        &self,
+        event_id: &str,
+        recipient: &str,
+        result: Option<String>,
+        app: Option<&AppHandle>,
+    ) -> bool {
+        let now = now_ms();
+        let changed = {
+            let mut store = self.inner.lock().expect("event store poisoned");
+            store.ack(event_id, recipient, result.clone(), now)
+        };
+        if changed {
+            self.persist_read_state();
+            if let Some(app) = app {
+                let _ = app.emit(
+                    MAILBOX_EVENT,
+                    &MailboxEvent::Acked {
+                        event_id: event_id.to_string(),
+                        recipient: recipient.to_string(),
+                        result,
+                    },
+                );
+            }
+        }
+        changed
+    }
+
+    pub fn clear_read(&self, recipient: &str, app: Option<&AppHandle>) -> usize {
+        let removed = {
+            let mut store = self.inner.lock().expect("event store poisoned");
+            store.clear_read(recipient)
+        };
+        if removed > 0 {
+            self.persist_read_state();
+            if let Some(app) = app {
+                let _ = app.emit(
+                    MAILBOX_EVENT,
+                    &MailboxEvent::Cleared {
+                        recipient: recipient.to_string(),
+                        count: removed as u32,
+                    },
+                );
+            }
+        }
+        removed
+    }
+
+    pub fn list_for_recipient(
+        &self,
+        recipient: &str,
+        unread_only: bool,
+        project_filter: ProjectFilter<'_>,
+    ) -> Vec<Event> {
+        let store = self.inner.lock().expect("event store poisoned");
+        store.list_for_recipient(recipient, unread_only, project_filter)
+    }
+
+    pub fn list_for_topic(
+        &self,
+        topic: &str,
+        project_filter: ProjectFilter<'_>,
+    ) -> Vec<Event> {
+        let store = self.inner.lock().expect("event store poisoned");
+        store.list_for_topic(topic, project_filter)
+    }
+
+    pub fn list_all(
+        &self,
+        project_filter: ProjectFilter<'_>,
+        limit: Option<usize>,
+    ) -> Vec<Event> {
+        let store = self.inner.lock().expect("event store poisoned");
+        store.list_all(project_filter, limit)
+    }
+
+    pub fn list_sent_by(
+        &self,
+        sender: &str,
+        recipient_filter: Option<&str>,
+        limit: Option<usize>,
+    ) -> Vec<(Event, Option<ReadState>)> {
+        let store = self.inner.lock().expect("event store poisoned");
+        store.list_sent_by(sender, recipient_filter, limit)
+    }
+
+    pub fn unread_count(&self, recipient: &str, project_filter: ProjectFilter<'_>) -> usize {
+        let store = self.inner.lock().expect("event store poisoned");
+        store.unread_count(recipient, project_filter)
+    }
+
+    pub fn get(&self, event_id: &str) -> Option<Event> {
+        let store = self.inner.lock().expect("event store poisoned");
+        store.get(event_id).cloned()
+    }
+
+    pub fn read_state(&self, event_id: &str, recipient: &str) -> Option<ReadState> {
+        let store = self.inner.lock().expect("event store poisoned");
+        store.read_state(event_id, recipient).cloned()
+    }
+
+    fn persist_read_state(&self) {
+        let Some(paths) = self.paths.as_ref() else {
+            return;
+        };
+        let states: Vec<ReadState> = {
+            let store = self.inner.lock().expect("event store poisoned");
+            store.all_read_state().cloned().collect()
+        };
+        if let Err(e) = save_read_state_to(&paths.read_state, &states) {
+            eprintln!(
+                "[roux] mailbox read_state.json save failed at {}: {e}",
+                paths.read_state.display()
+            );
+        }
+    }
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use roux_core::EventKind;
+    use tempfile::tempdir;
+
+    fn paths(dir: &std::path::Path) -> (PathBuf, PathBuf) {
+        (dir.join("events.jsonl"), dir.join("read_state.json"))
+    }
+
+    fn task(body: &str) -> EventBuilder {
+        EventBuilder::new(body).to("reviewer").from("me").kind(EventKind::Task)
+    }
+
+    #[test]
+    fn post_persists_to_events_jsonl() {
+        let dir = tempdir().unwrap();
+        let (e, r) = paths(dir.path());
+        let mgr = MailboxManager::load_from(e.clone(), r);
+        let event = mgr.post(task("hello"), None).unwrap();
+
+        let raw = std::fs::read_to_string(&e).unwrap();
+        assert!(raw.contains(&event.id), "events.jsonl must contain the new event id");
+    }
+
+    #[test]
+    fn post_round_trips_through_disk_reload() {
+        let dir = tempdir().unwrap();
+        let (e, r) = paths(dir.path());
+        let mgr1 = MailboxManager::load_from(e.clone(), r.clone());
+        mgr1.post(task("first"), None).unwrap();
+        mgr1.post(task("second"), None).unwrap();
+
+        let mgr2 = MailboxManager::load_from(e, r);
+        let mine = mgr2.list_for_recipient("reviewer", false, ProjectFilter::Any);
+        assert_eq!(mine.len(), 2);
+        let bodies: Vec<_> = mine.iter().map(|e| e.body.clone()).collect();
+        assert_eq!(bodies, vec!["first", "second"]);
+    }
+
+    #[test]
+    fn mark_read_persists_and_survives_reload() {
+        let dir = tempdir().unwrap();
+        let (e, r) = paths(dir.path());
+        let mgr1 = MailboxManager::load_from(e.clone(), r.clone());
+        let event = mgr1.post(task("hello"), None).unwrap();
+        assert!(mgr1.mark_read(&event.id, "reviewer", None));
+
+        let mgr2 = MailboxManager::load_from(e, r);
+        let state = mgr2.read_state(&event.id, "reviewer").unwrap();
+        assert!(state.is_read());
+    }
+
+    #[test]
+    fn ack_persists_with_result_string() {
+        let dir = tempdir().unwrap();
+        let (e, r) = paths(dir.path());
+        let mgr1 = MailboxManager::load_from(e.clone(), r.clone());
+        let event = mgr1.post(task("hello"), None).unwrap();
+        assert!(mgr1.ack(&event.id, "reviewer", Some("done!".into()), None));
+
+        let mgr2 = MailboxManager::load_from(e, r);
+        let state = mgr2.read_state(&event.id, "reviewer").unwrap();
+        assert!(state.is_acked());
+        assert_eq!(state.ack_result.as_deref(), Some("done!"));
+    }
+
+    #[test]
+    fn clear_read_returns_count_and_persists() {
+        let dir = tempdir().unwrap();
+        let (e, r) = paths(dir.path());
+        let mgr = MailboxManager::load_from(e, r);
+        let e1 = mgr.post(task("a"), None).unwrap();
+        let e2 = mgr.post(task("b"), None).unwrap();
+        mgr.mark_read(&e1.id, "reviewer", None);
+        mgr.mark_read(&e2.id, "reviewer", None);
+
+        let removed = mgr.clear_read("reviewer", None);
+        assert_eq!(removed, 2);
+        assert!(mgr.read_state(&e1.id, "reviewer").is_none());
+        assert!(mgr.read_state(&e2.id, "reviewer").is_none());
+    }
+
+    #[test]
+    fn unread_count_excludes_read() {
+        let mgr = MailboxManager::in_memory();
+        let e1 = mgr.post(task("a"), None).unwrap();
+        let _e2 = mgr.post(task("b"), None).unwrap();
+        assert_eq!(mgr.unread_count("reviewer", ProjectFilter::Any), 2);
+        mgr.mark_read(&e1.id, "reviewer", None);
+        assert_eq!(mgr.unread_count("reviewer", ProjectFilter::Any), 1);
+    }
+
+    #[test]
+    fn list_all_returns_newest_first() {
+        let mgr = MailboxManager::in_memory();
+        mgr.post(task("first"), None).unwrap();
+        mgr.post(task("second"), None).unwrap();
+        let all = mgr.list_all(ProjectFilter::Any, None);
+        assert_eq!(all[0].body, "second");
+    }
+
+    #[test]
+    fn redundant_mark_read_does_not_persist() {
+        let dir = tempdir().unwrap();
+        let (e, r) = paths(dir.path());
+        let mgr = MailboxManager::load_from(e, r.clone());
+        let event = mgr.post(task("hello"), None).unwrap();
+        mgr.mark_read(&event.id, "reviewer", None);
+        let mtime_before = std::fs::metadata(&r).unwrap().modified().unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        // Already read — should be a no-op (returns false).
+        assert!(!mgr.mark_read(&event.id, "reviewer", None));
+        let mtime_after = std::fs::metadata(&r).unwrap().modified().unwrap();
+        assert_eq!(mtime_before, mtime_after, "no-op mark_read must not rewrite read_state.json");
+    }
+}

--- a/src-tauri/src/mailbox/manager.rs
+++ b/src-tauri/src/mailbox/manager.rs
@@ -73,12 +73,19 @@ impl MailboxManager {
             let mut store = self.inner.lock().expect("event store poisoned");
             store.post(builder, id, now)?
         };
+        // Persist BEFORE emitting the success event. The mailbox's
+        // durable-queue contract is the whole point — if the event
+        // doesn't hit disk, the UI mustn't observe a "Posted" that
+        // disappears on restart. Roll the in-memory event back on
+        // persistence failure and surface the IO error.
         if let Some(paths) = self.paths.as_ref() {
             if let Err(e) = append_event_to(&paths.events, &event) {
-                eprintln!(
-                    "[roux] mailbox events.jsonl append failed at {}: {e}",
+                let mut store = self.inner.lock().expect("event store poisoned");
+                store.remove_event(&event.id);
+                return Err(PostError::Persist(format!(
+                    "events.jsonl append failed at {}: {e}",
                     paths.events.display()
-                );
+                )));
             }
         }
         if let Some(app) = app {
@@ -141,11 +148,16 @@ impl MailboxManager {
         changed
     }
 
-    pub fn clear_read(&self, recipient: &str, app: Option<&AppHandle>) -> usize {
+    pub fn clear_read(
+        &self,
+        recipient: &str,
+        project_filter: ProjectFilter<'_>,
+        app: Option<&AppHandle>,
+    ) -> usize {
         let now = now_ms();
         let cleared = {
             let mut store = self.inner.lock().expect("event store poisoned");
-            store.clear_read(recipient, now)
+            store.clear_read(recipient, project_filter, now)
         };
         if cleared > 0 {
             self.persist_read_state();
@@ -316,7 +328,7 @@ mod tests {
         mgr.mark_read(&e1.id, "reviewer", None);
         mgr.mark_read(&e2.id, "reviewer", None);
 
-        let cleared = mgr.clear_read("reviewer", None);
+        let cleared = mgr.clear_read("reviewer", ProjectFilter::Any, None);
         assert_eq!(cleared, 2);
         // Cleared events keep their ReadState (with cleared_at set) so
         // they don't re-surface as unread on the next list call.

--- a/src-tauri/src/mailbox/mod.rs
+++ b/src-tauri/src/mailbox/mod.rs
@@ -10,7 +10,7 @@
 //! - Bus view      ⇒ filter by `topic` (exact match in Phase 2)
 //! - Firehose view ⇒ no filter
 //!
-//! See `/docs/features/mailbox.md` (TODO) for usage. Mirrors the
+//! See `/docs/features/mailbox.md` for usage. Mirrors the
 //! `notifications` and `aliases` module split: `store` is in-memory and
 //! persistence/Tauri-free; `manager` (added next) layers persistence and
 //! event emission on top.

--- a/src-tauri/src/mailbox/mod.rs
+++ b/src-tauri/src/mailbox/mod.rs
@@ -1,0 +1,26 @@
+//! Categorical event store with mailbox + bus usage patterns.
+//!
+//! One append-only `Event` log with multi-axis addressing (`to` for
+//! direct mail, `topic` for broadcast, plus `kind`, `correlation_id`,
+//! `project_id`, `from`). Per-recipient read/ack state lives in
+//! `ReadState` so a single event can serve N consumers without
+//! duplicating the payload.
+//!
+//! - Mailbox view  ⇒ filter by `to=<alias>` + recipient read state
+//! - Bus view      ⇒ filter by `topic` (exact match in Phase 2)
+//! - Firehose view ⇒ no filter
+//!
+//! See `/docs/features/mailbox.md` (TODO) for usage. Mirrors the
+//! `notifications` and `aliases` module split: `store` is in-memory and
+//! persistence/Tauri-free; `manager` (added next) layers persistence and
+//! event emission on top.
+
+pub mod manager;
+pub mod persistence;
+pub mod store;
+
+pub use manager::{MailboxManager, MAILBOX_EVENT};
+pub use persistence::{
+    append_event, events_path, load_events, load_read_state, read_state_path, save_read_state,
+};
+pub use store::{EventStore, PostError};

--- a/src-tauri/src/mailbox/persistence.rs
+++ b/src-tauri/src/mailbox/persistence.rs
@@ -1,0 +1,307 @@
+//! On-disk persistence for the mailbox event store.
+//!
+//! Two files under `roux_config_dir()`:
+//!
+//! - `events.jsonl` — append-only NDJSON. Each row is a JSON object
+//!   carrying `schemaVersion` plus the flattened `Event` fields. Rows
+//!   with unknown future versions are preserved on disk but skipped at
+//!   load time, so a downgrade doesn't lose data.
+//! - `read_state.json` — versioned envelope `{ "version": N, "data": [...] }`.
+//!   Rewritten in full on mutation (read/ack/clear).
+//!
+//! Mirrors the alias persistence pattern (`crate::aliases::persistence`).
+
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+
+use roux_core::{Event, ReadState};
+use serde::{Deserialize, Serialize};
+
+const EVENT_SCHEMA_VERSION: u32 = 1;
+const READ_STATE_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct EventRowV1 {
+    #[serde(rename = "schemaVersion", default = "default_schema_version")]
+    schema_version: u32,
+    #[serde(flatten)]
+    event: Event,
+}
+
+fn default_schema_version() -> u32 {
+    EVENT_SCHEMA_VERSION
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ReadStateFile {
+    version: u32,
+    data: Vec<ReadState>,
+}
+
+pub fn events_path() -> PathBuf {
+    crate::paths::roux_config_dir().join("events.jsonl")
+}
+
+pub fn read_state_path() -> PathBuf {
+    crate::paths::roux_config_dir().join("read_state.json")
+}
+
+pub fn load_events() -> Vec<Event> {
+    load_events_from(&events_path())
+}
+
+pub fn load_read_state() -> Vec<ReadState> {
+    load_read_state_from(&read_state_path())
+}
+
+pub fn append_event(event: &Event) -> io::Result<()> {
+    append_event_to(&events_path(), event)
+}
+
+pub fn save_read_state(states: &[ReadState]) -> io::Result<()> {
+    save_read_state_to(&read_state_path(), states)
+}
+
+/// Read all events from `path`. Malformed JSON lines are skipped silently
+/// (logged via stderr). Rows whose `schemaVersion` is greater than the
+/// version this binary understands are skipped at load time but retained
+/// on disk by virtue of being append-only.
+pub(crate) fn load_events_from(path: &Path) -> Vec<Event> {
+    if !path.exists() {
+        return Vec::new();
+    }
+    let file = match File::open(path) {
+        Ok(f) => f,
+        Err(_) => return Vec::new(),
+    };
+    let reader = BufReader::new(file);
+    let mut out = Vec::new();
+    for (lineno, line) in reader.lines().enumerate() {
+        let Ok(line) = line else { continue };
+        if line.trim().is_empty() {
+            continue;
+        }
+        // First-pass parse to inspect schemaVersion — lets us silently
+        // skip future-version rows without a hard parse error.
+        let value: serde_json::Value = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!(
+                    "[roux] events.jsonl:{}: skipping malformed row: {e}",
+                    lineno + 1
+                );
+                continue;
+            }
+        };
+        let schema = value
+            .get("schemaVersion")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(EVENT_SCHEMA_VERSION as u64);
+        if schema > EVENT_SCHEMA_VERSION as u64 {
+            eprintln!(
+                "[roux] events.jsonl:{}: skipping future schemaVersion={schema}",
+                lineno + 1
+            );
+            continue;
+        }
+        match serde_json::from_value::<EventRowV1>(value) {
+            Ok(row) => out.push(row.event),
+            Err(e) => {
+                eprintln!(
+                    "[roux] events.jsonl:{}: row failed to deserialize: {e}",
+                    lineno + 1
+                );
+            }
+        }
+    }
+    out
+}
+
+pub(crate) fn append_event_to(path: &Path, event: &Event) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let row = EventRowV1 { schema_version: EVENT_SCHEMA_VERSION, event: event.clone() };
+    let json = serde_json::to_string(&row)?;
+    let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+    writeln!(file, "{}", json)?;
+    Ok(())
+}
+
+pub(crate) fn load_read_state_from(path: &Path) -> Vec<ReadState> {
+    if !path.exists() {
+        return Vec::new();
+    }
+    let content = match fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(_) => return Vec::new(),
+    };
+    if let Ok(file) = serde_json::from_str::<ReadStateFile>(&content) {
+        return file.data;
+    }
+    // Defensive fallback for hand-edited bare arrays.
+    serde_json::from_str::<Vec<ReadState>>(&content).unwrap_or_default()
+}
+
+pub(crate) fn save_read_state_to(path: &Path, states: &[ReadState]) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let envelope = ReadStateFile {
+        version: READ_STATE_SCHEMA_VERSION,
+        data: states.to_vec(),
+    };
+    let json = serde_json::to_string_pretty(&envelope)?;
+    fs::write(path, json)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use roux_core::{EventBuilder, EventKind};
+    use tempfile::tempdir;
+
+    fn sample_event(id: &str, body: &str) -> Event {
+        EventBuilder::new(body)
+            .to("reviewer")
+            .from("me")
+            .kind(EventKind::Task)
+            .build_with(id, 1234)
+            .unwrap()
+    }
+
+    #[test]
+    fn append_then_load_round_trips() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("events.jsonl");
+        append_event_to(&path, &sample_event("e1", "first")).unwrap();
+        append_event_to(&path, &sample_event("e2", "second")).unwrap();
+        let loaded = load_events_from(&path);
+        assert_eq!(loaded.len(), 2);
+        assert_eq!(loaded[0].id, "e1");
+        assert_eq!(loaded[1].id, "e2");
+    }
+
+    #[test]
+    fn load_returns_empty_when_file_missing() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("events.jsonl");
+        assert!(load_events_from(&path).is_empty());
+    }
+
+    #[test]
+    fn load_skips_malformed_rows_but_keeps_valid_ones() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("events.jsonl");
+        append_event_to(&path, &sample_event("e1", "good")).unwrap();
+        // Inject a garbage line.
+        let mut f = OpenOptions::new().append(true).open(&path).unwrap();
+        writeln!(f, "this is not json").unwrap();
+        append_event_to(&path, &sample_event("e2", "also good")).unwrap();
+        let loaded = load_events_from(&path);
+        let ids: Vec<_> = loaded.iter().map(|e| e.id.clone()).collect();
+        assert_eq!(ids, vec!["e1", "e2"]);
+    }
+
+    #[test]
+    fn load_skips_future_schema_versions() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("events.jsonl");
+        // Hand-write a future-version row plus a current-version one.
+        let future_row = serde_json::json!({
+            "schemaVersion": 999,
+            "id": "future-1",
+            "createdAt": 0,
+            "kind": "task",
+            "body": "from the future",
+        });
+        let mut f =
+            OpenOptions::new().create(true).append(true).open(&path).unwrap();
+        writeln!(f, "{}", future_row).unwrap();
+        drop(f);
+        append_event_to(&path, &sample_event("now-1", "current")).unwrap();
+        let loaded = load_events_from(&path);
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].id, "now-1");
+    }
+
+    #[test]
+    fn load_treats_missing_schema_version_as_v1() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("events.jsonl");
+        // A row WITHOUT schemaVersion — covers any pre-versioning leftover.
+        let event = sample_event("legacy", "no version");
+        let json = serde_json::to_string(&event).unwrap();
+        let mut f =
+            OpenOptions::new().create(true).append(true).open(&path).unwrap();
+        writeln!(f, "{}", json).unwrap();
+        let loaded = load_events_from(&path);
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].id, "legacy");
+    }
+
+    #[test]
+    fn append_creates_parent_directory() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("nested").join("events.jsonl");
+        append_event_to(&path, &sample_event("e1", "x")).unwrap();
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn append_writes_schema_version_field() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("events.jsonl");
+        append_event_to(&path, &sample_event("e1", "x")).unwrap();
+        let raw = fs::read_to_string(&path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(raw.trim()).unwrap();
+        assert_eq!(parsed["schemaVersion"], EVENT_SCHEMA_VERSION);
+        assert_eq!(parsed["id"], "e1");
+    }
+
+    #[test]
+    fn read_state_round_trip() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("read_state.json");
+        let mut s1 = ReadState::new("e1", "reviewer");
+        s1.read_at = Some(1000);
+        let mut s2 = ReadState::new("e2", "builder");
+        s2.acked_at = Some(2000);
+        s2.ack_result = Some("done".into());
+        save_read_state_to(&path, &[s1.clone(), s2.clone()]).unwrap();
+        let loaded = load_read_state_from(&path);
+        assert_eq!(loaded.len(), 2);
+        assert!(loaded.contains(&s1));
+        assert!(loaded.contains(&s2));
+    }
+
+    #[test]
+    fn read_state_save_emits_versioned_envelope() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("read_state.json");
+        save_read_state_to(&path, &[ReadState::new("e1", "reviewer")]).unwrap();
+        let raw = fs::read_to_string(&path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(parsed["version"], READ_STATE_SCHEMA_VERSION);
+        assert!(parsed["data"].is_array());
+    }
+
+    #[test]
+    fn read_state_load_accepts_bare_array_for_back_compat() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("read_state.json");
+        let bare = serde_json::to_string(&vec![ReadState::new("e1", "reviewer")]).unwrap();
+        fs::write(&path, bare).unwrap();
+        let loaded = load_read_state_from(&path);
+        assert_eq!(loaded.len(), 1);
+    }
+
+    #[test]
+    fn read_state_save_creates_parent_directory() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("nested").join("read_state.json");
+        save_read_state_to(&path, &[]).unwrap();
+        assert!(path.exists());
+    }
+}

--- a/src-tauri/src/mailbox/store.rs
+++ b/src-tauri/src/mailbox/store.rs
@@ -10,6 +10,11 @@ const DEFAULT_CAPACITY: usize = 5000;
 pub enum PostError {
     #[error(transparent)]
     Validation(#[from] EventValidationError),
+    /// Disk persistence failed after the in-memory append. The manager
+    /// rolls the in-memory state back before returning this so the UI
+    /// doesn't observe a "Posted" that disappears on restart.
+    #[error("persistence failed: {0}")]
+    Persist(String),
 }
 
 /// Append-only event store with per-recipient read/ack state. Events are
@@ -94,6 +99,21 @@ impl EventStore {
 
     pub fn get(&self, id: &str) -> Option<&Event> {
         self.events.iter().find(|e| e.id == id)
+    }
+
+    /// Remove an event by id. Used by `MailboxManager::post` to roll
+    /// back an in-memory append when the disk persist fails. Returns
+    /// true if the event existed.
+    pub fn remove_event(&mut self, id: &str) -> bool {
+        if let Some(pos) = self.events.iter().position(|e| e.id == id) {
+            self.events.remove(pos);
+            // Drop any ReadState rows that pointed at this event so the
+            // index never holds dangling refs.
+            self.read_state.retain(|(_, eid), _| eid != id);
+            true
+        } else {
+            false
+        }
     }
 
     pub fn len(&self) -> usize {
@@ -207,11 +227,30 @@ impl EventStore {
         out
     }
 
+    /// True when `recipient` is allowed to mutate ReadState for `event_id`.
+    /// For now: only the addressed recipient (or anyone if the event is
+    /// pure topic-broadcast — `to=None`). Future subscriptions / group
+    /// memberships extend this check.
+    fn recipient_owns(&self, event_id: &str, recipient: &str) -> bool {
+        let Some(event) = self.get(event_id) else {
+            return false;
+        };
+        match event.to.as_deref() {
+            Some(addressed) => addressed == recipient,
+            // Pure topic events have no addressed recipient; any caller
+            // can track their own read state against them.
+            None => true,
+        }
+    }
+
     /// Idempotently mark `event_id` as read for `recipient`. Returns true
-    /// when state changed (i.e. it wasn't already read).
+    /// when state changed (i.e. it wasn't already read). Returns false
+    /// when `recipient` is not the addressed owner of the event — that
+    /// prevents a caller from creating a bogus ReadState row that
+    /// `list_sent_by` would later report back to the sender as if a
+    /// stranger had read their direct mail.
     pub fn mark_read(&mut self, event_id: &str, recipient: &str, now_ms: u64) -> bool {
-        // Don't materialize ReadState for events that don't exist.
-        if self.get(event_id).is_none() {
+        if !self.recipient_owns(event_id, recipient) {
             return false;
         }
         let state = self.read_state_mut_or_insert(event_id, recipient);
@@ -224,6 +263,8 @@ impl EventStore {
 
     /// Ack with optional result string. Sets `acked_at` (and `read_at` if
     /// not already set — ack implies read). Returns true on state change.
+    /// Refuses to mutate state for callers that don't own the event (see
+    /// `mark_read`).
     pub fn ack(
         &mut self,
         event_id: &str,
@@ -231,7 +272,7 @@ impl EventStore {
         result: Option<String>,
         now_ms: u64,
     ) -> bool {
-        if self.get(event_id).is_none() {
+        if !self.recipient_owns(event_id, recipient) {
             return false;
         }
         let state = self.read_state_mut_or_insert(event_id, recipient);
@@ -262,7 +303,9 @@ impl EventStore {
             .count()
     }
 
-    /// Mark every read `ReadState` row for `recipient` as cleared.
+    /// Mark read `ReadState` rows for `recipient` as cleared, scoped to
+    /// the project filter so a clear action in project A doesn't blow
+    /// away read state for an alias of the same name in project B.
     /// Cleared events drop out of `list_for_recipient` and don't count
     /// as unread; the underlying events are preserved so other
     /// recipients still see them. Returns the count of newly-cleared
@@ -273,10 +316,29 @@ impl EventStore {
     /// re-surface the events as unread (the symptom of the prior bug).
     /// Adding a separate `cleared_at` marker keeps the prior read state
     /// intact while making the rows invisible to the recipient.
-    pub fn clear_read(&mut self, recipient: &str, now_ms: u64) -> usize {
+    pub fn clear_read(
+        &mut self,
+        recipient: &str,
+        project_filter: ProjectFilter<'_>,
+        now_ms: u64,
+    ) -> usize {
+        // Build the set of event ids that match the project filter so we
+        // can scope the ReadState mutation. Iterating `read_state` and
+        // event lookups separately keeps the borrow checker happy.
+        let scoped_event_ids: std::collections::HashSet<&String> = self
+            .events
+            .iter()
+            .filter(|e| project_filter.matches(e.project_id.as_deref()))
+            .map(|e| &e.id)
+            .collect();
+
         let mut cleared = 0;
-        for ((r, _), state) in self.read_state.iter_mut() {
-            if r == recipient && state.read_at.is_some() && state.cleared_at.is_none() {
+        for ((r, eid), state) in self.read_state.iter_mut() {
+            if r == recipient
+                && state.read_at.is_some()
+                && state.cleared_at.is_none()
+                && scoped_event_ids.contains(eid)
+            {
                 state.cleared_at = Some(now_ms);
                 cleared += 1;
             }
@@ -497,7 +559,7 @@ mod tests {
         store.mark_read("e1", "reviewer", 1000);
         store.mark_read("e3", "builder", 1000);
 
-        let cleared = store.clear_read("reviewer", 5000);
+        let cleared = store.clear_read("reviewer", ProjectFilter::Any, 5000);
         assert_eq!(cleared, 1);
 
         // Cleared event still has its ReadState row — but with cleared_at set.
@@ -555,13 +617,31 @@ mod tests {
     #[test]
     fn list_sent_by_recipient_filter_overrides_default() {
         let mut store = EventStore::new();
-        // Event addressed to reviewer; sender wants to see qa's view.
-        post_to(&mut store, "e1", "reviewer", "a", Some("me"), None);
-        store.mark_read("e1", "qa", 1500); // pretend qa is also tracking it
+        // Topic-only event (no `to`); any recipient can track read state
+        // for it because there's no addressed owner to gatekeep against.
+        // The sender then filters list_sent_by by an explicit recipient
+        // to see that subscriber's view.
+        let topic_event = EventBuilder::new("build green")
+            .topic("repo-a.build.completed")
+            .from("me")
+            .kind(EventKind::Signal);
+        store.post(topic_event, "e1".into(), 1000).unwrap();
+        store.mark_read("e1", "qa", 1500); // qa subscribes to the topic
 
         let sent_qa_view = store.list_sent_by("me", Some("qa"), None);
         assert_eq!(sent_qa_view.len(), 1);
         assert!(sent_qa_view[0].1.as_ref().unwrap().is_read());
+    }
+
+    #[test]
+    fn mark_read_rejects_non_addressed_recipient() {
+        let mut store = EventStore::new();
+        post_to(&mut store, "e1", "reviewer", "a", Some("me"), None);
+        // qa is NOT the addressed recipient — can't fabricate read state.
+        assert!(!store.mark_read("e1", "qa", 1500));
+        assert!(store.read_state("e1", "qa").is_none());
+        // The actual recipient still works fine.
+        assert!(store.mark_read("e1", "reviewer", 1500));
     }
 
     #[test]

--- a/src-tauri/src/mailbox/store.rs
+++ b/src-tauri/src/mailbox/store.rs
@@ -1,0 +1,545 @@
+use std::collections::{HashMap, VecDeque};
+
+use roux_core::{Event, EventBuilder, EventValidationError, ReadState};
+
+use crate::aliases::ProjectFilter;
+
+const DEFAULT_CAPACITY: usize = 5000;
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum PostError {
+    #[error(transparent)]
+    Validation(#[from] EventValidationError),
+}
+
+/// Append-only event store with per-recipient read/ack state. Events are
+/// keyed by `id`; `ReadState` is keyed by `(recipient, event_id)` so a
+/// single broadcast event can have N independent cursors without
+/// duplicating the payload.
+///
+/// Mirrors the `NotificationStore` shape: in-memory primary, intended to
+/// be wrapped by a `Manager` for persistence + Tauri event emission.
+pub struct EventStore {
+    events: VecDeque<Event>,
+    /// Indexed lookup keyed by `(recipient_alias, event_id)`.
+    read_state: HashMap<(String, String), ReadState>,
+    capacity: usize,
+    max_age_ms: Option<u64>,
+}
+
+impl EventStore {
+    pub fn new() -> Self {
+        Self::with_capacity(DEFAULT_CAPACITY, None)
+    }
+
+    pub fn with_capacity(capacity: usize, max_age_ms: Option<u64>) -> Self {
+        Self {
+            events: VecDeque::with_capacity(capacity.min(256)),
+            read_state: HashMap::new(),
+            capacity,
+            max_age_ms,
+        }
+    }
+
+    pub fn from_entries(events: Vec<Event>, read_state: Vec<ReadState>) -> Self {
+        let mut store = Self::new();
+        for e in events {
+            store.events.push_back(e);
+        }
+        for s in read_state {
+            store
+                .read_state
+                .insert((s.recipient.clone(), s.event_id.clone()), s);
+        }
+        store.evict_overflow();
+        store
+    }
+
+    /// Append `builder`'s event. Caller passes a generated `id` and `now_ms`
+    /// (the store doesn't depend on the uuid crate so roux-core stays free
+    /// of id-generation deps). Returns the stored event on success.
+    pub fn post(
+        &mut self,
+        builder: EventBuilder,
+        id: String,
+        now_ms: u64,
+    ) -> Result<Event, PostError> {
+        let event = builder.build_with(id, now_ms)?;
+        self.events.push_back(event.clone());
+        self.evict_overflow();
+        Ok(event)
+    }
+
+    /// Drop excess events past the capacity / age caps. Also drops orphaned
+    /// `ReadState` rows so the indexed lookup never points at a missing event.
+    fn evict_overflow(&mut self) {
+        while self.events.len() > self.capacity {
+            if let Some(dropped) = self.events.pop_front() {
+                self.read_state.retain(|(_, eid), _| eid != &dropped.id);
+            }
+        }
+        if let Some(max_age) = self.max_age_ms {
+            let now = now_ms();
+            let cutoff = now.saturating_sub(max_age);
+            while let Some(front) = self.events.front() {
+                if front.created_at < cutoff {
+                    let dropped = self.events.pop_front().expect("front existed");
+                    self.read_state.retain(|(_, eid), _| eid != &dropped.id);
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+
+    pub fn get(&self, id: &str) -> Option<&Event> {
+        self.events.iter().find(|e| e.id == id)
+    }
+
+    pub fn len(&self) -> usize {
+        self.events.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.events.is_empty()
+    }
+
+    pub fn events(&self) -> impl Iterator<Item = &Event> {
+        self.events.iter()
+    }
+
+    pub fn all_read_state(&self) -> impl Iterator<Item = &ReadState> {
+        self.read_state.values()
+    }
+
+    /// Per-recipient state for a specific event, if any has been recorded.
+    pub fn read_state(&self, event_id: &str, recipient: &str) -> Option<&ReadState> {
+        self.read_state.get(&(recipient.to_string(), event_id.to_string()))
+    }
+
+    fn read_state_mut_or_insert(&mut self, event_id: &str, recipient: &str) -> &mut ReadState {
+        self.read_state
+            .entry((recipient.to_string(), event_id.to_string()))
+            .or_insert_with(|| ReadState::new(event_id, recipient))
+    }
+
+    fn is_read_by(&self, event_id: &str, recipient: &str) -> bool {
+        self.read_state(event_id, recipient).map(|s| s.is_read()).unwrap_or(false)
+    }
+
+    /// Events addressed `to=<recipient>` matching the project filter. Oldest
+    /// first (insertion order). `unread_only` filters to events without a
+    /// `read_at` timestamp for this recipient.
+    pub fn list_for_recipient(
+        &self,
+        recipient: &str,
+        unread_only: bool,
+        project_filter: ProjectFilter<'_>,
+    ) -> Vec<Event> {
+        self.events
+            .iter()
+            .filter(|e| e.to.as_deref() == Some(recipient))
+            .filter(|e| project_filter.matches(e.project_id.as_deref()))
+            .filter(|e| !unread_only || !self.is_read_by(&e.id, recipient))
+            .cloned()
+            .collect()
+    }
+
+    /// Events on `topic` (exact match in Phase 2; glob support is a
+    /// follow-up). Includes events that also have `to` set.
+    pub fn list_for_topic(&self, topic: &str, project_filter: ProjectFilter<'_>) -> Vec<Event> {
+        self.events
+            .iter()
+            .filter(|e| e.topic.as_deref() == Some(topic))
+            .filter(|e| project_filter.matches(e.project_id.as_deref()))
+            .cloned()
+            .collect()
+    }
+
+    /// Firehose view: every event matching the project filter, newest first.
+    pub fn list_all(&self, project_filter: ProjectFilter<'_>, limit: Option<usize>) -> Vec<Event> {
+        let iter = self
+            .events
+            .iter()
+            .rev()
+            .filter(|e| project_filter.matches(e.project_id.as_deref()));
+        match limit {
+            Some(n) => iter.take(n).cloned().collect(),
+            None => iter.cloned().collect(),
+        }
+    }
+
+    /// Events sent BY `sender` (matches `from`), newest first. Each row pairs
+    /// the event with its `ReadState` for `recipient_filter` so the sender
+    /// can see read/ack state. When `recipient_filter` is `None`, every
+    /// event the sender posted is returned without per-recipient pairing.
+    pub fn list_sent_by(
+        &self,
+        sender: &str,
+        recipient_filter: Option<&str>,
+        limit: Option<usize>,
+    ) -> Vec<(Event, Option<ReadState>)> {
+        let mut out: Vec<(Event, Option<ReadState>)> = Vec::new();
+        for e in self.events.iter().rev() {
+            if e.from.as_deref() != Some(sender) {
+                continue;
+            }
+            let state = match recipient_filter {
+                Some(r) => self.read_state(&e.id, r).cloned(),
+                None => e
+                    .to
+                    .as_deref()
+                    .and_then(|t| self.read_state(&e.id, t).cloned()),
+            };
+            out.push((e.clone(), state));
+            if let Some(n) = limit {
+                if out.len() >= n {
+                    break;
+                }
+            }
+        }
+        out
+    }
+
+    /// Idempotently mark `event_id` as read for `recipient`. Returns true
+    /// when state changed (i.e. it wasn't already read).
+    pub fn mark_read(&mut self, event_id: &str, recipient: &str, now_ms: u64) -> bool {
+        // Don't materialize ReadState for events that don't exist.
+        if self.get(event_id).is_none() {
+            return false;
+        }
+        let state = self.read_state_mut_or_insert(event_id, recipient);
+        if state.read_at.is_some() {
+            return false;
+        }
+        state.read_at = Some(now_ms);
+        true
+    }
+
+    /// Ack with optional result string. Sets `acked_at` (and `read_at` if
+    /// not already set — ack implies read). Returns true on state change.
+    pub fn ack(
+        &mut self,
+        event_id: &str,
+        recipient: &str,
+        result: Option<String>,
+        now_ms: u64,
+    ) -> bool {
+        if self.get(event_id).is_none() {
+            return false;
+        }
+        let state = self.read_state_mut_or_insert(event_id, recipient);
+        if state.acked_at.is_some() {
+            // Allow updating the result string; it's the more informative
+            // change. But don't bump `acked_at` again.
+            if result.is_some() && state.ack_result != result {
+                state.ack_result = result;
+                return true;
+            }
+            return false;
+        }
+        state.acked_at = Some(now_ms);
+        if state.read_at.is_none() {
+            state.read_at = Some(now_ms);
+        }
+        state.ack_result = result;
+        true
+    }
+
+    pub fn unread_count(&self, recipient: &str, project_filter: ProjectFilter<'_>) -> usize {
+        self.events
+            .iter()
+            .filter(|e| e.to.as_deref() == Some(recipient))
+            .filter(|e| project_filter.matches(e.project_id.as_deref()))
+            .filter(|e| !self.is_read_by(&e.id, recipient))
+            .count()
+    }
+
+    /// Clear read events for `recipient`. Removes their `ReadState` rows
+    /// where `read_at` is set; the underlying events stay so other
+    /// recipients can still see them. Returns the count of removed rows.
+    pub fn clear_read(&mut self, recipient: &str) -> usize {
+        let before = self.read_state.len();
+        self.read_state
+            .retain(|(r, _), s| !(r == recipient && s.read_at.is_some()));
+        before - self.read_state.len()
+    }
+}
+
+impl Default for EventStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use roux_core::EventKind;
+
+    fn post_to(
+        store: &mut EventStore,
+        id: &str,
+        recipient: &str,
+        body: &str,
+        from: Option<&str>,
+        project: Option<&str>,
+    ) -> Event {
+        let mut b = EventBuilder::new(body).to(recipient).kind(EventKind::Task);
+        if let Some(f) = from {
+            b = b.from(f);
+        }
+        if let Some(p) = project {
+            b = b.project_id(p);
+        }
+        store.post(b, id.to_string(), 1000).unwrap()
+    }
+
+    #[test]
+    fn post_appends_event_and_returns_it() {
+        let mut store = EventStore::new();
+        let posted = post_to(&mut store, "evt-1", "reviewer", "hello", None, None);
+        assert_eq!(posted.id, "evt-1");
+        assert_eq!(store.len(), 1);
+        assert_eq!(store.get("evt-1").map(|e| e.id.clone()), Some("evt-1".to_string()));
+    }
+
+    #[test]
+    fn post_validates_addressing() {
+        let mut store = EventStore::new();
+        let err = store
+            .post(EventBuilder::new("hi"), "evt-1".into(), 0)
+            .unwrap_err();
+        assert!(matches!(err, PostError::Validation(_)));
+        assert_eq!(store.len(), 0);
+    }
+
+    #[test]
+    fn list_for_recipient_returns_only_addressed_events() {
+        let mut store = EventStore::new();
+        post_to(&mut store, "e1", "reviewer", "a", None, None);
+        post_to(&mut store, "e2", "builder", "b", None, None);
+        post_to(&mut store, "e3", "reviewer", "c", None, None);
+
+        let mine = store.list_for_recipient("reviewer", false, ProjectFilter::Any);
+        let ids: Vec<_> = mine.iter().map(|e| e.id.clone()).collect();
+        assert_eq!(ids, vec!["e1", "e3"]);
+    }
+
+    #[test]
+    fn list_for_recipient_unread_only_filters_read_events() {
+        let mut store = EventStore::new();
+        post_to(&mut store, "e1", "reviewer", "a", None, None);
+        post_to(&mut store, "e2", "reviewer", "b", None, None);
+        store.mark_read("e1", "reviewer", 2000);
+
+        let unread = store.list_for_recipient("reviewer", true, ProjectFilter::Any);
+        assert_eq!(unread.len(), 1);
+        assert_eq!(unread[0].id, "e2");
+    }
+
+    #[test]
+    fn list_for_recipient_respects_project_filter() {
+        let mut store = EventStore::new();
+        post_to(&mut store, "g", "reviewer", "global", None, None);
+        post_to(&mut store, "a", "reviewer", "in-a", None, Some("proj-a"));
+        post_to(&mut store, "b", "reviewer", "in-b", None, Some("proj-b"));
+
+        let only_a = store.list_for_recipient(
+            "reviewer",
+            false,
+            ProjectFilter::Exact(Some("proj-a")),
+        );
+        assert_eq!(only_a.len(), 1);
+        assert_eq!(only_a[0].id, "a");
+
+        let global_only = store.list_for_recipient("reviewer", false, ProjectFilter::Exact(None));
+        assert_eq!(global_only.len(), 1);
+        assert_eq!(global_only[0].id, "g");
+    }
+
+    #[test]
+    fn list_for_topic_returns_events_with_matching_topic() {
+        let mut store = EventStore::new();
+        let e1 = EventBuilder::new("build a").topic("build.completed");
+        let e2 = EventBuilder::new("build b").topic("build.failed");
+        let e3 = EventBuilder::new("hi").to("reviewer").topic("build.completed");
+        store.post(e1, "e1".into(), 1).unwrap();
+        store.post(e2, "e2".into(), 2).unwrap();
+        store.post(e3, "e3".into(), 3).unwrap();
+
+        let completed = store.list_for_topic("build.completed", ProjectFilter::Any);
+        let ids: Vec<_> = completed.iter().map(|e| e.id.clone()).collect();
+        assert_eq!(ids, vec!["e1", "e3"]);
+    }
+
+    #[test]
+    fn list_all_returns_newest_first() {
+        let mut store = EventStore::new();
+        post_to(&mut store, "e1", "reviewer", "first", None, None);
+        post_to(&mut store, "e2", "reviewer", "second", None, None);
+        post_to(&mut store, "e3", "reviewer", "third", None, None);
+
+        let all = store.list_all(ProjectFilter::Any, None);
+        let ids: Vec<_> = all.iter().map(|e| e.id.clone()).collect();
+        assert_eq!(ids, vec!["e3", "e2", "e1"]);
+    }
+
+    #[test]
+    fn list_all_respects_limit() {
+        let mut store = EventStore::new();
+        for i in 0..5 {
+            post_to(&mut store, &format!("e{i}"), "reviewer", "x", None, None);
+        }
+        let limited = store.list_all(ProjectFilter::Any, Some(2));
+        assert_eq!(limited.len(), 2);
+        assert_eq!(limited[0].id, "e4");
+        assert_eq!(limited[1].id, "e3");
+    }
+
+    #[test]
+    fn mark_read_is_idempotent() {
+        let mut store = EventStore::new();
+        post_to(&mut store, "e1", "reviewer", "x", None, None);
+        assert!(store.mark_read("e1", "reviewer", 1000));
+        assert!(!store.mark_read("e1", "reviewer", 2000), "second call should report no change");
+        let state = store.read_state("e1", "reviewer").unwrap();
+        assert_eq!(state.read_at, Some(1000), "first read_at should be preserved");
+    }
+
+    #[test]
+    fn mark_read_for_unknown_event_is_noop() {
+        let mut store = EventStore::new();
+        assert!(!store.mark_read("nope", "reviewer", 1000));
+        assert!(store.read_state("nope", "reviewer").is_none(), "no orphan state row");
+    }
+
+    #[test]
+    fn ack_implies_read() {
+        let mut store = EventStore::new();
+        post_to(&mut store, "e1", "reviewer", "x", None, None);
+        assert!(store.ack("e1", "reviewer", Some("done".into()), 1500));
+        let state = store.read_state("e1", "reviewer").unwrap();
+        assert!(state.is_read());
+        assert!(state.is_acked());
+        assert_eq!(state.read_at, Some(1500));
+        assert_eq!(state.acked_at, Some(1500));
+        assert_eq!(state.ack_result.as_deref(), Some("done"));
+    }
+
+    #[test]
+    fn ack_after_read_preserves_read_at() {
+        let mut store = EventStore::new();
+        post_to(&mut store, "e1", "reviewer", "x", None, None);
+        store.mark_read("e1", "reviewer", 1000);
+        assert!(store.ack("e1", "reviewer", None, 2000));
+        let state = store.read_state("e1", "reviewer").unwrap();
+        assert_eq!(state.read_at, Some(1000));
+        assert_eq!(state.acked_at, Some(2000));
+    }
+
+    #[test]
+    fn double_ack_is_noop_unless_result_changes() {
+        let mut store = EventStore::new();
+        post_to(&mut store, "e1", "reviewer", "x", None, None);
+        store.ack("e1", "reviewer", Some("first".into()), 1000);
+        assert!(!store.ack("e1", "reviewer", None, 2000), "redundant ack returns false");
+        // Updating the result is allowed.
+        assert!(store.ack("e1", "reviewer", Some("better".into()), 3000));
+        let state = store.read_state("e1", "reviewer").unwrap();
+        assert_eq!(state.acked_at, Some(1000), "acked_at preserved across re-ack");
+        assert_eq!(state.ack_result.as_deref(), Some("better"));
+    }
+
+    #[test]
+    fn unread_count_drops_after_read() {
+        let mut store = EventStore::new();
+        post_to(&mut store, "e1", "reviewer", "a", None, None);
+        post_to(&mut store, "e2", "reviewer", "b", None, None);
+        post_to(&mut store, "e3", "builder", "c", None, None);
+        assert_eq!(store.unread_count("reviewer", ProjectFilter::Any), 2);
+        store.mark_read("e1", "reviewer", 1500);
+        assert_eq!(store.unread_count("reviewer", ProjectFilter::Any), 1);
+    }
+
+    #[test]
+    fn clear_read_removes_only_read_rows_for_recipient() {
+        let mut store = EventStore::new();
+        post_to(&mut store, "e1", "reviewer", "a", None, None);
+        post_to(&mut store, "e2", "reviewer", "b", None, None);
+        post_to(&mut store, "e3", "builder", "c", None, None);
+        store.mark_read("e1", "reviewer", 1000);
+        store.mark_read("e3", "builder", 1000);
+
+        let cleared = store.clear_read("reviewer");
+        assert_eq!(cleared, 1);
+        assert!(store.read_state("e1", "reviewer").is_none());
+        // Builder's state is untouched.
+        assert!(store.read_state("e3", "builder").is_some());
+        // Underlying event is preserved.
+        assert!(store.get("e1").is_some());
+    }
+
+    #[test]
+    fn capacity_eviction_drops_orphan_read_state() {
+        let mut store = EventStore::with_capacity(2, None);
+        post_to(&mut store, "e1", "reviewer", "a", None, None);
+        store.mark_read("e1", "reviewer", 500);
+        post_to(&mut store, "e2", "reviewer", "b", None, None);
+        post_to(&mut store, "e3", "reviewer", "c", None, None);
+        // e1 should be evicted now; its read_state row should also be gone.
+        assert_eq!(store.len(), 2);
+        assert!(store.get("e1").is_none());
+        assert!(store.read_state("e1", "reviewer").is_none(), "orphan state must be cleaned up");
+    }
+
+    #[test]
+    fn list_sent_by_pairs_with_recipient_state() {
+        let mut store = EventStore::new();
+        post_to(&mut store, "e1", "reviewer", "a", Some("me"), None);
+        post_to(&mut store, "e2", "builder", "b", Some("me"), None);
+        store.mark_read("e1", "reviewer", 1500);
+
+        let sent = store.list_sent_by("me", None, None);
+        assert_eq!(sent.len(), 2);
+        // newest first
+        assert_eq!(sent[0].0.id, "e2");
+        assert_eq!(sent[1].0.id, "e1");
+        assert!(sent[0].1.is_none(), "builder hasn't read yet");
+        assert!(sent[1].1.as_ref().unwrap().is_read());
+    }
+
+    #[test]
+    fn list_sent_by_recipient_filter_overrides_default() {
+        let mut store = EventStore::new();
+        // Event addressed to reviewer; sender wants to see qa's view.
+        post_to(&mut store, "e1", "reviewer", "a", Some("me"), None);
+        store.mark_read("e1", "qa", 1500); // pretend qa is also tracking it
+
+        let sent_qa_view = store.list_sent_by("me", Some("qa"), None);
+        assert_eq!(sent_qa_view.len(), 1);
+        assert!(sent_qa_view[0].1.as_ref().unwrap().is_read());
+    }
+
+    #[test]
+    fn from_entries_round_trips_events_and_state() {
+        let mut store = EventStore::new();
+        post_to(&mut store, "e1", "reviewer", "a", None, None);
+        post_to(&mut store, "e2", "reviewer", "b", None, None);
+        store.mark_read("e1", "reviewer", 1000);
+
+        let events: Vec<_> = store.events().cloned().collect();
+        let states: Vec<_> = store.all_read_state().cloned().collect();
+        let restored = EventStore::from_entries(events, states);
+        assert_eq!(restored.len(), 2);
+        assert!(restored.read_state("e1", "reviewer").unwrap().is_read());
+        assert!(restored.read_state("e2", "reviewer").is_none());
+    }
+}

--- a/src-tauri/src/mailbox/store.rs
+++ b/src-tauri/src/mailbox/store.rs
@@ -10,6 +10,12 @@ const DEFAULT_CAPACITY: usize = 5000;
 pub enum PostError {
     #[error(transparent)]
     Validation(#[from] EventValidationError),
+    /// Caller passed an `id` that already exists in the store. Should
+    /// never happen with the uuid v4 generator the manager uses, but
+    /// keeping it as a typed error guards against id-collision races
+    /// in tests and future schemes (deterministic ids, etc.).
+    #[error("duplicate event id: {0}")]
+    DuplicateId(String),
     /// Disk persistence failed after the in-memory append. The manager
     /// rolls the in-memory state back before returning this so the UI
     /// doesn't observe a "Posted" that disappears on restart.
@@ -63,12 +69,17 @@ impl EventStore {
     /// Append `builder`'s event. Caller passes a generated `id` and `now_ms`
     /// (the store doesn't depend on the uuid crate so roux-core stays free
     /// of id-generation deps). Returns the stored event on success.
+    /// Rejects duplicate ids — the store is keyed by id, so collisions
+    /// would conflate ReadState rows across distinct events.
     pub fn post(
         &mut self,
         builder: EventBuilder,
         id: String,
         now_ms: u64,
     ) -> Result<Event, PostError> {
+        if self.get(&id).is_some() {
+            return Err(PostError::DuplicateId(id));
+        }
         let event = builder.build_with(id, now_ms)?;
         self.events.push_back(event.clone());
         self.evict_overflow();

--- a/src-tauri/src/mailbox/store.rs
+++ b/src-tauri/src/mailbox/store.rs
@@ -127,9 +127,14 @@ impl EventStore {
         self.read_state(event_id, recipient).map(|s| s.is_read()).unwrap_or(false)
     }
 
+    fn is_cleared_by(&self, event_id: &str, recipient: &str) -> bool {
+        self.read_state(event_id, recipient).map(|s| s.is_cleared()).unwrap_or(false)
+    }
+
     /// Events addressed `to=<recipient>` matching the project filter. Oldest
     /// first (insertion order). `unread_only` filters to events without a
-    /// `read_at` timestamp for this recipient.
+    /// `read_at` timestamp for this recipient. **Cleared events are always
+    /// filtered out** — `clear_read` is meant to hide them.
     pub fn list_for_recipient(
         &self,
         recipient: &str,
@@ -140,6 +145,7 @@ impl EventStore {
             .iter()
             .filter(|e| e.to.as_deref() == Some(recipient))
             .filter(|e| project_filter.matches(e.project_id.as_deref()))
+            .filter(|e| !self.is_cleared_by(&e.id, recipient))
             .filter(|e| !unread_only || !self.is_read_by(&e.id, recipient))
             .cloned()
             .collect()
@@ -251,18 +257,31 @@ impl EventStore {
             .iter()
             .filter(|e| e.to.as_deref() == Some(recipient))
             .filter(|e| project_filter.matches(e.project_id.as_deref()))
+            .filter(|e| !self.is_cleared_by(&e.id, recipient))
             .filter(|e| !self.is_read_by(&e.id, recipient))
             .count()
     }
 
-    /// Clear read events for `recipient`. Removes their `ReadState` rows
-    /// where `read_at` is set; the underlying events stay so other
-    /// recipients can still see them. Returns the count of removed rows.
-    pub fn clear_read(&mut self, recipient: &str) -> usize {
-        let before = self.read_state.len();
-        self.read_state
-            .retain(|(r, _), s| !(r == recipient && s.read_at.is_some()));
-        before - self.read_state.len()
+    /// Mark every read `ReadState` row for `recipient` as cleared.
+    /// Cleared events drop out of `list_for_recipient` and don't count
+    /// as unread; the underlying events are preserved so other
+    /// recipients still see them. Returns the count of newly-cleared
+    /// rows.
+    ///
+    /// We deliberately *do not* delete `ReadState` rows — that would
+    /// erase `read_at` and the next `list_for_recipient` call would
+    /// re-surface the events as unread (the symptom of the prior bug).
+    /// Adding a separate `cleared_at` marker keeps the prior read state
+    /// intact while making the rows invisible to the recipient.
+    pub fn clear_read(&mut self, recipient: &str, now_ms: u64) -> usize {
+        let mut cleared = 0;
+        for ((r, _), state) in self.read_state.iter_mut() {
+            if r == recipient && state.read_at.is_some() && state.cleared_at.is_none() {
+                state.cleared_at = Some(now_ms);
+                cleared += 1;
+            }
+        }
+        cleared
     }
 }
 
@@ -470,7 +489,7 @@ mod tests {
     }
 
     #[test]
-    fn clear_read_removes_only_read_rows_for_recipient() {
+    fn clear_read_marks_cleared_without_resurrecting_unread() {
         let mut store = EventStore::new();
         post_to(&mut store, "e1", "reviewer", "a", None, None);
         post_to(&mut store, "e2", "reviewer", "b", None, None);
@@ -478,9 +497,26 @@ mod tests {
         store.mark_read("e1", "reviewer", 1000);
         store.mark_read("e3", "builder", 1000);
 
-        let cleared = store.clear_read("reviewer");
+        let cleared = store.clear_read("reviewer", 5000);
         assert_eq!(cleared, 1);
-        assert!(store.read_state("e1", "reviewer").is_none());
+
+        // Cleared event still has its ReadState row — but with cleared_at set.
+        let state = store.read_state("e1", "reviewer").unwrap();
+        assert_eq!(state.read_at, Some(1000), "prior read state preserved");
+        assert_eq!(state.cleared_at, Some(5000));
+        assert!(state.is_cleared());
+
+        // Cleared events drop out of list_for_recipient.
+        let visible: Vec<_> = store
+            .list_for_recipient("reviewer", false, ProjectFilter::Any)
+            .iter()
+            .map(|e| e.id.clone())
+            .collect();
+        assert_eq!(visible, vec!["e2"], "e1 cleared, e2 still visible");
+
+        // And don't show up as unread either (regression of prior bug).
+        assert_eq!(store.unread_count("reviewer", ProjectFilter::Any), 1);
+
         // Builder's state is untouched.
         assert!(store.read_state("e3", "builder").is_some());
         // Underlying event is preserved.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -244,6 +244,8 @@ fn main() {
             watch_manager: watches::WatchManager::new(watch_store_handle),
             automation_hooks: automation_hooks::AutomationHookManager::new(),
             notification_manager: notifications::NotificationManager::new(),
+            alias_manager: roux_lib::aliases::AliasManager::load(),
+            mailbox_manager: roux_lib::mailbox::MailboxManager::load(),
             pending_replies: Mutex::new(std::collections::HashMap::new()),
             managed_proxy: services::managed_proxy::ManagedProxyState::new(),
         })
@@ -406,6 +408,20 @@ fn main() {
             commands::pty::set_pty_name,
             commands::user_themes::list_user_terminal_themes,
             commands::user_themes::user_themes_dir,
+            commands::aliases::aliases_list,
+            commands::aliases::aliases_get,
+            commands::aliases::aliases_whoami,
+            commands::mailbox::mailbox_list_for_recipient,
+            commands::mailbox::mailbox_list_for_topic,
+            commands::mailbox::mailbox_list_all,
+            commands::mailbox::mailbox_unread_count,
+            commands::mailbox::mailbox_get_event,
+            commands::mailbox::mailbox_read_state,
+            commands::mailbox::mailbox_post,
+            commands::mailbox::mailbox_mark_read,
+            commands::mailbox::mailbox_ack,
+            commands::mailbox::mailbox_clear_read,
+            commands::mailbox::mailbox_deliver_to_pane,
         ])
         .setup(|app| {
             // Install the roux-cli shim dir (~/.config/roux/bin) with

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -142,6 +142,172 @@ pub struct NotesAppendParams {
     pub tags: Vec<String>,
 }
 
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AliasSetParams {
+    pub alias: String,
+    pub session_id: Option<String>,
+    pub project_id: Option<String>,
+    #[serde(default)]
+    pub force: bool,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AliasUnsetParams {
+    pub alias: String,
+    pub project_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AliasClaimParams {
+    pub alias: String,
+    pub session_id: String,
+    pub project_id: Option<String>,
+    #[serde(default)]
+    pub steal: bool,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AliasListParams {
+    pub project_id: Option<String>,
+    #[serde(default)]
+    pub global: bool,
+    #[serde(default)]
+    pub only_unbound: bool,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AliasGetParams {
+    pub alias: String,
+    pub project_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AliasWhoamiParams {
+    pub session_id: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MailboxPostParams {
+    /// Recipient alias. At least one of `to` or `topic` is required.
+    pub to: Option<String>,
+    /// Topic for broadcast / bus-style fan-out.
+    pub topic: Option<String>,
+    /// Body text (required unless `structured` carries the payload).
+    pub body: String,
+    pub subject: Option<String>,
+    /// One of: task | result | question | fyi | signal. Defaults to "task".
+    pub kind: Option<String>,
+    pub project_id: Option<String>,
+    /// Thread key — copy from a previous event id to thread replies.
+    pub correlation_id: Option<String>,
+    /// Optional structured JSON payload (`{ task, context, expectsReply }` is
+    /// the recommended shape, not enforced).
+    pub structured: Option<Value>,
+    /// Override sender. Defaults to the calling session's primary alias.
+    pub from: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MailboxPeekParams {
+    /// Recipient alias. Defaults to the calling session's primary alias.
+    pub alias: Option<String>,
+    pub project_id: Option<String>,
+    #[serde(default)]
+    pub global: bool,
+    #[serde(default)]
+    pub unread: bool,
+    pub limit: Option<u64>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MailboxReadParams {
+    pub alias: Option<String>,
+    pub project_id: Option<String>,
+    #[serde(default)]
+    pub global: bool,
+    /// Also ack each drained event.
+    #[serde(default)]
+    pub ack: bool,
+    pub limit: Option<u64>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MailboxAckParams {
+    pub event_id: String,
+    /// Optional short result string visible to the sender.
+    pub result: Option<String>,
+    pub alias: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MailboxCountParams {
+    pub alias: Option<String>,
+    pub project_id: Option<String>,
+    #[serde(default)]
+    pub global: bool,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MailboxClearParams {
+    pub alias: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MailboxReplyParams {
+    pub event_id: String,
+    pub body: String,
+    pub subject: Option<String>,
+    /// Defaults to "result".
+    pub kind: Option<String>,
+    pub structured: Option<Value>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MailboxSentParams {
+    /// Filter to one recipient.
+    pub to: Option<String>,
+    /// Override sender lookup.
+    pub sender: Option<String>,
+    pub limit: Option<u64>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct BusPublishParams {
+    pub topic: String,
+    pub body: String,
+    /// Defaults to "signal".
+    pub kind: Option<String>,
+    pub project_id: Option<String>,
+    pub subject: Option<String>,
+    pub structured: Option<Value>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct BusTailParams {
+    /// When omitted, returns the firehose (all events) newest first.
+    pub topic: Option<String>,
+    pub project_id: Option<String>,
+    #[serde(default)]
+    pub global: bool,
+    pub limit: Option<u64>,
+}
+
 #[derive(Debug, Clone)]
 pub struct RouxMcpServer;
 
@@ -277,6 +443,406 @@ impl RouxMcpServer {
     async fn roux_notes_vault_root(&self) -> Result<CallToolResult, ErrorData> {
         call_socket(json!({ "command": "notes-vault-root", "args": {} })).await
     }
+
+    #[tool(
+        description = "Bind an agent alias to a session. Aliases give sessions stable, restart-durable identity (e.g. 'reviewer', 'frontend'). Pass `sessionId` to target a specific session, or omit to use the calling session."
+    )]
+    async fn roux_alias_set(
+        &self,
+        Parameters(params): Parameters<AliasSetParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let mut args = serde_json::Map::new();
+        args.insert("alias".into(), Value::String(params.alias));
+        if let Some(s) = params.session_id {
+            args.insert("session_id".into(), Value::String(s));
+        }
+        if let Some(p) = params.project_id {
+            args.insert("project_id".into(), Value::String(p));
+        }
+        if params.force {
+            args.insert("force".into(), Value::Bool(true));
+        }
+        call_socket(json!({
+            "command": "alias-set",
+            "args": Value::Object(args),
+        }))
+        .await
+    }
+
+    #[tool(
+        description = "Release an alias's session binding. Queued mail addressed to the alias persists for the next session that claims it."
+    )]
+    async fn roux_alias_unset(
+        &self,
+        Parameters(params): Parameters<AliasUnsetParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let mut args = serde_json::Map::new();
+        args.insert("alias".into(), Value::String(params.alias));
+        if let Some(p) = params.project_id {
+            args.insert("project_id".into(), Value::String(p));
+        }
+        call_socket(json!({
+            "command": "alias-unset",
+            "args": Value::Object(args),
+        }))
+        .await
+    }
+
+    #[tool(
+        description = "Claim an alias for the named session. Set `steal: true` to override an existing binding to a different session."
+    )]
+    async fn roux_alias_claim(
+        &self,
+        Parameters(params): Parameters<AliasClaimParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let mut args = serde_json::Map::new();
+        args.insert("alias".into(), Value::String(params.alias));
+        if let Some(p) = params.project_id {
+            args.insert("project_id".into(), Value::String(p));
+        }
+        if params.steal {
+            args.insert("steal".into(), Value::Bool(true));
+        }
+        call_socket(json!({
+            "command": "alias-claim",
+            "session_id": params.session_id,
+            "args": Value::Object(args),
+        }))
+        .await
+    }
+
+    #[tool(
+        description = "List agent aliases. Pass `projectId` to scope to one project, or `global: true` to limit to project-less aliases. `onlyUnbound: true` filters to aliases without a current session binding."
+    )]
+    async fn roux_alias_list(
+        &self,
+        Parameters(params): Parameters<AliasListParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let mut args = serde_json::Map::new();
+        if let Some(p) = params.project_id {
+            args.insert("project_id".into(), Value::String(p));
+        }
+        if params.global {
+            args.insert("global".into(), Value::Bool(true));
+        }
+        if params.only_unbound {
+            args.insert("only_unbound".into(), Value::Bool(true));
+        }
+        call_socket(json!({
+            "command": "alias-list",
+            "args": Value::Object(args),
+        }))
+        .await
+    }
+
+    #[tool(
+        description = "Resolve an alias to its current session binding. Returns an error with the candidate projects when the bare alias name is ambiguous across multiple projects."
+    )]
+    async fn roux_alias_get(
+        &self,
+        Parameters(params): Parameters<AliasGetParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let mut args = serde_json::Map::new();
+        args.insert("alias".into(), Value::String(params.alias));
+        if let Some(p) = params.project_id {
+            args.insert("project_id".into(), Value::String(p));
+        }
+        call_socket(json!({
+            "command": "alias-get",
+            "args": Value::Object(args),
+        }))
+        .await
+    }
+
+    #[tool(
+        description = "List the aliases currently bound to a session. Useful for an agent to discover its own identity."
+    )]
+    async fn roux_alias_whoami(
+        &self,
+        Parameters(params): Parameters<AliasWhoamiParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        call_socket(json!({
+            "command": "alias-whoami",
+            "session_id": params.session_id,
+            "args": {},
+        }))
+        .await
+    }
+
+    #[tool(
+        description = "Post a message to a recipient alias (mailbox-style direct addressing) and/or a topic (bus-style broadcast). At least one of `to` or `topic` is required. Defaults: kind=task, from=calling session's primary alias."
+    )]
+    async fn roux_mailbox_post(
+        &self,
+        Parameters(params): Parameters<MailboxPostParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let mut args = serde_json::Map::new();
+        args.insert("body".into(), Value::String(params.body));
+        if let Some(v) = params.to {
+            args.insert("to".into(), Value::String(v));
+        }
+        if let Some(v) = params.topic {
+            args.insert("topic".into(), Value::String(v));
+        }
+        if let Some(v) = params.subject {
+            args.insert("subject".into(), Value::String(v));
+        }
+        if let Some(v) = params.kind {
+            args.insert("kind".into(), Value::String(v));
+        }
+        if let Some(v) = params.project_id {
+            args.insert("project_id".into(), Value::String(v));
+        }
+        if let Some(v) = params.correlation_id {
+            args.insert("correlation_id".into(), Value::String(v));
+        }
+        if let Some(v) = params.structured {
+            args.insert("structured".into(), v);
+        }
+        if let Some(v) = params.from {
+            args.insert("from".into(), Value::String(v));
+        }
+        call_socket(json!({
+            "command": "mailbox-post",
+            "args": Value::Object(args),
+        }))
+        .await
+    }
+
+    #[tool(
+        description = "Peek at events addressed to me (or to `alias`) without changing read state. `unread: true` filters to events I haven't read yet."
+    )]
+    async fn roux_mailbox_peek(
+        &self,
+        Parameters(params): Parameters<MailboxPeekParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        call_socket(json!({
+            "command": "mailbox-peek",
+            "args": mailbox_recv_args(
+                params.alias,
+                params.project_id,
+                params.global,
+                Some(params.unread),
+                params.limit,
+            ),
+        }))
+        .await
+    }
+
+    #[tool(
+        description = "Drain unread mail addressed to me (or `alias`) and mark each event read. `ack: true` also acks every drained event."
+    )]
+    async fn roux_mailbox_read(
+        &self,
+        Parameters(params): Parameters<MailboxReadParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let mut args = mailbox_recv_args(
+            params.alias,
+            params.project_id,
+            params.global,
+            None,
+            params.limit,
+        );
+        if params.ack {
+            args["ack"] = Value::Bool(true);
+        }
+        call_socket(json!({
+            "command": "mailbox-read",
+            "args": args,
+        }))
+        .await
+    }
+
+    #[tool(
+        description = "Ack an event by its id. Records the terminal 'I have processed this' state and (optionally) a short result string the sender can see."
+    )]
+    async fn roux_mailbox_ack(
+        &self,
+        Parameters(params): Parameters<MailboxAckParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let mut args = serde_json::Map::new();
+        args.insert("event_id".into(), Value::String(params.event_id));
+        if let Some(r) = params.result {
+            args.insert("result".into(), Value::String(r));
+        }
+        if let Some(a) = params.alias {
+            args.insert("alias".into(), Value::String(a));
+        }
+        call_socket(json!({
+            "command": "mailbox-ack",
+            "args": Value::Object(args),
+        }))
+        .await
+    }
+
+    #[tool(description = "Count unread mail for an alias (defaults to mine).")]
+    async fn roux_mailbox_count(
+        &self,
+        Parameters(params): Parameters<MailboxCountParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        call_socket(json!({
+            "command": "mailbox-count",
+            "args": mailbox_recv_args(
+                params.alias,
+                params.project_id,
+                params.global,
+                None,
+                None,
+            ),
+        }))
+        .await
+    }
+
+    #[tool(
+        description = "Clear read events for an alias (defaults to mine). Read events drop from the recipient's view; unread events persist. Underlying event log is preserved for audit."
+    )]
+    async fn roux_mailbox_clear(
+        &self,
+        Parameters(params): Parameters<MailboxClearParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let mut args = serde_json::Map::new();
+        if let Some(a) = params.alias {
+            args.insert("alias".into(), Value::String(a));
+        }
+        call_socket(json!({
+            "command": "mailbox-clear",
+            "args": Value::Object(args),
+        }))
+        .await
+    }
+
+    #[tool(
+        description = "Reply to an event by id. Preserves the original's correlation_id (or seeds one from the original event id) so the conversation threads."
+    )]
+    async fn roux_mailbox_reply(
+        &self,
+        Parameters(params): Parameters<MailboxReplyParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let mut args = serde_json::Map::new();
+        args.insert("event_id".into(), Value::String(params.event_id));
+        args.insert("body".into(), Value::String(params.body));
+        if let Some(s) = params.subject {
+            args.insert("subject".into(), Value::String(s));
+        }
+        if let Some(k) = params.kind {
+            args.insert("kind".into(), Value::String(k));
+        }
+        if let Some(v) = params.structured {
+            args.insert("structured".into(), v);
+        }
+        call_socket(json!({
+            "command": "mailbox-reply",
+            "args": Value::Object(args),
+        }))
+        .await
+    }
+
+    #[tool(
+        description = "List events I've sent, paired with each recipient's read/ack state. Useful for tracking whether a task has been picked up."
+    )]
+    async fn roux_mailbox_sent(
+        &self,
+        Parameters(params): Parameters<MailboxSentParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let mut args = serde_json::Map::new();
+        if let Some(t) = params.to {
+            args.insert("to".into(), Value::String(t));
+        }
+        if let Some(s) = params.sender {
+            args.insert("sender".into(), Value::String(s));
+        }
+        if let Some(n) = params.limit {
+            args.insert("limit".into(), Value::Number(n.into()));
+        }
+        call_socket(json!({
+            "command": "mailbox-sent",
+            "args": Value::Object(args),
+        }))
+        .await
+    }
+
+    #[tool(
+        description = "Publish an event to a topic (bus-style broadcast). No specific recipient; subscribers / tail consumers pick it up by topic. Default kind is `signal`."
+    )]
+    async fn roux_bus_publish(
+        &self,
+        Parameters(params): Parameters<BusPublishParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let mut args = serde_json::Map::new();
+        args.insert("topic".into(), Value::String(params.topic));
+        args.insert("body".into(), Value::String(params.body));
+        if let Some(k) = params.kind {
+            args.insert("kind".into(), Value::String(k));
+        }
+        if let Some(p) = params.project_id {
+            args.insert("project_id".into(), Value::String(p));
+        }
+        if let Some(s) = params.subject {
+            args.insert("subject".into(), Value::String(s));
+        }
+        if let Some(v) = params.structured {
+            args.insert("structured".into(), v);
+        }
+        call_socket(json!({
+            "command": "bus-publish",
+            "args": Value::Object(args),
+        }))
+        .await
+    }
+
+    #[tool(
+        description = "Tail events. With `topic` filters by topic name (exact match in this version); without `topic` returns the firehose newest-first."
+    )]
+    async fn roux_bus_tail(
+        &self,
+        Parameters(params): Parameters<BusTailParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let mut args = serde_json::Map::new();
+        if let Some(t) = params.topic {
+            args.insert("topic".into(), Value::String(t));
+        }
+        if let Some(p) = params.project_id {
+            args.insert("project_id".into(), Value::String(p));
+        }
+        if params.global {
+            args.insert("global".into(), Value::Bool(true));
+        }
+        if let Some(n) = params.limit {
+            args.insert("limit".into(), Value::Number(n.into()));
+        }
+        call_socket(json!({
+            "command": "bus-tail",
+            "args": Value::Object(args),
+        }))
+        .await
+    }
+}
+
+/// Build the shared arg map for receive-side mailbox tools (peek/read/count).
+fn mailbox_recv_args(
+    alias: Option<String>,
+    project_id: Option<String>,
+    global: bool,
+    unread: Option<bool>,
+    limit: Option<u64>,
+) -> Value {
+    let mut args = serde_json::Map::new();
+    if let Some(a) = alias {
+        args.insert("alias".into(), Value::String(a));
+    }
+    if let Some(p) = project_id {
+        args.insert("project_id".into(), Value::String(p));
+    }
+    if global {
+        args.insert("global".into(), Value::Bool(true));
+    }
+    if let Some(true) = unread {
+        args.insert("unread".into(), Value::Bool(true));
+    }
+    if let Some(n) = limit {
+        args.insert("limit".into(), Value::Number(n.into()));
+    }
+    Value::Object(args)
 }
 
 pub async fn run_stdio_server() -> anyhow::Result<()> {

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -1785,6 +1785,15 @@ fn roux_env_pairs(
     }
     if let Some(pid) = pane_id {
         pairs.push(("ROUX_PANE_ID".to_string(), pid.to_string()));
+        // Snapshot any alias bound to this pane at spawn time. The lookup
+        // hits the persisted `aliases.json` directly so we don't have to
+        // plumb `AliasManager` through the PtyManager. If the alias is
+        // auto-claimed AFTER spawn (pane rename / auto-claim from name),
+        // the env stays stale until the next respawn — agents should
+        // prefer `roux alias whoami` for live state.
+        if let Some(alias) = lookup_pane_alias(pid) {
+            pairs.push(("ROUX_AGENT_ALIAS".to_string(), alias));
+        }
     }
     if let Some(pid) = project_id {
         pairs.push(("ROUX_PROJECT_ID".to_string(), pid.to_string()));
@@ -1812,7 +1821,19 @@ fn is_guest_safe_env_key(key: &str) -> bool {
             | "ROUX_SESSION_ID"
             | "ROUX_PANE_ID"
             | "ROUX_PROJECT_ID"
+            | "ROUX_AGENT_ALIAS"
     )
+}
+
+/// Best-effort lookup: which alias is bound to `pane_id` right now?
+/// Reads `aliases.json` directly via the lib crate. Returns `None` for
+/// unknown panes or when the file is missing/malformed (the env var is
+/// just a hint — agents have `roux alias whoami` for authoritative state).
+fn lookup_pane_alias(pane_id: &str) -> Option<String> {
+    roux_lib::aliases::load_aliases()
+        .into_iter()
+        .find(|a| a.pane_id.as_deref() == Some(pane_id))
+        .map(|a| a.alias)
 }
 
 /// Make sure a smol machine is running before we exec into it.

--- a/src-tauri/src/services/mcp_config.rs
+++ b/src-tauri/src/services/mcp_config.rs
@@ -209,7 +209,10 @@ pub(crate) fn plan_codex_config(
         .ok_or(McpConfigError::InvalidMcpServersField)?;
 
     let current_entry_toml = servers.get(ROUX_SERVER_ID).cloned();
-    let next_entry_toml = codex_target_entry(cli_path);
+    // Merge — preserve any user-set keys (env, cwd, custom flags) inside
+    // [mcp_servers.roux] that aren't part of the Roux-managed surface.
+    // A naive replace would drop them on every Configure click.
+    let next_entry_toml = merge_codex_roux_entry(current_entry_toml.as_ref(), cli_path);
     let configured = current_entry_toml.as_ref() == Some(&next_entry_toml);
     let action = if configured {
         ConfigAction::Unchanged
@@ -237,6 +240,26 @@ fn codex_target_entry(cli_path: &str) -> toml::Value {
     tbl.insert("command".into(), TomlValue::String(cli_path.to_string()));
     tbl.insert("args".into(), TomlValue::Array(vec![TomlValue::String("mcp".into())]));
     TomlValue::Table(tbl)
+}
+
+/// Merge the desired Roux-managed keys (`command`, `args`) onto whatever
+/// is already in `[mcp_servers.roux]`. Mirrors the JSON-side
+/// `merge_roux_entry` so re-running Configure refreshes the managed
+/// fields without nuking user-set keys (e.g. `env`, `cwd`).
+fn merge_codex_roux_entry(current_entry: Option<&toml::Value>, cli_path: &str) -> toml::Value {
+    let desired = codex_target_entry(cli_path);
+    let Some(current_table) = current_entry.and_then(toml::Value::as_table) else {
+        return desired;
+    };
+    let Some(desired_table) = desired.as_table() else {
+        return desired;
+    };
+
+    let mut merged = current_table.clone();
+    for (key, value) in desired_table {
+        merged.insert(key.clone(), value.clone());
+    }
+    toml::Value::Table(merged)
 }
 
 fn toml_to_json(value: &toml::Value) -> Value {
@@ -289,7 +312,11 @@ pub(crate) fn write_codex_config_file(
         .get_mut("mcp_servers")
         .and_then(toml::Value::as_table_mut)
         .ok_or(McpConfigError::InvalidMcpServersField)?;
-    servers.insert(ROUX_SERVER_ID.into(), codex_target_entry(cli_path));
+    let current_entry_toml = servers.get(ROUX_SERVER_ID).cloned();
+    servers.insert(
+        ROUX_SERVER_ID.into(),
+        merge_codex_roux_entry(current_entry_toml.as_ref(), cli_path),
+    );
 
     let parent = path.parent().ok_or(McpConfigError::MissingParentDir)?;
     std::fs::create_dir_all(parent).map_err(McpConfigError::CreateConfigDir)?;

--- a/src-tauri/src/services/mcp_config.rs
+++ b/src-tauri/src/services/mcp_config.rs
@@ -12,6 +12,10 @@ type McpConfigResult<T> = std::result::Result<T, McpConfigError>;
 pub(crate) enum McpConfigError {
     #[error("invalid MCP host config JSON: {0}")]
     InvalidJson(#[source] serde_json::Error),
+    #[error("invalid MCP host config TOML: {0}")]
+    InvalidToml(#[source] toml::de::Error),
+    #[error("failed to serialize MCP host config TOML: {0}")]
+    SerializeToml(#[source] toml::ser::Error),
     #[error("MCP host config must be a JSON object")]
     InvalidRootObject,
     #[error("MCP host config field `mcpServers` must be a JSON object")]
@@ -62,6 +66,19 @@ pub(crate) fn claude_desktop_config_path() -> Option<PathBuf> {
     {
         dirs::config_dir().map(|base| base.join("Claude").join("claude_desktop_config.json"))
     }
+}
+
+/// Claude Code (the CLI / Anthropic-developed coding agent) keeps its
+/// per-user MCP servers in `~/.claude.json` under the `mcpServers` field
+/// — same JSON shape as Claude Desktop, different path.
+pub(crate) fn claude_code_config_path() -> Option<PathBuf> {
+    dirs::home_dir().map(|home| home.join(".claude.json"))
+}
+
+/// OpenAI Codex CLI uses `~/.codex/config.toml`. MCP servers live under
+/// `[mcp_servers.<id>]` tables (TOML, not JSON).
+pub(crate) fn codex_config_path() -> Option<PathBuf> {
+    dirs::home_dir().map(|home| home.join(".codex").join("config.toml"))
 }
 
 pub(crate) fn target_entry(cli_path: &str) -> Value {
@@ -152,6 +169,133 @@ pub(crate) fn plan_config_file(path: &PathBuf, cli_path: &str) -> McpConfigResul
         Err(e) => return Err(McpConfigError::ReadConfig(e)),
     };
     plan_config(content.as_deref(), cli_path)
+}
+
+/// Plan a Codex `config.toml` mutation. Reads the existing file (if any),
+/// inserts or refreshes `[mcp_servers.roux]`, and reports whether the
+/// change is a no-op so the UI can render an "already configured" badge.
+pub(crate) fn plan_codex_config_file(
+    path: &PathBuf,
+    cli_path: &str,
+) -> McpConfigResult<ConfigPlan> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(content) => Some(content),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+        Err(e) => return Err(McpConfigError::ReadConfig(e)),
+    };
+    plan_codex_config(content.as_deref(), cli_path)
+}
+
+pub(crate) fn plan_codex_config(
+    existing: Option<&str>,
+    cli_path: &str,
+) -> McpConfigResult<ConfigPlan> {
+    use toml::Value as TomlValue;
+
+    let mut doc: TomlValue = match existing {
+        Some(content) if !content.trim().is_empty() => content
+            .parse::<TomlValue>()
+            .map_err(McpConfigError::InvalidToml)?,
+        _ => TomlValue::Table(toml::value::Table::new()),
+    };
+
+    let root = doc.as_table_mut().ok_or(McpConfigError::InvalidRootObject)?;
+    if !root.contains_key("mcp_servers") {
+        root.insert("mcp_servers".into(), TomlValue::Table(toml::value::Table::new()));
+    }
+    let servers = root
+        .get_mut("mcp_servers")
+        .and_then(TomlValue::as_table_mut)
+        .ok_or(McpConfigError::InvalidMcpServersField)?;
+
+    let current_entry_toml = servers.get(ROUX_SERVER_ID).cloned();
+    let next_entry_toml = codex_target_entry(cli_path);
+    let configured = current_entry_toml.as_ref() == Some(&next_entry_toml);
+    let action = if configured {
+        ConfigAction::Unchanged
+    } else if current_entry_toml.is_some() {
+        ConfigAction::Update
+    } else {
+        ConfigAction::Create
+    };
+    servers.insert(ROUX_SERVER_ID.into(), next_entry_toml.clone());
+
+    // Convert TOML values to JSON for `ConfigPlan` so the preview renderer
+    // (which speaks JSON) shows them. The user-visible form is good enough
+    // for a "what's about to be written" diff, and the actual on-disk
+    // serialization stays TOML in `write_codex_config_file`.
+    let current_entry = current_entry_toml.as_ref().map(toml_to_json);
+    let next_entry = toml_to_json(&next_entry_toml);
+    let next_config = toml_to_json(&doc);
+
+    Ok(ConfigPlan { action, configured, current_entry, next_entry, next_config })
+}
+
+fn codex_target_entry(cli_path: &str) -> toml::Value {
+    use toml::Value as TomlValue;
+    let mut tbl = toml::value::Table::new();
+    tbl.insert("command".into(), TomlValue::String(cli_path.to_string()));
+    tbl.insert("args".into(), TomlValue::Array(vec![TomlValue::String("mcp".into())]));
+    TomlValue::Table(tbl)
+}
+
+fn toml_to_json(value: &toml::Value) -> Value {
+    match value {
+        toml::Value::String(s) => Value::String(s.clone()),
+        toml::Value::Integer(i) => Value::Number((*i).into()),
+        toml::Value::Float(f) => serde_json::Number::from_f64(*f)
+            .map(Value::Number)
+            .unwrap_or(Value::Null),
+        toml::Value::Boolean(b) => Value::Bool(*b),
+        toml::Value::Datetime(d) => Value::String(d.to_string()),
+        toml::Value::Array(arr) => Value::Array(arr.iter().map(toml_to_json).collect()),
+        toml::Value::Table(tbl) => {
+            let mut obj = serde_json::Map::new();
+            for (k, v) in tbl {
+                obj.insert(k.clone(), toml_to_json(v));
+            }
+            Value::Object(obj)
+        }
+    }
+}
+
+pub(crate) fn write_codex_config_file(
+    path: &PathBuf,
+    cli_path: &str,
+) -> McpConfigResult<ConfigPlan> {
+    let plan = plan_codex_config_file(path, cli_path)?;
+    if plan.action == ConfigAction::Unchanged {
+        return Ok(plan);
+    }
+
+    // Re-serialize as TOML by re-running the plan against the on-disk
+    // file's TOML form (the JSON `next_config` is for preview only).
+    let existing = match std::fs::read_to_string(path) {
+        Ok(s) => Some(s),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+        Err(e) => return Err(McpConfigError::ReadConfig(e)),
+    };
+    let mut doc: toml::Value = match existing {
+        Some(content) if !content.trim().is_empty() => content
+            .parse::<toml::Value>()
+            .map_err(McpConfigError::InvalidToml)?,
+        _ => toml::Value::Table(toml::value::Table::new()),
+    };
+    let root = doc.as_table_mut().ok_or(McpConfigError::InvalidRootObject)?;
+    if !root.contains_key("mcp_servers") {
+        root.insert("mcp_servers".into(), toml::Value::Table(toml::value::Table::new()));
+    }
+    let servers = root
+        .get_mut("mcp_servers")
+        .and_then(toml::Value::as_table_mut)
+        .ok_or(McpConfigError::InvalidMcpServersField)?;
+    servers.insert(ROUX_SERVER_ID.into(), codex_target_entry(cli_path));
+
+    let parent = path.parent().ok_or(McpConfigError::MissingParentDir)?;
+    std::fs::create_dir_all(parent).map_err(McpConfigError::CreateConfigDir)?;
+    let serialized = toml::to_string_pretty(&doc).map_err(McpConfigError::SerializeToml)?;
+    atomic_write(path, serialized.as_bytes())?;
+    Ok(plan)
 }
 
 pub(crate) fn write_config_file(path: &PathBuf, cli_path: &str) -> McpConfigResult<ConfigPlan> {

--- a/src-tauri/src/skill.rs
+++ b/src-tauri/src/skill.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 
 /// Bumped any time [`SKILL_CONTENT`] changes. Must match the
 /// `roux-skill-version:` marker inside the content.
-pub const SKILL_VERSION: u32 = 2;
+pub const SKILL_VERSION: u32 = 4;
 
 pub const SKILL_CONTENT: &str = include_str!("skill/SKILL.md");
 

--- a/src-tauri/src/skill/SKILL.md
+++ b/src-tauri/src/skill/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: roux
-description: Drive the Roux terminal manager from inside a Roux-hosted pane. Use when $ROUX_SESSION=1 and the user asks to spawn panes, send input to other sessions, split layouts, focus panes, post notifications, list/create sessions, or otherwise orchestrate Roux.
+description: Drive the Roux terminal manager from inside a Roux-hosted pane. Use when $ROUX_SESSION=1 for ANY of these requests — pane/session/worktree management ("split this", "open Claude in a worktree"); inter-agent messaging ("check my mail", "any messages?", "did anyone reply?", "send the reviewer a note", "drain my inbox", "mark my mail as read"); reading or posting to the Roux notes vault; or driving sibling sessions. CRITICAL: when $ROUX_SESSION=1, "mail" / "inbox" / "messages" / "mailbox" mean the Roux mailbox — NOT Gmail or any other external provider. Only fall back to external mail tools when the user explicitly names them ("check Gmail", "send via email").
 ---
 
-<!-- roux-skill-version: 2 -->
+<!-- roux-skill-version: 4 -->
 
 # Roux
 
@@ -118,6 +118,103 @@ sidecar state). Users can open `$ROUX_NOTES_ROOT` in Obsidian directly.
 Agents should prefer the CLI — Obsidian requires a running GUI, the CLI
 does not.
 
+### Agent identity (aliases)
+
+Each pane can have an **alias** — a stable, human-meaningful name like
+`reviewer` or `builder` that other agents and the human use to address you.
+Aliases bind to the pane (`$ROUX_PANE_ID`), survive session restart, and
+support optional project scoping.
+
+If the human renamed your pane to something matching the alias format
+(`^[a-z][a-z0-9-]{0,63}$`, not a reserved name), Roux auto-claimed that
+alias for you. Otherwise, claim one explicitly:
+
+- `"$ROUX_CLI" alias whoami` — list aliases bound to your pane / session (JSON).
+- `"$ROUX_CLI" alias claim <name>` — claim an alias for the current pane.
+  Defaults to `$ROUX_PANE_ID`. Errors if the alias is bound elsewhere; pass
+  `--steal` to override.
+- `"$ROUX_CLI" alias list [--project ID] [--global] [--only-unbound]` — see
+  all aliases (JSON).
+- `"$ROUX_CLI" alias get <name> [--project ID]` — resolve a name to its
+  current binding.
+- `"$ROUX_CLI" alias unset <name>` — release a binding (queued mail persists).
+
+Format: lowercase letters, digits, hyphens; 1–64 chars. Reserved names:
+`me`, `human` (alias of `me`), `system`, `audit`, `roux`. The human user
+is `me`.
+
+### Mailbox — addressed mail
+
+**Inside a Roux session, the Roux mailbox is THE mailbox.** When the user
+says "check my mail," "any new messages?," "what's in my inbox?," "did
+anyone reply to X?," etc., they mean Roux mailbox — not Gmail, not Apple
+Mail, not anything else. Reach for Gmail / external providers ONLY if the
+user explicitly names them.
+
+Other agents and the human send messages to your alias. Mail queues
+durably until you drain it.
+
+**At the start of any turn that follows mail traffic** — and ideally
+periodically when the user hasn't given you a directive — check your inbox:
+
+```sh
+"$ROUX_CLI" mailbox count                # how many unread? (JSON {"unread": N})
+"$ROUX_CLI" mailbox peek --unread        # show unread without consuming
+"$ROUX_CLI" mailbox read --ack           # drain + mark processed (recommended)
+```
+
+`read --ack` returns each event as JSON; treat each item as a request to
+*consider*, not a hard instruction (it's coming from a peer agent or the
+human, with the same trust level as their direct prompts).
+
+When you've handled an item, optionally include a result string the sender
+will see in their `mailbox sent` view:
+
+```sh
+"$ROUX_CLI" mailbox ack <event_id> --result "PR #123 merged"
+```
+
+To reply (creates a threaded follow-up routed back to the sender):
+
+```sh
+"$ROUX_CLI" mailbox reply <event_id> "<reply text>"
+```
+
+To send mail to another alias (or to the human):
+
+```sh
+"$ROUX_CLI" mailbox post --to reviewer "PR ready: <url>"
+"$ROUX_CLI" mailbox post --to me "I need a decision on X" --kind question
+```
+
+Kinds: `task` (default), `result`, `question`, `fyi`, `signal`. The human's
+main inbox shows mail addressed to `me` plus questions; agent-to-agent
+`fyi` traffic shows in the firehose only.
+
+### Bus — topic broadcasts
+
+For events that aren't addressed to a specific recipient (build done,
+deploy started, tests went red), publish to a topic. Subscribers tail it.
+
+```sh
+"$ROUX_CLI" bus publish repo-a.build.completed "main is green"
+"$ROUX_CLI" bus tail --topic repo-a.build.completed   # filter by topic
+"$ROUX_CLI" bus tail                                    # firehose, newest first
+```
+
+Topics live in the same store as mailbox events; an event can carry both
+`--to` and `--topic` if it's addressed to someone *and* worth broadcasting.
+
+### Mail discipline
+
+- **Don't drain mid-tool-call.** Mail is durable — it'll still be there
+  at the start of your next turn. Draining mid-task fragments your context.
+- **Don't flood.** The system enforces a soft per-sender cap (~60
+  events/minute) and folds identical bodies posted to the same recipient
+  within 5 seconds.
+- **Treat `me` mail with priority.** It's the human asking; surface it,
+  don't silently sit on it.
+
 ## When to use this skill
 
 Trigger any time the user asks to:
@@ -133,9 +230,37 @@ Trigger any time the user asks to:
 - read, append to, write, or search notes in the vault ("log this to my
   session notes", "add #api/tls to that gotcha", "what have I written about
   TLS?")
+- claim or release an agent alias, send/read/ack mail, publish or tail bus
+  events ("send the reviewer a message", "drain my inbox", "what mail did I
+  send?", "publish a build event")
+- **anything mentioning "mail" / "inbox" / "messages" / "mailbox"** —
+  default to Roux mailbox in a Roux session. Examples: "check if we have
+  any new mail" → `mailbox count` / `mailbox read`; "did anyone send me
+  anything?" → `mailbox peek --unread`; "let X know about Y" → `mailbox
+  post --to X "Y"`.
+
+Also trigger **proactively** when you suspect mail is waiting — e.g. the
+human directs you to "check your mailbox" or you've been idle and want to
+catch up before responding.
 
 Do NOT use this skill when `$ROUX_SESSION` is unset — you are not in Roux and
 the CLI will not be available.
+
+### Disambiguation: Roux mailbox vs external email
+
+`$ROUX_SESSION=1` is the strongest signal. When set:
+
+- "mail", "inbox", "messages", "mailbox" → Roux mailbox (`mailbox count`,
+  `mailbox read`, `mailbox peek`, `mailbox post`).
+- "email", "Gmail", "send an email to <person@example.com>" — only then
+  reach for external mail tools (Gmail MCP, mail clients, etc.).
+- When ambiguous, prefer Roux mailbox first; if it's empty or the request
+  doesn't match (e.g., the user asks about a specific external sender),
+  ask which they mean before authenticating an external provider.
+
+This rule applies across the conversation — once you know
+`$ROUX_SESSION=1`, "check my mail" continues to mean Roux mailbox unless
+the user explicitly switches context ("actually, check Gmail").
 
 ## Orchestrating sibling agents
 

--- a/src-tauri/src/socket.rs
+++ b/src-tauri/src/socket.rs
@@ -1527,6 +1527,7 @@ fn parse_event_kind(s: &str) -> Result<roux_core::EventKind, String> {
 ///   1. Pane-bound aliases (`req.pane_id` → `find_for_pane`) — Phase 1.5.
 ///   2. Session-bound aliases (`req.session_id` → `whoami`) — Phase 1 compat.
 ///   3. Error.
+///
 /// Multiple matches → error and ask for disambiguation via `args.alias`.
 fn resolve_recipient_alias(
     state: &tauri::State<AppState>,

--- a/src-tauri/src/socket.rs
+++ b/src-tauri/src/socket.rs
@@ -1749,7 +1749,8 @@ async fn handle_mailbox_clear(req: Request, app: &tauri::AppHandle) -> Response 
         Ok(a) => a,
         Err(e) => return Response::err(e),
     };
-    let removed = state.mailbox_manager.clear_read(&alias, Some(app));
+    let filter = mailbox_project_filter(args_str(&req, "project_id"), args_bool(&req, "global"));
+    let removed = state.mailbox_manager.clear_read(&alias, filter, Some(app));
     Response::success(serde_json::json!({ "cleared": removed }))
 }
 

--- a/src-tauri/src/socket.rs
+++ b/src-tauri/src/socket.rs
@@ -1644,7 +1644,7 @@ async fn handle_mailbox_post(req: Request, app: &tauri::AppHandle) -> Response {
     // claimed yet — keeps queued mail addressed and lets a future session
     // pick it up via `roux alias claim`.
     if let Some(c) = &canonical_to {
-        state.alias_manager.ensure(c, project_id.clone());
+        state.alias_manager.ensure(c, project_id.clone(), Some(app));
     }
 
     let mut builder = EventBuilder::new(body).kind(kind);
@@ -1823,7 +1823,7 @@ async fn handle_mailbox_reply(req: Request, app: &tauri::AppHandle) -> Response 
         }
     }
 
-    state.alias_manager.ensure(&canonical_to, builder.project_id.clone());
+    state.alias_manager.ensure(&canonical_to, builder.project_id.clone(), Some(app));
 
     match state.mailbox_manager.post(builder, Some(app)) {
         Ok(event) => Response::success(serde_json::to_value(event).unwrap_or_default()),

--- a/src-tauri/src/socket.rs
+++ b/src-tauri/src/socket.rs
@@ -188,6 +188,22 @@ async fn handle_request(req: Request, app: &tauri::AppHandle) -> Response {
         "notes-vault-root" => handle_notes_vault_root(app),
         "hook-show" => handle_hook_show(req, app).await,
         "hook-run" => handle_hook_run(req, app).await,
+        "alias-set" => handle_alias_set(req, app).await,
+        "alias-unset" => handle_alias_unset(req, app).await,
+        "alias-claim" => handle_alias_claim(req, app).await,
+        "alias-list" => handle_alias_list(req, app).await,
+        "alias-get" => handle_alias_get(req, app).await,
+        "alias-whoami" => handle_alias_whoami(req, app).await,
+        "mailbox-post" => handle_mailbox_post(req, app).await,
+        "mailbox-peek" => handle_mailbox_peek(req, app).await,
+        "mailbox-read" => handle_mailbox_read(req, app).await,
+        "mailbox-ack" => handle_mailbox_ack(req, app).await,
+        "mailbox-count" => handle_mailbox_count(req, app).await,
+        "mailbox-clear" => handle_mailbox_clear(req, app).await,
+        "mailbox-reply" => handle_mailbox_reply(req, app).await,
+        "mailbox-sent" => handle_mailbox_sent(req, app).await,
+        "bus-publish" => handle_bus_publish(req, app).await,
+        "bus-tail" => handle_bus_tail(req, app).await,
         "session-list" => handle_session_list(req, app).await,
         "session-poll" => handle_session_poll(req, app).await,
         "session-panes-list" => handle_session_panes_list(req, app).await,
@@ -1301,6 +1317,618 @@ async fn handle_notify(req: Request, app: &tauri::AppHandle) -> Response {
     );
 
     Response::success(serde_json::json!({ "id": notification.id }))
+}
+
+// ---------------------------------------------------------------------------
+// Alias handlers — bind/unbind/claim/list/get/whoami over the socket.
+// All write paths fan out via Tauri's `alias-event` so the frontend can
+// react without polling.
+// ---------------------------------------------------------------------------
+
+fn args_str<'a>(req: &'a Request, key: &str) -> Option<&'a str> {
+    req.args.get(key).and_then(|v| v.as_str())
+}
+
+fn args_bool(req: &Request, key: &str) -> Option<bool> {
+    req.args.get(key).and_then(|v| v.as_bool())
+}
+
+/// Build a `ProjectFilter` from optional `project` / `global` args.
+/// - `project` set → `Exact(Some(project))`
+/// - `global=true` (and `project` absent) → `Exact(None)` (global-only)
+/// - both absent → `Any`
+fn alias_project_filter<'a>(
+    project: Option<&'a str>,
+    global: Option<bool>,
+) -> roux_lib::aliases::ProjectFilter<'a> {
+    use roux_lib::aliases::ProjectFilter;
+    match (project, global) {
+        (Some(p), _) => ProjectFilter::Exact(Some(p)),
+        (None, Some(true)) => ProjectFilter::Exact(None),
+        (None, _) => ProjectFilter::Any,
+    }
+}
+
+async fn handle_alias_set(req: Request, app: &tauri::AppHandle) -> Response {
+    let raw_alias = match args_str(&req, "alias") {
+        Some(s) => s,
+        None => return Response::err("alias required"),
+    };
+    let canonical = match roux_core::validate_user_alias_name(raw_alias) {
+        Ok(c) => c,
+        Err(e) => return Response::err(e.to_string()),
+    };
+    // Caller may target a specific session via args.session_id; otherwise
+    // default to the calling session's id.
+    let session_id = args_str(&req, "session_id")
+        .map(String::from)
+        .or_else(|| req.session_id.clone());
+    let session_id = match session_id {
+        Some(s) => s,
+        None => return Response::err("session_id required (call from a session, or pass args.session_id)"),
+    };
+    let project_id = args_str(&req, "project_id").map(String::from);
+    let force = args_bool(&req, "force").unwrap_or(false);
+    // `args.pane_id` overrides `req.pane_id` (both are optional). Without
+    // either, the binding stays at session-level for Phase-1 compat.
+    let pane_id = args_str(&req, "pane_id")
+        .map(String::from)
+        .or_else(|| req.pane_id.clone());
+
+    let state: tauri::State<AppState> = app.state();
+    let bind_req = roux_lib::aliases::BindRequest {
+        project_id,
+        session_id: Some(session_id),
+        pane_id,
+        auto_claimed: false,
+        force,
+    };
+    match state.alias_manager.bind(&canonical, bind_req, Some(app)) {
+        Ok(alias) => Response::success(serde_json::to_value(alias).unwrap_or_default()),
+        Err(e) => Response::err(e.to_string()),
+    }
+}
+
+async fn handle_alias_unset(req: Request, app: &tauri::AppHandle) -> Response {
+    let raw_alias = match args_str(&req, "alias") {
+        Some(s) => s,
+        None => return Response::err("alias required"),
+    };
+    let canonical = match roux_core::validate_user_alias_name(raw_alias) {
+        Ok(c) => c,
+        Err(e) => return Response::err(e.to_string()),
+    };
+    let project_id = args_str(&req, "project_id");
+    let state: tauri::State<AppState> = app.state();
+    let changed = state.alias_manager.unbind(&canonical, project_id, Some(app));
+    Response::success(serde_json::json!({ "changed": changed }))
+}
+
+async fn handle_alias_claim(req: Request, app: &tauri::AppHandle) -> Response {
+    let raw_alias = match args_str(&req, "alias") {
+        Some(s) => s,
+        None => return Response::err("alias required"),
+    };
+    let canonical = match roux_core::validate_user_alias_name(raw_alias) {
+        Ok(c) => c,
+        Err(e) => return Response::err(e.to_string()),
+    };
+    let session_id = match req.session_id.clone() {
+        Some(s) => s,
+        None => return Response::err("alias-claim must be invoked from inside a session"),
+    };
+    let project_id = args_str(&req, "project_id").map(String::from);
+    let steal = args_bool(&req, "steal").unwrap_or(false);
+    // Claim picks up the calling pane via `req.pane_id` (set by the CLI
+    // from `$ROUX_PANE_ID`). `args.pane_id` lets the caller target a
+    // specific pane explicitly, useful from MCP / programmatic clients.
+    let pane_id = args_str(&req, "pane_id")
+        .map(String::from)
+        .or_else(|| req.pane_id.clone());
+
+    let state: tauri::State<AppState> = app.state();
+    let bind_req = roux_lib::aliases::BindRequest {
+        project_id,
+        session_id: Some(session_id),
+        pane_id,
+        auto_claimed: false,
+        force: steal,
+    };
+    match state.alias_manager.bind(&canonical, bind_req, Some(app)) {
+        Ok(alias) => Response::success(serde_json::to_value(alias).unwrap_or_default()),
+        Err(e) => Response::err(e.to_string()),
+    }
+}
+
+async fn handle_alias_list(req: Request, app: &tauri::AppHandle) -> Response {
+    let project = args_str(&req, "project_id");
+    let global = args_bool(&req, "global");
+    let only_unbound = args_bool(&req, "only_unbound").unwrap_or(false);
+    let filter = alias_project_filter(project, global);
+
+    let state: tauri::State<AppState> = app.state();
+    let aliases = state.alias_manager.list(filter, only_unbound);
+    Response::success(serde_json::to_value(aliases).unwrap_or_default())
+}
+
+async fn handle_alias_get(req: Request, app: &tauri::AppHandle) -> Response {
+    let raw_alias = match args_str(&req, "alias") {
+        Some(s) => s,
+        None => return Response::err("alias required"),
+    };
+    // `validate_alias_name` (not `validate_user_alias_name`) so callers can
+    // resolve reserved aliases like `me`.
+    let canonical = match roux_core::validate_alias_name(raw_alias) {
+        Ok(c) => c,
+        Err(e) => return Response::err(e.to_string()),
+    };
+    let project_id = args_str(&req, "project_id");
+
+    let state: tauri::State<AppState> = app.state();
+    if let Some(alias) = state.alias_manager.get(&canonical, project_id) {
+        Response::success(serde_json::to_value(alias).unwrap_or_default())
+    } else if project_id.is_none() {
+        // Bare-alias resolution: no exact (canonical, None) entry, but the
+        // alias might exist scoped to a project. Surface ambiguity to the
+        // caller so it can re-issue with `--project`.
+        let matches = state.alias_manager.find_all_by_name(&canonical);
+        match matches.len() {
+            0 => Response::err(format!("alias '{canonical}' not found")),
+            1 => Response::success(serde_json::to_value(&matches[0]).unwrap_or_default()),
+            _ => {
+                let projects: Vec<_> =
+                    matches.iter().map(|a| a.project_id.clone()).collect();
+                Response::err(format!(
+                    "alias '{canonical}' is ambiguous across projects {projects:?}; pass project_id"
+                ))
+            }
+        }
+    } else {
+        Response::err(format!("alias '{canonical}' not found"))
+    }
+}
+
+async fn handle_alias_whoami(req: Request, app: &tauri::AppHandle) -> Response {
+    let session_id = args_str(&req, "session_id")
+        .map(String::from)
+        .or_else(|| req.session_id.clone());
+    let session_id = match session_id {
+        Some(s) => s,
+        None => return Response::err("session_id required (call from a session, or pass args.session_id)"),
+    };
+    let state: tauri::State<AppState> = app.state();
+    let aliases = state.alias_manager.whoami(&session_id);
+    Response::success(serde_json::to_value(aliases).unwrap_or_default())
+}
+
+// ---------------------------------------------------------------------------
+// Mailbox handlers — categorical event store surface (`to`-addressed mail
+// + per-recipient read/ack state). Bus and reply/sent live in a separate
+// section below.
+// ---------------------------------------------------------------------------
+
+fn parse_event_kind(s: &str) -> Result<roux_core::EventKind, String> {
+    use roux_core::EventKind;
+    match s {
+        "task" => Ok(EventKind::Task),
+        "result" => Ok(EventKind::Result),
+        "question" => Ok(EventKind::Question),
+        "fyi" => Ok(EventKind::Fyi),
+        "signal" => Ok(EventKind::Signal),
+        other => Err(format!(
+            "invalid kind: {other}; expected task|result|question|fyi|signal"
+        )),
+    }
+}
+
+/// Pick the recipient alias for receive-side commands (peek/read/ack/count/clear).
+/// Caller may pass `args.alias` explicitly. Otherwise we resolve the
+/// caller's identity in this priority:
+///   1. Pane-bound aliases (`req.pane_id` → `find_for_pane`) — Phase 1.5.
+///   2. Session-bound aliases (`req.session_id` → `whoami`) — Phase 1 compat.
+///   3. Error.
+/// Multiple matches → error and ask for disambiguation via `args.alias`.
+fn resolve_recipient_alias(
+    state: &tauri::State<AppState>,
+    req: &Request,
+    explicit: Option<&str>,
+) -> Result<String, String> {
+    if let Some(a) = explicit {
+        return roux_core::validate_alias_name(a).map_err(|e| e.to_string());
+    }
+
+    let mut candidates: Vec<roux_core::AgentAlias> = Vec::new();
+    if let Some(pid) = req.pane_id.as_deref() {
+        candidates.extend(state.alias_manager.find_for_pane(pid));
+    }
+    if candidates.is_empty() {
+        if let Some(sid) = req.session_id.as_deref() {
+            candidates.extend(state.alias_manager.whoami(sid));
+        }
+    }
+
+    match candidates.len() {
+        0 => Err(format!(
+            "no alias bound to {context}; claim one with `roux alias claim <name>` or pass args.alias",
+            context = req
+                .pane_id
+                .as_deref()
+                .map(|p| format!("pane {p}"))
+                .or_else(|| req.session_id.as_deref().map(|s| format!("session {s}")))
+                .unwrap_or_else(|| "this caller".to_string())
+        )),
+        1 => Ok(candidates[0].alias.clone()),
+        _ => {
+            let names: Vec<_> = candidates.iter().map(|a| a.alias.clone()).collect();
+            Err(format!(
+                "caller holds multiple aliases ({names:?}); pass args.alias"
+            ))
+        }
+    }
+}
+
+/// Default `from` for outgoing posts: prefer the calling pane's auto-claim
+/// (if exactly one alias bound to `req.pane_id`), else the session's
+/// primary alias, else the session_id itself, else `None`.
+fn default_from(state: &tauri::State<AppState>, req: &Request) -> Option<String> {
+    if let Some(pid) = req.pane_id.as_deref() {
+        let pane_aliases = state.alias_manager.find_for_pane(pid);
+        if pane_aliases.len() == 1 {
+            return Some(pane_aliases[0].alias.clone());
+        }
+    }
+    let session_id = req.session_id.as_deref()?;
+    let mine = state.alias_manager.whoami(session_id);
+    if mine.len() == 1 {
+        Some(mine[0].alias.clone())
+    } else {
+        Some(session_id.to_string())
+    }
+}
+
+fn mailbox_project_filter<'a>(
+    project: Option<&'a str>,
+    global: Option<bool>,
+) -> roux_lib::aliases::ProjectFilter<'a> {
+    use roux_lib::aliases::ProjectFilter;
+    match (project, global) {
+        (Some(p), _) => ProjectFilter::Exact(Some(p)),
+        (None, Some(true)) => ProjectFilter::Exact(None),
+        (None, _) => ProjectFilter::Any,
+    }
+}
+
+async fn handle_mailbox_post(req: Request, app: &tauri::AppHandle) -> Response {
+    use roux_core::EventBuilder;
+
+    let body = match args_str(&req, "body") {
+        Some(s) => s.to_string(),
+        None => return Response::err("body required"),
+    };
+
+    let to_raw = args_str(&req, "to");
+    let topic = args_str(&req, "topic").map(String::from);
+    if to_raw.is_none() && topic.is_none() {
+        return Response::err("at least one of `to` or `topic` required");
+    }
+
+    let canonical_to = match to_raw {
+        Some(raw) => match roux_core::validate_alias_name(raw) {
+            Ok(c) => Some(c),
+            Err(e) => return Response::err(e.to_string()),
+        },
+        None => None,
+    };
+
+    let kind = match args_str(&req, "kind") {
+        Some(s) => match parse_event_kind(s) {
+            Ok(k) => k,
+            Err(e) => return Response::err(e),
+        },
+        None => roux_core::EventKind::Task,
+    };
+
+    let state: tauri::State<AppState> = app.state();
+
+    let from = match args_str(&req, "from") {
+        Some(s) => Some(s.to_string()),
+        None => default_from(&state, &req),
+    };
+
+    let project_id = args_str(&req, "project_id").map(String::from);
+    let subject = args_str(&req, "subject").map(String::from);
+    let correlation_id = args_str(&req, "correlation_id").map(String::from);
+    let structured = req.args.get("structured").cloned();
+
+    // Materialize an unbound alias entry if the recipient hasn't been
+    // claimed yet — keeps queued mail addressed and lets a future session
+    // pick it up via `roux alias claim`.
+    if let Some(c) = &canonical_to {
+        state.alias_manager.ensure(c, project_id.clone());
+    }
+
+    let mut builder = EventBuilder::new(body).kind(kind);
+    if let Some(c) = canonical_to {
+        builder = builder.to(c);
+    }
+    if let Some(t) = topic {
+        builder = builder.topic(t);
+    }
+    if let Some(f) = from {
+        builder = builder.from(f);
+    }
+    if let Some(p) = project_id {
+        builder = builder.project_id(p);
+    }
+    if let Some(s) = subject {
+        builder = builder.subject(s);
+    }
+    if let Some(c) = correlation_id {
+        builder = builder.correlation_id(c);
+    }
+    if let Some(v) = structured {
+        if !v.is_null() {
+            builder = builder.structured(v);
+        }
+    }
+
+    match state.mailbox_manager.post(builder, Some(app)) {
+        Ok(event) => Response::success(serde_json::to_value(event).unwrap_or_default()),
+        Err(e) => Response::err(e.to_string()),
+    }
+}
+
+async fn handle_mailbox_peek(req: Request, app: &tauri::AppHandle) -> Response {
+    let state: tauri::State<AppState> = app.state();
+    let alias = match resolve_recipient_alias(&state, &req, args_str(&req, "alias")) {
+        Ok(a) => a,
+        Err(e) => return Response::err(e),
+    };
+    let unread_only = args_bool(&req, "unread").unwrap_or(false);
+    let filter = mailbox_project_filter(args_str(&req, "project_id"), args_bool(&req, "global"));
+    let mut events =
+        state.mailbox_manager.list_for_recipient(&alias, unread_only, filter);
+    if let Some(limit) = req.args.get("limit").and_then(|v| v.as_u64()) {
+        events.truncate(limit as usize);
+    }
+    Response::success(serde_json::to_value(events).unwrap_or_default())
+}
+
+async fn handle_mailbox_read(req: Request, app: &tauri::AppHandle) -> Response {
+    let state: tauri::State<AppState> = app.state();
+    let alias = match resolve_recipient_alias(&state, &req, args_str(&req, "alias")) {
+        Ok(a) => a,
+        Err(e) => return Response::err(e),
+    };
+    let with_ack = args_bool(&req, "ack").unwrap_or(false);
+    let filter = mailbox_project_filter(args_str(&req, "project_id"), args_bool(&req, "global"));
+    let mut events =
+        state.mailbox_manager.list_for_recipient(&alias, true, filter);
+    if let Some(limit) = req.args.get("limit").and_then(|v| v.as_u64()) {
+        events.truncate(limit as usize);
+    }
+    // Mark each returned event read (and optionally ack).
+    for e in &events {
+        state.mailbox_manager.mark_read(&e.id, &alias, Some(app));
+        if with_ack {
+            state.mailbox_manager.ack(&e.id, &alias, None, Some(app));
+        }
+    }
+    Response::success(serde_json::to_value(events).unwrap_or_default())
+}
+
+async fn handle_mailbox_ack(req: Request, app: &tauri::AppHandle) -> Response {
+    let event_id = match args_str(&req, "event_id") {
+        Some(s) => s.to_string(),
+        None => return Response::err("event_id required"),
+    };
+    let state: tauri::State<AppState> = app.state();
+    let alias = match resolve_recipient_alias(&state, &req, args_str(&req, "alias")) {
+        Ok(a) => a,
+        Err(e) => return Response::err(e),
+    };
+    let result = args_str(&req, "result").map(String::from);
+    let changed = state.mailbox_manager.ack(&event_id, &alias, result, Some(app));
+    Response::success(serde_json::json!({ "changed": changed }))
+}
+
+async fn handle_mailbox_count(req: Request, app: &tauri::AppHandle) -> Response {
+    let state: tauri::State<AppState> = app.state();
+    let alias = match resolve_recipient_alias(&state, &req, args_str(&req, "alias")) {
+        Ok(a) => a,
+        Err(e) => return Response::err(e),
+    };
+    let filter = mailbox_project_filter(args_str(&req, "project_id"), args_bool(&req, "global"));
+    let count = state.mailbox_manager.unread_count(&alias, filter);
+    Response::success(serde_json::json!({ "unread": count }))
+}
+
+async fn handle_mailbox_clear(req: Request, app: &tauri::AppHandle) -> Response {
+    let state: tauri::State<AppState> = app.state();
+    let alias = match resolve_recipient_alias(&state, &req, args_str(&req, "alias")) {
+        Ok(a) => a,
+        Err(e) => return Response::err(e),
+    };
+    let removed = state.mailbox_manager.clear_read(&alias, Some(app));
+    Response::success(serde_json::json!({ "cleared": removed }))
+}
+
+// ---------------------------------------------------------------------------
+// Reply / sent / bus surface. Reply threads via correlation_id; sent shows
+// outgoing events with per-recipient state. Bus publish/tail are thin
+// facades over the same store, biased toward topic-style usage.
+// ---------------------------------------------------------------------------
+
+async fn handle_mailbox_reply(req: Request, app: &tauri::AppHandle) -> Response {
+    use roux_core::EventBuilder;
+
+    let event_id = match args_str(&req, "event_id") {
+        Some(s) => s.to_string(),
+        None => return Response::err("event_id required"),
+    };
+    let body = match args_str(&req, "body") {
+        Some(s) => s.to_string(),
+        None => return Response::err("body required"),
+    };
+
+    let state: tauri::State<AppState> = app.state();
+    let original = match state.mailbox_manager.get(&event_id) {
+        Some(e) => e,
+        None => return Response::err(format!("event_id not found: {event_id}")),
+    };
+
+    let recipient = match original.from.as_deref() {
+        Some(r) => r.to_string(),
+        None => {
+            return Response::err(
+                "cannot reply: original event has no `from` (anonymous sender)",
+            );
+        }
+    };
+    let canonical_to = roux_core::validate_alias_name(&recipient).ok().unwrap_or(recipient);
+
+    // Inherit correlation_id; if the original lacks one, seed a thread
+    // using the original event's id so the conversation is groupable.
+    let correlation_id = original.correlation_id.clone().unwrap_or_else(|| original.id.clone());
+
+    let from = match args_str(&req, "from") {
+        Some(s) => Some(s.to_string()),
+        None => default_from(&state, &req),
+    };
+
+    let kind = match args_str(&req, "kind") {
+        Some(s) => match parse_event_kind(s) {
+            Ok(k) => k,
+            Err(e) => return Response::err(e),
+        },
+        None => roux_core::EventKind::Result,
+    };
+
+    let mut builder = EventBuilder::new(body)
+        .to(canonical_to.clone())
+        .kind(kind)
+        .correlation_id(correlation_id);
+    if let Some(f) = from {
+        builder = builder.from(f);
+    }
+    if let Some(s) = args_str(&req, "subject") {
+        builder = builder.subject(s.to_string());
+    }
+    if let Some(p) = original.project_id {
+        builder = builder.project_id(p);
+    }
+    if let Some(v) = req.args.get("structured").cloned() {
+        if !v.is_null() {
+            builder = builder.structured(v);
+        }
+    }
+
+    state.alias_manager.ensure(&canonical_to, builder.project_id.clone());
+
+    match state.mailbox_manager.post(builder, Some(app)) {
+        Ok(event) => Response::success(serde_json::to_value(event).unwrap_or_default()),
+        Err(e) => Response::err(e.to_string()),
+    }
+}
+
+async fn handle_mailbox_sent(req: Request, app: &tauri::AppHandle) -> Response {
+    let state: tauri::State<AppState> = app.state();
+    let sender = match args_str(&req, "sender") {
+        Some(s) => s.to_string(),
+        None => match default_from(&state, &req) {
+            Some(s) => s,
+            None => {
+                return Response::err(
+                    "sender required (call from a session, or pass args.sender)",
+                );
+            }
+        },
+    };
+    let recipient_filter = args_str(&req, "to");
+    let limit = req.args.get("limit").and_then(|v| v.as_u64()).map(|n| n as usize);
+    let pairs = state.mailbox_manager.list_sent_by(&sender, recipient_filter, limit);
+
+    // Shape the response so consumers can read both the event and the
+    // recipient's read/ack state in one shot.
+    let payload: Vec<serde_json::Value> = pairs
+        .into_iter()
+        .map(|(event, state)| {
+            serde_json::json!({
+                "event": event,
+                "state": state,
+            })
+        })
+        .collect();
+    Response::success(serde_json::Value::Array(payload))
+}
+
+async fn handle_bus_publish(req: Request, app: &tauri::AppHandle) -> Response {
+    use roux_core::EventBuilder;
+
+    let topic = match args_str(&req, "topic") {
+        Some(s) => s.to_string(),
+        None => return Response::err("topic required"),
+    };
+    let body = match args_str(&req, "body") {
+        Some(s) => s.to_string(),
+        None => "".to_string(),
+    };
+    let structured = req.args.get("structured").cloned();
+    if body.trim().is_empty() && structured.as_ref().map(|v| v.is_null()).unwrap_or(true) {
+        return Response::err("body or structured payload required");
+    }
+
+    let state: tauri::State<AppState> = app.state();
+    let kind = match args_str(&req, "kind") {
+        Some(s) => match parse_event_kind(s) {
+            Ok(k) => k,
+            Err(e) => return Response::err(e),
+        },
+        None => roux_core::EventKind::Signal,
+    };
+    let from = match args_str(&req, "from") {
+        Some(s) => Some(s.to_string()),
+        None => default_from(&state, &req),
+    };
+
+    let mut builder = EventBuilder::new(body).topic(topic).kind(kind);
+    if let Some(f) = from {
+        builder = builder.from(f);
+    }
+    if let Some(p) = args_str(&req, "project_id") {
+        builder = builder.project_id(p.to_string());
+    }
+    if let Some(s) = args_str(&req, "subject") {
+        builder = builder.subject(s.to_string());
+    }
+    if let Some(v) = structured {
+        if !v.is_null() {
+            builder = builder.structured(v);
+        }
+    }
+
+    match state.mailbox_manager.post(builder, Some(app)) {
+        Ok(event) => Response::success(serde_json::to_value(event).unwrap_or_default()),
+        Err(e) => Response::err(e.to_string()),
+    }
+}
+
+async fn handle_bus_tail(req: Request, app: &tauri::AppHandle) -> Response {
+    let state: tauri::State<AppState> = app.state();
+    let limit = req.args.get("limit").and_then(|v| v.as_u64()).map(|n| n as usize);
+    let filter = mailbox_project_filter(args_str(&req, "project_id"), args_bool(&req, "global"));
+
+    let events = match args_str(&req, "topic") {
+        Some(t) => {
+            let mut events = state.mailbox_manager.list_for_topic(t, filter);
+            if let Some(n) = limit {
+                events.truncate(n);
+            }
+            events
+        }
+        None => state.mailbox_manager.list_all(filter, limit),
+    };
+    Response::success(serde_json::to_value(events).unwrap_or_default())
 }
 
 fn crypto_random_uuid() -> String {

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -3,6 +3,9 @@ use std::sync::{Arc, Mutex};
 
 use tokio::sync::oneshot;
 
+use roux_lib::aliases::AliasManager;
+use roux_lib::mailbox::MailboxManager;
+
 use crate::notifications::NotificationManager;
 use crate::pane_service::PaneHandle;
 use crate::project_service::ProjectHandle;
@@ -23,6 +26,8 @@ pub(crate) struct AppState {
     pub(crate) watch_manager: crate::watches::WatchManager,
     pub(crate) automation_hooks: crate::automation_hooks::AutomationHookManager,
     pub(crate) notification_manager: NotificationManager,
+    pub(crate) alias_manager: AliasManager,
+    pub(crate) mailbox_manager: MailboxManager,
     pub(crate) pending_replies: PendingReplies,
     pub(crate) managed_proxy: Arc<crate::services::managed_proxy::ManagedProxyState>,
 }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -37,6 +37,11 @@
   import { addSession, setActiveSession, sessionState, updateSessionStatus } from "$lib/stores/sessions";
   import { addOrUpdateWatch, watchState, ghAvailable as ghAvailableStore, flashSession } from "$lib/stores/watches";
   import { hydrateNotifications, applyNotificationEvent } from "$lib/stores/notifications";
+  import {
+    hydrateMailbox,
+    applyMailboxEvent,
+    applyAliasEvent,
+  } from "$lib/stores/mailbox";
   import { initPtyInventoryPolling } from "$lib/stores/ptyInventory";
   import { initSessionWithProfile, splitPane } from "$lib/panes/actions";
   import { hasSplitPanes } from "$lib/panes/layout";
@@ -67,7 +72,7 @@
   } from "$lib/stores/sessionPrLookup";
   import { installSessionBranchPoller } from "$lib/stores/sessionBranchPoller";
   import { clearPermissionInfo } from "$lib/panes/agentState";
-  import { listSessions, checkSetupStatus, checkSetupNeeded, onRouxStatusUpdate, onAgentAttentionCleared, onRouxCommand, spawnShell, onWatchUpdate, listWatches, onNotificationEvent, quitApp, submitRouxReply } from "$lib/tauri";
+  import { listSessions, checkSetupStatus, checkSetupNeeded, onRouxStatusUpdate, onAgentAttentionCleared, onRouxCommand, spawnShell, onWatchUpdate, listWatches, onNotificationEvent, onMailboxEvent, onAliasEvent, quitApp, submitRouxReply } from "$lib/tauri";
   import { collectPaneTree } from "$lib/panes/query";
   import { profileRegistry } from "$lib/panes/profiles";
   import { runProfileInPane } from "$lib/panes/profileRunner";
@@ -808,6 +813,17 @@
       applyNotificationEvent(payload);
     }));
     initNotificationAutoRead();
+
+    // Hydrate + subscribe to the mailbox / alias stream. Hydration is
+    // cheap (one list-all + one alias-list + per-alias unread counts);
+    // the listener keeps the store in sync without polling.
+    await hydrateMailbox();
+    tauriUnlisteners.push(
+      await onMailboxEvent((payload) => applyMailboxEvent(payload)),
+    );
+    tauriUnlisteners.push(
+      await onAliasEvent((payload) => applyAliasEvent(payload)),
+    );
 
     // Listen for global status updates from hooks. Tier-1 routing (with a
     // `rouxPaneId` in the payload) updates the pane's runtime agentState so

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -732,7 +732,7 @@ export type McpHostConfigPreview = {
 	nextEntryJson: string,
 };
 
-export type McpHostId = "claudeDesktop";
+export type McpHostId = "claudeDesktop" | "claudeCode" | "codex";
 
 export type McpHostStatus = {
 	id: McpHostId,

--- a/src/lib/components/ActivityRail.svelte
+++ b/src/lib/components/ActivityRail.svelte
@@ -6,6 +6,7 @@
   import Library from "@lucide/svelte/icons/library";
   import BookOpen from "@lucide/svelte/icons/book-open";
   import Bell from "@lucide/svelte/icons/bell";
+  import Inbox from "@lucide/svelte/icons/inbox";
   import SettingsIcon from "@lucide/svelte/icons/settings";
   import Trees from "@lucide/svelte/icons/trees";
   import Container from "@lucide/svelte/icons/container";
@@ -27,6 +28,7 @@
   } from "$lib/stores/ui";
   import { sidebarLayout } from "$lib/stores/sidebarLayout";
   import { unreadTotal } from "$lib/stores/notifications";
+  import { meUnread } from "$lib/stores/mailbox";
 
   interface Item {
     id: SidebarId;
@@ -45,6 +47,7 @@
     { id: "tasks", label: "Tasks", icon: ListTodo },
     { id: "docs", label: "Docs", icon: BookOpen },
     { id: "notifications", label: "Notifications", icon: Bell },
+    { id: "mailbox", label: "Mailbox", icon: Inbox },
   ];
   const worktrunkItem: Item = {
     id: "worktrunk",
@@ -121,7 +124,13 @@
   {#each dockItems as item (item.id)}
     {@const active = $activeSidebar === item.id}
     {@const pinned = $pinnedSidebar === item.id}
-    {@const showBadge = item.id === "notifications" && $unreadTotal > 0}
+    {@const badgeCount =
+      item.id === "notifications"
+        ? $unreadTotal
+        : item.id === "mailbox"
+          ? $meUnread
+          : 0}
+    {@const showBadge = badgeCount > 0}
     <button
       type="button"
       aria-label={item.label}
@@ -141,7 +150,7 @@
       {/if}
       {#if showBadge}
         <span class="absolute -top-1 -right-1 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-red-500 px-1 text-[9px] font-semibold leading-none text-white">
-          {$unreadTotal > 9 ? "9+" : $unreadTotal}
+          {badgeCount > 9 ? "9+" : badgeCount}
         </span>
       {/if}
     </button>

--- a/src/lib/components/MailboxPanel.svelte
+++ b/src/lib/components/MailboxPanel.svelte
@@ -104,9 +104,17 @@
           projectId: project,
           global: project == null,
         });
-        // Selection may have changed during the await — guard against
-        // stale results overwriting a newer fetch.
-        if (selectedAlias !== alias || selectedProjectId !== project) return;
+        // Selection — including unreadOnly + visibility — may have
+        // changed during the await. Bail if any input shifted so an
+        // older response can't overwrite a newer fetch's results.
+        if (
+          !visible ||
+          selectedAlias !== alias ||
+          selectedProjectId !== project ||
+          unreadOnly !== filter
+        ) {
+          return;
+        }
         recipientEvents = evs;
 
         // Fetch read state per event so we can show greyed-out / acked
@@ -117,7 +125,14 @@
             mailboxReadState(e.id, alias).catch(() => null),
           ),
         );
-        if (selectedAlias !== alias || selectedProjectId !== project) return;
+        if (
+          !visible ||
+          selectedAlias !== alias ||
+          selectedProjectId !== project ||
+          unreadOnly !== filter
+        ) {
+          return;
+        }
         const map = new Map<string, ReadState | null>();
         evs.forEach((e, i) => map.set(e.id, states[i]));
         recipientReadStates = map;
@@ -231,12 +246,21 @@
 
   /**
    * True when the event's recipient currently has a pane bound — we
-   * only enable the Deliver button in that case. Computed lazily per
-   * event row.
+   * only enable the Deliver button in that case. Scoped by both alias
+   * and projectId, otherwise an alias of the same name in a different
+   * project would falsely enable Deliver here.
    */
-  function recipientHasPane(toAlias: string | null): boolean {
+  function recipientHasPane(
+    toAlias: string | null,
+    projectId: string | null,
+  ): boolean {
     if (!toAlias) return false;
-    return $aliases.some((a) => a.alias === toAlias && a.paneId !== null);
+    return $aliases.some(
+      (a) =>
+        a.alias === toAlias &&
+        (a.projectId ?? null) === projectId &&
+        a.paneId !== null,
+    );
   }
 
   onMount(() => {
@@ -456,7 +480,7 @@
                 onclick={() => handleAck(e.id)}
                 disabled={isAcked}
               >ack</button>
-              {#if recipientHasPane(e.to)}
+              {#if recipientHasPane(e.to, e.projectId)}
                 <button
                   class="cursor-pointer rounded border border-accent-dim/60 bg-accent/10 px-1.5 py-0.5 text-[10px] text-accent hover:bg-accent/20 disabled:opacity-50"
                   onclick={() => handleDeliver(e.id)}

--- a/src/lib/components/MailboxPanel.svelte
+++ b/src/lib/components/MailboxPanel.svelte
@@ -2,17 +2,28 @@
   import { onMount } from "svelte";
   import {
     aliases,
+    aliasKey,
     ackEvent,
     clearReadFor,
     events,
     hydrateMailbox,
+    mailboxMutationTick,
     markRead,
     postMailboxMessage,
     refreshUnreadCount,
     unreadByAlias,
   } from "$lib/stores/mailbox";
-  import { mailboxDeliverToPane } from "$lib/tauri";
-  import type { AgentAlias, EventKind } from "$lib/tauri";
+  import {
+    mailboxDeliverToPane,
+    mailboxListForRecipient,
+    mailboxReadState,
+  } from "$lib/tauri";
+  import type {
+    AgentAlias,
+    EventKind,
+    MailboxEventPayload,
+    ReadState,
+  } from "$lib/tauri";
   import CollapseSidebarButton from "./CollapseSidebarButton.svelte";
   import PinButton from "./PinButton.svelte";
   import SidebarPanelHeader from "./SidebarPanelHeader.svelte";
@@ -27,7 +38,14 @@
   let { visible, onclose, pinned = false, onTogglePin }: Props = $props();
 
   // ── Local UI state ──────────────────────────────────────────────────────────
+  // `selectedAlias` and `selectedProjectId` together identify a single
+  // entry in `$aliases`. Tracked as separate fields (rather than a
+  // compound key string) so filtering / lookup helpers stay obvious.
+  // Same alias name in different projects is a real case — without the
+  // projectId, "reviewer@proj-a" and "reviewer@proj-b" would silently
+  // share an inbox view.
   let selectedAlias = $state<string>("me");
+  let selectedProjectId = $state<string | null>(null);
   let composeOpen = $state(false);
   let composeTo = $state("");
   let composeSubject = $state("");
@@ -55,15 +73,63 @@
     }
   });
 
-  // ── Derived views ───────────────────────────────────────────────────────────
-  let recipientEvents = $derived(
-    visible
-      ? $events
-          .filter((e) => e.to === selectedAlias)
-          .slice()
-          .reverse() // oldest first for drain semantics
-      : [],
-  );
+  // ── Inbox: backend-driven listing ───────────────────────────────────────────
+  // The Inbox view pulls from `mailboxListForRecipient` rather than
+  // filtering `$events` so the backend's read/clear semantics flow
+  // through correctly: cleared events drop out, unread-only filtering
+  // works, and mark-read/ack actions visibly affect the displayed list
+  // when paired with the unread-only toggle. Refetched on selection
+  // changes and on every `mailboxMutationTick` bump so backend
+  // mutations propagate without polling.
+  let recipientEvents = $state<MailboxEventPayload[]>([]);
+  let recipientReadStates = $state<Map<string, ReadState | null>>(new Map());
+  let unreadOnly = $state(false);
+
+  $effect(() => {
+    // Touch each dependency so the effect re-runs on any of them.
+    void $mailboxMutationTick;
+    const alias = selectedAlias;
+    const project = selectedProjectId;
+    const filter = unreadOnly;
+    if (!visible) {
+      recipientEvents = [];
+      recipientReadStates = new Map();
+      return;
+    }
+
+    void (async () => {
+      try {
+        const evs = await mailboxListForRecipient(alias, {
+          unreadOnly: filter,
+          projectId: project,
+          global: project == null,
+        });
+        // Selection may have changed during the await — guard against
+        // stale results overwriting a newer fetch.
+        if (selectedAlias !== alias || selectedProjectId !== project) return;
+        recipientEvents = evs;
+
+        // Fetch read state per event so we can show greyed-out / acked
+        // styling. Cheap (in-memory backend); fine for inboxes with
+        // dozens of events.
+        const states = await Promise.all(
+          evs.map((e) =>
+            mailboxReadState(e.id, alias).catch(() => null),
+          ),
+        );
+        if (selectedAlias !== alias || selectedProjectId !== project) return;
+        const map = new Map<string, ReadState | null>();
+        evs.forEach((e, i) => map.set(e.id, states[i]));
+        recipientReadStates = map;
+      } catch (err) {
+        console.warn("inbox fetch failed", err);
+      }
+    })();
+  });
+
+  function eventReadState(id: string): ReadState | null {
+    return recipientReadStates.get(id) ?? null;
+  }
 
   let firehoseEvents = $derived(visible ? $events : []);
 
@@ -73,8 +139,8 @@
       // `me` always first.
       if (a.alias === "me") return -1;
       if (b.alias === "me") return 1;
-      const ua = $unreadByAlias.get(a.alias) ?? 0;
-      const ub = $unreadByAlias.get(b.alias) ?? 0;
+      const ua = $unreadByAlias.get(aliasKey(a.alias, a.projectId)) ?? 0;
+      const ub = $unreadByAlias.get(aliasKey(b.alias, b.projectId)) ?? 0;
       if (ub !== ua) return ub - ua;
       return a.alias.localeCompare(b.alias);
     });
@@ -82,8 +148,8 @@
   });
 
   // ── Handlers ────────────────────────────────────────────────────────────────
-  function unreadFor(a: string): number {
-    return $unreadByAlias.get(a) ?? 0;
+  function unreadFor(alias: string, projectId: string | null): number {
+    return $unreadByAlias.get(aliasKey(alias, projectId)) ?? 0;
   }
 
   function formatRelative(ts: number): string {
@@ -126,7 +192,9 @@
       composeOpen = false;
       // The recipient may not be one of `selectedAlias`'s set, so refresh
       // its count too — covers the cross-repo "post to reviewer" case.
-      void refreshUnreadCount(composeTo);
+      // Pass `undefined` so the helper refreshes every known scope for
+      // that name (we don't track projectId on the compose form yet).
+      void refreshUnreadCount(composeTo, undefined);
     } catch (err) {
       postError = String(err);
     } finally {
@@ -301,13 +369,17 @@
       class="flex shrink-0 gap-1 overflow-x-auto border-b border-border-subtle p-1"
     >
       {#each sortedAliases as a (a.alias + (a.projectId ?? ""))}
-        {@const u = unreadFor(a.alias)}
+        {@const u = unreadFor(a.alias, a.projectId)}
+        {@const isSelected =
+          selectedAlias === a.alias && selectedProjectId === a.projectId}
         <button
-          class="flex shrink-0 items-center gap-1 rounded border px-2 py-1 text-[11px] {selectedAlias ===
-          a.alias
+          class="flex shrink-0 items-center gap-1 rounded border px-2 py-1 text-[11px] {isSelected
             ? 'border-accent-dim bg-accent/15 text-text-primary'
             : 'border-border-subtle bg-transparent text-text-muted hover:bg-bg-hover hover:text-text-primary'}"
-          onclick={() => (selectedAlias = a.alias)}
+          onclick={() => {
+            selectedAlias = a.alias;
+            selectedProjectId = a.projectId;
+          }}
         >
           <span>{a.alias}</span>
           {#if u > 0}
@@ -326,11 +398,16 @@
       {#if recipientEvents.length === 0}
         <div
           class="flex h-full items-center justify-center text-sm text-text-muted"
-        >No mail for {selectedAlias}</div>
+        >No {unreadOnly ? "unread" : ""} mail for {selectedAlias}</div>
       {:else}
         {#each recipientEvents as e (e.id)}
+          {@const state = eventReadState(e.id)}
+          {@const isRead = state?.readAt != null}
+          {@const isAcked = state?.ackedAt != null}
           <article
-            class="mb-2 flex flex-col gap-1 rounded-lg border border-border-subtle bg-bg-surface/30 px-2 py-1.5"
+            class="mb-2 flex flex-col gap-1 rounded-lg border border-border-subtle bg-bg-surface/30 px-2 py-1.5 {isRead
+              ? 'opacity-60'
+              : ''}"
           >
             <header class="flex items-center gap-2">
               <span
@@ -345,6 +422,13 @@
                 <span class="truncate text-[10px] text-text-muted"
                   >from {e.from}</span
                 >
+              {/if}
+              {#if isAcked}
+                <span class="text-[10px] text-green" title={state?.ackResult ?? "Acked"}
+                  >✓ ack{state?.ackResult ? `: ${state.ackResult}` : ""}</span
+                >
+              {:else if isRead}
+                <span class="text-[10px] text-text-muted">read</span>
               {/if}
               <span class="ml-auto shrink-0 text-[10px] text-text-muted/70"
                 >{formatRelative(e.createdAt)}</span
@@ -363,12 +447,14 @@
             {/if}
             <footer class="flex flex-wrap gap-1">
               <button
-                class="cursor-pointer rounded border border-transparent bg-transparent px-1.5 py-0.5 text-[10px] text-text-muted hover:border-border-subtle hover:bg-bg-hover hover:text-text-primary"
+                class="cursor-pointer rounded border border-transparent bg-transparent px-1.5 py-0.5 text-[10px] text-text-muted hover:border-border-subtle hover:bg-bg-hover hover:text-text-primary disabled:opacity-40"
                 onclick={() => handleMarkRead(e.id)}
+                disabled={isRead}
               >mark read</button>
               <button
-                class="cursor-pointer rounded border border-transparent bg-transparent px-1.5 py-0.5 text-[10px] text-text-muted hover:border-border-subtle hover:bg-bg-hover hover:text-text-primary"
+                class="cursor-pointer rounded border border-transparent bg-transparent px-1.5 py-0.5 text-[10px] text-text-muted hover:border-border-subtle hover:bg-bg-hover hover:text-text-primary disabled:opacity-40"
                 onclick={() => handleAck(e.id)}
+                disabled={isAcked}
               >ack</button>
               {#if recipientHasPane(e.to)}
                 <button
@@ -390,14 +476,19 @@
       </div>
     {/if}
 
-    {#if recipientEvents.length > 0}
-      <div class="border-t border-border-subtle p-1.5">
+    <div class="flex items-center gap-2 border-t border-border-subtle p-1.5">
+      <label class="flex items-center gap-1 text-[10px] text-text-muted">
+        <input type="checkbox" bind:checked={unreadOnly} class="h-3 w-3" />
+        unread only
+      </label>
+      {#if recipientEvents.length > 0}
         <button
-          class="cursor-pointer rounded border border-transparent bg-transparent px-2 py-0.5 text-[10px] text-text-muted hover:border-border-subtle hover:bg-bg-hover hover:text-text-primary"
+          class="ml-auto cursor-pointer rounded border border-transparent bg-transparent px-2 py-0.5 text-[10px] text-text-muted hover:border-border-subtle hover:bg-bg-hover hover:text-text-primary"
           onclick={handleClearRead}
+          title="Hide read mail from this view. Underlying events are preserved for audit."
         >clear read</button>
-      </div>
-    {/if}
+      {/if}
+    </div>
   {:else}
     <!-- Firehose: every event newest first, no per-recipient state -->
     <div class="flex-1 overflow-y-auto p-2">

--- a/src/lib/components/MailboxPanel.svelte
+++ b/src/lib/components/MailboxPanel.svelte
@@ -1,0 +1,441 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import {
+    aliases,
+    ackEvent,
+    clearReadFor,
+    events,
+    hydrateMailbox,
+    markRead,
+    postMailboxMessage,
+    refreshUnreadCount,
+    unreadByAlias,
+  } from "$lib/stores/mailbox";
+  import { mailboxDeliverToPane } from "$lib/tauri";
+  import type { AgentAlias, EventKind } from "$lib/tauri";
+  import CollapseSidebarButton from "./CollapseSidebarButton.svelte";
+  import PinButton from "./PinButton.svelte";
+  import SidebarPanelHeader from "./SidebarPanelHeader.svelte";
+
+  interface Props {
+    visible: boolean;
+    onclose: () => void;
+    pinned?: boolean;
+    onTogglePin?: () => void;
+  }
+
+  let { visible, onclose, pinned = false, onTogglePin }: Props = $props();
+
+  // ── Local UI state ──────────────────────────────────────────────────────────
+  let selectedAlias = $state<string>("me");
+  let composeOpen = $state(false);
+  let composeTo = $state("");
+  let composeSubject = $state("");
+  let composeBody = $state("");
+  let composeKind = $state<EventKind>("task");
+  let posting = $state(false);
+  let postError = $state<string | null>(null);
+  let view = $state<"mailbox" | "firehose">("mailbox");
+
+  // Hydrate the first time the panel is shown. (`hydrateMailbox` is
+  // idempotent, but a guard keeps it from spamming on re-mount.)
+  let hydrated = $state(false);
+  $effect(() => {
+    if (visible && !hydrated) {
+      hydrated = true;
+      void hydrateMailbox();
+    }
+  });
+
+  // Pre-fill `to` once an alias is selected so the compose form is one
+  // less click for "reply to whoever I'm looking at."
+  $effect(() => {
+    if (composeTo === "") {
+      composeTo = selectedAlias === "me" ? "" : selectedAlias;
+    }
+  });
+
+  // ── Derived views ───────────────────────────────────────────────────────────
+  let recipientEvents = $derived(
+    visible
+      ? $events
+          .filter((e) => e.to === selectedAlias)
+          .slice()
+          .reverse() // oldest first for drain semantics
+      : [],
+  );
+
+  let firehoseEvents = $derived(visible ? $events : []);
+
+  let sortedAliases = $derived.by((): AgentAlias[] => {
+    const list = $aliases.slice();
+    list.sort((a, b) => {
+      // `me` always first.
+      if (a.alias === "me") return -1;
+      if (b.alias === "me") return 1;
+      const ua = $unreadByAlias.get(a.alias) ?? 0;
+      const ub = $unreadByAlias.get(b.alias) ?? 0;
+      if (ub !== ua) return ub - ua;
+      return a.alias.localeCompare(b.alias);
+    });
+    return list;
+  });
+
+  // ── Handlers ────────────────────────────────────────────────────────────────
+  function unreadFor(a: string): number {
+    return $unreadByAlias.get(a) ?? 0;
+  }
+
+  function formatRelative(ts: number): string {
+    const secs = Math.floor((Date.now() - ts) / 1000);
+    if (secs < 10) return "just now";
+    if (secs < 60) return `${secs}s ago`;
+    if (secs < 3600) return `${Math.floor(secs / 60)}m ago`;
+    if (secs < 86400) return `${Math.floor(secs / 3600)}h ago`;
+    return `${Math.floor(secs / 86400)}d ago`;
+  }
+
+  function kindColor(kind: EventKind): string {
+    switch (kind) {
+      case "task":
+        return "bg-accent";
+      case "question":
+        return "bg-amber";
+      case "result":
+        return "bg-green";
+      case "fyi":
+        return "bg-text-muted";
+      case "signal":
+        return "bg-blue-400";
+    }
+  }
+
+  async function handlePost() {
+    if (!composeBody.trim() || !composeTo.trim()) return;
+    posting = true;
+    postError = null;
+    try {
+      await postMailboxMessage({
+        to: composeTo,
+        body: composeBody,
+        subject: composeSubject || null,
+        kind: composeKind,
+      });
+      composeBody = "";
+      composeSubject = "";
+      composeOpen = false;
+      // The recipient may not be one of `selectedAlias`'s set, so refresh
+      // its count too — covers the cross-repo "post to reviewer" case.
+      void refreshUnreadCount(composeTo);
+    } catch (err) {
+      postError = String(err);
+    } finally {
+      posting = false;
+    }
+  }
+
+  async function handleMarkRead(eventId: string) {
+    await markRead(eventId, selectedAlias);
+  }
+
+  async function handleAck(eventId: string) {
+    await ackEvent(eventId, selectedAlias);
+  }
+
+  async function handleClearRead() {
+    await clearReadFor(selectedAlias);
+  }
+
+  let deliveringId = $state<string | null>(null);
+  let deliverError = $state<string | null>(null);
+
+  async function handleDeliver(eventId: string) {
+    deliveringId = eventId;
+    deliverError = null;
+    try {
+      await mailboxDeliverToPane(eventId);
+    } catch (err) {
+      deliverError = `Delivery failed: ${String(err)}`;
+    } finally {
+      deliveringId = null;
+    }
+  }
+
+  /**
+   * True when the event's recipient currently has a pane bound — we
+   * only enable the Deliver button in that case. Computed lazily per
+   * event row.
+   */
+  function recipientHasPane(toAlias: string | null): boolean {
+    if (!toAlias) return false;
+    return $aliases.some((a) => a.alias === toAlias && a.paneId !== null);
+  }
+
+  onMount(() => {
+    // No teardown needed — the global `mailbox-event` listener is
+    // installed at app bootstrap (see `App.svelte` wiring), not here.
+  });
+</script>
+
+<div
+  class="flex h-full w-full min-h-0 flex-col bg-bg-deep"
+  class:hidden={!visible}
+>
+  <SidebarPanelHeader title="Mailbox">
+    {#snippet actions()}
+      <div
+        class="flex items-center gap-0.5 rounded border border-border-subtle bg-bg-surface/40 p-0.5"
+        title="Switch between per-alias inbox and the full event firehose"
+      >
+        <button
+          class="rounded px-2 py-0.5 text-[11px] {view === 'mailbox'
+            ? 'bg-bg-hover text-text-primary'
+            : 'text-text-muted hover:text-text-primary'}"
+          onclick={() => (view = "mailbox")}
+          title="Mailbox view — events addressed to the selected alias"
+        >Inbox</button>
+        <button
+          class="rounded px-2 py-0.5 text-[11px] {view === 'firehose'
+            ? 'bg-bg-hover text-text-primary'
+            : 'text-text-muted hover:text-text-primary'}"
+          onclick={() => (view = "firehose")}
+          title="Firehose view — every event in the store, newest first"
+        >All</button>
+      </div>
+      <button
+        class="cursor-pointer rounded border border-transparent bg-transparent px-2 py-0.5 text-[10px] text-text-muted hover:border-border-subtle hover:bg-bg-hover hover:text-text-primary"
+        onclick={() => (composeOpen = !composeOpen)}
+        title={composeOpen ? "Cancel" : "Compose"}
+      >{composeOpen ? "cancel" : "+ new"}</button>
+      {#if onTogglePin}
+        <PinButton {pinned} ontoggle={onTogglePin} />
+      {/if}
+      <CollapseSidebarButton
+        onclick={onclose}
+        label="Collapse mailbox sidebar"
+        title="Collapse mailbox sidebar"
+      />
+    {/snippet}
+  </SidebarPanelHeader>
+
+  {#if composeOpen}
+    <form
+      class="flex flex-col gap-1 border-b border-border-subtle bg-bg-surface/30 p-2"
+      onsubmit={(e) => {
+        e.preventDefault();
+        void handlePost();
+      }}
+    >
+      <div class="flex gap-1">
+        <input
+          class="flex-1 rounded border border-border-subtle bg-bg-deep px-2 py-1 text-[11px] text-text-primary placeholder:text-text-muted/60"
+          bind:value={composeTo}
+          placeholder="To (alias)"
+          list="mailbox-compose-aliases"
+          autocomplete="off"
+          required
+        />
+        <select
+          class="rounded border border-border-subtle bg-bg-deep px-1 py-1 text-[11px] text-text-primary"
+          bind:value={composeKind}
+        >
+          <option value="task">task</option>
+          <option value="question">question</option>
+          <option value="result">result</option>
+          <option value="fyi">fyi</option>
+        </select>
+      </div>
+      <!--
+        Native datalist: the input shows whatever the user types verbatim,
+        and the browser surfaces matching `$aliases` entries as suggestions.
+        New aliases the user types are still accepted — `mailbox-post` will
+        ensure-create them on the backend.
+
+        Labels include enough context to disambiguate Claude/Codex/shell
+        panes that happen to share a name across sessions, plus a hint
+        when the alias was auto-claimed from the pane's name.
+      -->
+      <datalist id="mailbox-compose-aliases">
+        {#each sortedAliases as a (a.alias + (a.projectId ?? ""))}
+          {@const status = a.paneId
+            ? a.autoClaimed
+              ? "auto-claimed"
+              : "claimed"
+            : a.sessionId
+              ? "session"
+              : "unbound"}
+          {@const projectSuffix = a.projectId ? ` · @${a.projectId}` : ""}
+          <option
+            value={a.alias}
+            label={`${a.alias}${projectSuffix} · ${status}`}
+          ></option>
+        {/each}
+      </datalist>
+      <input
+        class="rounded border border-border-subtle bg-bg-deep px-2 py-1 text-[11px] text-text-primary placeholder:text-text-muted/60"
+        bind:value={composeSubject}
+        placeholder="Subject (optional)"
+      />
+      <textarea
+        class="min-h-[60px] resize-y rounded border border-border-subtle bg-bg-deep px-2 py-1 text-[11px] text-text-primary placeholder:text-text-muted/60"
+        bind:value={composeBody}
+        placeholder="Body"
+        required
+      ></textarea>
+      {#if postError}
+        <div class="text-[10px] text-red">{postError}</div>
+      {/if}
+      <div class="flex justify-end">
+        <button
+          type="submit"
+          class="cursor-pointer rounded border border-accent-dim bg-accent/20 px-2 py-1 text-[11px] text-text-primary hover:bg-accent/30 disabled:opacity-50"
+          disabled={posting}
+        >{posting ? "Sending…" : "Send"}</button>
+      </div>
+    </form>
+  {/if}
+
+  {#if view === "mailbox"}
+    <!-- Alias selector strip -->
+    <div
+      class="flex shrink-0 gap-1 overflow-x-auto border-b border-border-subtle p-1"
+    >
+      {#each sortedAliases as a (a.alias + (a.projectId ?? ""))}
+        {@const u = unreadFor(a.alias)}
+        <button
+          class="flex shrink-0 items-center gap-1 rounded border px-2 py-1 text-[11px] {selectedAlias ===
+          a.alias
+            ? 'border-accent-dim bg-accent/15 text-text-primary'
+            : 'border-border-subtle bg-transparent text-text-muted hover:bg-bg-hover hover:text-text-primary'}"
+          onclick={() => (selectedAlias = a.alias)}
+        >
+          <span>{a.alias}</span>
+          {#if u > 0}
+            <span class="rounded bg-accent px-1 text-[9px] text-bg-deep">{u}</span>
+          {/if}
+          {#if a.projectId}
+            <span class="text-[9px] text-text-muted/70">@{a.projectId}</span>
+          {/if}
+        </button>
+      {:else}
+        <span class="px-2 py-1 text-[11px] text-text-muted">No aliases</span>
+      {/each}
+    </div>
+
+    <div class="flex-1 overflow-y-auto p-2">
+      {#if recipientEvents.length === 0}
+        <div
+          class="flex h-full items-center justify-center text-sm text-text-muted"
+        >No mail for {selectedAlias}</div>
+      {:else}
+        {#each recipientEvents as e (e.id)}
+          <article
+            class="mb-2 flex flex-col gap-1 rounded-lg border border-border-subtle bg-bg-surface/30 px-2 py-1.5"
+          >
+            <header class="flex items-center gap-2">
+              <span
+                class="inline-block h-2 w-2 shrink-0 rounded-full {kindColor(
+                  e.kind,
+                )}"
+              ></span>
+              <span class="text-[10px] uppercase tracking-wider text-text-muted"
+                >{e.kind}</span
+              >
+              {#if e.from}
+                <span class="truncate text-[10px] text-text-muted"
+                  >from {e.from}</span
+                >
+              {/if}
+              <span class="ml-auto shrink-0 text-[10px] text-text-muted/70"
+                >{formatRelative(e.createdAt)}</span
+              >
+            </header>
+            {#if e.subject}
+              <h4 class="text-[11px] font-medium text-text-primary">
+                {e.subject}
+              </h4>
+            {/if}
+            <p class="whitespace-pre-wrap text-[11px] text-text-secondary">
+              {e.body}
+            </p>
+            {#if e.topic}
+              <span class="text-[9px] text-text-muted">topic: {e.topic}</span>
+            {/if}
+            <footer class="flex flex-wrap gap-1">
+              <button
+                class="cursor-pointer rounded border border-transparent bg-transparent px-1.5 py-0.5 text-[10px] text-text-muted hover:border-border-subtle hover:bg-bg-hover hover:text-text-primary"
+                onclick={() => handleMarkRead(e.id)}
+              >mark read</button>
+              <button
+                class="cursor-pointer rounded border border-transparent bg-transparent px-1.5 py-0.5 text-[10px] text-text-muted hover:border-border-subtle hover:bg-bg-hover hover:text-text-primary"
+                onclick={() => handleAck(e.id)}
+              >ack</button>
+              {#if recipientHasPane(e.to)}
+                <button
+                  class="cursor-pointer rounded border border-accent-dim/60 bg-accent/10 px-1.5 py-0.5 text-[10px] text-accent hover:bg-accent/20 disabled:opacity-50"
+                  onclick={() => handleDeliver(e.id)}
+                  disabled={deliveringId === e.id}
+                  title="Type this message into the recipient's pane and ack it. Bypasses the agent's drain step — use when you want immediate delivery."
+                >{deliveringId === e.id ? "delivering…" : "deliver →"}</button>
+              {/if}
+            </footer>
+          </article>
+        {/each}
+      {/if}
+    </div>
+
+    {#if deliverError}
+      <div class="shrink-0 border-t border-red-500/40 bg-red-500/10 px-2 py-1 text-[10px] text-red-300">
+        {deliverError}
+      </div>
+    {/if}
+
+    {#if recipientEvents.length > 0}
+      <div class="border-t border-border-subtle p-1.5">
+        <button
+          class="cursor-pointer rounded border border-transparent bg-transparent px-2 py-0.5 text-[10px] text-text-muted hover:border-border-subtle hover:bg-bg-hover hover:text-text-primary"
+          onclick={handleClearRead}
+        >clear read</button>
+      </div>
+    {/if}
+  {:else}
+    <!-- Firehose: every event newest first, no per-recipient state -->
+    <div class="flex-1 overflow-y-auto p-2">
+      {#if firehoseEvents.length === 0}
+        <div
+          class="flex h-full items-center justify-center text-sm text-text-muted"
+        >No events</div>
+      {:else}
+        {#each firehoseEvents as e (e.id)}
+          <article
+            class="mb-1 flex flex-col gap-0.5 rounded border border-transparent bg-transparent px-2 py-1 hover:border-border-subtle hover:bg-bg-hover"
+          >
+            <div class="flex items-center gap-2 text-[10px]">
+              <span
+                class="inline-block h-2 w-2 shrink-0 rounded-full {kindColor(
+                  e.kind,
+                )}"
+              ></span>
+              <span class="text-text-muted">{e.kind}</span>
+              {#if e.from}<span class="truncate text-text-muted"
+                  >from {e.from}</span
+                >{/if}
+              {#if e.to}<span class="truncate text-text-muted"
+                  >→ {e.to}</span
+                >{/if}
+              {#if e.topic}<span class="truncate text-text-muted"
+                  >· {e.topic}</span
+                >{/if}
+              <span class="ml-auto shrink-0 text-text-muted/70"
+                >{formatRelative(e.createdAt)}</span
+              >
+            </div>
+            <p class="truncate text-[11px] text-text-secondary">
+              {e.subject ?? e.body}
+            </p>
+          </article>
+        {/each}
+      {/if}
+    </div>
+  {/if}
+</div>

--- a/src/lib/components/PaneShell.svelte
+++ b/src/lib/components/PaneShell.svelte
@@ -19,6 +19,10 @@
     notificationsPush,
   } from "$lib/tauri";
   import { settings } from "$lib/stores/settings";
+  import {
+    aliases as mailboxAliases,
+    unreadByAlias as mailboxUnreadByAlias,
+  } from "$lib/stores/mailbox";
   import { showPaneHints, paneSlotById } from "$lib/stores/ui";
   import {
     clearDraggedLibraryPrompt,
@@ -62,6 +66,16 @@
   let elapsed = $state("0s");
 
   const instance = $derived($paneInstances.get(paneId));
+
+  // Aliases auto-claimed (or manually claimed) for this pane. Rendered as
+  // a small chip in the title bar so the user can tell at a glance that
+  // mail addressed to e.g. `reviewer` lands here.
+  const paneAlias = $derived(
+    $mailboxAliases.find((a) => a.paneId === paneId) ?? null,
+  );
+  const paneAliasUnread = $derived(
+    paneAlias ? ($mailboxUnreadByAlias.get(paneAlias.alias) ?? 0) : 0,
+  );
   const terminalState = $derived(instance?.terminalState);
   const isFocused = $derived($focusedPaneId === paneId);
   const hasMultipleVisiblePanes = $derived.by<boolean>(() => {
@@ -490,6 +504,31 @@
         <span class="min-w-0 flex-1 truncate text-[11px] text-text-secondary">{instance.name}</span>
       {:else}
         <span class="flex-1"></span>
+      {/if}
+      {#if paneAlias}
+        <!--
+          Alias chip + optional unread badge. Auto-claimed bindings get a
+          lighter outline; manual claims use the filled accent so the
+          user can tell whether the alias came from the pane's name or
+          from `roux alias claim`. Unread count appears as a tighter
+          inline badge — keeps the chip small but visible at a glance.
+        -->
+        <span
+          class="flex shrink-0 items-center gap-1 rounded px-1.5 py-px text-[10px] leading-none {paneAlias.autoClaimed
+            ? 'border border-accent-dim/50 text-accent-dim'
+            : 'bg-accent/20 text-accent'}"
+          title={paneAlias.autoClaimed
+            ? `Auto-claimed alias '${paneAlias.alias}' from pane name. Mail to ${paneAlias.alias} lands here. Rename pane or close it to release.`
+            : `Manual alias '${paneAlias.alias}'. Mail to ${paneAlias.alias} lands here.`}
+        >
+          <span>@{paneAlias.alias}</span>
+          {#if paneAliasUnread > 0}
+            <span
+              class="rounded bg-red-500 px-1 text-[9px] font-semibold leading-none text-white"
+              title={`${paneAliasUnread} unread mail item${paneAliasUnread === 1 ? "" : "s"}`}
+            >{paneAliasUnread > 9 ? "9+" : paneAliasUnread}</span>
+          {/if}
+        </span>
       {/if}
       <div
         class="flex shrink-0 items-center gap-0.5 opacity-0 pointer-events-none transition-opacity duration-150 group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto"

--- a/src/lib/components/PaneShell.svelte
+++ b/src/lib/components/PaneShell.svelte
@@ -20,6 +20,7 @@
   } from "$lib/tauri";
   import { settings } from "$lib/stores/settings";
   import {
+    aliasKey as mailboxAliasKey,
     aliases as mailboxAliases,
     unreadByAlias as mailboxUnreadByAlias,
   } from "$lib/stores/mailbox";
@@ -74,7 +75,11 @@
     $mailboxAliases.find((a) => a.paneId === paneId) ?? null,
   );
   const paneAliasUnread = $derived(
-    paneAlias ? ($mailboxUnreadByAlias.get(paneAlias.alias) ?? 0) : 0,
+    paneAlias
+      ? ($mailboxUnreadByAlias.get(
+          mailboxAliasKey(paneAlias.alias, paneAlias.projectId),
+        ) ?? 0)
+      : 0,
   );
   const terminalState = $derived(instance?.terminalState);
   const isFocused = $derived($focusedPaneId === paneId);

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -167,11 +167,13 @@
   let gitDetection = $state<IntegrationDetection | null>(null);
   let worktrunkDetection = $state<WorktrunkDetection | null>(null);
   let mcpStatus = $state<McpStatus | null>(null);
-  let mcpPreview = $state<McpHostConfigPreview | null>(null);
-  let mcpMessage = $state<string | null>(null);
-  let mcpError = $state<string | null>(null);
-  let mcpBusy = $state<"preview" | "configure" | null>(null);
-  const claudeMcpHost = $derived(mcpStatus?.hosts.find((host) => host.id === "claudeDesktop") ?? null);
+  // Per-host UI state, keyed by host id (`claudeDesktop`, `claudeCode`,
+  // `codex`). Each host gets its own preview blob + status message so a
+  // configure-Codex run doesn't blow away a preview-Claude-Code result.
+  let mcpPreviewByHost = $state<Record<string, McpHostConfigPreview | null>>({});
+  let mcpMessageByHost = $state<Record<string, string | null>>({});
+  let mcpErrorByHost = $state<Record<string, string | null>>({});
+  let mcpBusyByHost = $state<Record<string, "preview" | "configure" | null>>({});
   let agentNotificationStatus = $state<AgentNotificationSetupStatus | null>(null);
   let agentNotificationMessage = $state<string | null>(null);
   let agentNotificationError = $state<string | null>(null);
@@ -318,42 +320,60 @@
     return () => clearTimeout(timer);
   });
 
-  async function previewMcpHostConfig() {
-    mcpBusy = "preview";
-    mcpError = null;
-    mcpMessage = null;
+  type McpHostIdT = "claudeDesktop" | "claudeCode" | "codex";
+
+  async function previewMcpHostConfig(hostId: McpHostIdT, label: string) {
+    mcpBusyByHost = { ...mcpBusyByHost, [hostId]: "preview" };
+    mcpErrorByHost = { ...mcpErrorByHost, [hostId]: null };
+    mcpMessageByHost = { ...mcpMessageByHost, [hostId]: null };
     try {
-      const result = await commands.cmdPreviewMcpHostConfig("claudeDesktop");
+      const result = await commands.cmdPreviewMcpHostConfig(hostId);
       if (result.status === "error") {
         throw new Error(result.error);
       }
-      mcpPreview = result.data;
-      mcpMessage = mcpPreview.configured ? "Claude Desktop is already configured." : "Preview ready.";
+      mcpPreviewByHost = { ...mcpPreviewByHost, [hostId]: result.data };
+      mcpMessageByHost = {
+        ...mcpMessageByHost,
+        [hostId]: result.data.configured
+          ? `${label} is already configured.`
+          : "Preview ready.",
+      };
     } catch (e) {
-      mcpPreview = null;
-      mcpError = e instanceof Error ? e.message : String(e);
+      mcpPreviewByHost = { ...mcpPreviewByHost, [hostId]: null };
+      mcpErrorByHost = {
+        ...mcpErrorByHost,
+        [hostId]: e instanceof Error ? e.message : String(e),
+      };
     } finally {
-      mcpBusy = null;
+      mcpBusyByHost = { ...mcpBusyByHost, [hostId]: null };
     }
   }
 
-  async function configureMcpHost() {
-    mcpBusy = "configure";
-    mcpError = null;
-    mcpMessage = null;
+  async function configureMcpHost(hostId: McpHostIdT, label: string) {
+    mcpBusyByHost = { ...mcpBusyByHost, [hostId]: "configure" };
+    mcpErrorByHost = { ...mcpErrorByHost, [hostId]: null };
+    mcpMessageByHost = { ...mcpMessageByHost, [hostId]: null };
     try {
-      const result = await commands.cmdConfigureMcpHost("claudeDesktop");
+      const result = await commands.cmdConfigureMcpHost(hostId);
       if (result.status === "error") {
         throw new Error(result.error);
       }
-      mcpPreview = result.data;
-      mcpMessage = mcpPreview.configured ? "Claude Desktop was already configured." : "Claude Desktop configuration updated.";
+      mcpPreviewByHost = { ...mcpPreviewByHost, [hostId]: result.data };
+      mcpMessageByHost = {
+        ...mcpMessageByHost,
+        [hostId]: result.data.configured
+          ? `${label} was already configured.`
+          : `${label} configuration updated.`,
+      };
       const run = ++mcpStatusRun;
       await refreshMcpStatus(run);
     } catch (e) {
-      mcpError = e instanceof Error ? e.message : String(e);
+      mcpErrorByHost = {
+        ...mcpErrorByHost,
+        [hostId]: e instanceof Error ? e.message : String(e),
+      };
     } finally {
-      mcpBusy = null;
+      mcpBusyByHost = { ...mcpBusyByHost, [hostId]: null };
     }
   }
 
@@ -1073,47 +1093,56 @@
                   </div>
                 </div>
               {/if}
-              <div class="mt-3 rounded border border-border-subtle bg-bg-deep/60 p-2">
-                <div class="flex items-center justify-between gap-2">
-                  <div>
-                    <div class="text-[12px] font-medium">Claude Desktop</div>
-                    <div class="mt-0.5 max-w-[22rem] truncate font-mono text-[10px] text-text-muted" title={claudeMcpHost?.configPath ?? ""}>
-                      {claudeMcpHost?.configPath ?? "Config path unavailable"}
+              {#if mcpStatus}
+                {#each mcpStatus.hosts as host (host.id)}
+                  {@const hostId = host.id as McpHostIdT}
+                  {@const busy = mcpBusyByHost[hostId] ?? null}
+                  {@const message = mcpMessageByHost[hostId] ?? null}
+                  {@const error = mcpErrorByHost[hostId] ?? null}
+                  {@const preview = mcpPreviewByHost[hostId] ?? null}
+                  <div class="mt-3 rounded border border-border-subtle bg-bg-deep/60 p-2">
+                    <div class="flex items-center justify-between gap-2">
+                      <div>
+                        <div class="text-[12px] font-medium">{host.label}</div>
+                        <div class="mt-0.5 max-w-[22rem] truncate font-mono text-[10px] text-text-muted" title={host.configPath ?? ""}>
+                          {host.configPath ?? "Config path unavailable"}
+                        </div>
+                      </div>
+                      {#if host.configured}
+                        <span class="rounded bg-green/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-green">configured</span>
+                      {:else if host.error}
+                        <span class="rounded bg-red/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-red">needs attention</span>
+                      {:else}
+                        <span class="rounded bg-bg-active px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-text-muted">not configured</span>
+                      {/if}
                     </div>
+                    <div class="mt-2 flex gap-1">
+                      <button
+                        class="rounded border border-border bg-bg-elevated px-2 py-1 text-[11px] text-text-secondary hover:bg-bg-hover disabled:cursor-not-allowed disabled:opacity-40"
+                        disabled={!($settings.mcpEnabled ?? false) || busy !== null}
+                        onclick={() => previewMcpHostConfig(hostId, host.label)}
+                      >{busy === "preview" ? "Previewing" : "Preview"}</button>
+                      <button
+                        class="rounded border border-accent-dim bg-accent/15 px-2 py-1 text-[11px] text-text-primary hover:bg-accent/25 disabled:cursor-not-allowed disabled:opacity-40"
+                        disabled={!($settings.mcpEnabled ?? false) || busy !== null}
+                        onclick={() => configureMcpHost(hostId, host.label)}
+                      >{busy === "configure" ? "Adding…" : `Add to ${host.label}`}</button>
+                    </div>
+                    {#if message}
+                      <div class="mt-2 text-[11px] text-green">{message}</div>
+                    {/if}
+                    {#if error || host.error}
+                      <div class="mt-2 text-[11px] text-red">{error ?? host.error}</div>
+                    {/if}
+                    {#if preview}
+                      <div class="mt-2 rounded border border-border-subtle bg-bg-deep/70 p-2">
+                        <div class="mb-1 text-[10px] uppercase tracking-wider text-text-muted">Roux entry</div>
+                        <pre class="app-scrollbar max-h-28 overflow-auto whitespace-pre-wrap break-words font-mono text-[10px] text-text-secondary">{preview.nextEntryJson}</pre>
+                      </div>
+                    {/if}
                   </div>
-                  {#if claudeMcpHost?.configured}
-                    <span class="rounded bg-green/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-green">configured</span>
-                  {:else if claudeMcpHost?.error}
-                    <span class="rounded bg-red/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-red">needs attention</span>
-                  {:else}
-                    <span class="rounded bg-bg-active px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-text-muted">not configured</span>
-                  {/if}
-                </div>
-                <div class="mt-2 flex gap-1">
-                  <button
-                    class="rounded border border-border bg-bg-elevated px-2 py-1 text-[11px] text-text-secondary hover:bg-bg-hover disabled:cursor-not-allowed disabled:opacity-40"
-                    disabled={!($settings.mcpEnabled ?? false) || mcpBusy !== null}
-                    onclick={previewMcpHostConfig}
-                  >{mcpBusy === "preview" ? "Previewing" : "Preview"}</button>
-                  <button
-                    class="rounded border border-border bg-bg-elevated px-2 py-1 text-[11px] text-text-secondary hover:bg-bg-hover disabled:cursor-not-allowed disabled:opacity-40"
-                    disabled={!($settings.mcpEnabled ?? false) || mcpBusy !== null}
-                    onclick={configureMcpHost}
-                  >{mcpBusy === "configure" ? "Configuring" : "Configure"}</button>
-                </div>
-                {#if mcpMessage}
-                  <div class="mt-2 text-[11px] text-green">{mcpMessage}</div>
-                {/if}
-                {#if mcpError || claudeMcpHost?.error}
-                  <div class="mt-2 text-[11px] text-red">{mcpError ?? claudeMcpHost?.error}</div>
-                {/if}
-                {#if mcpPreview}
-                  <div class="mt-2 rounded border border-border-subtle bg-bg-deep/70 p-2">
-                    <div class="mb-1 text-[10px] uppercase tracking-wider text-text-muted">Roux entry</div>
-                    <pre class="app-scrollbar max-h-28 overflow-auto whitespace-pre-wrap break-words font-mono text-[10px] text-text-secondary">{mcpPreview.nextEntryJson}</pre>
-                  </div>
-                {/if}
-              </div>
+                {/each}
+              {/if}
             </div>
 
             <div class="rounded-xl border border-border-subtle bg-bg-surface/35 p-3">

--- a/src/lib/components/SidebarDock.svelte
+++ b/src/lib/components/SidebarDock.svelte
@@ -26,6 +26,7 @@
   import WorktrunkPanel from "./WorktrunkPanel.svelte";
   import WatchesPane from "./WatchesPane.svelte";
   import NotificationsPane from "./NotificationsPane.svelte";
+  import MailboxPanel from "./MailboxPanel.svelte";
   import DocPanel from "./DocPanel.svelte";
   import LibraryPanel from "./LibraryPanel.svelte";
   import TaskPanel from "./TaskPanel.svelte";
@@ -124,6 +125,7 @@
     "library",
     "tasks",
     "notifications",
+    "mailbox",
     "docs",
     "smolMachines",
     "worktrunk",
@@ -271,6 +273,13 @@
             />
           {:else if id === "notifications"}
             <NotificationsPane
+              {visible}
+              onclose={onCloseFor(id)}
+              pinned={$pinnedSidebar === id}
+              onTogglePin={onTogglePinFor(id)}
+            />
+          {:else if id === "mailbox"}
+            <MailboxPanel
               {visible}
               onclose={onCloseFor(id)}
               pinned={$pinnedSidebar === id}

--- a/src/lib/stores/mailbox.ts
+++ b/src/lib/stores/mailbox.ts
@@ -19,6 +19,16 @@ import type {
 const EVENT_LIMIT = 500;
 
 /**
+ * Compound key for `unreadByAlias` and any other map that needs to
+ * disambiguate same-name aliases across project scopes. `null` projectId
+ * encodes the global scope; the empty-string sentinel keeps the key a
+ * plain string for Map use.
+ */
+export function aliasKey(alias: string, projectId: string | null): string {
+  return `${alias}|${projectId ?? ""}`;
+}
+
+/**
  * Authoritative store of recent events, newest-first. Capped at
  * `EVENT_LIMIT` so the firehose view stays bounded; the on-disk audit
  * log keeps everything regardless.
@@ -29,13 +39,18 @@ export const events = writable<MailboxEventPayload[]>([]);
 export const aliases = writable<AgentAlias[]>([]);
 
 /**
- * Per-alias unread count. Refreshed whenever a relevant `mailbox-event`
- * fires; caller can also force-refresh via `refreshUnreadCount`.
+ * Per-alias unread count, keyed by `aliasKey(alias, projectId)` so the
+ * same alias name in different project scopes doesn't collide. Refreshed
+ * whenever a relevant `mailbox-event` fires; caller can also force-refresh
+ * via `refreshUnreadCount`.
  */
 export const unreadByAlias = writable<Map<string, number>>(new Map());
 
-/** Total unread count for the human-user mailbox (`me`). */
-export const meUnread = derived(unreadByAlias, ($u) => $u.get("me") ?? 0);
+/** Total unread count for the human-user mailbox (`me`, global scope). */
+export const meUnread = derived(
+  unreadByAlias,
+  ($u) => $u.get(aliasKey("me", null)) ?? 0,
+);
 
 /** Events addressed to `recipient` (oldest first to match drain semantics). */
 export function eventsForRecipient(recipient: string) {
@@ -68,8 +83,11 @@ async function refreshAllUnreadCounts(): Promise<void> {
   await Promise.all(
     aliasList.map(async (a) => {
       try {
-        const c = await mailboxUnreadCount(a.alias);
-        counts.set(a.alias, c);
+        const c = await mailboxUnreadCount(a.alias, {
+          projectId: a.projectId ?? null,
+          global: a.projectId == null,
+        });
+        counts.set(aliasKey(a.alias, a.projectId), c);
       } catch (err) {
         console.warn(`unread count for ${a.alias} failed`, err);
       }
@@ -78,12 +96,36 @@ async function refreshAllUnreadCounts(): Promise<void> {
   unreadByAlias.set(counts);
 }
 
-export async function refreshUnreadCount(alias: string): Promise<void> {
+/**
+ * Refresh the unread count for a specific (alias, projectId) scope.
+ * When the caller doesn't know the projectId (e.g. a `Read`/`Acked`/
+ * `Cleared` Tauri event that only carries the recipient name), pass
+ * `undefined` and we'll refresh all known scopes for that alias name.
+ */
+export async function refreshUnreadCount(
+  alias: string,
+  projectId: string | null | undefined,
+): Promise<void> {
+  if (projectId === undefined) {
+    // Unknown scope — refresh every alias entry that matches this name.
+    const matching = get(aliases).filter((a) => a.alias === alias);
+    if (matching.length === 0) {
+      // No alias entry yet (e.g. mailbox event for an alias we haven't
+      // hydrated). Refresh the global scope as a best-effort default.
+      await refreshUnreadCount(alias, null);
+      return;
+    }
+    await Promise.all(matching.map((a) => refreshUnreadCount(alias, a.projectId)));
+    return;
+  }
   try {
-    const c = await mailboxUnreadCount(alias);
+    const c = await mailboxUnreadCount(alias, {
+      projectId,
+      global: projectId == null,
+    });
     unreadByAlias.update((m) => {
       const next = new Map(m);
-      next.set(alias, c);
+      next.set(aliasKey(alias, projectId), c);
       return next;
     });
   } catch (err) {
@@ -92,11 +134,21 @@ export async function refreshUnreadCount(alias: string): Promise<void> {
 }
 
 /**
+ * Bumped on every `applyMailboxEvent` call so per-recipient views can
+ * react to backend mutations (mark-read / ack / clear) by refetching
+ * their backend-driven listings. The `events` store doesn't change for
+ * read-state-only mutations, so components that need to refresh on
+ * those events subscribe to this tick instead.
+ */
+export const mailboxMutationTick = writable(0);
+
+/**
  * Apply a `MailboxEvent` to the local store. Idempotent for duplicates.
  * The store is a cache of the backend; if state diverges, callers can
  * always re-hydrate.
  */
 export function applyMailboxEvent(event: MailboxEvent): void {
+  mailboxMutationTick.update((n) => n + 1);
   switch (event.kind) {
     case "posted": {
       const e = event.event;
@@ -106,19 +158,20 @@ export function applyMailboxEvent(event: MailboxEvent): void {
         return next.length > EVENT_LIMIT ? next.slice(0, EVENT_LIMIT) : next;
       });
       // The recipient (and the human, who can see fanout into Firehose)
-      // both need their unread totals refreshed.
+      // both need their unread totals refreshed. The event carries
+      // `projectId`, so the refresh targets exactly the right scope.
       if (e.to) {
-        void refreshUnreadCount(e.to);
+        void refreshUnreadCount(e.to, e.projectId);
       }
       break;
     }
     case "read":
     case "acked":
     case "cleared": {
-      // Read-state-only mutations don't change the events array. Refresh
-      // the affected recipient's unread total — Cleared is a single
-      // recipient too. Cheap query against the in-memory store.
-      void refreshUnreadCount(event.recipient);
+      // Read-state-only mutations don't change the events array. The
+      // Tauri payload doesn't carry projectId — refresh every known
+      // scope for that recipient (fan-out is small in practice).
+      void refreshUnreadCount(event.recipient, undefined);
       break;
     }
   }
@@ -138,10 +191,15 @@ export function applyAliasEvent(event: AliasEvent): void {
       break;
     }
     case "unset": {
+      // Clear ALL binding fields (sessionId, paneId, autoClaimed) — not
+      // just sessionId. The Phase 1.5 model binds aliases to panes, so
+      // leaving paneId set would keep the @alias chip on the pane and
+      // the Deliver button enabled even after the backend unbound the
+      // alias.
       aliases.update((list) =>
         list.map((x) =>
           x.alias === event.canonical && x.projectId === event.projectId
-            ? { ...x, sessionId: null }
+            ? { ...x, sessionId: null, paneId: null, autoClaimed: false }
             : x,
         ),
       );

--- a/src/lib/stores/mailbox.ts
+++ b/src/lib/stores/mailbox.ts
@@ -1,0 +1,182 @@
+import { writable, derived, get } from "svelte/store";
+import {
+  aliasesList,
+  mailboxAck as tauriMailboxAck,
+  mailboxClearRead as tauriMailboxClearRead,
+  mailboxListAll,
+  mailboxMarkRead as tauriMailboxMarkRead,
+  mailboxPost as tauriMailboxPost,
+  mailboxUnreadCount,
+} from "$lib/tauri";
+import type {
+  AgentAlias,
+  AliasEvent,
+  MailboxEvent,
+  MailboxEventPayload,
+  MailboxPostInput,
+} from "$lib/tauri";
+
+const EVENT_LIMIT = 500;
+
+/**
+ * Authoritative store of recent events, newest-first. Capped at
+ * `EVENT_LIMIT` so the firehose view stays bounded; the on-disk audit
+ * log keeps everything regardless.
+ */
+export const events = writable<MailboxEventPayload[]>([]);
+
+/** Authoritative store of all aliases (bound + unbound). */
+export const aliases = writable<AgentAlias[]>([]);
+
+/**
+ * Per-alias unread count. Refreshed whenever a relevant `mailbox-event`
+ * fires; caller can also force-refresh via `refreshUnreadCount`.
+ */
+export const unreadByAlias = writable<Map<string, number>>(new Map());
+
+/** Total unread count for the human-user mailbox (`me`). */
+export const meUnread = derived(unreadByAlias, ($u) => $u.get("me") ?? 0);
+
+/** Events addressed to `recipient` (oldest first to match drain semantics). */
+export function eventsForRecipient(recipient: string) {
+  return derived(events, ($events) =>
+    $events
+      .filter((e) => e.to === recipient)
+      .slice()
+      .reverse(),
+  );
+}
+
+/** Hydrate the stores from the backend. Call once on app start. */
+export async function hydrateMailbox(): Promise<void> {
+  try {
+    const [evs, als] = await Promise.all([
+      mailboxListAll({ limit: EVENT_LIMIT }),
+      aliasesList({}),
+    ]);
+    events.set(evs);
+    aliases.set(als);
+    await refreshAllUnreadCounts();
+  } catch (err) {
+    console.error("Failed to hydrate mailbox", err);
+  }
+}
+
+async function refreshAllUnreadCounts(): Promise<void> {
+  const aliasList = get(aliases);
+  const counts = new Map<string, number>();
+  await Promise.all(
+    aliasList.map(async (a) => {
+      try {
+        const c = await mailboxUnreadCount(a.alias);
+        counts.set(a.alias, c);
+      } catch (err) {
+        console.warn(`unread count for ${a.alias} failed`, err);
+      }
+    }),
+  );
+  unreadByAlias.set(counts);
+}
+
+export async function refreshUnreadCount(alias: string): Promise<void> {
+  try {
+    const c = await mailboxUnreadCount(alias);
+    unreadByAlias.update((m) => {
+      const next = new Map(m);
+      next.set(alias, c);
+      return next;
+    });
+  } catch (err) {
+    console.warn(`unread count for ${alias} failed`, err);
+  }
+}
+
+/**
+ * Apply a `MailboxEvent` to the local store. Idempotent for duplicates.
+ * The store is a cache of the backend; if state diverges, callers can
+ * always re-hydrate.
+ */
+export function applyMailboxEvent(event: MailboxEvent): void {
+  switch (event.kind) {
+    case "posted": {
+      const e = event.event;
+      events.update((list) => {
+        if (list.some((x) => x.id === e.id)) return list;
+        const next = [e, ...list];
+        return next.length > EVENT_LIMIT ? next.slice(0, EVENT_LIMIT) : next;
+      });
+      // The recipient (and the human, who can see fanout into Firehose)
+      // both need their unread totals refreshed.
+      if (e.to) {
+        void refreshUnreadCount(e.to);
+      }
+      break;
+    }
+    case "read":
+    case "acked":
+    case "cleared": {
+      // Read-state-only mutations don't change the events array. Refresh
+      // the affected recipient's unread total — Cleared is a single
+      // recipient too. Cheap query against the in-memory store.
+      void refreshUnreadCount(event.recipient);
+      break;
+    }
+  }
+}
+
+/** Apply an `AliasEvent` to the alias store. */
+export function applyAliasEvent(event: AliasEvent): void {
+  switch (event.kind) {
+    case "set": {
+      const a = event.alias;
+      aliases.update((list) => {
+        const filtered = list.filter(
+          (x) => !(x.alias === a.alias && x.projectId === a.projectId),
+        );
+        return [...filtered, a];
+      });
+      break;
+    }
+    case "unset": {
+      aliases.update((list) =>
+        list.map((x) =>
+          x.alias === event.canonical && x.projectId === event.projectId
+            ? { ...x, sessionId: null }
+            : x,
+        ),
+      );
+      break;
+    }
+  }
+}
+
+// ── Mutation helpers (call the backend; the local store is updated via the
+// event channel emitted from Rust). Returning the awaited result lets
+// optimistic-UI callers settle.
+
+export async function postMailboxMessage(
+  input: MailboxPostInput,
+): Promise<MailboxEventPayload> {
+  return tauriMailboxPost(input);
+}
+
+export async function markRead(eventId: string, recipient: string): Promise<boolean> {
+  return tauriMailboxMarkRead(eventId, recipient);
+}
+
+export async function ackEvent(
+  eventId: string,
+  recipient: string,
+  result: string | null = null,
+): Promise<boolean> {
+  return tauriMailboxAck(eventId, recipient, result);
+}
+
+export async function clearReadFor(recipient: string): Promise<number> {
+  return tauriMailboxClearRead(recipient);
+}
+
+/** Synchronous snapshot for action handlers. */
+export function getEventSnapshot(id: string): MailboxEventPayload | undefined {
+  return get(events).find((e) => e.id === id);
+}

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -15,6 +15,7 @@ export type SidebarId =
   | "watches"
   | "library"
   | "notifications"
+  | "mailbox"
   | "tasks"
   | "docs"
   | "sessions"
@@ -28,6 +29,7 @@ export const PINNABLE_SIDEBARS: ReadonlySet<SidebarId> = new Set<SidebarId>([
   "library",
   "tasks",
   "notifications",
+  "mailbox",
   "smolMachines",
   "worktrunk",
 ]);

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1326,3 +1326,188 @@ export async function upsertPaneRecord(record: PaneRecordPayload): Promise<void>
 export async function removePaneRecord(id: string): Promise<void> {
   return invoke("remove_pane_record", { id });
 }
+
+// ── Mailbox + alias events ────────────────────────────────────────────────────
+//
+// Hand-rolled command wrappers because `Event.structured` is `serde_json::Value`,
+// which specta cannot render as TypeScript. Mirrors how `pane_state` is exposed.
+
+import type {
+  AgentAlias,
+  AliasEvent,
+  Event as MailboxEventPayload,
+  MailboxEvent,
+  ReadState,
+} from "./types/mailbox";
+
+export type {
+  AgentAlias,
+  AliasEvent,
+  EventKind,
+  MailboxEvent,
+  ReadState,
+} from "./types/mailbox";
+export type { Event as MailboxEventPayload } from "./types/mailbox";
+
+export function onMailboxEvent(
+  callback: (payload: MailboxEvent) => void,
+): Promise<UnlistenFn> {
+  return listen<MailboxEvent>("mailbox-event", (e) => callback(e.payload));
+}
+
+export function onAliasEvent(
+  callback: (payload: AliasEvent) => void,
+): Promise<UnlistenFn> {
+  return listen<AliasEvent>("alias-event", (e) => callback(e.payload));
+}
+
+export interface MailboxListOptions {
+  unreadOnly?: boolean;
+  projectId?: string | null;
+  global?: boolean;
+}
+
+export async function mailboxListForRecipient(
+  alias: string,
+  options: MailboxListOptions = {},
+): Promise<MailboxEventPayload[]> {
+  return invoke("mailbox_list_for_recipient", {
+    alias,
+    unreadOnly: options.unreadOnly ?? null,
+    projectId: options.projectId ?? null,
+    global: options.global ?? null,
+  });
+}
+
+export async function mailboxListForTopic(
+  topic: string,
+  options: { projectId?: string | null; global?: boolean } = {},
+): Promise<MailboxEventPayload[]> {
+  return invoke("mailbox_list_for_topic", {
+    topic,
+    projectId: options.projectId ?? null,
+    global: options.global ?? null,
+  });
+}
+
+export async function mailboxListAll(
+  options: { projectId?: string | null; global?: boolean; limit?: number } = {},
+): Promise<MailboxEventPayload[]> {
+  return invoke("mailbox_list_all", {
+    projectId: options.projectId ?? null,
+    global: options.global ?? null,
+    limit: options.limit ?? null,
+  });
+}
+
+export async function mailboxUnreadCount(
+  alias: string,
+  options: { projectId?: string | null; global?: boolean } = {},
+): Promise<number> {
+  return invoke("mailbox_unread_count", {
+    alias,
+    projectId: options.projectId ?? null,
+    global: options.global ?? null,
+  });
+}
+
+export async function mailboxGetEvent(
+  eventId: string,
+): Promise<MailboxEventPayload | null> {
+  return invoke("mailbox_get_event", { eventId });
+}
+
+export async function mailboxReadState(
+  eventId: string,
+  recipient: string,
+): Promise<ReadState | null> {
+  return invoke("mailbox_read_state", { eventId, recipient });
+}
+
+export interface MailboxPostInput {
+  to?: string | null;
+  topic?: string | null;
+  body: string;
+  subject?: string | null;
+  kind?: import("./types/mailbox").EventKind | null;
+  projectId?: string | null;
+  correlationId?: string | null;
+  structured?: unknown;
+  from?: string | null;
+}
+
+export async function mailboxPost(
+  input: MailboxPostInput,
+): Promise<MailboxEventPayload> {
+  return invoke("mailbox_post", {
+    input: {
+      to: input.to ?? null,
+      topic: input.topic ?? null,
+      body: input.body,
+      subject: input.subject ?? null,
+      kind: input.kind ?? null,
+      projectId: input.projectId ?? null,
+      correlationId: input.correlationId ?? null,
+      structured: input.structured ?? null,
+      from: input.from ?? null,
+    },
+  });
+}
+
+export async function mailboxMarkRead(
+  eventId: string,
+  recipient: string,
+): Promise<boolean> {
+  return invoke("mailbox_mark_read", { eventId, recipient });
+}
+
+export async function mailboxAck(
+  eventId: string,
+  recipient: string,
+  result: string | null = null,
+): Promise<boolean> {
+  return invoke("mailbox_ack", { eventId, recipient, result });
+}
+
+export async function mailboxClearRead(recipient: string): Promise<number> {
+  return invoke("mailbox_clear_read", { recipient });
+}
+
+/**
+ * Type a mailbox event's body into the recipient's pane (plus trailing CR
+ * so Claude/Codex see it as submitted input). Backend looks up
+ * recipient → alias → pane_id → pty_id and writes via the existing PTY
+ * write path. Auto-acks the event with a "delivered" marker.
+ *
+ * Errors when the recipient alias has no pane bound — that's the
+ * "delivery requires a live pane" rule. Use `roux mailbox post` for
+ * durable queueing without delivery.
+ */
+export async function mailboxDeliverToPane(eventId: string): Promise<void> {
+  return invoke("mailbox_deliver_to_pane", { eventId });
+}
+
+export async function aliasesList(
+  options: {
+    projectId?: string | null;
+    global?: boolean;
+    onlyUnbound?: boolean;
+  } = {},
+): Promise<AgentAlias[]> {
+  return invoke("aliases_list", {
+    projectId: options.projectId ?? null,
+    global: options.global ?? null,
+    onlyUnbound: options.onlyUnbound ?? null,
+  });
+}
+
+export async function aliasesGet(
+  alias: string,
+  projectId: string | null = null,
+): Promise<AgentAlias | null> {
+  return invoke("aliases_get", { alias, projectId });
+}
+
+export async function aliasesWhoami(sessionId: string): Promise<AgentAlias[]> {
+  return invoke("aliases_whoami", { sessionId });
+}

--- a/src/lib/types/mailbox.ts
+++ b/src/lib/types/mailbox.ts
@@ -1,0 +1,72 @@
+/**
+ * Frontend types mirroring `roux_core::event` and `roux_core::alias`.
+ *
+ * Hand-written rather than generated via specta because `Event.structured`
+ * is `serde_json::Value`, which specta can't render as valid TypeScript
+ * (same constraint as `pane_state` commands). Keep the field names
+ * `serde(rename_all = "camelCase")` matches what Rust emits.
+ */
+
+export type EventKind = "task" | "result" | "question" | "fyi" | "signal";
+
+export interface Event {
+  id: string;
+  createdAt: number;
+  to: string | null;
+  topic: string | null;
+  from: string | null;
+  kind: EventKind;
+  correlationId: string | null;
+  projectId: string | null;
+  subject: string | null;
+  body: string;
+  /** Free-form structured payload. May be any JSON value. */
+  structured: unknown | null;
+}
+
+export interface ReadState {
+  eventId: string;
+  recipient: string;
+  readAt: number | null;
+  ackedAt: number | null;
+  ackResult: string | null;
+}
+
+export interface AgentAlias {
+  alias: string;
+  /** Cached parent session id (Phase 1 / legacy session-only bindings). */
+  sessionId: string | null;
+  /** Phase-1.5 canonical addressable target. When null, the alias falls
+   *  back to the session's primary pane at delivery time. */
+  paneId: string | null;
+  projectId: string | null;
+  /** True when the alias was auto-derived from the pane's name (vs an
+   *  explicit `roux alias claim`). UI surfaces this with a lighter
+   *  outline on the badge so the user can tell it's automatic. */
+  autoClaimed: boolean;
+  createdAt: number;
+  updatedAt: number;
+}
+
+/**
+ * Frontend mirror of `roux_core::MailboxEvent`. Tagged with `kind` matching
+ * the Rust `#[serde(tag = "kind")]` annotation. Emitted on the
+ * `mailbox-event` Tauri event channel for every store mutation.
+ */
+export type MailboxEvent =
+  | { kind: "posted"; event: Event }
+  | { kind: "read"; eventId: string; recipient: string }
+  | {
+      kind: "acked";
+      eventId: string;
+      recipient: string;
+      result: string | null;
+    }
+  | { kind: "cleared"; recipient: string; count: number };
+
+/**
+ * Frontend mirror of `roux_core::AliasEvent`. Tagged with `kind`.
+ */
+export type AliasEvent =
+  | { kind: "set"; alias: AgentAlias }
+  | { kind: "unset"; canonical: string; projectId: string | null };


### PR DESCRIPTION
## Summary

A categorical event store with two usage patterns: per-recipient **mailboxes** (`to=<alias>` with read/ack state) and topic-based **bus** broadcasts. Aliases bind to **panes** and survive session restart; **auto-claim from pane name** removes the manual-claim friction — rename a pane to `reviewer` and mail addressed to `reviewer` lands there.

Motivation: today's `roux send` is a dumb pipe that types into a target session's PTY mid-task. The mailbox keeps the same intent but adds durable queueing, per-recipient ack/read state, alias addressing that survives restart, and a backend the UI / CLI / MCP all share.

## What's in this change

**Backend (Rust)**
- `roux-core`: `AgentAlias`, `Event`, `ReadState`, `EventKind`, `MailboxEvent`, `AliasEvent` models.
- `aliases/` module: store + manager with auto-claim helpers and `unbind_for_pane`. Versioned `aliases.json` persistence.
- `mailbox/` module: append-only NDJSON event log (`events.jsonl`, `schemaVersion: 1`) plus versioned `read_state.json`.
- Socket: `alias-*`, `mailbox-*`, `bus-*` commands.
- Tauri: `mailbox_deliver_to_pane` for the UI Deliver button + the rest.
- MCP tools (`roux_mailbox_*`, `roux_alias_*`, `roux_bus_*`).
- `commands::panes` auto-claims from pane name on upsert; releases on close.
- `pty.rs` injects `ROUX_AGENT_ALIAS` at PTY spawn time.

**Frontend (Svelte 5)**
- `MailboxPanel.svelte` — Inbox + Firehose views, alias autocomplete, mark-read/ack/deliver per event, compose form.
- Pane title bar `@<alias>` chip with unread badge (outline = auto-claimed, filled = manual).
- Activity rail entry with `me`-mailbox badge.
- Reactive store wired to `mailbox-event` / `alias-event` Tauri events.

**MCP integrations** (Settings → Integrations)
- "Add to Claude Code" (`~/.claude.json` `mcpServers`).
- "Add to Claude Desktop" (was already there).
- "Add to Codex" (`~/.codex/config.toml` `[mcp_servers.roux]`).
- Per-host preview/configure + status badges.

**Skill** (`SKILL.md` v4)
- Teaches Claude about aliases, mailbox, bus.
- Disambiguates "mail" / "inbox" → Roux mailbox (NOT Gmail) inside `\$ROUX_SESSION=1`.

**Docs**: new `docs/features/mailbox.md`, linked from index and mkdocs.

## Test plan

- [ ] \`cargo test -p roux-core --lib\` (162 passing, ~26 new model tests)
- [ ] \`cargo test -p roux --lib\` (94 passing, ~50 new alias/mailbox tests)
- [ ] \`npm run test --\` (999 passing)
- [ ] \`npm run check\` (0 errors)
- [ ] \`task dev\` end-to-end:
  - [ ] Mailbox icon in activity rail
  - [ ] Rename pane to \`reviewer\` → \`@reviewer\` chip appears
  - [ ] \`roux mailbox post --to reviewer "hello"\` → lands in inbox
  - [ ] Deliver button types message into recipient pane
  - [ ] Settings → MCP: "Add to Claude Code" / "Add to Codex" write right config
  - [ ] After Roux restart in a Claude Code pane: "check if we have any new mail" → uses Roux mailbox, not Gmail

## Persistence

- \`aliases.json\` — versioned envelope, full rewrite
- \`events.jsonl\` — append-only NDJSON, audit log
- \`read_state.json\` — versioned envelope, full rewrite on read/ack/clear

All under \`roux_config_dir()\`. Future-version rows pass through on load.

## Known follow-ups

- Persistent bus subscriptions / glob topic patterns
- Group aliases / competing-consumer mode
- Long-lived \`mailbox-watch\` for push notification
- Project-scoping auto-claims (currently global)
- Pane → session → project lookup for richer auto-claim metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mailbox: addressed messaging with per-recipient read/ack state, topic broadcasts, persistence, event stream, delivery-to-pane, CLI/MCP/frontend commands and typed APIs
  * Agent aliases: stable alias routing to panes with auto-claim, project scoping, whoami/claim/list/get/unset, validation/canonicalization, and UI events/badges
  * Expanded MCP host support and PTY env exposure for bound alias

* **Documentation**
  * Added Mailbox & Bus docs and updated skill guidance and examples
<!-- end of auto-generated comment: release notes by coderabbit.ai -->