### PR TITLE
feat(mailbox): mailbox-watch — push delivery via long-lived socket stream

### DIFF
--- a/docs/features/mailbox.md
+++ b/docs/features/mailbox.md
@@ -104,10 +104,20 @@ to-agent `fyi` traffic shows in the Firehose tab only.
 roux mailbox count                    # how many unread? (JSON)
 roux mailbox peek --unread            # see them without consuming
 roux mailbox read --ack               # drain + mark processed (recommended)
+roux mailbox watch --ack              # follow new mail in real time (long-lived)
 ```
 
 `read` returns each event as JSON. `--ack` also flips `acked_at` on each so
 the sender's `mailbox sent` view shows the work was processed.
+
+`watch` opens a long-lived socket connection and prints each new event as
+a JSON line as it arrives — no polling. Initial unread mail is replayed
+first (pass `--no-backlog` to skip), then the stream stays open until
+you disconnect (Ctrl+C). With `--ack`, every delivered event is marked
+read+acked with a `"watched"` result so the sender sees you saw it.
+Subscribed-topic events (see [Subscriptions](#subscriptions)) flow
+through the same stream. CLI-only for now — the in-app Mailbox panel
+already gets push delivery through Tauri events.
 
 ### Acking with results
 

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -234,6 +234,23 @@ enum MailboxAction {
         #[arg(short = 'l', long)]
         limit: Option<u32>,
     },
+    /// Stream new mail as it arrives (push, no polling). Prints each
+    /// event as a JSON line; exits on Ctrl+C or socket close.
+    Watch {
+        /// Recipient alias (default: calling session's primary alias)
+        #[arg(short = 'a', long)]
+        alias: Option<String>,
+        /// Also ack each delivered event with a "watched" marker
+        #[arg(long)]
+        ack: bool,
+        /// Skip the initial unread backlog and only stream future events
+        #[arg(long)]
+        no_backlog: bool,
+        #[arg(short = 'p', long)]
+        project: Option<String>,
+        #[arg(long, conflicts_with = "project")]
+        global: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -723,6 +740,58 @@ fn run_socket_command(request: Value) {
     }
 }
 
+/// Stream a long-lived command and print each event-bearing frame as a
+/// JSON line to stdout. `ready`/`warning`/`error` frames are surfaced
+/// on stderr so a downstream `jq` pipeline only sees event payloads.
+fn run_streaming_command(request: Value) {
+    use crate::cli_socket::stream_socket_command;
+    let exit_code = std::sync::Arc::new(std::sync::atomic::AtomicI32::new(0));
+    let exit_clone = exit_code.clone();
+
+    let result = stream_socket_command(request, move |line| {
+        let value: Value = match serde_json::from_str(line) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("watch: invalid frame from server: {e}");
+                return true; // keep going; one bad line shouldn't kill the watch
+            }
+        };
+        match value.get("type").and_then(|t| t.as_str()) {
+            Some("event") => {
+                if let Some(event) = value.get("event") {
+                    println!("{}", event);
+                }
+                true
+            }
+            Some("ready") => true,
+            Some("warning") => {
+                if let Some(msg) = value.get("message").and_then(|m| m.as_str()) {
+                    eprintln!("watch: warning: {msg}");
+                }
+                true
+            }
+            // Server-emitted error frames (auth/dispatch failures) come
+            // through as `{"ok":false,"error":"..."}` per Response::err.
+            _ if value.get("ok").and_then(|v| v.as_bool()) == Some(false) => {
+                let err = value.get("error").and_then(|e| e.as_str()).unwrap_or("unknown error");
+                eprintln!("Error: {err}");
+                exit_clone.store(1, std::sync::atomic::Ordering::SeqCst);
+                false
+            }
+            _ => true,
+        }
+    });
+
+    if let Err(e) = result {
+        eprintln!("{e}");
+        std::process::exit(1);
+    }
+    let code = exit_code.load(std::sync::atomic::Ordering::SeqCst);
+    if code != 0 {
+        std::process::exit(code);
+    }
+}
+
 fn handle_hook(status: &str) {
     let mut input = String::new();
     if std::io::stdin().read_to_string(&mut input).is_err() {
@@ -1173,6 +1242,30 @@ fn main() {
                 }
                 run_socket_command(serde_json::json!({
                     "command": "mailbox-sent",
+                    "session_id": get_session_id(),
+                    "pane_id": get_pane_id(),
+                    "args": Value::Object(args),
+                }));
+            }
+            MailboxAction::Watch { alias, ack, no_backlog, project, global } => {
+                let mut args = serde_json::Map::new();
+                if let Some(a) = alias {
+                    args.insert("alias".into(), Value::String(a));
+                }
+                if let Some(p) = project {
+                    args.insert("project_id".into(), Value::String(p));
+                }
+                if global {
+                    args.insert("global".into(), Value::Bool(true));
+                }
+                if ack {
+                    args.insert("ack".into(), Value::Bool(true));
+                }
+                if no_backlog {
+                    args.insert("backlog".into(), Value::Bool(false));
+                }
+                run_streaming_command(serde_json::json!({
+                    "command": "mailbox-watch",
                     "session_id": get_session_id(),
                     "pane_id": get_pane_id(),
                     "args": Value::Object(args),

--- a/src-tauri/src/cli_socket.rs
+++ b/src-tauri/src/cli_socket.rs
@@ -2,6 +2,121 @@ use serde_json::Value;
 
 use crate::platform;
 
+/// Connect to Roux and stream a long-lived command (e.g. `mailbox-watch`).
+/// Each newline-delimited JSON line the server emits is passed to
+/// `on_line`. Returns when the server closes the connection or
+/// `on_line` returns false. Read timeout is intentionally absent —
+/// streaming commands block until events arrive.
+pub fn stream_socket_command<F>(request: Value, mut on_line: F) -> Result<(), String>
+where
+    F: FnMut(&str) -> bool,
+{
+    use std::io::BufRead;
+
+    #[cfg(windows)]
+    let stream: Box<dyn StreamSocket> = {
+        use std::net::TcpStream;
+        let mut request = request;
+        let auth_token = platform::load_socket_auth_token()
+            .ok_or_else(|| "Roux command channel token not found".to_string())?;
+        if let Some(obj) = request.as_object_mut() {
+            obj.insert("auth_token".to_string(), Value::String(auth_token));
+        }
+        let endpoint =
+            platform::resolve_socket_endpoint().ok_or_else(|| "Roux is not running".to_string())?;
+        let s = TcpStream::connect(&endpoint).map_err(map_connect_err)?;
+        Box::new(WindowsStream(s, request))
+    };
+
+    #[cfg(not(windows))]
+    let stream: Box<dyn StreamSocket> = {
+        use std::os::unix::net::UnixStream;
+        let path = platform::socket_path();
+        let s = UnixStream::connect(&path).map_err(map_connect_err)?;
+        Box::new(UnixStreamHolder(s, request))
+    };
+
+    stream.send_request()?;
+
+    let reader = stream.into_reader();
+    let mut reader = std::io::BufReader::new(reader);
+    let mut line = String::new();
+    loop {
+        line.clear();
+        match reader.read_line(&mut line) {
+            Ok(0) => return Ok(()), // server closed
+            Ok(_) => {
+                let trimmed = line.trim_end();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                if !on_line(trimmed) {
+                    return Ok(());
+                }
+            }
+            Err(e) => return Err(format!("Read failed: {e}")),
+        }
+    }
+}
+
+fn map_connect_err(e: std::io::Error) -> String {
+    if matches!(
+        e.kind(),
+        std::io::ErrorKind::NotFound
+            | std::io::ErrorKind::ConnectionRefused
+            | std::io::ErrorKind::AddrNotAvailable
+    ) {
+        "Roux is not running".to_string()
+    } else {
+        format!("Failed to connect to Roux: {e}")
+    }
+}
+
+/// Internal trait so `stream_socket_command` works for both Unix and
+/// Windows transports without duplicating the loop. Each impl carries
+/// the request JSON it was constructed with so `send_request` is a
+/// straightforward "serialize + write line."
+trait StreamSocket {
+    fn send_request(&self) -> Result<(), String>;
+    fn into_reader(self: Box<Self>) -> Box<dyn std::io::Read + Send>;
+}
+
+#[cfg(not(windows))]
+struct UnixStreamHolder(std::os::unix::net::UnixStream, Value);
+
+#[cfg(not(windows))]
+impl StreamSocket for UnixStreamHolder {
+    fn send_request(&self) -> Result<(), String> {
+        use std::io::Write;
+        let json = serde_json::to_string(&self.1).unwrap();
+        let mut s = &self.0;
+        s.write_all(json.as_bytes())
+            .and_then(|_| s.write_all(b"\n"))
+            .map_err(|e| format!("Failed to send command: {e}"))
+    }
+    fn into_reader(self: Box<Self>) -> Box<dyn std::io::Read + Send> {
+        Box::new(self.0)
+    }
+}
+
+#[cfg(windows)]
+struct WindowsStream(std::net::TcpStream, Value);
+
+#[cfg(windows)]
+impl StreamSocket for WindowsStream {
+    fn send_request(&self) -> Result<(), String> {
+        use std::io::Write;
+        let json = serde_json::to_string(&self.1).unwrap();
+        let mut s = &self.0;
+        s.write_all(json.as_bytes())
+            .and_then(|_| s.write_all(b"\n"))
+            .map_err(|e| format!("Failed to send command: {e}"))
+    }
+    fn into_reader(self: Box<Self>) -> Box<dyn std::io::Read + Send> {
+        Box::new(self.0)
+    }
+}
+
 pub fn send_socket_command(request: Value) -> Result<Value, String> {
     #[cfg(windows)]
     {

--- a/src-tauri/src/mailbox/manager.rs
+++ b/src-tauri/src/mailbox/manager.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, Mutex};
 
 use roux_core::{Event, EventBuilder, MailboxEvent, ReadState};
 use tauri::{AppHandle, Emitter};
+use tokio::sync::broadcast;
 
 use crate::aliases::ProjectFilter;
 use crate::subscriptions::SubscriptionManager;
@@ -15,6 +16,13 @@ use super::store::{EventStore, PostError};
 /// Tauri event name emitted on every mailbox mutation. Frontend listens
 /// here to update the inbox / firehose without polling.
 pub const MAILBOX_EVENT: &str = "mailbox-event";
+
+/// In-process broadcast capacity. Each `mailbox watch` socket connection
+/// holds one receiver. 256 buffered events is well above any realistic
+/// burst — if a slow consumer ever falls behind, `broadcast::Receiver`
+/// surfaces a `Lagged` error and the watch handler can decide whether
+/// to reconnect or drop.
+const BROADCAST_CAPACITY: usize = 256;
 
 struct MailboxPaths {
     events: PathBuf,
@@ -34,11 +42,16 @@ struct MailboxPaths {
 /// `subscriptions` is optional so test fixtures and other call paths can
 /// construct a manager without a live subscription store. When absent,
 /// recipient pattern lookup is empty (legacy exact-match semantics).
+///
+/// `broadcast_tx` is always present and fires on every mutation so
+/// in-process consumers (`mailbox watch` socket handler, future
+/// internal listeners) can subscribe without going through Tauri.
 #[derive(Clone)]
 pub struct MailboxManager {
     inner: Arc<Mutex<EventStore>>,
     paths: Option<Arc<MailboxPaths>>,
     subscriptions: Option<SubscriptionManager>,
+    broadcast_tx: broadcast::Sender<MailboxEvent>,
 }
 
 impl MailboxManager {
@@ -52,6 +65,7 @@ impl MailboxManager {
         let events = load_events_from(&events_path);
         let read_state = load_read_state_from(&read_state_path);
         let store = EventStore::from_entries(events, read_state);
+        let (broadcast_tx, _) = broadcast::channel(BROADCAST_CAPACITY);
         Self {
             inner: Arc::new(Mutex::new(store)),
             paths: Some(Arc::new(MailboxPaths {
@@ -59,6 +73,7 @@ impl MailboxManager {
                 read_state: read_state_path,
             })),
             subscriptions: None,
+            broadcast_tx,
         }
     }
 
@@ -74,11 +89,29 @@ impl MailboxManager {
     /// don't care about disk IO.
     #[cfg(test)]
     pub fn in_memory() -> Self {
+        let (broadcast_tx, _) = broadcast::channel(BROADCAST_CAPACITY);
         Self {
             inner: Arc::new(Mutex::new(EventStore::new())),
             paths: None,
             subscriptions: None,
+            broadcast_tx,
         }
+    }
+
+    /// Subscribe to in-process mailbox events. Each call returns a
+    /// fresh `broadcast::Receiver` — caller drops it when done. Used by
+    /// the `mailbox watch` socket handler to push events to a long-
+    /// lived CLI client without polling.
+    pub fn subscribe_events(&self) -> broadcast::Receiver<MailboxEvent> {
+        self.broadcast_tx.subscribe()
+    }
+
+    /// Send a `MailboxEvent` to in-process subscribers. Failures (no
+    /// receivers, lagged consumer) are intentionally ignored — the Tauri
+    /// emit and persistence are the durable paths; this channel is a
+    /// best-effort fast path for live consumers.
+    fn broadcast(&self, event: &MailboxEvent) {
+        let _ = self.broadcast_tx.send(event.clone());
     }
 
     /// Patterns subscribed to by `recipient` in scopes compatible with
@@ -138,22 +171,25 @@ impl MailboxManager {
                 )));
             }
         }
+        let posted = MailboxEvent::Posted { event: event.clone() };
+        self.broadcast(&posted);
         if let Some(app) = app {
-            let _ = app.emit(MAILBOX_EVENT, &MailboxEvent::Posted { event: event.clone() });
-            // Topic-event subscriptions: notify each matching subscriber.
-            // Frontend uses these to bump the subscriber alias's unread
-            // count and surface the delivery without a new mailbox row.
-            if let (Some(topic), Some(subs)) = (event.topic.as_deref(), self.subscriptions.as_ref())
-            {
-                for sub in subs.matching_topic(topic, event.project_id.as_deref()) {
-                    let _ = app.emit(
-                        MAILBOX_EVENT,
-                        &MailboxEvent::TopicDelivered {
-                            event_id: event.id.clone(),
-                            recipient: sub.alias,
-                            subscription_id: sub.id,
-                        },
-                    );
+            let _ = app.emit(MAILBOX_EVENT, &posted);
+        }
+        // Topic-event subscriptions: notify each matching subscriber.
+        // Frontend uses these to bump the subscriber alias's unread
+        // count and surface the delivery without a new mailbox row.
+        // CLI watchers see the same events through `subscribe_events()`.
+        if let (Some(topic), Some(subs)) = (event.topic.as_deref(), self.subscriptions.as_ref()) {
+            for sub in subs.matching_topic(topic, event.project_id.as_deref()) {
+                let delivered = MailboxEvent::TopicDelivered {
+                    event_id: event.id.clone(),
+                    recipient: sub.alias,
+                    subscription_id: sub.id,
+                };
+                self.broadcast(&delivered);
+                if let Some(app) = app {
+                    let _ = app.emit(MAILBOX_EVENT, &delivered);
                 }
             }
         }
@@ -181,14 +217,13 @@ impl MailboxManager {
         };
         if changed {
             self.persist_read_state();
+            let evt = MailboxEvent::Read {
+                event_id: event_id.to_string(),
+                recipient: recipient.to_string(),
+            };
+            self.broadcast(&evt);
             if let Some(app) = app {
-                let _ = app.emit(
-                    MAILBOX_EVENT,
-                    &MailboxEvent::Read {
-                        event_id: event_id.to_string(),
-                        recipient: recipient.to_string(),
-                    },
-                );
+                let _ = app.emit(MAILBOX_EVENT, &evt);
             }
         }
         changed
@@ -212,15 +247,14 @@ impl MailboxManager {
         };
         if changed {
             self.persist_read_state();
+            let evt = MailboxEvent::Acked {
+                event_id: event_id.to_string(),
+                recipient: recipient.to_string(),
+                result,
+            };
+            self.broadcast(&evt);
             if let Some(app) = app {
-                let _ = app.emit(
-                    MAILBOX_EVENT,
-                    &MailboxEvent::Acked {
-                        event_id: event_id.to_string(),
-                        recipient: recipient.to_string(),
-                        result,
-                    },
-                );
+                let _ = app.emit(MAILBOX_EVENT, &evt);
             }
         }
         changed
@@ -239,14 +273,13 @@ impl MailboxManager {
         };
         if cleared > 0 {
             self.persist_read_state();
+            let evt = MailboxEvent::Cleared {
+                recipient: recipient.to_string(),
+                count: cleared as u32,
+            };
+            self.broadcast(&evt);
             if let Some(app) = app {
-                let _ = app.emit(
-                    MAILBOX_EVENT,
-                    &MailboxEvent::Cleared {
-                        recipient: recipient.to_string(),
-                        count: cleared as u32,
-                    },
-                );
+                let _ = app.emit(MAILBOX_EVENT, &evt);
             }
         }
         cleared
@@ -590,5 +623,83 @@ mod tests {
             !mgr.ack(&event.id, "auditor", Some("done".into()), None),
             "p2-scoped subscription must not authorize p1 event ack",
         );
+    }
+
+    // ── In-process broadcast (powers `mailbox watch`) ──────────────
+
+    #[tokio::test]
+    async fn broadcast_fires_on_post() {
+        let mgr = MailboxManager::in_memory();
+        let mut rx = mgr.subscribe_events();
+        mgr.post(task("hello"), None).unwrap();
+        match rx.recv().await.expect("broadcast must deliver") {
+            MailboxEvent::Posted { event } => assert_eq!(event.body, "hello"),
+            other => panic!("expected Posted, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn broadcast_fires_topic_delivered_for_each_subscription() {
+        let mgr = MailboxManager::in_memory()
+            .with_subscriptions(SubscriptionManager::in_memory());
+        mgr.subscriptions
+            .as_ref()
+            .unwrap()
+            .subscribe("auditor", "**.completed", None, None)
+            .unwrap();
+        mgr.subscriptions
+            .as_ref()
+            .unwrap()
+            .subscribe("watcher", "**", None, None)
+            .unwrap();
+
+        let mut rx = mgr.subscribe_events();
+        let topic_event = EventBuilder::new("a")
+            .topic("build.completed")
+            .kind(EventKind::Signal);
+        mgr.post(topic_event, None).unwrap();
+
+        // First message: Posted. Then one TopicDelivered per matching sub.
+        let mut delivered_recipients: Vec<String> = Vec::new();
+        for _ in 0..3 {
+            match rx.recv().await {
+                Ok(MailboxEvent::Posted { .. }) => {}
+                Ok(MailboxEvent::TopicDelivered { recipient, .. }) => {
+                    delivered_recipients.push(recipient);
+                }
+                Ok(other) => panic!("unexpected {other:?}"),
+                Err(e) => panic!("recv failed: {e:?}"),
+            }
+        }
+        delivered_recipients.sort();
+        assert_eq!(
+            delivered_recipients,
+            vec!["auditor".to_string(), "watcher".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn broadcast_fires_on_mark_read_and_ack() {
+        let mgr = MailboxManager::in_memory();
+        let event = mgr.post(task("hi"), None).unwrap();
+
+        let mut rx = mgr.subscribe_events();
+        mgr.mark_read(&event.id, "reviewer", None);
+        mgr.ack(&event.id, "reviewer", Some("done".into()), None);
+
+        let first = rx.recv().await.unwrap();
+        assert!(matches!(first, MailboxEvent::Read { .. }));
+        let second = rx.recv().await.unwrap();
+        assert!(matches!(second, MailboxEvent::Acked { .. }));
+    }
+
+    #[tokio::test]
+    async fn broadcast_each_subscriber_gets_independent_stream() {
+        let mgr = MailboxManager::in_memory();
+        let mut rx_a = mgr.subscribe_events();
+        let mut rx_b = mgr.subscribe_events();
+        mgr.post(task("hi"), None).unwrap();
+        assert!(matches!(rx_a.recv().await.unwrap(), MailboxEvent::Posted { .. }));
+        assert!(matches!(rx_b.recv().await.unwrap(), MailboxEvent::Posted { .. }));
     }
 }

--- a/src-tauri/src/socket.rs
+++ b/src-tauri/src/socket.rs
@@ -2111,7 +2111,6 @@ async fn handle_mailbox_watch<R, W>(
 
     watch_stream_loop(
         &state.mailbox_manager,
-        &state.subscription_manager,
         &alias,
         project_filter,
         ack,
@@ -2126,9 +2125,13 @@ async fn handle_mailbox_watch<R, W>(
 /// can be exercised in unit tests without a Tauri AppState. Owns the
 /// reader/writer for the lifetime of the watch and returns when the
 /// client disconnects, the broadcast closes, or a write fails.
+///
+/// The `MailboxManager` already carries the `SubscriptionManager` (via
+/// `with_subscriptions`); subscription matches reach this loop through
+/// the broadcast channel as `MailboxEvent::TopicDelivered` frames, so
+/// the loop doesn't need a separate handle on subscriptions.
 pub(crate) async fn watch_stream_loop<R, W>(
     mailbox: &roux_lib::mailbox::MailboxManager,
-    subscriptions: &roux_lib::subscriptions::SubscriptionManager,
     alias: &str,
     project_filter: roux_lib::aliases::ProjectFilter<'_>,
     ack: bool,
@@ -2145,16 +2148,28 @@ pub(crate) async fn watch_stream_loop<R, W>(
     };
 
     // Subscribe BEFORE replaying the backlog so we don't drop events
-    // posted during the handshake.
+    // posted during the handshake. The trade-off is that an event
+    // posted between `subscribe_events()` and `list_for_recipient()`
+    // can appear in both — `forwarded_ids` below dedupes those.
     let mut rx = mailbox.subscribe_events();
 
     if write_frame(&mut writer, &serde_json::json!({"type": "ready"})).await.is_err() {
         return;
     }
 
+    // Track event IDs we've already forwarded so the same event can't
+    // arrive twice via:
+    // (a) backlog list + live broadcast race, or
+    // (b) `Posted` arm + `TopicDelivered` arm for the same subscribed
+    //     event (both broadcast on every post — the watcher must
+    //     deliver only once).
+    let mut forwarded_ids: std::collections::HashSet<String> =
+        std::collections::HashSet::new();
+
     if send_backlog {
         let backlog = mailbox.list_for_recipient(alias, true, project_filter);
         for event in backlog {
+            forwarded_ids.insert(event.id.clone());
             if !forward_event(mailbox, &mut writer, &event, alias, ack).await {
                 return;
             }
@@ -2167,8 +2182,20 @@ pub(crate) async fn watch_stream_loop<R, W>(
         tokio::select! {
             recv = rx.recv() => {
                 match recv {
+                    // Direct-mail-only on this arm: subscription events
+                    // are forwarded via TopicDelivered below. Without
+                    // this restriction, a subscribed alias would see
+                    // each match twice (once here, once on TopicDelivered).
                     Ok(roux_core::MailboxEvent::Posted { event }) => {
-                        if !visible_to_alias(subscriptions, &event, alias, project_scope.as_deref()) {
+                        if event.to.as_deref() != Some(alias) {
+                            continue;
+                        }
+                        if let Some(scope) = project_scope.as_deref() {
+                            if event.project_id.as_deref() != Some(scope) {
+                                continue;
+                            }
+                        }
+                        if !forwarded_ids.insert(event.id.clone()) {
                             continue;
                         }
                         if !forward_event(mailbox, &mut writer, &event, alias, ack).await {
@@ -2184,6 +2211,9 @@ pub(crate) async fn watch_stream_loop<R, W>(
                             if event.project_id.as_deref() != Some(scope) {
                                 continue;
                             }
+                        }
+                        if !forwarded_ids.insert(event.id.clone()) {
+                            continue;
                         }
                         if !forward_event(mailbox, &mut writer, &event, alias, ack).await {
                             return;
@@ -2219,29 +2249,6 @@ pub(crate) async fn watch_stream_loop<R, W>(
 
 /// True when the event is visible to `alias` under the requested
 /// project scope. Visibility = direct mail OR matching subscription.
-fn visible_to_alias(
-    subscriptions: &roux_lib::subscriptions::SubscriptionManager,
-    event: &roux_core::Event,
-    alias: &str,
-    project_scope: Option<&str>,
-) -> bool {
-    if let Some(scope) = project_scope {
-        if event.project_id.as_deref() != Some(scope) {
-            return false;
-        }
-    }
-    if event.to.as_deref() == Some(alias) {
-        return true;
-    }
-    let Some(topic) = event.topic.as_deref() else {
-        return false;
-    };
-    let patterns = subscriptions.patterns_for_alias(alias, event.project_id.as_deref());
-    patterns
-        .iter()
-        .any(|p| roux_core::topic_matches(p, topic))
-}
-
 /// Write one event frame, optionally acking. Returns false on write
 /// error so the caller can exit the loop.
 async fn forward_event<W>(
@@ -3234,9 +3241,13 @@ mod tests {
 
     /// Helper: spawn the watch loop against a tokio duplex pipe, return
     /// the client side so the test can read frames and close on demand.
+    /// `subs` is kept on the signature so callers can wire subscriptions
+    /// into the mailbox before spawning; the loop itself reads them via
+    /// the broadcast channel, not directly.
+    #[allow(clippy::needless_pass_by_value)]
     fn spawn_watch_for_test(
         mailbox: roux_lib::mailbox::MailboxManager,
-        subs: roux_lib::subscriptions::SubscriptionManager,
+        _subs: roux_lib::subscriptions::SubscriptionManager,
         alias: &'static str,
         ack: bool,
         send_backlog: bool,
@@ -3247,7 +3258,6 @@ mod tests {
         tokio::spawn(async move {
             watch_stream_loop(
                 &mailbox,
-                &subs,
                 alias,
                 roux_lib::aliases::ProjectFilter::Any,
                 ack,
@@ -3410,9 +3420,51 @@ mod tests {
             )
             .unwrap();
 
-        let frames = read_frames(&mut client, 2, std::time::Duration::from_millis(500)).await;
-        let event_frame = frames.iter().find(|f| f["type"] == "event").unwrap();
-        assert_eq!(event_frame["event"]["id"], event.id);
+        // Read enough frames to catch any duplicate. Pre-fix the loop
+        // emitted the same event twice (once via `Posted`, once via
+        // `TopicDelivered`); requesting 3 frames and asserting exactly
+        // one event row catches the regression.
+        let frames = read_frames(&mut client, 3, std::time::Duration::from_millis(300)).await;
+        let event_frames: Vec<_> = frames.iter().filter(|f| f["type"] == "event").collect();
+        assert_eq!(
+            event_frames.len(),
+            1,
+            "subscribed topic event must be delivered exactly once: {frames:?}"
+        );
+        assert_eq!(event_frames[0]["event"]["id"], event.id);
+    }
+
+    /// Regression for the TOCTOU between `subscribe_events()` and the
+    /// backlog `list_for_recipient` call. An event posted in that
+    /// window can appear in both, so the watcher needs an in-loop
+    /// dedup guard.
+    #[tokio::test]
+    async fn watch_dedupes_event_seen_in_backlog_and_live_stream() {
+        let (_dir, mgr, subs) = watch_test_managers();
+
+        // Post first so the event is unread → goes into the backlog.
+        let event = mgr
+            .post(
+                roux_core::EventBuilder::new("queued")
+                    .to("auditor")
+                    .from("builder"),
+                None,
+            )
+            .unwrap();
+
+        // The watcher's broadcast subscribe happens inside the spawn,
+        // so the broadcast for `event` already fired. The backlog read
+        // will surface the same event. Without dedup the watcher would
+        // forward it twice.
+        let mut client = spawn_watch_for_test(mgr, subs, "auditor", false, true);
+        let frames = read_frames(&mut client, 3, std::time::Duration::from_millis(300)).await;
+        let event_frames: Vec<_> = frames.iter().filter(|f| f["type"] == "event").collect();
+        assert_eq!(
+            event_frames.len(),
+            1,
+            "backlog event must not also be delivered through the live stream: {frames:?}"
+        );
+        assert_eq!(event_frames[0]["event"]["id"], event.id);
     }
 
     #[tokio::test]

--- a/src-tauri/src/socket.rs
+++ b/src-tauri/src/socket.rs
@@ -2142,9 +2142,16 @@ pub(crate) async fn watch_stream_loop<R, W>(
     R: tokio::io::AsyncRead + Unpin + Send + 'static,
     W: tokio::io::AsyncWrite + Unpin + Send + 'static,
 {
-    let project_scope: Option<String> = match project_filter {
-        roux_lib::aliases::ProjectFilter::Exact(Some(p)) => Some(p.to_string()),
-        _ => None,
+    // Three states, not two: `None` = no filter (Any); `Some(None)` =
+    // global-only (event.project_id must be None); `Some(Some(p))` =
+    // exact project match. Collapsing `Exact(None)` to `None` would
+    // make `--global` watchers receive cross-project events on the
+    // live stream while the backlog (which goes through
+    // `list_for_recipient(... Exact(None))`) correctly filtered them.
+    let project_scope: Option<Option<String>> = match project_filter {
+        roux_lib::aliases::ProjectFilter::Any => None,
+        roux_lib::aliases::ProjectFilter::Exact(None) => Some(None),
+        roux_lib::aliases::ProjectFilter::Exact(Some(p)) => Some(Some(p.to_string())),
     };
 
     // Subscribe BEFORE replaying the backlog so we don't drop events
@@ -2190,10 +2197,8 @@ pub(crate) async fn watch_stream_loop<R, W>(
                         if event.to.as_deref() != Some(alias) {
                             continue;
                         }
-                        if let Some(scope) = project_scope.as_deref() {
-                            if event.project_id.as_deref() != Some(scope) {
-                                continue;
-                            }
+                        if !event_in_scope(&event, project_scope.as_ref()) {
+                            continue;
                         }
                         if !forwarded_ids.insert(event.id.clone()) {
                             continue;
@@ -2207,10 +2212,8 @@ pub(crate) async fn watch_stream_loop<R, W>(
                             continue;
                         }
                         let Some(event) = mailbox.get(&event_id) else { continue };
-                        if let Some(scope) = project_scope.as_deref() {
-                            if event.project_id.as_deref() != Some(scope) {
-                                continue;
-                            }
+                        if !event_in_scope(&event, project_scope.as_ref()) {
+                            continue;
                         }
                         if !forwarded_ids.insert(event.id.clone()) {
                             continue;
@@ -2249,6 +2252,19 @@ pub(crate) async fn watch_stream_loop<R, W>(
 
 /// True when the event is visible to `alias` under the requested
 /// project scope. Visibility = direct mail OR matching subscription.
+/// True when `event` falls inside the requested project scope.
+/// `scope`:
+/// - `None` ⇒ no filter (Any).
+/// - `Some(None)` ⇒ global-only; event must also be unscoped.
+/// - `Some(Some(p))` ⇒ event must be scoped to project `p`.
+fn event_in_scope(event: &roux_core::Event, scope: Option<&Option<String>>) -> bool {
+    match scope {
+        None => true,
+        Some(None) => event.project_id.is_none(),
+        Some(Some(p)) => event.project_id.as_deref() == Some(p.as_str()),
+    }
+}
+
 /// Write one event frame, optionally acking. Returns false on write
 /// error so the caller can exit the loop.
 async fn forward_event<W>(
@@ -3252,18 +3268,28 @@ mod tests {
         ack: bool,
         send_backlog: bool,
     ) -> tokio::io::DuplexStream {
+        spawn_watch_with_filter(
+            mailbox,
+            alias,
+            roux_lib::aliases::ProjectFilter::Any,
+            ack,
+            send_backlog,
+        )
+    }
+
+    fn spawn_watch_with_filter(
+        mailbox: roux_lib::mailbox::MailboxManager,
+        alias: &'static str,
+        filter: roux_lib::aliases::ProjectFilter<'static>,
+        ack: bool,
+        send_backlog: bool,
+    ) -> tokio::io::DuplexStream {
         let (server_side, client_side) = tokio::io::duplex(8192);
         let (server_read, server_write) = tokio::io::split(server_side);
         let buf_reader = BufReader::new(server_read);
         tokio::spawn(async move {
             watch_stream_loop(
-                &mailbox,
-                alias,
-                roux_lib::aliases::ProjectFilter::Any,
-                ack,
-                send_backlog,
-                buf_reader,
-                server_write,
+                &mailbox, alias, filter, ack, send_backlog, buf_reader, server_write,
             )
             .await;
         });
@@ -3465,6 +3491,55 @@ mod tests {
             "backlog event must not also be delivered through the live stream: {frames:?}"
         );
         assert_eq!(event_frames[0]["event"]["id"], event.id);
+    }
+
+    /// Regression for the `--global` filter being silently dropped on
+    /// the live stream. Pre-fix the live arm collapsed `Exact(None)` to
+    /// `None` (no filter), so a `--global` watcher would receive
+    /// project-scoped events even though the backlog correctly hid
+    /// them. The two paths must agree.
+    #[tokio::test]
+    async fn watch_global_filter_excludes_project_scoped_live_events() {
+        let (_dir, mgr, _subs) = watch_test_managers();
+        let mut client = spawn_watch_with_filter(
+            mgr.clone(),
+            "auditor",
+            roux_lib::aliases::ProjectFilter::Exact(None),
+            false,
+            true,
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+        // Project-scoped event must NOT propagate to a global watcher.
+        mgr.post(
+            roux_core::EventBuilder::new("p1")
+                .to("auditor")
+                .from("builder")
+                .project_id("p1"),
+            None,
+        )
+        .unwrap();
+        // Global event MUST propagate.
+        let global = mgr
+            .post(
+                roux_core::EventBuilder::new("g")
+                    .to("auditor")
+                    .from("builder"),
+                None,
+            )
+            .unwrap();
+
+        let frames = read_frames(&mut client, 3, std::time::Duration::from_millis(300)).await;
+        let event_ids: Vec<_> = frames
+            .iter()
+            .filter(|f| f["type"] == "event")
+            .map(|f| f["event"]["id"].as_str().unwrap_or("").to_string())
+            .collect();
+        assert_eq!(
+            event_ids,
+            vec![global.id],
+            "global watcher must skip project-scoped events: {frames:?}"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/socket.rs
+++ b/src-tauri/src/socket.rs
@@ -145,11 +145,28 @@ pub fn start_socket_server(app: tauri::AppHandle) {
                     }
                 }
 
-                let response = match serde_json::from_str::<Request>(line.trim()) {
-                    Ok(req) => handle_request(req, &app).await,
-                    Err(e) => Response::err(format!("Invalid request: {}", e)),
+                let req = match serde_json::from_str::<Request>(line.trim()) {
+                    Ok(req) => req,
+                    Err(e) => {
+                        let resp = Response::err(format!("Invalid request: {}", e));
+                        let json = serde_json::to_string(&resp).unwrap_or_default();
+                        let _ = writer.write_all(json.as_bytes()).await;
+                        let _ = writer.write_all(b"\n").await;
+                        let _ = writer.shutdown().await;
+                        return;
+                    }
                 };
 
+                // Streaming commands keep the writer open and push
+                // newline-delimited JSON until the client disconnects.
+                // One-shot commands (the default) write a single
+                // Response and shut the writer down.
+                if is_streaming_command(&req.command) {
+                    handle_streaming_request(req, &app, buf_reader, writer).await;
+                    return;
+                }
+
+                let response = handle_request(req, &app).await;
                 let json = serde_json::to_string(&response).unwrap_or_default();
                 let _ = writer.write_all(json.as_bytes()).await;
                 let _ = writer.write_all(b"\n").await;
@@ -157,6 +174,58 @@ pub fn start_socket_server(app: tauri::AppHandle) {
             });
         }
     });
+}
+
+/// True for commands that switch to a streaming protocol (multiple
+/// newline-delimited JSON objects) instead of the default
+/// request/response. Must stay in sync with `handle_streaming_request`.
+fn is_streaming_command(cmd: &str) -> bool {
+    matches!(cmd, "mailbox-watch")
+}
+
+/// Dispatch streaming commands. Owns the writer for the lifetime of the
+/// connection; the handler returns when the client disconnects, an
+/// error happens, or the watch is cancelled. Generic over reader/writer
+/// types so the same code path works for Unix sockets and Windows TCP.
+async fn handle_streaming_request<R, W>(
+    req: Request,
+    app: &tauri::AppHandle,
+    reader: BufReader<R>,
+    writer: W,
+) where
+    R: tokio::io::AsyncRead + Unpin + Send + 'static,
+    W: tokio::io::AsyncWrite + Unpin + Send + 'static,
+{
+    #[cfg(windows)]
+    {
+        let Some(expected_token) = platform::load_socket_auth_token() else {
+            stream_error(writer, "Socket auth token unavailable").await;
+            return;
+        };
+        if req.auth_token.as_deref() != Some(expected_token.as_str()) {
+            stream_error(writer, "unauthorized").await;
+            return;
+        }
+    }
+    match req.command.as_str() {
+        "mailbox-watch" => handle_mailbox_watch(req, app, reader, writer).await,
+        // Should never be reached: `is_streaming_command` is the source
+        // of truth and only routes known streaming commands here.
+        other => stream_error(writer, format!("unknown streaming command: {other}")).await,
+    }
+}
+
+/// Write a single error frame and close. Used for auth/dispatch failures
+/// before the streaming loop starts.
+async fn stream_error<W>(mut writer: W, msg: impl Into<String>)
+where
+    W: tokio::io::AsyncWrite + Unpin + Send,
+{
+    let resp = Response::err(msg);
+    let json = serde_json::to_string(&resp).unwrap_or_default();
+    let _ = writer.write_all(json.as_bytes()).await;
+    let _ = writer.write_all(b"\n").await;
+    let _ = writer.shutdown().await;
 }
 
 async fn handle_request(req: Request, app: &tauri::AppHandle) -> Response {
@@ -1533,7 +1602,7 @@ fn parse_event_kind(s: &str) -> Result<roux_core::EventKind, String> {
 ///
 /// Multiple matches → error and ask for disambiguation via `args.alias`.
 fn resolve_recipient_alias(
-    state: &tauri::State<AppState>,
+    state: &tauri::State<'_, AppState>,
     req: &Request,
     explicit: Option<&str>,
 ) -> Result<String, String> {
@@ -2005,6 +2074,204 @@ async fn handle_bus_subscriptions(req: Request, app: &tauri::AppHandle) -> Respo
         None => state.subscription_manager.list(filter),
     };
     Response::success(serde_json::to_value(subs).unwrap_or_default())
+}
+
+/// Long-lived `mailbox watch` stream. The client connects, receives a
+/// `ready` line, then reads newline-delimited JSON frames until it
+/// disconnects:
+///
+/// - `{"type":"ready"}` — handshake; safe to start consuming.
+/// - `{"type":"event","event":{...}}` — a fresh event (initial backlog
+///   or live delivery). When `args.ack=true` the watch handler also
+///   calls `mark_read+ack` on the recipient before forwarding.
+/// - `{"type":"error","error":"..."}` — terminal error; stream ends.
+///
+/// The reader side of the stream is consulted only for client
+/// disconnect detection — any line the client sends terminates the
+/// watch (treated as "client done"). Real bidirectional control is
+/// future work.
+async fn handle_mailbox_watch<R, W>(
+    req: Request,
+    app: &tauri::AppHandle,
+    reader: BufReader<R>,
+    writer: W,
+) where
+    R: tokio::io::AsyncRead + Unpin + Send + 'static,
+    W: tokio::io::AsyncWrite + Unpin + Send + 'static,
+{
+    let state: tauri::State<AppState> = app.state();
+    let alias = match resolve_recipient_alias(&state, &req, args_str(&req, "alias")) {
+        Ok(a) => a,
+        Err(e) => return stream_error(writer, e).await,
+    };
+    let project_filter =
+        mailbox_project_filter(args_str(&req, "project_id"), args_bool(&req, "global"));
+    let ack = args_bool(&req, "ack").unwrap_or(false);
+    let send_backlog = args_bool(&req, "backlog").unwrap_or(true);
+
+    watch_stream_loop(
+        &state.mailbox_manager,
+        &state.subscription_manager,
+        &alias,
+        project_filter,
+        ack,
+        send_backlog,
+        reader,
+        writer,
+    )
+    .await;
+}
+
+/// Streaming watch loop, factored out of `handle_mailbox_watch` so it
+/// can be exercised in unit tests without a Tauri AppState. Owns the
+/// reader/writer for the lifetime of the watch and returns when the
+/// client disconnects, the broadcast closes, or a write fails.
+pub(crate) async fn watch_stream_loop<R, W>(
+    mailbox: &roux_lib::mailbox::MailboxManager,
+    subscriptions: &roux_lib::subscriptions::SubscriptionManager,
+    alias: &str,
+    project_filter: roux_lib::aliases::ProjectFilter<'_>,
+    ack: bool,
+    send_backlog: bool,
+    mut reader: BufReader<R>,
+    mut writer: W,
+) where
+    R: tokio::io::AsyncRead + Unpin + Send + 'static,
+    W: tokio::io::AsyncWrite + Unpin + Send + 'static,
+{
+    let project_scope: Option<String> = match project_filter {
+        roux_lib::aliases::ProjectFilter::Exact(Some(p)) => Some(p.to_string()),
+        _ => None,
+    };
+
+    // Subscribe BEFORE replaying the backlog so we don't drop events
+    // posted during the handshake.
+    let mut rx = mailbox.subscribe_events();
+
+    if write_frame(&mut writer, &serde_json::json!({"type": "ready"})).await.is_err() {
+        return;
+    }
+
+    if send_backlog {
+        let backlog = mailbox.list_for_recipient(alias, true, project_filter);
+        for event in backlog {
+            if !forward_event(mailbox, &mut writer, &event, alias, ack).await {
+                return;
+            }
+        }
+    }
+
+    let mut line = String::new();
+    loop {
+        line.clear();
+        tokio::select! {
+            recv = rx.recv() => {
+                match recv {
+                    Ok(roux_core::MailboxEvent::Posted { event }) => {
+                        if !visible_to_alias(subscriptions, &event, alias, project_scope.as_deref()) {
+                            continue;
+                        }
+                        if !forward_event(mailbox, &mut writer, &event, alias, ack).await {
+                            return;
+                        }
+                    }
+                    Ok(roux_core::MailboxEvent::TopicDelivered { event_id, recipient, .. }) => {
+                        if recipient != alias {
+                            continue;
+                        }
+                        let Some(event) = mailbox.get(&event_id) else { continue };
+                        if let Some(scope) = project_scope.as_deref() {
+                            if event.project_id.as_deref() != Some(scope) {
+                                continue;
+                            }
+                        }
+                        if !forward_event(mailbox, &mut writer, &event, alias, ack).await {
+                            return;
+                        }
+                    }
+                    // Read/Acked/Cleared aren't watch payloads.
+                    Ok(_) => continue,
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                        let warn = serde_json::json!({
+                            "type": "warning",
+                            "message": format!("dropped {n} buffered events; consumer fell behind"),
+                        });
+                        if write_frame(&mut writer, &warn).await.is_err() {
+                            return;
+                        }
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => return,
+                }
+            }
+            client = reader.read_line(&mut line) => {
+                match client {
+                    Ok(0) | Err(_) => return,
+                    Ok(_) => {
+                        // Any client write terminates the watch. Reserved
+                        // for future control frames (e.g. dynamic ack).
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// True when the event is visible to `alias` under the requested
+/// project scope. Visibility = direct mail OR matching subscription.
+fn visible_to_alias(
+    subscriptions: &roux_lib::subscriptions::SubscriptionManager,
+    event: &roux_core::Event,
+    alias: &str,
+    project_scope: Option<&str>,
+) -> bool {
+    if let Some(scope) = project_scope {
+        if event.project_id.as_deref() != Some(scope) {
+            return false;
+        }
+    }
+    if event.to.as_deref() == Some(alias) {
+        return true;
+    }
+    let Some(topic) = event.topic.as_deref() else {
+        return false;
+    };
+    let patterns = subscriptions.patterns_for_alias(alias, event.project_id.as_deref());
+    patterns
+        .iter()
+        .any(|p| roux_core::topic_matches(p, topic))
+}
+
+/// Write one event frame, optionally acking. Returns false on write
+/// error so the caller can exit the loop.
+async fn forward_event<W>(
+    mailbox: &roux_lib::mailbox::MailboxManager,
+    writer: &mut W,
+    event: &roux_core::Event,
+    alias: &str,
+    ack: bool,
+) -> bool
+where
+    W: tokio::io::AsyncWrite + Unpin + Send,
+{
+    if ack {
+        // Mark read + ack with a "watched" marker so the sender's
+        // `mailbox sent` view reflects that the watcher saw it.
+        mailbox.mark_read(&event.id, alias, None);
+        mailbox.ack(&event.id, alias, Some("watched".into()), None);
+    }
+    let frame = serde_json::json!({ "type": "event", "event": event });
+    write_frame(writer, &frame).await.is_ok()
+}
+
+async fn write_frame<W>(writer: &mut W, value: &serde_json::Value) -> std::io::Result<()>
+where
+    W: tokio::io::AsyncWrite + Unpin + Send,
+{
+    let json = serde_json::to_string(value).unwrap_or_else(|_| "{}".to_string());
+    writer.write_all(json.as_bytes()).await?;
+    writer.write_all(b"\n").await?;
+    writer.flush().await
 }
 
 fn crypto_random_uuid() -> String {
@@ -2942,5 +3209,236 @@ mod tests {
         assert_eq!(resp["ok"], true);
 
         server.await.unwrap();
+    }
+
+    // ── mailbox-watch streaming ─────────────────────────────────────
+
+    /// Build an in-memory MailboxManager + SubscriptionManager pair for
+    /// streaming tests. Both `in_memory()` ctors are gated to the
+    /// owning module's tests, so we go through `load_from` with a
+    /// tempdir — same pattern other cross-module tests use.
+    fn watch_test_managers() -> (
+        tempfile::TempDir,
+        roux_lib::mailbox::MailboxManager,
+        roux_lib::subscriptions::SubscriptionManager,
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+        let events = dir.path().join("events.jsonl");
+        let state = dir.path().join("read_state.json");
+        let subs_path = dir.path().join("subscriptions.json");
+        let subs = roux_lib::subscriptions::SubscriptionManager::load_from(subs_path);
+        let mgr = roux_lib::mailbox::MailboxManager::load_from(events, state)
+            .with_subscriptions(subs.clone());
+        (dir, mgr, subs)
+    }
+
+    /// Helper: spawn the watch loop against a tokio duplex pipe, return
+    /// the client side so the test can read frames and close on demand.
+    fn spawn_watch_for_test(
+        mailbox: roux_lib::mailbox::MailboxManager,
+        subs: roux_lib::subscriptions::SubscriptionManager,
+        alias: &'static str,
+        ack: bool,
+        send_backlog: bool,
+    ) -> tokio::io::DuplexStream {
+        let (server_side, client_side) = tokio::io::duplex(8192);
+        let (server_read, server_write) = tokio::io::split(server_side);
+        let buf_reader = BufReader::new(server_read);
+        tokio::spawn(async move {
+            watch_stream_loop(
+                &mailbox,
+                &subs,
+                alias,
+                roux_lib::aliases::ProjectFilter::Any,
+                ack,
+                send_backlog,
+                buf_reader,
+                server_write,
+            )
+            .await;
+        });
+        client_side
+    }
+
+    /// Read newline-delimited frames from the watch socket until either
+    /// `count` frames are collected or `timeout` elapses. Returns
+    /// whatever was read.
+    async fn read_frames(
+        client: &mut tokio::io::DuplexStream,
+        count: usize,
+        timeout: std::time::Duration,
+    ) -> Vec<serde_json::Value> {
+        let (read, _write) = tokio::io::split(client);
+        let mut reader = BufReader::new(read);
+        let deadline = tokio::time::Instant::now() + timeout;
+        let mut frames: Vec<serde_json::Value> = Vec::new();
+        while frames.len() < count {
+            let mut line = String::new();
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            match tokio::time::timeout(remaining, reader.read_line(&mut line)).await {
+                Ok(Ok(0)) => break,
+                Ok(Ok(_)) => {
+                    let trimmed = line.trim_end();
+                    if trimmed.is_empty() {
+                        continue;
+                    }
+                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(trimmed) {
+                        frames.push(v);
+                    }
+                }
+                Ok(Err(_)) | Err(_) => break,
+            }
+        }
+        frames
+    }
+
+    #[tokio::test]
+    async fn watch_emits_ready_then_streams_addressed_event() {
+        let (_dir, mgr, subs) = watch_test_managers();
+        let mut client = spawn_watch_for_test(mgr.clone(), subs, "auditor", false, true);
+
+        // Give the watch loop a moment to write `ready` before we post.
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+        // Post an event addressed to auditor. Must come AFTER `ready`
+        // so we hit the live-loop path, not the backlog path.
+        let event = mgr
+            .post(
+                roux_core::EventBuilder::new("hi")
+                    .to("auditor")
+                    .from("builder")
+                    .kind(roux_core::EventKind::Task),
+                None,
+            )
+            .unwrap();
+
+        let frames = read_frames(&mut client, 2, std::time::Duration::from_millis(500)).await;
+        assert!(!frames.is_empty(), "expected at least the ready frame");
+        assert_eq!(frames[0]["type"], "ready");
+        // Find the event frame (might be at index 1).
+        let event_frame = frames.iter().find(|f| f["type"] == "event").unwrap();
+        assert_eq!(event_frame["event"]["id"], event.id);
+    }
+
+    #[tokio::test]
+    async fn watch_replays_unread_backlog_first() {
+        let (_dir, mgr, subs) = watch_test_managers();
+        // Post BEFORE starting the watcher → the event lives in backlog.
+        let event = mgr
+            .post(
+                roux_core::EventBuilder::new("queued")
+                    .to("auditor")
+                    .from("builder"),
+                None,
+            )
+            .unwrap();
+
+        let mut client = spawn_watch_for_test(mgr, subs, "auditor", false, true);
+
+        let frames = read_frames(&mut client, 2, std::time::Duration::from_millis(500)).await;
+        let event_frame = frames.iter().find(|f| f["type"] == "event").unwrap();
+        assert_eq!(event_frame["event"]["id"], event.id);
+    }
+
+    #[tokio::test]
+    async fn watch_no_backlog_skips_existing_events() {
+        let (_dir, mgr, subs) = watch_test_managers();
+        mgr.post(
+            roux_core::EventBuilder::new("queued")
+                .to("auditor")
+                .from("builder"),
+            None,
+        )
+        .unwrap();
+
+        let mut client =
+            spawn_watch_for_test(mgr.clone(), subs, "auditor", false, /* send_backlog */ false);
+
+        let frames = read_frames(&mut client, 1, std::time::Duration::from_millis(150)).await;
+        // Only `ready` — no event (queued was unread but backlog suppressed).
+        assert_eq!(frames.len(), 1);
+        assert_eq!(frames[0]["type"], "ready");
+    }
+
+    #[tokio::test]
+    async fn watch_filters_other_recipients_from_live_stream() {
+        let (_dir, mgr, subs) = watch_test_managers();
+        let mut client = spawn_watch_for_test(mgr.clone(), subs, "auditor", false, true);
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+        // Post one to a different alias, one to auditor.
+        mgr.post(
+            roux_core::EventBuilder::new("not for you")
+                .to("reviewer")
+                .from("builder"),
+            None,
+        )
+        .unwrap();
+        let mine = mgr
+            .post(
+                roux_core::EventBuilder::new("for you")
+                    .to("auditor")
+                    .from("builder"),
+                None,
+            )
+            .unwrap();
+
+        let frames = read_frames(&mut client, 3, std::time::Duration::from_millis(500)).await;
+        let event_ids: Vec<_> = frames
+            .iter()
+            .filter(|f| f["type"] == "event")
+            .map(|f| f["event"]["id"].as_str().unwrap_or("").to_string())
+            .collect();
+        assert_eq!(event_ids, vec![mine.id], "only auditor-addressed events propagate");
+    }
+
+    #[tokio::test]
+    async fn watch_streams_subscribed_topic_events() {
+        let (_dir, mgr, subs) = watch_test_managers();
+        subs.subscribe("auditor", "**.completed", None, None).unwrap();
+
+        let mut client = spawn_watch_for_test(mgr.clone(), subs, "auditor", false, true);
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+        let event = mgr
+            .post(
+                roux_core::EventBuilder::new("green")
+                    .topic("repo-a.build.completed")
+                    .from("builder")
+                    .kind(roux_core::EventKind::Signal),
+                None,
+            )
+            .unwrap();
+
+        let frames = read_frames(&mut client, 2, std::time::Duration::from_millis(500)).await;
+        let event_frame = frames.iter().find(|f| f["type"] == "event").unwrap();
+        assert_eq!(event_frame["event"]["id"], event.id);
+    }
+
+    #[tokio::test]
+    async fn watch_with_ack_marks_event_read_and_acked() {
+        let (_dir, mgr, subs) = watch_test_managers();
+        let event = mgr
+            .post(
+                roux_core::EventBuilder::new("queued")
+                    .to("auditor")
+                    .from("builder"),
+                None,
+            )
+            .unwrap();
+
+        let mut client =
+            spawn_watch_for_test(mgr.clone(), subs, "auditor", /* ack */ true, true);
+
+        // Read until we've seen the event frame, then drop the client to
+        // close the watch and let the ack persist before we assert.
+        let _ = read_frames(&mut client, 2, std::time::Duration::from_millis(500)).await;
+        drop(client);
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let state = mgr.read_state(&event.id, "auditor").unwrap();
+        assert!(state.is_read(), "watch --ack must mark read");
+        assert!(state.is_acked(), "watch --ack must ack");
+        assert_eq!(state.ack_result.as_deref(), Some("watched"));
     }
 }

--- a/src-tauri/src/socket.rs
+++ b/src-tauri/src/socket.rs
@@ -2277,14 +2277,18 @@ async fn forward_event<W>(
 where
     W: tokio::io::AsyncWrite + Unpin + Send,
 {
-    if ack {
-        // Mark read + ack with a "watched" marker so the sender's
-        // `mailbox sent` view reflects that the watcher saw it.
+    // Write the frame first, then ack — if the socket write fails
+    // (client disconnected mid-stream), we must NOT stamp the event
+    // "watched" since the recipient's agent never actually saw it.
+    // Acking before delivery confirmation would corrupt the sender's
+    // `mailbox sent` view with a false delivery record.
+    let frame = serde_json::json!({ "type": "event", "event": event });
+    let delivered = write_frame(writer, &frame).await.is_ok();
+    if delivered && ack {
         mailbox.mark_read(&event.id, alias, None);
         mailbox.ack(&event.id, alias, Some("watched".into()), None);
     }
-    let frame = serde_json::json!({ "type": "event", "event": event });
-    write_frame(writer, &frame).await.is_ok()
+    delivered
 }
 
 async fn write_frame<W>(writer: &mut W, value: &serde_json::Value) -> std::io::Result<()>
@@ -3567,5 +3571,38 @@ mod tests {
         assert!(state.is_read(), "watch --ack must mark read");
         assert!(state.is_acked(), "watch --ack must ack");
         assert_eq!(state.ack_result.as_deref(), Some("watched"));
+    }
+
+    /// Regression: don't ack on undelivered events. Pre-fix
+    /// `forward_event` called `mark_read`/`ack` BEFORE the socket write,
+    /// so a client that dropped mid-stream still ended up with the
+    /// event stamped "watched" — a false delivery record visible to the
+    /// sender. Now we write first and only ack on successful delivery.
+    #[tokio::test]
+    async fn forward_event_does_not_ack_when_write_fails() {
+        let (_dir, mgr, _subs) = watch_test_managers();
+        let event = mgr
+            .post(
+                roux_core::EventBuilder::new("queued")
+                    .to("auditor")
+                    .from("builder"),
+                None,
+            )
+            .unwrap();
+
+        // tokio::io::sink() with a custom Empty wouldn't fail — instead
+        // we close the duplex stream by dropping the client side, then
+        // call forward_event against the dead writer.
+        let (server_side, client_side) = tokio::io::duplex(8);
+        drop(client_side);
+        let (_r, mut w) = tokio::io::split(server_side);
+        let delivered = forward_event(&mgr, &mut w, &event, "auditor", true).await;
+        assert!(!delivered, "write to a closed pipe must report failure");
+
+        let state = mgr.read_state(&event.id, "auditor");
+        assert!(
+            state.is_none() || !state.unwrap().is_acked(),
+            "failed delivery must not leave an acked ReadState behind",
+        );
     }
 }


### PR DESCRIPTION
## Summary
- New \`roux mailbox watch [--ack] [--no-backlog]\` CLI subcommand. Opens a long-lived socket connection and prints each new event as a JSON line as it arrives — no polling, near-zero latency from \`bus publish\` to delivery.
- Subscribed-topic events flow through the same stream, so an agent running \`mailbox watch --ack\` in a hook sees both direct mail and bus subscription matches in one place.
- Closes the **mailbox-watch** follow-up from #161.

## Stack
This PR is **stacked on top of #163** (\`feature/bus-subscriptions\`). Base is \`feature/bus-subscriptions\`; the diff here is just the watch work. When #162 lands, #163 rebases onto \`main\`; when #163 lands, this PR rebases onto \`main\`.

Review order: **#162 → #163 → #164**.

## Surface
- **Backend**: \`MailboxManager\` gains a \`tokio::sync::broadcast\` channel that fires on every mutation (\`Posted\` / \`Read\` / \`Acked\` / \`Cleared\` / \`TopicDelivered\`). \`subscribe_events()\` hands out receivers; the existing Tauri emit and disk persistence are unchanged. UI behavior untouched.
- **Socket protocol**: streaming framing path. \`is_streaming_command\` routes \`mailbox-watch\` to \`watch_stream_loop\`, which owns the writer for the connection's lifetime: emits \`{"type":"ready"}\`, replays unread backlog (skip with \`--no-backlog\`), then streams \`{"type":"event",...}\` frames until the client disconnects. \`--ack\` marks every delivered event read+acked with a \`"watched"\` result string so the sender's \`mailbox sent\` view reflects the watcher saw it.
- **CLI**: \`MailboxAction::Watch { alias, ack, no_backlog, project, global }\`. A new \`stream_socket_command\` helper in \`cli_socket\` handles the persistent connection with per-line callback.
- **MCP / Tauri**: not exposed in v1. The in-app Mailbox panel already gets push delivery through the existing \`mailbox-event\` Tauri channel; MCP streaming is a separate framing question.

## Test plan
- [x] \`cargo test --bin roux\` — 484 pass (+6 new watch tests: ready+stream, backlog replay, --no-backlog suppression, recipient filter, subscription delivery, --ack persistence)
- [x] \`cargo test --lib --workspace\` — 389 pass (+4 broadcast channel tests)
- [x] \`npm run test\` — 1003 pass (no frontend changes)
- [x] \`npm run check\` — 0 errors
- [x] \`cargo clippy --bin roux --tests\` — clean
- [ ] Manual end-to-end:
  - In one pane: \`roux mailbox watch --alias auditor --ack\`
  - In another pane: \`roux mailbox post --to auditor "ping"\` — confirm watcher prints the JSON line immediately.
  - With \`feature/bus-subscriptions\` merged: subscribe \`auditor\` to \`**.completed\`, \`bus publish foo.completed "..."\`, watcher receives.
  - Ctrl+C the watcher; confirm the server-side stream closes cleanly (no leaked socket).

## Out of scope (explicit)
- MCP / Tauri \`watch\` surface. (CLI is enough for hook integration.)
- Reconnect-with-cursor on transient socket loss. The CLI exits on disconnect; agents wrap in a shell loop if they want resilience.
- Multi-recipient watch. One alias per connection keeps the visibility / ack semantics clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Introduces `roux mailbox watch` as a long-lived push-delivery CLI command: the server-side `watch_stream_loop` subscribes to a `tokio::sync::broadcast` channel on `MailboxManager`, replays the unread backlog, then streams live `Posted` and `TopicDelivered` events as newline-delimited JSON frames with full deduplication via `forwarded_ids`.
- All four issues from the previous review round (duplicate subscription delivery, TOCTOU backlog/live-stream race, `--global` filter dropped on live path, ack-before-delivery) are fixed with regression tests that directly exercise each invariant.
- One minor doc comment on `event_in_scope` carries stale copy-pasted lines from the old `visible_to_alias` concept and should be trimmed.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all previously flagged P1 issues are resolved with regression tests, and the one remaining finding is a stale doc comment.

No P0 or P1 findings. The four critical issues from the prior review (duplicate delivery, TOCTOU race, global-filter gap, pre-delivery ack) are each fixed and covered by dedicated regression tests. The only new finding is a two-line stale doc comment on `event_in_scope` (P2 style). The `Result<_, String>` convention issue was already flagged in a prior outside-diff comment and is not new to this round.

No files require special attention beyond the minor doc comment in `src-tauri/src/socket.rs`.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/features/mailbox.md | Documentation update: adds `watch` subcommand description, backlog/ack/no-backlog flags, and streaming semantics. Content is accurate and matches implementation. |
| src-tauri/src/cli.rs | Adds `MailboxAction::Watch` variant and `run_streaming_command` helper. CLI arg mapping to socket JSON is straightforward; `run_streaming_command` correctly routes control/error frames to stderr and event frames to stdout. |
| src-tauri/src/cli_socket.rs | Adds `stream_socket_command` with a `StreamSocket` trait for cross-platform transport. Returns `Result<(), String>` which conflicts with the project's typed-error convention (already flagged in a prior review comment outside the diff). |
| src-tauri/src/mailbox/manager.rs | Adds tokio broadcast channel (capacity 256) to `MailboxManager`; fires on Posted/Read/Acked/Cleared/TopicDelivered. Refactored emit+broadcast pattern is clean; broadcast failures are intentionally ignored as a best-effort fast path. Four new broadcast unit tests. |
| src-tauri/src/socket.rs | Core streaming infrastructure: `is_streaming_command`, `handle_streaming_request`, `watch_stream_loop`, `forward_event`, `event_in_scope`, `write_frame`. Previously-flagged issues (duplicate delivery, TOCTOU race, global-filter gap, pre-delivery ack) are all addressed. One doc comment on `event_in_scope` has stale copy-pasted lines from the old `visible_to_alias` concept. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI as roux mailbox watch
    participant CSock as stream_socket_command
    participant Srv as handle_streaming_request
    participant WL as watch_stream_loop
    participant MM as MailboxManager
    participant BC as broadcast channel

    CLI->>CSock: connect + send mailbox-watch JSON
    CSock->>Srv: socket write
    Srv->>WL: dispatch to watch_stream_loop
    WL->>MM: subscribe_events()
    MM-->>WL: Receiver
    WL->>CLI: "{"type":"ready"}"
    WL->>MM: list_for_recipient(alias, unread)
    MM-->>WL: backlog events
    WL->>CLI: event frames (backlog replay)

    Note over WL,BC: Live stream begins

    MM->>BC: broadcast(Posted / TopicDelivered)
    BC-->>WL: recv()
    WL->>WL: forwarded_ids dedup + event_in_scope
    WL->>MM: mark_read + ack (if --ack flag)
    WL->>CLI: "{"type":"event","event":{...}}"

    CLI->>WL: EOF / Ctrl+C
    WL-->>Srv: return
    CSock-->>CLI: Ok(())
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src-tauri/src/cli_socket.rs`, line 158-160 ([link](https://github.com/phin-tech/roux/blob/1f0dd1cc6be5e451e0e53ef93e57be8a9d91a75e/src-tauri/src/cli_socket.rs#L158-L160)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`Result<_, String>` in public API violates project convention**

   Per AGENTS.md/CLAUDE.md: "Prefer typed internal errors over `Result<_, String>`". `stream_socket_command` returns `Result<(), String>` and the internal `send_request` trait method also returns `Result<(), String>`. A small error enum (e.g., `SocketError { NotRunning, ConnectFailed(io::Error), SendFailed(io::Error), ReadFailed(io::Error) }`) would make downstream error handling exhaustive and consistent with the project's stated backend convention.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src-tauri%2Fsrc%2Fcli_socket.rs%0ALine%3A%20158-160%0A%0AComment%3A%0A**%60Result%3C_%2C%20String%3E%60%20in%20public%20API%20violates%20project%20convention**%0A%0APer%20AGENTS.md%2FCLAUDE.md%3A%20%22Prefer%20typed%20internal%20errors%20over%20%60Result%3C_%2C%20String%3E%60%22.%20%60stream_socket_command%60%20returns%20%60Result%3C%28%29%2C%20String%3E%60%20and%20the%20internal%20%60send_request%60%20trait%20method%20also%20returns%20%60Result%3C%28%29%2C%20String%3E%60.%20A%20small%20error%20enum%20%28e.g.%2C%20%60SocketError%20%7B%20NotRunning%2C%20ConnectFailed%28io%3A%3AError%29%2C%20SendFailed%28io%3A%3AError%29%2C%20ReadFailed%28io%3A%3AError%29%20%7D%60%29%20would%20make%20downstream%20error%20handling%20exhaustive%20and%20consistent%20with%20the%20project's%20stated%20backend%20convention.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=phin-tech%2Froux&pr=164&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22feature%2Fmailbox-watch%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fmailbox-watch%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src-tauri%2Fsrc%2Fcli_socket.rs%0ALine%3A%20158-160%0A%0AComment%3A%0A**%60Result%3C_%2C%20String%3E%60%20in%20public%20API%20violates%20project%20convention**%0A%0APer%20AGENTS.md%2FCLAUDE.md%3A%20%22Prefer%20typed%20internal%20errors%20over%20%60Result%3C_%2C%20String%3E%60%22.%20%60stream_socket_command%60%20returns%20%60Result%3C%28%29%2C%20String%3E%60%20and%20the%20internal%20%60send_request%60%20trait%20method%20also%20returns%20%60Result%3C%28%29%2C%20String%3E%60.%20A%20small%20error%20enum%20%28e.g.%2C%20%60SocketError%20%7B%20NotRunning%2C%20ConnectFailed%28io%3A%3AError%29%2C%20SendFailed%28io%3A%3AError%29%2C%20ReadFailed%28io%3A%3AError%29%20%7D%60%29%20would%20make%20downstream%20error%20handling%20exhaustive%20and%20consistent%20with%20the%20project's%20stated%20backend%20convention.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc-tauri%2Fsrc%2Fsocket.rs%3A2233-2236%0A**Stale%20doc%20comment%20lines%20copied%20from%20%60visible_to_alias%60**%0A%0AThe%20first%20two%20lines%20of%20the%20%60event_in_scope%60%20doc%20block%20describe%20the%20old%20alias-visibility%20concept%20%28%60%22direct%20mail%20OR%20matching%20subscription%22%60%29%2C%20which%20has%20nothing%20to%20do%20with%20project%20scoping.%20The%20function%20only%20checks%20project%20scope%20%E2%80%94%20the%20first%20two%20lines%20are%20a%20leftover%20copy-paste%20artifact%20and%20contradict%20what%20the%20function%20actually%20does.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20True%20when%20%60event%60%20falls%20inside%20the%20requested%20project%20scope.%0A%2F%2F%2F%20%60scope%60%3A%0A%2F%2F%2F%20-%20%60None%60%20%E2%87%92%20no%20filter%20%28Any%29.%0A%2F%2F%2F%20-%20%60Some%28None%29%60%20%E2%87%92%20global-only%3B%20event%20must%20also%20be%20unscoped.%0A%2F%2F%2F%20-%20%60Some%28Some%28p%29%29%60%20%E2%87%92%20event%20must%20be%20scoped%20to%20project%20%60p%60.%0A%60%60%60%0A%0A&repo=phin-tech%2Froux&pr=164&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22feature%2Fmailbox-watch%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fmailbox-watch%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc-tauri%2Fsrc%2Fsocket.rs%3A2233-2236%0A**Stale%20doc%20comment%20lines%20copied%20from%20%60visible_to_alias%60**%0A%0AThe%20first%20two%20lines%20of%20the%20%60event_in_scope%60%20doc%20block%20describe%20the%20old%20alias-visibility%20concept%20%28%60%22direct%20mail%20OR%20matching%20subscription%22%60%29%2C%20which%20has%20nothing%20to%20do%20with%20project%20scoping.%20The%20function%20only%20checks%20project%20scope%20%E2%80%94%20the%20first%20two%20lines%20are%20a%20leftover%20copy-paste%20artifact%20and%20contradict%20what%20the%20function%20actually%20does.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20True%20when%20%60event%60%20falls%20inside%20the%20requested%20project%20scope.%0A%2F%2F%2F%20%60scope%60%3A%0A%2F%2F%2F%20-%20%60None%60%20%E2%87%92%20no%20filter%20%28Any%29.%0A%2F%2F%2F%20-%20%60Some%28None%29%60%20%E2%87%92%20global-only%3B%20event%20must%20also%20be%20unscoped.%0A%2F%2F%2F%20-%20%60Some%28Some%28p%29%29%60%20%E2%87%92%20event%20must%20be%20scoped%20to%20project%20%60p%60.%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<sub>Reviews (4): Last reviewed commit: ["fix: don&#39;t ack watch deliveries before t..."](https://github.com/phin-tech/roux/commit/4cd630384f8aae960463946f4ed4e569f20dfa83) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31441034)</sub>

<!-- /greptile_comment -->