### PR TITLE
feat(mailbox): project-scope auto-claimed pane aliases

### DIFF
--- a/docs/features/mailbox.md
+++ b/docs/features/mailbox.md
@@ -316,9 +316,12 @@ holds the alias. Either rename the conflicting pane (auto-release), use
 `roux alias claim reviewer --steal` to take it over, or pick a different
 name.
 
-**My pane name auto-claimed but other pane has the same name**: only the
-first auto-claim wins; the second pane keeps its name but no alias.
-Manually `roux alias claim <some-other-name>` for the second pane.
+**My pane name auto-claimed but other pane has the same name**: auto-claims
+are scoped per project, so `reviewer` in project A and `reviewer` in
+project B coexist. Within the same project (or both panes outside any
+project) only the first auto-claim wins; the second pane keeps its name
+but no alias — manually `roux alias claim <some-other-name>` for the
+second pane.
 
 **Mail isn't arriving even though I posted**: check `roux alias list` to
 confirm the recipient alias exists and has a `paneId` set. Posts to

--- a/src-tauri/src/commands/panes.rs
+++ b/src-tauri/src/commands/panes.rs
@@ -1,25 +1,23 @@
-use crate::pane_service::{PaneHandle, PaneRecord};
+use crate::pane_service::PaneRecord;
 use crate::session_service::SessionHandle;
 use crate::state::AppState;
 
-/// Resolve the project scope for a pane by walking pane → pty → session →
-/// project_id. Returns `None` (the global scope) when any link is missing —
-/// e.g. the PTY hasn't registered yet or the session has no project. This
-/// is best-effort: a later upsert (rename, replacePty) re-resolves with
-/// whatever state exists at that moment.
+/// Resolve the project scope of the PTY at `pty_id` by walking pty →
+/// session → project_id. Returns `None` (the global scope) when any
+/// link is missing — e.g. the PTY hasn't registered yet or its session
+/// has no project. This is best-effort: a later upsert (rename,
+/// replacePty) re-resolves with whatever state exists at that moment.
 ///
-/// `pty_session_lookup` maps a pty_id → its session_id. In production the
-/// caller passes a closure over `PtyManager::get_info_direct`; tests pass
-/// a closure backed by a simple map so they don't need a live PTY manager.
-async fn pane_project_scope(
-    pane_handle: &PaneHandle,
+/// `pty_session_lookup` maps a pty_id → its session_id. In production
+/// the caller passes a closure over `PtyManager::get_info_direct`;
+/// tests pass a closure backed by a simple map so they don't need a
+/// live PTY manager.
+async fn pty_project_scope(
     session_handle: &SessionHandle,
     pty_session_lookup: impl Fn(&str) -> Option<String>,
-    pane_id: &str,
+    pty_id: &str,
 ) -> Option<String> {
-    let records = pane_handle.list_by_ids(vec![pane_id.to_string()]).await.ok()?;
-    let record = records.into_iter().next()?;
-    let session_id = pty_session_lookup(&record.pty_id)?;
+    let session_id = pty_session_lookup(pty_id)?;
     let session = session_handle.get(&session_id).await.ok().flatten()?;
     session.project_id
 }
@@ -32,6 +30,10 @@ pub(crate) async fn upsert_pane_record(
 ) -> Result<(), String> {
     let pane_id = record.id.clone();
     let pane_name = record.name.clone();
+    // Capture pty_id BEFORE the upsert moves the record so the resolver
+    // doesn't need a second round-trip through the pane service to
+    // recover what we already had.
+    let pty_id = record.pty_id.clone();
     state.pane_handle.upsert(record).await.map_err(|e| e.to_string())?;
 
     // Try to auto-claim an alias from the pane's name. No-op if the
@@ -45,11 +47,10 @@ pub(crate) async fn upsert_pane_record(
     // upsert (rename, replacePty) re-runs the resolver and corrects the
     // scope.
     let pty_manager = state.pty_manager.clone();
-    let project_id = pane_project_scope(
-        &state.pane_handle,
+    let project_id = pty_project_scope(
         &state.session_handle,
-        move |pty_id| pty_manager.get_info_direct(pty_id).and_then(|info| info.session_id),
-        &pane_id,
+        move |pty| pty_manager.get_info_direct(pty).and_then(|info| info.session_id),
+        &pty_id,
     )
     .await;
 
@@ -80,28 +81,8 @@ pub(crate) async fn remove_pane_record(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::pane_service;
     use crate::session_service;
     use roux_core::Session;
-
-    fn pane_record(id: &str, pty_id: &str) -> PaneRecord {
-        PaneRecord {
-            id: id.into(),
-            pane_type: "shell".into(),
-            pty_id: pty_id.into(),
-            name: None,
-            working_dir: None,
-            command: None,
-            doc_path: None,
-            spawn_profile_ref: None,
-            provider: None,
-            provider_session_id: None,
-            nono_profile: None,
-            nono_allow_dirs: None,
-            notes_scope: None,
-            notes_view_mode: None,
-        }
-    }
 
     fn session_with_project(id: &str, project_id: Option<&str>) -> Session {
         Session {
@@ -139,88 +120,57 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn pane_project_scope_resolves_via_pty_to_session_project() {
-        let (panes, _pjoin) = pane_service::spawn();
+    async fn pty_project_scope_resolves_via_pty_to_session_project() {
         let dir = tempfile::tempdir().unwrap();
         let (sessions, _sjoin) = session_service::spawn_with_path(
             vec![session_with_project("sess-1", Some("proj-A"))],
             dir.path().join("sessions.json"),
         );
-        panes.upsert(pane_record("pane-1", "pty-X")).await.unwrap();
 
-        let project = pane_project_scope(
-            &panes,
-            &sessions,
-            pty_lookup(&[("pty-X", "sess-1")]),
-            "pane-1",
-        )
-        .await;
+        let project =
+            pty_project_scope(&sessions, pty_lookup(&[("pty-X", "sess-1")]), "pty-X").await;
         assert_eq!(project.as_deref(), Some("proj-A"));
     }
 
     #[tokio::test]
-    async fn pane_project_scope_returns_none_when_session_has_no_project() {
-        let (panes, _pjoin) = pane_service::spawn();
+    async fn pty_project_scope_returns_none_when_session_has_no_project() {
         let dir = tempfile::tempdir().unwrap();
         let (sessions, _sjoin) = session_service::spawn_with_path(
             vec![session_with_project("sess-1", None)],
             dir.path().join("sessions.json"),
         );
-        panes.upsert(pane_record("pane-1", "pty-X")).await.unwrap();
 
-        let project = pane_project_scope(
-            &panes,
-            &sessions,
-            pty_lookup(&[("pty-X", "sess-1")]),
-            "pane-1",
-        )
-        .await;
+        let project =
+            pty_project_scope(&sessions, pty_lookup(&[("pty-X", "sess-1")]), "pty-X").await;
         assert!(project.is_none());
     }
 
     #[tokio::test]
-    async fn pane_project_scope_returns_none_when_pty_lookup_fails() {
+    async fn pty_project_scope_returns_none_when_pty_lookup_fails() {
         // PTY hasn't registered yet at the moment upsert fires. Resolver
         // gracefully returns None; auto-claim lands in the global scope
         // and a later upsert can re-resolve.
-        let (panes, _pjoin) = pane_service::spawn();
-        let dir = tempfile::tempdir().unwrap();
-        let (sessions, _sjoin) =
-            session_service::spawn_with_path(vec![], dir.path().join("sessions.json"));
-        panes.upsert(pane_record("pane-1", "pty-missing")).await.unwrap();
-
-        let project = pane_project_scope(&panes, &sessions, pty_lookup(&[]), "pane-1").await;
-        assert!(project.is_none());
-    }
-
-    #[tokio::test]
-    async fn pane_project_scope_returns_none_when_pane_not_found() {
-        let (panes, _pjoin) = pane_service::spawn();
         let dir = tempfile::tempdir().unwrap();
         let (sessions, _sjoin) =
             session_service::spawn_with_path(vec![], dir.path().join("sessions.json"));
 
-        let project =
-            pane_project_scope(&panes, &sessions, pty_lookup(&[]), "ghost-pane").await;
+        let project = pty_project_scope(&sessions, pty_lookup(&[]), "pty-missing").await;
         assert!(project.is_none());
     }
 
     #[tokio::test]
-    async fn pane_project_scope_returns_none_when_session_missing() {
+    async fn pty_project_scope_returns_none_when_session_missing() {
         // PTY says session-X but session-X isn't in the session store.
         // Could happen during a tear-down race. Resolver returns None
         // rather than panicking.
-        let (panes, _pjoin) = pane_service::spawn();
         let dir = tempfile::tempdir().unwrap();
         let (sessions, _sjoin) =
             session_service::spawn_with_path(vec![], dir.path().join("sessions.json"));
-        panes.upsert(pane_record("pane-1", "pty-X")).await.unwrap();
 
-        let project = pane_project_scope(
-            &panes,
+        let project = pty_project_scope(
             &sessions,
             pty_lookup(&[("pty-X", "missing-sess")]),
-            "pane-1",
+            "pty-X",
         )
         .await;
         assert!(project.is_none());
@@ -234,7 +184,6 @@ mod tests {
     async fn cross_project_auto_claim_does_not_collide() {
         use roux_lib::aliases::AliasManager;
 
-        let (panes, _pjoin) = pane_service::spawn();
         let dir = tempfile::tempdir().unwrap();
         let (sessions, _sjoin) = session_service::spawn_with_path(
             vec![
@@ -244,16 +193,9 @@ mod tests {
             dir.path().join("sessions.json"),
         );
 
-        let mut pane_a = pane_record("pane-A", "pty-A");
-        pane_a.name = Some("reviewer".into());
-        let mut pane_b = pane_record("pane-B", "pty-B");
-        pane_b.name = Some("reviewer".into());
-        panes.upsert(pane_a).await.unwrap();
-        panes.upsert(pane_b).await.unwrap();
-
         let lookup = pty_lookup(&[("pty-A", "sess-A"), ("pty-B", "sess-B")]);
-        let project_a = pane_project_scope(&panes, &sessions, &lookup, "pane-A").await;
-        let project_b = pane_project_scope(&panes, &sessions, &lookup, "pane-B").await;
+        let project_a = pty_project_scope(&sessions, &lookup, "pty-A").await;
+        let project_b = pty_project_scope(&sessions, &lookup, "pty-B").await;
         assert_eq!(project_a.as_deref(), Some("proj-A"));
         assert_eq!(project_b.as_deref(), Some("proj-B"));
 

--- a/src-tauri/src/commands/panes.rs
+++ b/src-tauri/src/commands/panes.rs
@@ -1,5 +1,28 @@
-use crate::pane_service::PaneRecord;
+use crate::pane_service::{PaneHandle, PaneRecord};
+use crate::session_service::SessionHandle;
 use crate::state::AppState;
+
+/// Resolve the project scope for a pane by walking pane → pty → session →
+/// project_id. Returns `None` (the global scope) when any link is missing —
+/// e.g. the PTY hasn't registered yet or the session has no project. This
+/// is best-effort: a later upsert (rename, replacePty) re-resolves with
+/// whatever state exists at that moment.
+///
+/// `pty_session_lookup` maps a pty_id → its session_id. In production the
+/// caller passes a closure over `PtyManager::get_info_direct`; tests pass
+/// a closure backed by a simple map so they don't need a live PTY manager.
+async fn pane_project_scope(
+    pane_handle: &PaneHandle,
+    session_handle: &SessionHandle,
+    pty_session_lookup: impl Fn(&str) -> Option<String>,
+    pane_id: &str,
+) -> Option<String> {
+    let records = pane_handle.list_by_ids(vec![pane_id.to_string()]).await.ok()?;
+    let record = records.into_iter().next()?;
+    let session_id = pty_session_lookup(&record.pty_id)?;
+    let session = session_handle.get(&session_id).await.ok().flatten()?;
+    session.project_id
+}
 
 #[tauri::command]
 pub(crate) async fn upsert_pane_record(
@@ -14,12 +37,26 @@ pub(crate) async fn upsert_pane_record(
     // Try to auto-claim an alias from the pane's name. No-op if the
     // name doesn't match the alias format (capitals, spaces, reserved)
     // or if the canonical alias is already held by another pane.
-    // Project scope is `None` for the MVP — pane→session→project lookup
-    // is a follow-up.
+    //
+    // Resolve the pane's project scope from the live PTY/session graph
+    // so two panes named "reviewer" in different projects can both
+    // auto-claim. Falls back to the global scope when the lookup chain
+    // breaks (e.g. PTY isn't registered yet at first upsert) — a later
+    // upsert (rename, replacePty) re-runs the resolver and corrects the
+    // scope.
+    let pty_manager = state.pty_manager.clone();
+    let project_id = pane_project_scope(
+        &state.pane_handle,
+        &state.session_handle,
+        move |pty_id| pty_manager.get_info_direct(pty_id).and_then(|info| info.session_id),
+        &pane_id,
+    )
+    .await;
+
     state.alias_manager.try_auto_claim_from_pane_name(
         &pane_id,
         pane_name.as_deref(),
-        None,
+        project_id,
         Some(&app),
     );
     Ok(())
@@ -38,4 +75,271 @@ pub(crate) async fn remove_pane_record(
     // for the next session that claims them.
     state.alias_manager.unbind_for_pane(&id, true, Some(&app));
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pane_service;
+    use crate::session_service;
+    use roux_core::Session;
+
+    fn pane_record(id: &str, pty_id: &str) -> PaneRecord {
+        PaneRecord {
+            id: id.into(),
+            pane_type: "shell".into(),
+            pty_id: pty_id.into(),
+            name: None,
+            working_dir: None,
+            command: None,
+            doc_path: None,
+            spawn_profile_ref: None,
+            provider: None,
+            provider_session_id: None,
+            nono_profile: None,
+            nono_allow_dirs: None,
+            notes_scope: None,
+            notes_view_mode: None,
+        }
+    }
+
+    fn session_with_project(id: &str, project_id: Option<&str>) -> Session {
+        Session {
+            id: id.into(),
+            name: format!("Session {id}"),
+            repo_root: "/tmp/repo".into(),
+            worktree_path: "/tmp/repo".into(),
+            branch: "main".into(),
+            is_worktree: false,
+            status: roux_core::SessionStatus::Idle,
+            model: None,
+            cost: None,
+            created_at: 0,
+            project_id: project_id.map(str::to_string),
+            is_git_repo: false,
+            name_override: None,
+            primary_pty_id: None,
+            archived: false,
+            ended_at: None,
+            blueprint_id: None,
+            pinned_pr_url: None,
+            smol_machine_name: None,
+        }
+    }
+
+    /// Helper: build a closure over a static pty→session table so the
+    /// tests don't need a live PtyManager.
+    fn pty_lookup(table: &'static [(&'static str, &'static str)]) -> impl Fn(&str) -> Option<String> {
+        move |pty_id| {
+            table
+                .iter()
+                .find(|(p, _)| *p == pty_id)
+                .map(|(_, s)| s.to_string())
+        }
+    }
+
+    #[tokio::test]
+    async fn pane_project_scope_resolves_via_pty_to_session_project() {
+        let (panes, _pjoin) = pane_service::spawn();
+        let dir = tempfile::tempdir().unwrap();
+        let (sessions, _sjoin) = session_service::spawn_with_path(
+            vec![session_with_project("sess-1", Some("proj-A"))],
+            dir.path().join("sessions.json"),
+        );
+        panes.upsert(pane_record("pane-1", "pty-X")).await.unwrap();
+
+        let project = pane_project_scope(
+            &panes,
+            &sessions,
+            pty_lookup(&[("pty-X", "sess-1")]),
+            "pane-1",
+        )
+        .await;
+        assert_eq!(project.as_deref(), Some("proj-A"));
+    }
+
+    #[tokio::test]
+    async fn pane_project_scope_returns_none_when_session_has_no_project() {
+        let (panes, _pjoin) = pane_service::spawn();
+        let dir = tempfile::tempdir().unwrap();
+        let (sessions, _sjoin) = session_service::spawn_with_path(
+            vec![session_with_project("sess-1", None)],
+            dir.path().join("sessions.json"),
+        );
+        panes.upsert(pane_record("pane-1", "pty-X")).await.unwrap();
+
+        let project = pane_project_scope(
+            &panes,
+            &sessions,
+            pty_lookup(&[("pty-X", "sess-1")]),
+            "pane-1",
+        )
+        .await;
+        assert!(project.is_none());
+    }
+
+    #[tokio::test]
+    async fn pane_project_scope_returns_none_when_pty_lookup_fails() {
+        // PTY hasn't registered yet at the moment upsert fires. Resolver
+        // gracefully returns None; auto-claim lands in the global scope
+        // and a later upsert can re-resolve.
+        let (panes, _pjoin) = pane_service::spawn();
+        let dir = tempfile::tempdir().unwrap();
+        let (sessions, _sjoin) =
+            session_service::spawn_with_path(vec![], dir.path().join("sessions.json"));
+        panes.upsert(pane_record("pane-1", "pty-missing")).await.unwrap();
+
+        let project = pane_project_scope(&panes, &sessions, pty_lookup(&[]), "pane-1").await;
+        assert!(project.is_none());
+    }
+
+    #[tokio::test]
+    async fn pane_project_scope_returns_none_when_pane_not_found() {
+        let (panes, _pjoin) = pane_service::spawn();
+        let dir = tempfile::tempdir().unwrap();
+        let (sessions, _sjoin) =
+            session_service::spawn_with_path(vec![], dir.path().join("sessions.json"));
+
+        let project =
+            pane_project_scope(&panes, &sessions, pty_lookup(&[]), "ghost-pane").await;
+        assert!(project.is_none());
+    }
+
+    #[tokio::test]
+    async fn pane_project_scope_returns_none_when_session_missing() {
+        // PTY says session-X but session-X isn't in the session store.
+        // Could happen during a tear-down race. Resolver returns None
+        // rather than panicking.
+        let (panes, _pjoin) = pane_service::spawn();
+        let dir = tempfile::tempdir().unwrap();
+        let (sessions, _sjoin) =
+            session_service::spawn_with_path(vec![], dir.path().join("sessions.json"));
+        panes.upsert(pane_record("pane-1", "pty-X")).await.unwrap();
+
+        let project = pane_project_scope(
+            &panes,
+            &sessions,
+            pty_lookup(&[("pty-X", "missing-sess")]),
+            "pane-1",
+        )
+        .await;
+        assert!(project.is_none());
+    }
+
+    /// Cross-project auto-claim integration: two panes named `reviewer`,
+    /// each in a different project, both succeed. Pre-fix, the second
+    /// would silently fail to claim because the first held the alias
+    /// in the global scope.
+    #[tokio::test]
+    async fn cross_project_auto_claim_does_not_collide() {
+        use roux_lib::aliases::AliasManager;
+
+        let (panes, _pjoin) = pane_service::spawn();
+        let dir = tempfile::tempdir().unwrap();
+        let (sessions, _sjoin) = session_service::spawn_with_path(
+            vec![
+                session_with_project("sess-A", Some("proj-A")),
+                session_with_project("sess-B", Some("proj-B")),
+            ],
+            dir.path().join("sessions.json"),
+        );
+
+        let mut pane_a = pane_record("pane-A", "pty-A");
+        pane_a.name = Some("reviewer".into());
+        let mut pane_b = pane_record("pane-B", "pty-B");
+        pane_b.name = Some("reviewer".into());
+        panes.upsert(pane_a).await.unwrap();
+        panes.upsert(pane_b).await.unwrap();
+
+        let lookup = pty_lookup(&[("pty-A", "sess-A"), ("pty-B", "sess-B")]);
+        let project_a = pane_project_scope(&panes, &sessions, &lookup, "pane-A").await;
+        let project_b = pane_project_scope(&panes, &sessions, &lookup, "pane-B").await;
+        assert_eq!(project_a.as_deref(), Some("proj-A"));
+        assert_eq!(project_b.as_deref(), Some("proj-B"));
+
+        let alias_dir = tempfile::tempdir().unwrap();
+        let alias_mgr = AliasManager::load_from(alias_dir.path().join("aliases.json"));
+        let claim_a = alias_mgr
+            .try_auto_claim_from_pane_name("pane-A", Some("reviewer"), project_a, None)
+            .expect("pane-A should claim");
+        let claim_b = alias_mgr
+            .try_auto_claim_from_pane_name("pane-B", Some("reviewer"), project_b, None)
+            .expect("pane-B should also claim — different project scope");
+
+        assert_eq!(claim_a.project_id.as_deref(), Some("proj-A"));
+        assert_eq!(claim_a.pane_id.as_deref(), Some("pane-A"));
+        assert_eq!(claim_b.project_id.as_deref(), Some("proj-B"));
+        assert_eq!(claim_b.pane_id.as_deref(), Some("pane-B"));
+    }
+
+    /// Late-binding transition: the first upsert fires before the PTY
+    /// is registered (so the resolver returns `None` and auto-claim lands
+    /// in the global scope). A subsequent upsert (e.g. on rename or
+    /// replacePty) finds the now-registered PTY and re-resolves to the
+    /// project scope. The old global-scope binding for this pane must be
+    /// released so we don't leave a stale entry behind.
+    #[tokio::test]
+    async fn auto_claim_transitions_from_global_to_project_scope() {
+        use roux_lib::aliases::AliasManager;
+
+        let alias_dir = tempfile::tempdir().unwrap();
+        let alias_mgr = AliasManager::load_from(alias_dir.path().join("aliases.json"));
+
+        // First call: PTY not registered yet, project resolves to None.
+        alias_mgr
+            .try_auto_claim_from_pane_name("pane-A", Some("reviewer"), None, None)
+            .expect("first claim succeeds in global scope");
+        assert_eq!(
+            alias_mgr.get("reviewer", None).and_then(|a| a.pane_id),
+            Some("pane-A".to_string()),
+        );
+
+        // Second call: PTY now registered, project resolves to proj-A.
+        alias_mgr
+            .try_auto_claim_from_pane_name(
+                "pane-A",
+                Some("reviewer"),
+                Some("proj-A".into()),
+                None,
+            )
+            .expect("re-claim under project scope succeeds");
+
+        // The new project-scoped binding is held by pane-A.
+        assert_eq!(
+            alias_mgr.get("reviewer", Some("proj-A")).and_then(|a| a.pane_id),
+            Some("pane-A".to_string()),
+        );
+        // The old global-scope entry was released (pane_id cleared) so
+        // it doesn't shadow the project-scoped one.
+        assert!(
+            alias_mgr.get("reviewer", None).and_then(|a| a.pane_id).is_none(),
+            "old global-scope binding must be released",
+        );
+    }
+
+    /// Same-project collision still respects the original "first wins"
+    /// rule. The fix scopes by project — it doesn't loosen the conflict
+    /// model within a scope.
+    #[tokio::test]
+    async fn same_project_auto_claim_still_collides() {
+        use roux_lib::aliases::AliasManager;
+
+        let alias_dir = tempfile::tempdir().unwrap();
+        let alias_mgr = AliasManager::load_from(alias_dir.path().join("aliases.json"));
+        alias_mgr
+            .try_auto_claim_from_pane_name(
+                "pane-A",
+                Some("reviewer"),
+                Some("proj-A".into()),
+                None,
+            )
+            .expect("pane-A claims first");
+        let second = alias_mgr.try_auto_claim_from_pane_name(
+            "pane-B",
+            Some("reviewer"),
+            Some("proj-A".into()),
+            None,
+        );
+        assert!(second.is_none(), "second pane in same project must not steal");
+    }
 }


### PR DESCRIPTION
## Summary
- Auto-claimed aliases now resolve their project scope via pane → pty → session → project_id at upsert time, so the same pane name in two different projects no longer collides on a single global binding.
- Falls back to the global scope (legacy behavior) when the lookup chain is incomplete — e.g. PTY hasn't registered yet at the moment of first upsert. A subsequent upsert (rename, replacePty) re-resolves and migrates the binding cleanly.
- Closes the **project-scoping for auto-claims** item from #161.

## Stack
This PR is **the base of #163 → #164**. Review and merge this one first; downstream PRs auto-rebase onto \`main\` as their bases land.

Review order: **#162 → #163 → #164**.

## Test plan
- [x] \`cargo test --bin roux commands::panes\` — 8 new tests pass (resolver edge cases + cross-project / same-project / late-binding integration)
- [x] \`cargo test --bin roux\` — full suite, no regressions
- [x] \`cargo clippy --bin roux --tests\` — clean
- [ ] Manual: create two projects with a pane named \`reviewer\` in each, confirm both auto-claim @reviewer chips show up

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Alias auto-claims are now scoped per project, allowing the same alias name to coexist across different projects. Within a project, the first auto-claim takes effect; subsequent panes require manual alias assignment.

* **Documentation**
  * Updated mailbox troubleshooting guide to clarify alias auto-claim behavior when multiple panes share identical names.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phin-tech/roux/pull/162)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Introduces `pty_project_scope` to walk the `pty → session → project_id` chain at upsert time, so same-named panes in different projects each get their own scoped auto-claimed alias. Gracefully falls back to the global scope and re-resolves on subsequent upserts (rename, `replacePty`).
- `pty_id` is now captured from the record before the `upsert` move, eliminating a previously possible second round-trip through the pane service.
- Eight new tests cover the resolver's edge cases (missing PTY, missing session, no project), cross-project non-collision, the global→project scope migration path, and the within-project first-wins invariant.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the resolution logic is sound, all fallback paths return `None` gracefully, and the migration from global to project scope is correctly handled by the cross-scope `unbind_for_pane` before re-bind.

Thoroughly traced all scope-migration edge cases (global→project, project→global, dual-race, empty pty_id sentinel, idempotent re-upsert). No P0 or P1 issues found. The two previously flagged code-quality items (`'static` bound on test lookup, redundant round-trip) are already in prior review threads; the round-trip issue is in fact fixed by this PR's `pty_id` pre-capture.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src-tauri/src/commands/panes.rs | Adds `pty_project_scope` async helper and integrates it into `upsert_pane_record` to resolve project-scoped alias claims; captures `pty_id` before the move to avoid a second round-trip; adds 8 well-structured unit/integration tests covering resolver edge cases and the late-binding migration scenario. |
| docs/features/mailbox.md | Troubleshooting entry updated to reflect per-project auto-claim scoping; accurately describes the new behavior where same-named panes in different projects coexist. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant FE as Frontend
    participant CMD as upsert_pane_record
    participant PTY as PtyManager
    participant SES as SessionHandle
    participant ALI as AliasManager

    FE->>CMD: upsert_pane_record(record)
    CMD->>CMD: "capture pty_id = record.pty_id.clone()"
    CMD->>CMD: pane_handle.upsert(record)
    CMD->>PTY: get_info_direct(pty_id)
    alt PTY registered
        PTY-->>CMD: Some(info) → session_id
        CMD->>SES: get(session_id)
        alt "Session found & has project"
            SES-->>CMD: Some(session) → project_id
        else Session missing or no project
            SES-->>CMD: "None → project_id = None (global)"
        end
    else PTY not yet registered
        PTY-->>CMD: "None → project_id = None (global)"
    end
    CMD->>ALI: try_auto_claim_from_pane_name(pane_id, name, project_id)
    alt First upsert (no PTY)
        ALI-->>CMD: global scope claim (reviewer, None)
    else Later upsert (PTY registered)
        ALI->>ALI: unbind_for_pane (release prior scope)
        ALI->>ALI: bind under project scope
        ALI-->>CMD: project-scoped claim (reviewer, proj-A)
    end
```

<sub>Reviews (4): Last reviewed commit: ["fix: address PR #162 review findings"](https://github.com/phin-tech/roux/commit/47ada6dd7edb181f4dad829599fa034277d42f2c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31437477)</sub>

<!-- /greptile_comment -->