### PR TITLE
feat(mailbox): persistent bus subscriptions + glob topic patterns

### DIFF
--- a/crates/roux-core/src/lib.rs
+++ b/crates/roux-core/src/lib.rs
@@ -7,9 +7,11 @@
 pub mod agent_fsm;
 pub mod models;
 pub mod smolvm;
+pub mod topic_glob;
 pub mod worktree;
 
 pub use models::*;
+pub use topic_glob::{topic_matches, validate_topic, validate_topic_pattern, PatternError};
 pub use smolvm::{SmolMachine, SmolMachineCreateRequest, SmolvmDetection, SmolvmError};
 pub use worktree::{
     create_worktree, create_worktree_with_provider, expand_base_template, fetch_origin,

--- a/crates/roux-core/src/models/event.rs
+++ b/crates/roux-core/src/models/event.rs
@@ -156,6 +156,15 @@ pub enum MailboxEvent {
     },
     /// Recipient cleared their inbox (or a project-scoped slice of it).
     Cleared { recipient: String, count: u32 },
+    /// A `bus publish` matched a persistent subscription. Frontend uses
+    /// this to bump unread counts for the subscriber alias and to surface
+    /// the delivery in the recipient's inbox without an explicit
+    /// `to=<alias>` on the underlying event.
+    TopicDelivered {
+        event_id: String,
+        recipient: String,
+        subscription_id: String,
+    },
 }
 
 /// Builder for new events. Validates at construction so callers get a

--- a/crates/roux-core/src/models/mod.rs
+++ b/crates/roux-core/src/models/mod.rs
@@ -8,6 +8,7 @@ mod profile;
 mod project;
 mod session;
 mod settings;
+mod subscription;
 mod task;
 mod user_terminal_themes;
 mod watch;
@@ -20,6 +21,7 @@ pub use alias::{
 pub use event::{
     Event, EventBuilder, EventKind, EventValidationError, MailboxEvent, ReadState,
 };
+pub use subscription::{BusSubscription, BusSubscriptionEvent};
 pub use events::{RouxCommand, SessionExitPayload, SessionExitReason};
 pub use keymap::{
     merge_keymaps, parse_keymap_kdl, Bind, HudMode, KeyRef, KeymapAction, KeymapParseError,

--- a/crates/roux-core/src/models/subscription.rs
+++ b/crates/roux-core/src/models/subscription.rs
@@ -1,0 +1,90 @@
+use serde::{Deserialize, Serialize};
+
+/// A persistent subscription that ties an alias to a topic glob pattern.
+/// When `bus publish` fires an event whose topic matches `pattern`, the
+/// subscriber alias receives the event in its mailbox (subject to project
+/// scope) and a `MailboxEvent::TopicDelivered` is emitted for the UI.
+///
+/// Patterns are MQTT-style globs validated by `topic_glob::validate_topic_pattern`.
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct BusSubscription {
+    /// Stable id (uuid v4). Used to delete a subscription without
+    /// guessing on alias+pattern equality.
+    pub id: String,
+    /// Canonical alias receiving deliveries. Need not be currently bound
+    /// to a pane — queued mail accrues for whoever claims it next.
+    pub alias: String,
+    /// Validated glob pattern. Empty / invalid patterns are rejected at
+    /// the manager boundary.
+    pub pattern: String,
+    /// Project scope. `None` = global. A subscription only matches
+    /// events whose `project_id` is `None` or equals this scope.
+    #[serde(default)]
+    pub project_id: Option<String>,
+    /// Unix epoch milliseconds.
+    pub created_at: u64,
+}
+
+/// Tauri event emitted on subscription mutation. Mirrors `AliasEvent`
+/// shape so the frontend can keep its subscriptions store in sync.
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+pub enum BusSubscriptionEvent {
+    Created { subscription: BusSubscription },
+    Removed { id: String },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture() -> BusSubscription {
+        BusSubscription {
+            id: "sub-1".into(),
+            alias: "auditor".into(),
+            pattern: "*.build.completed".into(),
+            project_id: Some("repo-a".into()),
+            created_at: 12345,
+        }
+    }
+
+    #[test]
+    fn serde_round_trip_preserves_all_fields() {
+        let original = fixture();
+        let json = serde_json::to_string(&original).unwrap();
+        let parsed: BusSubscription = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, original);
+    }
+
+    #[test]
+    fn project_id_serializes_camel_case() {
+        let json = serde_json::to_value(fixture()).unwrap();
+        assert_eq!(json["projectId"], "repo-a");
+        assert_eq!(json["createdAt"], 12345);
+    }
+
+    #[test]
+    fn missing_project_id_defaults_to_none_on_load() {
+        // Older / hand-rolled rows might omit projectId entirely.
+        let raw = r#"{"id":"sub-1","alias":"a","pattern":"*","createdAt":1}"#;
+        let parsed: BusSubscription = serde_json::from_str(raw).unwrap();
+        assert!(parsed.project_id.is_none());
+    }
+
+    #[test]
+    fn event_serializes_with_kind_tag() {
+        let evt = BusSubscriptionEvent::Created { subscription: fixture() };
+        let json = serde_json::to_value(&evt).unwrap();
+        assert_eq!(json["kind"], "created");
+        assert!(json["subscription"].is_object());
+    }
+
+    #[test]
+    fn removed_event_carries_id() {
+        let evt = BusSubscriptionEvent::Removed { id: "sub-1".into() };
+        let json = serde_json::to_value(&evt).unwrap();
+        assert_eq!(json["kind"], "removed");
+        assert_eq!(json["id"], "sub-1");
+    }
+}

--- a/crates/roux-core/src/models/subscription.rs
+++ b/crates/roux-core/src/models/subscription.rs
@@ -18,8 +18,11 @@ pub struct BusSubscription {
     /// Validated glob pattern. Empty / invalid patterns are rejected at
     /// the manager boundary.
     pub pattern: String,
-    /// Project scope. `None` = global. A subscription only matches
-    /// events whose `project_id` is `None` or equals this scope.
+    /// Project scope. `None` = global (matches events in any scope).
+    /// A scoped subscription (`Some(p)`) only matches events whose
+    /// `project_id` is exactly `p` — it does NOT match global events
+    /// or events from other projects. This asymmetry keeps cross-
+    /// project authorization closed.
     #[serde(default)]
     pub project_id: Option<String>,
     /// Unix epoch milliseconds.

--- a/crates/roux-core/src/topic_glob.rs
+++ b/crates/roux-core/src/topic_glob.rs
@@ -102,40 +102,66 @@ fn is_literal_segment(s: &str) -> bool {
 /// Caller is responsible for passing a validated pattern; an unvalidated
 /// pattern with weird tokens like `foo*bar` will be treated as a literal
 /// segment and won't match anything that doesn't equal it byte-for-byte.
+///
+/// Complexity: `O(P * T)` for adversarial inputs thanks to the
+/// `(pi, ti)` memo table — a naïve recursive `**` matcher is exponential
+/// when the pattern contains multiple `**` over a long topic.
 pub fn topic_matches(pattern: &str, topic: &str) -> bool {
     if pattern.is_empty() || topic.is_empty() {
         return false;
     }
     let pat: Vec<&str> = pattern.split('.').collect();
     let top: Vec<&str> = topic.split('.').collect();
-    matches_segments(&pat, &top)
+    // Memo entries are keyed by (pattern_index, topic_index). Since
+    // both bounds are typically tiny (< 16 segments) we use a flat
+    // `Vec<Option<bool>>` of size `(P+1) * (T+1)` for cache locality
+    // — faster than HashMap and indexable by simple arithmetic.
+    let p_len = pat.len();
+    let t_len = top.len();
+    let mut memo = vec![None; (p_len + 1) * (t_len + 1)];
+    matches_segments(&pat, &top, 0, 0, &mut memo)
 }
 
-fn matches_segments(pattern: &[&str], topic: &[&str]) -> bool {
-    match (pattern.first(), topic.first()) {
+fn matches_segments(
+    pattern: &[&str],
+    topic: &[&str],
+    pi: usize,
+    ti: usize,
+    memo: &mut [Option<bool>],
+) -> bool {
+    let row = topic.len() + 1;
+    let key = pi * row + ti;
+    if let Some(cached) = memo[key] {
+        return cached;
+    }
+    let result = match (pattern.get(pi), topic.get(ti)) {
         (None, None) => true,
         (None, Some(_)) => false,
         (Some(p), _) if *p == "**" => {
             // `**` matches zero or more segments. Try every length.
-            let rest_pat = &pattern[1..];
             // zero segments: drop the `**` and continue against the same topic
-            if matches_segments(rest_pat, topic) {
-                return true;
-            }
-            // one or more segments: consume one topic segment, retry
-            for i in 1..=topic.len() {
-                if matches_segments(rest_pat, &topic[i..]) {
-                    return true;
+            if matches_segments(pattern, topic, pi + 1, ti, memo) {
+                true
+            } else {
+                // one or more segments: consume one topic segment, retry
+                let mut found = false;
+                for i in 1..=(topic.len() - ti) {
+                    if matches_segments(pattern, topic, pi + 1, ti + i, memo) {
+                        found = true;
+                        break;
+                    }
                 }
+                found
             }
-            false
         }
         (Some(_), None) => false,
         (Some(p), Some(t)) => {
             let head_ok = *p == "*" || *p == *t;
-            head_ok && matches_segments(&pattern[1..], &topic[1..])
+            head_ok && matches_segments(pattern, topic, pi + 1, ti + 1, memo)
         }
-    }
+    };
+    memo[key] = Some(result);
+    result
 }
 
 #[cfg(test)]
@@ -228,6 +254,22 @@ mod tests {
         assert!(topic_matches("*.*.completed", "repo-a.build.completed"));
         assert!(!topic_matches("*.*.completed", "repo-a.completed"));
         assert!(!topic_matches("*.*.completed", "a.b.c.completed"));
+    }
+
+    #[test]
+    fn many_double_stars_over_long_topic_is_fast() {
+        // Adversarial pattern that would explode in a naïve recursive
+        // matcher (each `**` retries every suffix). With memoization the
+        // worst case is O(P * T). 16 segments × 8 stars completes
+        // instantly; without memo the naïve walk takes >2s on this box.
+        let pattern = "**.**.**.**.**.**.**.**";
+        let topic = "a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p";
+        let start = std::time::Instant::now();
+        assert!(topic_matches(pattern, topic));
+        assert!(
+            start.elapsed() < std::time::Duration::from_millis(100),
+            "memoized matcher must finish quickly even with adversarial patterns",
+        );
     }
 
     // ── validate_topic_pattern ──────────────────────────────────────

--- a/crates/roux-core/src/topic_glob.rs
+++ b/crates/roux-core/src/topic_glob.rs
@@ -1,0 +1,324 @@
+//! Topic glob matching for bus subscriptions.
+//!
+//! MQTT-style segment-aware globbing. Topics are dot-separated segments
+//! (`repo-a.build.completed`); patterns may use literal segments, `*` for
+//! exactly one segment, and `**` for zero or more segments.
+//!
+//! Examples:
+//! - `repo-a.*` matches `repo-a.build`, NOT `repo-a.build.completed`
+//! - `repo-a.**` matches `repo-a`, `repo-a.build`, `repo-a.build.completed`
+//! - `*.completed` matches `build.completed`, NOT `repo-a.build.completed`
+//! - `**.completed` matches both
+//!
+//! Pattern segments are restricted to the same alphabet as topics
+//! (lowercase letters, digits, hyphens) plus the wildcards. Mixed tokens
+//! (e.g. `foo*`) are rejected at validation time so we don't have to
+//! reason about partial-segment globbing.
+
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PatternError {
+    Empty,
+    EmptySegment,
+    InvalidSegment(String),
+    TooLong,
+}
+
+impl fmt::Display for PatternError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PatternError::Empty => f.write_str("topic pattern is empty"),
+            PatternError::EmptySegment => f.write_str(
+                "topic pattern has an empty segment (consecutive dots or leading/trailing dot)",
+            ),
+            PatternError::InvalidSegment(s) => write!(
+                f,
+                "topic pattern segment '{s}' is invalid; must be `*`, `**`, or [a-z0-9-]+",
+            ),
+            PatternError::TooLong => f.write_str("topic pattern is too long (max 256 chars)"),
+        }
+    }
+}
+
+impl std::error::Error for PatternError {}
+
+const MAX_PATTERN_LEN: usize = 256;
+
+/// Validate a topic pattern. Returns the canonical form (currently a
+/// no-op pass-through; reserved for future case-folding). Patterns are
+/// the only place wildcards are allowed; concrete topics should pass
+/// `validate_topic` instead.
+pub fn validate_topic_pattern(pattern: &str) -> Result<String, PatternError> {
+    if pattern.is_empty() {
+        return Err(PatternError::Empty);
+    }
+    if pattern.len() > MAX_PATTERN_LEN {
+        return Err(PatternError::TooLong);
+    }
+    for segment in pattern.split('.') {
+        if segment.is_empty() {
+            return Err(PatternError::EmptySegment);
+        }
+        if segment == "*" || segment == "**" {
+            continue;
+        }
+        if !is_literal_segment(segment) {
+            return Err(PatternError::InvalidSegment(segment.to_string()));
+        }
+    }
+    Ok(pattern.to_string())
+}
+
+/// Validate a concrete (no-wildcard) topic. Used by `bus publish` to
+/// reject malformed topic strings before they hit the store.
+pub fn validate_topic(topic: &str) -> Result<String, PatternError> {
+    if topic.is_empty() {
+        return Err(PatternError::Empty);
+    }
+    if topic.len() > MAX_PATTERN_LEN {
+        return Err(PatternError::TooLong);
+    }
+    for segment in topic.split('.') {
+        if segment.is_empty() {
+            return Err(PatternError::EmptySegment);
+        }
+        if !is_literal_segment(segment) {
+            return Err(PatternError::InvalidSegment(segment.to_string()));
+        }
+    }
+    Ok(topic.to_string())
+}
+
+fn is_literal_segment(s: &str) -> bool {
+    !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+}
+
+/// True when `topic` matches `pattern`. Both are dot-separated. `pattern`
+/// may use `*` (exactly one segment) and `**` (zero or more segments).
+///
+/// Caller is responsible for passing a validated pattern; an unvalidated
+/// pattern with weird tokens like `foo*bar` will be treated as a literal
+/// segment and won't match anything that doesn't equal it byte-for-byte.
+pub fn topic_matches(pattern: &str, topic: &str) -> bool {
+    if pattern.is_empty() || topic.is_empty() {
+        return false;
+    }
+    let pat: Vec<&str> = pattern.split('.').collect();
+    let top: Vec<&str> = topic.split('.').collect();
+    matches_segments(&pat, &top)
+}
+
+fn matches_segments(pattern: &[&str], topic: &[&str]) -> bool {
+    match (pattern.first(), topic.first()) {
+        (None, None) => true,
+        (None, Some(_)) => false,
+        (Some(p), _) if *p == "**" => {
+            // `**` matches zero or more segments. Try every length.
+            let rest_pat = &pattern[1..];
+            // zero segments: drop the `**` and continue against the same topic
+            if matches_segments(rest_pat, topic) {
+                return true;
+            }
+            // one or more segments: consume one topic segment, retry
+            for i in 1..=topic.len() {
+                if matches_segments(rest_pat, &topic[i..]) {
+                    return true;
+                }
+            }
+            false
+        }
+        (Some(_), None) => false,
+        (Some(p), Some(t)) => {
+            let head_ok = *p == "*" || *p == *t;
+            head_ok && matches_segments(&pattern[1..], &topic[1..])
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── topic_matches ───────────────────────────────────────────────
+
+    #[test]
+    fn exact_match_succeeds() {
+        assert!(topic_matches("repo-a.build", "repo-a.build"));
+    }
+
+    #[test]
+    fn exact_pattern_rejects_extra_segments() {
+        assert!(!topic_matches("repo-a.build", "repo-a.build.completed"));
+        assert!(!topic_matches("repo-a.build", "repo-a"));
+    }
+
+    #[test]
+    fn single_star_consumes_exactly_one_segment() {
+        assert!(topic_matches("repo-a.*", "repo-a.build"));
+        assert!(!topic_matches("repo-a.*", "repo-a.build.completed"));
+        assert!(!topic_matches("repo-a.*", "repo-a"));
+    }
+
+    #[test]
+    fn single_star_at_head_matches_one_leading_segment() {
+        assert!(topic_matches("*.completed", "build.completed"));
+        assert!(!topic_matches("*.completed", "repo-a.build.completed"));
+    }
+
+    #[test]
+    fn double_star_at_tail_matches_any_suffix_including_zero() {
+        assert!(topic_matches("repo-a.**", "repo-a"));
+        assert!(topic_matches("repo-a.**", "repo-a.build"));
+        assert!(topic_matches("repo-a.**", "repo-a.build.completed"));
+        assert!(!topic_matches("repo-a.**", "repo-b.build"));
+    }
+
+    #[test]
+    fn double_star_at_head_matches_any_prefix() {
+        assert!(topic_matches("**.completed", "completed"));
+        assert!(topic_matches("**.completed", "build.completed"));
+        assert!(topic_matches("**.completed", "repo-a.build.completed"));
+        assert!(!topic_matches("**.completed", "build.failed"));
+    }
+
+    #[test]
+    fn double_star_in_middle_matches_anything_between() {
+        assert!(topic_matches("repo-a.**.completed", "repo-a.completed"));
+        assert!(topic_matches("repo-a.**.completed", "repo-a.build.completed"));
+        assert!(topic_matches("repo-a.**.completed", "repo-a.x.y.z.completed"));
+        assert!(!topic_matches("repo-a.**.completed", "repo-a.x.y.z.failed"));
+    }
+
+    #[test]
+    fn standalone_double_star_matches_anything() {
+        assert!(topic_matches("**", "x"));
+        assert!(topic_matches("**", "x.y.z"));
+    }
+
+    #[test]
+    fn standalone_single_star_matches_only_one_segment() {
+        assert!(topic_matches("*", "x"));
+        assert!(!topic_matches("*", "x.y"));
+    }
+
+    #[test]
+    fn mismatched_literal_does_not_match() {
+        assert!(!topic_matches("repo-a.build", "repo-b.build"));
+    }
+
+    #[test]
+    fn empty_inputs_never_match() {
+        assert!(!topic_matches("", ""));
+        assert!(!topic_matches("", "build"));
+        assert!(!topic_matches("build", ""));
+    }
+
+    #[test]
+    fn star_does_not_match_empty_segment() {
+        // there is no concept of an empty topic segment; topic.split('.')
+        // never yields one for valid topics.
+        assert!(!topic_matches("repo-a.*.completed", "repo-a.completed"));
+    }
+
+    #[test]
+    fn multiple_single_stars_must_align() {
+        assert!(topic_matches("*.*.completed", "repo-a.build.completed"));
+        assert!(!topic_matches("*.*.completed", "repo-a.completed"));
+        assert!(!topic_matches("*.*.completed", "a.b.c.completed"));
+    }
+
+    // ── validate_topic_pattern ──────────────────────────────────────
+
+    #[test]
+    fn validate_pattern_accepts_literal() {
+        assert_eq!(
+            validate_topic_pattern("repo-a.build.completed").as_deref(),
+            Ok("repo-a.build.completed"),
+        );
+    }
+
+    #[test]
+    fn validate_pattern_accepts_wildcards() {
+        assert!(validate_topic_pattern("repo-a.*").is_ok());
+        assert!(validate_topic_pattern("repo-a.**").is_ok());
+        assert!(validate_topic_pattern("**.completed").is_ok());
+        assert!(validate_topic_pattern("*").is_ok());
+        assert!(validate_topic_pattern("**").is_ok());
+    }
+
+    #[test]
+    fn validate_pattern_rejects_empty() {
+        assert_eq!(validate_topic_pattern(""), Err(PatternError::Empty));
+    }
+
+    #[test]
+    fn validate_pattern_rejects_empty_segments() {
+        assert_eq!(
+            validate_topic_pattern("repo-a..build"),
+            Err(PatternError::EmptySegment),
+        );
+        assert_eq!(
+            validate_topic_pattern(".repo-a"),
+            Err(PatternError::EmptySegment),
+        );
+        assert_eq!(
+            validate_topic_pattern("repo-a."),
+            Err(PatternError::EmptySegment),
+        );
+    }
+
+    #[test]
+    fn validate_pattern_rejects_mixed_tokens() {
+        // partial-segment globbing not supported: `foo*` is neither a
+        // valid literal nor a wildcard token.
+        assert!(matches!(
+            validate_topic_pattern("repo-a.foo*"),
+            Err(PatternError::InvalidSegment(_)),
+        ));
+        assert!(matches!(
+            validate_topic_pattern("**foo"),
+            Err(PatternError::InvalidSegment(_)),
+        ));
+    }
+
+    #[test]
+    fn validate_pattern_rejects_disallowed_chars() {
+        for bad in ["repo_a", "repo a.build", "REPO-A.build", "repo-a/build"] {
+            assert!(
+                matches!(validate_topic_pattern(bad), Err(PatternError::InvalidSegment(_))),
+                "expected reject for {bad:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn validate_pattern_rejects_too_long() {
+        let too_long = "a".repeat(MAX_PATTERN_LEN + 1);
+        assert_eq!(validate_topic_pattern(&too_long), Err(PatternError::TooLong));
+    }
+
+    // ── validate_topic (no wildcards allowed) ───────────────────────
+
+    #[test]
+    fn validate_topic_rejects_wildcards() {
+        assert!(matches!(
+            validate_topic("repo-a.*"),
+            Err(PatternError::InvalidSegment(_)),
+        ));
+        assert!(matches!(
+            validate_topic("**"),
+            Err(PatternError::InvalidSegment(_)),
+        ));
+    }
+
+    #[test]
+    fn validate_topic_accepts_literal() {
+        assert_eq!(
+            validate_topic("repo-a.build.completed").as_deref(),
+            Ok("repo-a.build.completed"),
+        );
+    }
+}

--- a/docs/features/mailbox.md
+++ b/docs/features/mailbox.md
@@ -155,6 +155,50 @@ anyone tailing that topic.
 
 Default `kind` for `bus publish` is `signal`.
 
+### Subscriptions
+
+Tail-and-grep is fine for ad-hoc inspection, but for durable "tell my
+alias whenever X fires" wiring use a **subscription**. A subscription
+ties an alias to a topic glob; matched events land in the subscriber's
+mailbox so `roux mailbox read` (and the `UserPromptSubmit` hook) just
+work. Subscriptions persist across app restarts.
+
+```sh
+# Auditor wants every completion event from any repo:
+roux bus subscribe '**.completed' --alias auditor
+
+# Same alias also wants build failures, but only in repo-a:
+roux bus subscribe 'repo-a.build.failed' --alias auditor
+
+roux bus subscriptions               # list everything
+roux bus subscriptions --alias auditor
+roux bus unsubscribe <subscription-id>
+```
+
+Glob syntax (MQTT-style segment-aware):
+
+| Pattern | Matches | Doesn't match |
+|---|---|---|
+| `repo-a.build` | exact `repo-a.build` | anything else |
+| `repo-a.*` | `repo-a.build` | `repo-a.build.completed` |
+| `repo-a.**` | `repo-a`, `repo-a.build`, `repo-a.build.completed` | `repo-b.build` |
+| `*.completed` | `build.completed` | `repo-a.build.completed` |
+| `**.completed` | `completed`, `build.completed`, `repo-a.build.completed` | `build.failed` |
+| `repo-a.**.completed` | `repo-a.completed`, `repo-a.x.y.completed` | `repo-a.x.failed` |
+
+Pattern segments are lowercase letters, digits, and hyphens — same
+alphabet as topics and aliases. `*` and `**` must occupy a whole
+segment; partial-segment globbing (`foo*`) is rejected at validation
+time.
+
+Project scoping: a subscription with `--project p1` only matches events
+whose `project_id` is also `p1`. A subscription with no project (the
+default) matches events in any scope.
+
+Subscribed events appear in the subscriber's `mailbox read` output and
+update their unread count via the same `mailbox-event` Tauri channel —
+the UI's per-alias badge increments on every match.
+
 ## The Mailbox panel (UI)
 
 Click the inbox icon in the activity rail (or use the keybinding for
@@ -239,6 +283,7 @@ CLI uses; you get parity with the CLI surface, just typed.
 | File | Format | Notes |
 |---|---|---|
 | `aliases.json` | Versioned envelope (`{version: 1, data: [...]}`) | Full rewrite on mutation |
+| `subscriptions.json` | Versioned envelope | Full rewrite on subscribe / unsubscribe |
 | `events.jsonl` | Append-only NDJSON, one event per line, with `schemaVersion: 1` | Audit log; never compacted |
 | `read_state.json` | Versioned envelope | Full rewrite on mark-read / ack / clear-read |
 
@@ -298,8 +343,16 @@ roux mailbox post --to frontend --kind result "/reviews implemented in commit ab
 roux bus publish repo-a.build.completed "main is green at sha abc123"
 ```
 
-Anyone tailing `repo-a.*` (or a wildcard subscriber, once subscriptions
-land) sees it.
+Anyone tailing the topic sees it. To get push delivery rather than
+poll-via-tail, an alias subscribes once:
+
+```sh
+roux bus subscribe 'repo-a.**.completed' --alias auditor
+```
+
+After that, every matching publish lands in `auditor`'s mailbox; the
+auditor agent's `UserPromptSubmit` hook (or `roux mailbox read --ack`)
+picks them up at the start of the next turn.
 
 ### "Send me a note from a script"
 

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -262,6 +262,33 @@ enum BusAction {
         #[arg(short = 'l', long)]
         limit: Option<u32>,
     },
+    /// Subscribe an alias to topic events matching a glob pattern.
+    /// `*` matches one segment, `**` matches many (e.g. `repo-a.*`,
+    /// `**.completed`). Defaults `--alias` to the current pane's alias.
+    Subscribe {
+        /// Glob pattern (validated server-side). Quote in shells that
+        /// expand `*` themselves.
+        pattern: String,
+        /// Alias receiving deliveries. Defaults to the calling pane's
+        /// auto-claimed alias.
+        #[arg(short = 'a', long)]
+        alias: Option<String>,
+        #[arg(short = 'p', long)]
+        project: Option<String>,
+    },
+    /// Remove a subscription by id.
+    Unsubscribe {
+        id: String,
+    },
+    /// List subscriptions. Without --alias / --project, lists all.
+    Subscriptions {
+        #[arg(short = 'a', long)]
+        alias: Option<String>,
+        #[arg(short = 'p', long)]
+        project: Option<String>,
+        #[arg(long, conflicts_with = "project")]
+        global: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1190,6 +1217,50 @@ fn main() {
                 }
                 run_socket_command(serde_json::json!({
                     "command": "bus-tail",
+                    "session_id": get_session_id(),
+                    "pane_id": get_pane_id(),
+                    "args": Value::Object(args),
+                }));
+            }
+            BusAction::Subscribe { pattern, alias, project } => {
+                let mut args = serde_json::Map::new();
+                args.insert("pattern".into(), Value::String(pattern));
+                if let Some(a) = alias {
+                    args.insert("alias".into(), Value::String(a));
+                }
+                if let Some(p) = project {
+                    args.insert("project_id".into(), Value::String(p));
+                }
+                run_socket_command(serde_json::json!({
+                    "command": "bus-subscribe",
+                    "session_id": get_session_id(),
+                    "pane_id": get_pane_id(),
+                    "args": Value::Object(args),
+                }));
+            }
+            BusAction::Unsubscribe { id } => {
+                let mut args = serde_json::Map::new();
+                args.insert("id".into(), Value::String(id));
+                run_socket_command(serde_json::json!({
+                    "command": "bus-unsubscribe",
+                    "session_id": get_session_id(),
+                    "pane_id": get_pane_id(),
+                    "args": Value::Object(args),
+                }));
+            }
+            BusAction::Subscriptions { alias, project, global } => {
+                let mut args = serde_json::Map::new();
+                if let Some(a) = alias {
+                    args.insert("alias".into(), Value::String(a));
+                }
+                if let Some(p) = project {
+                    args.insert("project_id".into(), Value::String(p));
+                }
+                if global {
+                    args.insert("global".into(), Value::Bool(true));
+                }
+                run_socket_command(serde_json::json!({
+                    "command": "bus-subscriptions",
                     "session_id": get_session_id(),
                     "pane_id": get_pane_id(),
                     "args": Value::Object(args),

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod sessions;
 pub(crate) mod settings;
 pub(crate) mod setup;
 pub(crate) mod smol_machines;
+pub(crate) mod subscriptions;
 pub(crate) mod updater;
 pub(crate) mod user_themes;
 pub(crate) mod worktrees;

--- a/src-tauri/src/commands/subscriptions.rs
+++ b/src-tauri/src/commands/subscriptions.rs
@@ -53,5 +53,8 @@ pub async fn subscriptions_delete(
     state: tauri::State<'_, AppState>,
     app: tauri::AppHandle,
 ) -> Result<bool, String> {
-    Ok(state.subscription_manager.unsubscribe(&id, Some(&app)))
+    state
+        .subscription_manager
+        .unsubscribe(&id, Some(&app))
+        .map_err(|e| e.to_string())
 }

--- a/src-tauri/src/commands/subscriptions.rs
+++ b/src-tauri/src/commands/subscriptions.rs
@@ -1,0 +1,57 @@
+//! Tauri commands exposing the bus subscription surface to the frontend.
+//!
+//! The Mailbox panel uses these to render a Subscriptions tab and let
+//! the user create/delete subscriptions interactively. CLI/MCP mutations
+//! flow through the socket protocol — both paths share the same
+//! `SubscriptionManager` instance on `AppState`, so changes from one
+//! show up immediately on the other.
+
+use roux_core::BusSubscription;
+use roux_lib::aliases::ProjectFilter;
+
+use crate::state::AppState;
+
+fn project_filter<'a>(project_id: Option<&'a str>, global: bool) -> ProjectFilter<'a> {
+    match (project_id, global) {
+        (Some(p), _) => ProjectFilter::Exact(Some(p)),
+        (None, true) => ProjectFilter::Exact(None),
+        (None, false) => ProjectFilter::Any,
+    }
+}
+
+#[tauri::command]
+pub async fn subscriptions_list(
+    alias: Option<String>,
+    project_id: Option<String>,
+    global: Option<bool>,
+    state: tauri::State<'_, AppState>,
+) -> Result<Vec<BusSubscription>, String> {
+    let filter = project_filter(project_id.as_deref(), global.unwrap_or(false));
+    Ok(match alias {
+        Some(a) => state.subscription_manager.for_alias(&a, filter),
+        None => state.subscription_manager.list(filter),
+    })
+}
+
+#[tauri::command]
+pub async fn subscriptions_create(
+    alias: String,
+    pattern: String,
+    project_id: Option<String>,
+    state: tauri::State<'_, AppState>,
+    app: tauri::AppHandle,
+) -> Result<BusSubscription, String> {
+    state
+        .subscription_manager
+        .subscribe(&alias, &pattern, project_id, Some(&app))
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn subscriptions_delete(
+    id: String,
+    state: tauri::State<'_, AppState>,
+    app: tauri::AppHandle,
+) -> Result<bool, String> {
+    Ok(state.subscription_manager.unsubscribe(&id, Some(&app)))
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod aliases;
 pub mod mailbox;
 pub mod paths;
+pub mod subscriptions;
 
 pub fn run() {
     tauri::Builder::default()

--- a/src-tauri/src/mailbox/manager.rs
+++ b/src-tauri/src/mailbox/manager.rs
@@ -84,22 +84,32 @@ impl MailboxManager {
     /// Patterns subscribed to by `recipient` in scopes compatible with
     /// `project_filter`. Returns an empty vec when no subscription
     /// manager is wired or the recipient has no subscriptions.
+    ///
+    /// When `project_filter` is `Any`, returns global subscriptions
+    /// (`project_id == None`) only — scoped patterns must NOT cross
+    /// project boundaries even on broad list calls. The `list_for_recipient`
+    /// callers that need cross-project visibility iterate per-event scope
+    /// via `patterns_for_event`.
     fn patterns_for(&self, recipient: &str, project_filter: ProjectFilter<'_>) -> Vec<String> {
         let Some(subs) = self.subscriptions.as_ref() else {
             return Vec::new();
         };
         match project_filter {
-            // For the "Any" filter, give the recipient every pattern they
-            // hold regardless of project — visibility broadens with the
-            // request scope.
-            ProjectFilter::Any => {
-                subs.for_alias(recipient, ProjectFilter::Any)
-                    .into_iter()
-                    .map(|s| s.pattern)
-                    .collect()
-            }
+            ProjectFilter::Any => subs.patterns_for_alias(recipient, None),
             ProjectFilter::Exact(scope) => subs.patterns_for_alias(recipient, scope),
         }
+    }
+
+    /// Patterns for `recipient` scoped to a specific event. Used by the
+    /// per-event ownership check (`mark_read`, `ack`) so a `p2`-scoped
+    /// subscription can't authorize ReadState writes against a `p1`
+    /// event. Caller passes the event so we can derive its `project_id`
+    /// from a single `store.get` rather than asking the caller to.
+    fn patterns_for_event(&self, recipient: &str, event: &Event) -> Vec<String> {
+        let Some(subs) = self.subscriptions.as_ref() else {
+            return Vec::new();
+        };
+        subs.patterns_for_alias(recipient, event.project_id.as_deref())
     }
 
     pub fn post(
@@ -157,7 +167,14 @@ impl MailboxManager {
         app: Option<&AppHandle>,
     ) -> bool {
         let now = now_ms();
-        let patterns = self.patterns_for(recipient, ProjectFilter::Any);
+        // Patterns are scoped to the event's own project so a recipient's
+        // p2-scoped subscription can't authorize ReadState writes against
+        // a p1-scoped event. Empty if the event doesn't exist — store will
+        // then refuse the write either way.
+        let patterns = self
+            .get(event_id)
+            .map(|e| self.patterns_for_event(recipient, &e))
+            .unwrap_or_default();
         let changed = {
             let mut store = self.inner.lock().expect("event store poisoned");
             store.mark_read(event_id, recipient, &patterns, now)
@@ -185,7 +202,10 @@ impl MailboxManager {
         app: Option<&AppHandle>,
     ) -> bool {
         let now = now_ms();
-        let patterns = self.patterns_for(recipient, ProjectFilter::Any);
+        let patterns = self
+            .get(event_id)
+            .map(|e| self.patterns_for_event(recipient, &e))
+            .unwrap_or_default();
         let changed = {
             let mut store = self.inner.lock().expect("event store poisoned");
             store.ack(event_id, recipient, &patterns, result.clone(), now)
@@ -528,5 +548,47 @@ mod tests {
             ProjectFilter::Exact(Some("p2")),
         );
         assert!(visible_p2.is_empty());
+    }
+
+    /// Regression for the cross-project authorization bug: a p2-scoped
+    /// subscription must NOT let the recipient mark p1 events read.
+    /// Pre-fix `patterns_for(Any)` flattened all the recipient's
+    /// patterns and the store's ownership check granted access whenever
+    /// any pattern matched the topic, regardless of project.
+    #[test]
+    fn cross_project_subscription_cannot_authorize_other_project_events() {
+        let mgr = MailboxManager::in_memory()
+            .with_subscriptions(SubscriptionManager::in_memory());
+        // Auditor only subscribes inside p2.
+        mgr.subscriptions
+            .as_ref()
+            .unwrap()
+            .subscribe("auditor", "*", Some("p2".into()), None)
+            .unwrap();
+
+        // Bob posts a topic event in p1, addressed to reviewer (not auditor).
+        let event = mgr
+            .post(
+                EventBuilder::new("p1 work")
+                    .to("reviewer")
+                    .topic("foo")
+                    .from("bob")
+                    .project_id("p1")
+                    .kind(EventKind::Task),
+                None,
+            )
+            .unwrap();
+
+        // Auditor must NOT be able to mark this read — their p2 sub
+        // doesn't apply to p1 events.
+        assert!(
+            !mgr.mark_read(&event.id, "auditor", None),
+            "p2-scoped subscription must not authorize p1 event ownership",
+        );
+        assert!(mgr.read_state(&event.id, "auditor").is_none());
+        assert!(
+            !mgr.ack(&event.id, "auditor", Some("done".into()), None),
+            "p2-scoped subscription must not authorize p1 event ack",
+        );
     }
 }

--- a/src-tauri/src/mailbox/manager.rs
+++ b/src-tauri/src/mailbox/manager.rs
@@ -5,6 +5,7 @@ use roux_core::{Event, EventBuilder, MailboxEvent, ReadState};
 use tauri::{AppHandle, Emitter};
 
 use crate::aliases::ProjectFilter;
+use crate::subscriptions::SubscriptionManager;
 
 use super::persistence::{
     self, append_event_to, load_events_from, load_read_state_from, save_read_state_to,
@@ -29,10 +30,15 @@ struct MailboxPaths {
 ///
 /// The events file grows monotonically — the in-memory store applies
 /// retention caps at load time, but the on-disk audit log is preserved.
+///
+/// `subscriptions` is optional so test fixtures and other call paths can
+/// construct a manager without a live subscription store. When absent,
+/// recipient pattern lookup is empty (legacy exact-match semantics).
 #[derive(Clone)]
 pub struct MailboxManager {
     inner: Arc<Mutex<EventStore>>,
     paths: Option<Arc<MailboxPaths>>,
+    subscriptions: Option<SubscriptionManager>,
 }
 
 impl MailboxManager {
@@ -52,14 +58,48 @@ impl MailboxManager {
                 events: events_path,
                 read_state: read_state_path,
             })),
+            subscriptions: None,
         }
+    }
+
+    /// Wire the subscription manager so topic-matched events become
+    /// visible / ack-able to subscribers. Returns `self` for chaining
+    /// at construction sites in `main.rs`.
+    pub fn with_subscriptions(mut self, subscriptions: SubscriptionManager) -> Self {
+        self.subscriptions = Some(subscriptions);
+        self
     }
 
     /// In-memory only. No load, no persist on mutation. For tests that
     /// don't care about disk IO.
     #[cfg(test)]
     pub fn in_memory() -> Self {
-        Self { inner: Arc::new(Mutex::new(EventStore::new())), paths: None }
+        Self {
+            inner: Arc::new(Mutex::new(EventStore::new())),
+            paths: None,
+            subscriptions: None,
+        }
+    }
+
+    /// Patterns subscribed to by `recipient` in scopes compatible with
+    /// `project_filter`. Returns an empty vec when no subscription
+    /// manager is wired or the recipient has no subscriptions.
+    fn patterns_for(&self, recipient: &str, project_filter: ProjectFilter<'_>) -> Vec<String> {
+        let Some(subs) = self.subscriptions.as_ref() else {
+            return Vec::new();
+        };
+        match project_filter {
+            // For the "Any" filter, give the recipient every pattern they
+            // hold regardless of project — visibility broadens with the
+            // request scope.
+            ProjectFilter::Any => {
+                subs.for_alias(recipient, ProjectFilter::Any)
+                    .into_iter()
+                    .map(|s| s.pattern)
+                    .collect()
+            }
+            ProjectFilter::Exact(scope) => subs.patterns_for_alias(recipient, scope),
+        }
     }
 
     pub fn post(
@@ -90,6 +130,22 @@ impl MailboxManager {
         }
         if let Some(app) = app {
             let _ = app.emit(MAILBOX_EVENT, &MailboxEvent::Posted { event: event.clone() });
+            // Topic-event subscriptions: notify each matching subscriber.
+            // Frontend uses these to bump the subscriber alias's unread
+            // count and surface the delivery without a new mailbox row.
+            if let (Some(topic), Some(subs)) = (event.topic.as_deref(), self.subscriptions.as_ref())
+            {
+                for sub in subs.matching_topic(topic, event.project_id.as_deref()) {
+                    let _ = app.emit(
+                        MAILBOX_EVENT,
+                        &MailboxEvent::TopicDelivered {
+                            event_id: event.id.clone(),
+                            recipient: sub.alias,
+                            subscription_id: sub.id,
+                        },
+                    );
+                }
+            }
         }
         Ok(event)
     }
@@ -101,9 +157,10 @@ impl MailboxManager {
         app: Option<&AppHandle>,
     ) -> bool {
         let now = now_ms();
+        let patterns = self.patterns_for(recipient, ProjectFilter::Any);
         let changed = {
             let mut store = self.inner.lock().expect("event store poisoned");
-            store.mark_read(event_id, recipient, now)
+            store.mark_read(event_id, recipient, &patterns, now)
         };
         if changed {
             self.persist_read_state();
@@ -128,9 +185,10 @@ impl MailboxManager {
         app: Option<&AppHandle>,
     ) -> bool {
         let now = now_ms();
+        let patterns = self.patterns_for(recipient, ProjectFilter::Any);
         let changed = {
             let mut store = self.inner.lock().expect("event store poisoned");
-            store.ack(event_id, recipient, result.clone(), now)
+            store.ack(event_id, recipient, &patterns, result.clone(), now)
         };
         if changed {
             self.persist_read_state();
@@ -180,8 +238,9 @@ impl MailboxManager {
         unread_only: bool,
         project_filter: ProjectFilter<'_>,
     ) -> Vec<Event> {
+        let patterns = self.patterns_for(recipient, project_filter);
         let store = self.inner.lock().expect("event store poisoned");
-        store.list_for_recipient(recipient, unread_only, project_filter)
+        store.list_for_recipient(recipient, &patterns, unread_only, project_filter)
     }
 
     pub fn list_for_topic(
@@ -213,8 +272,9 @@ impl MailboxManager {
     }
 
     pub fn unread_count(&self, recipient: &str, project_filter: ProjectFilter<'_>) -> usize {
+        let patterns = self.patterns_for(recipient, project_filter);
         let store = self.inner.lock().expect("event store poisoned");
-        store.unread_count(recipient, project_filter)
+        store.unread_count(recipient, &patterns, project_filter)
     }
 
     pub fn get(&self, event_id: &str) -> Option<Event> {
@@ -368,5 +428,105 @@ mod tests {
         assert!(!mgr.mark_read(&event.id, "reviewer", None));
         let mtime_after = std::fs::metadata(&r).unwrap().modified().unwrap();
         assert_eq!(mtime_before, mtime_after, "no-op mark_read must not rewrite read_state.json");
+    }
+
+    // ── Subscription wiring ─────────────────────────────────────────
+
+    #[test]
+    fn subscriber_sees_topic_event_in_inbox() {
+        let mgr = MailboxManager::in_memory()
+            .with_subscriptions(SubscriptionManager::in_memory());
+        // Set up the subscription via the wired manager so the manager
+        // sees it. Need to grab the inner manager handle for that.
+        // (For tests we reach in via a helper.)
+        let subs = mgr.subscriptions.as_ref().unwrap();
+        subs.subscribe("auditor", "**.completed", None, None).unwrap();
+
+        // Publish a topic event.
+        let topic_event = EventBuilder::new("main is green")
+            .topic("repo-a.build.completed")
+            .from("builder")
+            .kind(EventKind::Signal);
+        mgr.post(topic_event, None).unwrap();
+
+        // Auditor's inbox includes the topic event.
+        let mine = mgr.list_for_recipient("auditor", false, ProjectFilter::Any);
+        assert_eq!(mine.len(), 1);
+        assert_eq!(mine[0].topic.as_deref(), Some("repo-a.build.completed"));
+    }
+
+    #[test]
+    fn unsubscribed_recipient_does_not_see_topic_events() {
+        let mgr = MailboxManager::in_memory()
+            .with_subscriptions(SubscriptionManager::in_memory());
+
+        let topic_event = EventBuilder::new("hi")
+            .topic("repo-a.build.completed")
+            .kind(EventKind::Signal);
+        mgr.post(topic_event, None).unwrap();
+
+        let mine = mgr.list_for_recipient("auditor", false, ProjectFilter::Any);
+        assert!(mine.is_empty());
+    }
+
+    #[test]
+    fn subscriber_unread_count_includes_topic_matches() {
+        let mgr = MailboxManager::in_memory()
+            .with_subscriptions(SubscriptionManager::in_memory());
+        mgr.subscriptions
+            .as_ref()
+            .unwrap()
+            .subscribe("auditor", "**.completed", None, None)
+            .unwrap();
+
+        let topic_event = EventBuilder::new("hi")
+            .topic("build.completed")
+            .kind(EventKind::Signal);
+        let event = mgr.post(topic_event, None).unwrap();
+
+        assert_eq!(mgr.unread_count("auditor", ProjectFilter::Any), 1);
+        // Auditor reads the topic event via the manager (subscription
+        // ownership lets them).
+        assert!(mgr.mark_read(&event.id, "auditor", None));
+        assert_eq!(mgr.unread_count("auditor", ProjectFilter::Any), 0);
+    }
+
+    #[test]
+    fn project_scoped_subscription_only_matches_in_scope() {
+        let mgr = MailboxManager::in_memory()
+            .with_subscriptions(SubscriptionManager::in_memory());
+        mgr.subscriptions
+            .as_ref()
+            .unwrap()
+            .subscribe("auditor", "*", Some("p1".into()), None)
+            .unwrap();
+
+        // Event in p1: matches.
+        let in_p1 = EventBuilder::new("a")
+            .topic("foo")
+            .project_id("p1")
+            .kind(EventKind::Signal);
+        mgr.post(in_p1, None).unwrap();
+
+        // Event in p2: must not match.
+        let in_p2 = EventBuilder::new("b")
+            .topic("foo")
+            .project_id("p2")
+            .kind(EventKind::Signal);
+        mgr.post(in_p2, None).unwrap();
+
+        let visible_p1 = mgr.list_for_recipient(
+            "auditor",
+            false,
+            ProjectFilter::Exact(Some("p1")),
+        );
+        assert_eq!(visible_p1.len(), 1);
+
+        let visible_p2 = mgr.list_for_recipient(
+            "auditor",
+            false,
+            ProjectFilter::Exact(Some("p2")),
+        );
+        assert!(visible_p2.is_empty());
     }
 }

--- a/src-tauri/src/mailbox/store.rs
+++ b/src-tauri/src/mailbox/store.rs
@@ -1,8 +1,14 @@
 use std::collections::{HashMap, VecDeque};
 
-use roux_core::{Event, EventBuilder, EventValidationError, ReadState};
+use roux_core::{topic_matches, Event, EventBuilder, EventValidationError, ReadState};
 
 use crate::aliases::ProjectFilter;
+
+/// Empty pattern slice — convenience for callers that don't have
+/// subscriptions wired (most existing tests, the in-memory mailbox
+/// manager, the bus-tail handler). Equivalent to "this recipient is not
+/// subscribed to anything", so subscription semantics are a no-op.
+pub const NO_SUBSCRIPTIONS: &[String] = &[];
 
 const DEFAULT_CAPACITY: usize = 5000;
 
@@ -162,19 +168,32 @@ impl EventStore {
         self.read_state(event_id, recipient).map(|s| s.is_cleared()).unwrap_or(false)
     }
 
-    /// Events addressed `to=<recipient>` matching the project filter. Oldest
-    /// first (insertion order). `unread_only` filters to events without a
-    /// `read_at` timestamp for this recipient. **Cleared events are always
-    /// filtered out** — `clear_read` is meant to hide them.
+    /// Events visible to `recipient`, oldest-first. An event is visible
+    /// when either:
+    ///
+    /// - `e.to == recipient` (direct mail), or
+    /// - `e.topic` matches any pattern in `subscribed_patterns` (bus
+    ///   subscription delivery).
+    ///
+    /// `unread_only` filters to events without a `read_at` timestamp for
+    /// this recipient. **Cleared events are always filtered out** —
+    /// `clear_read` is meant to hide them.
+    ///
+    /// Caller is responsible for sourcing `subscribed_patterns` —
+    /// typically the manager looks them up via the SubscriptionStore
+    /// scoped to the project filter. Pass `NO_SUBSCRIPTIONS` when the
+    /// recipient has no subscriptions or to preserve pre-subscription
+    /// semantics.
     pub fn list_for_recipient(
         &self,
         recipient: &str,
+        subscribed_patterns: &[String],
         unread_only: bool,
         project_filter: ProjectFilter<'_>,
     ) -> Vec<Event> {
         self.events
             .iter()
-            .filter(|e| e.to.as_deref() == Some(recipient))
+            .filter(|e| event_visible_to(e, recipient, subscribed_patterns))
             .filter(|e| project_filter.matches(e.project_id.as_deref()))
             .filter(|e| !self.is_cleared_by(&e.id, recipient))
             .filter(|e| !unread_only || !self.is_read_by(&e.id, recipient))
@@ -238,16 +257,29 @@ impl EventStore {
         out
     }
 
-    /// True when `recipient` is allowed to mutate ReadState for `event_id`.
-    /// For now: only the addressed recipient (or anyone if the event is
-    /// pure topic-broadcast — `to=None`). Future subscriptions / group
-    /// memberships extend this check.
-    fn recipient_owns(&self, event_id: &str, recipient: &str) -> bool {
+    /// True when `recipient` is allowed to mutate ReadState for
+    /// `event_id`. Permitted when:
+    ///
+    /// - `event.to == recipient` (direct mail), or
+    /// - `event.to.is_none()` and the event has a topic (pure bus
+    ///   broadcast — anyone can track their own state), or
+    /// - the recipient is subscribed to a pattern matching the event's
+    ///   topic (delivery via subscription).
+    ///
+    /// The caller threads `subscribed_patterns` so the store stays
+    /// dependency-free of the subscription module.
+    fn recipient_owns(
+        &self,
+        event_id: &str,
+        recipient: &str,
+        subscribed_patterns: &[String],
+    ) -> bool {
         let Some(event) = self.get(event_id) else {
             return false;
         };
         match event.to.as_deref() {
-            Some(addressed) => addressed == recipient,
+            Some(addressed) if addressed == recipient => true,
+            Some(_) => topic_matches_any(event.topic.as_deref(), subscribed_patterns),
             // Pure topic events have no addressed recipient; any caller
             // can track their own read state against them.
             None => true,
@@ -256,12 +288,18 @@ impl EventStore {
 
     /// Idempotently mark `event_id` as read for `recipient`. Returns true
     /// when state changed (i.e. it wasn't already read). Returns false
-    /// when `recipient` is not the addressed owner of the event — that
-    /// prevents a caller from creating a bogus ReadState row that
-    /// `list_sent_by` would later report back to the sender as if a
-    /// stranger had read their direct mail.
-    pub fn mark_read(&mut self, event_id: &str, recipient: &str, now_ms: u64) -> bool {
-        if !self.recipient_owns(event_id, recipient) {
+    /// when `recipient` doesn't own the event — that prevents a caller
+    /// from creating a bogus ReadState row that `list_sent_by` would
+    /// later report back to the sender as if a stranger had read their
+    /// direct mail.
+    pub fn mark_read(
+        &mut self,
+        event_id: &str,
+        recipient: &str,
+        subscribed_patterns: &[String],
+        now_ms: u64,
+    ) -> bool {
+        if !self.recipient_owns(event_id, recipient, subscribed_patterns) {
             return false;
         }
         let state = self.read_state_mut_or_insert(event_id, recipient);
@@ -280,10 +318,11 @@ impl EventStore {
         &mut self,
         event_id: &str,
         recipient: &str,
+        subscribed_patterns: &[String],
         result: Option<String>,
         now_ms: u64,
     ) -> bool {
-        if !self.recipient_owns(event_id, recipient) {
+        if !self.recipient_owns(event_id, recipient, subscribed_patterns) {
             return false;
         }
         let state = self.read_state_mut_or_insert(event_id, recipient);
@@ -304,10 +343,15 @@ impl EventStore {
         true
     }
 
-    pub fn unread_count(&self, recipient: &str, project_filter: ProjectFilter<'_>) -> usize {
+    pub fn unread_count(
+        &self,
+        recipient: &str,
+        subscribed_patterns: &[String],
+        project_filter: ProjectFilter<'_>,
+    ) -> usize {
         self.events
             .iter()
-            .filter(|e| e.to.as_deref() == Some(recipient))
+            .filter(|e| event_visible_to(e, recipient, subscribed_patterns))
             .filter(|e| project_filter.matches(e.project_id.as_deref()))
             .filter(|e| !self.is_cleared_by(&e.id, recipient))
             .filter(|e| !self.is_read_by(&e.id, recipient))
@@ -362,6 +406,23 @@ impl Default for EventStore {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// True if `event` is visible to `recipient` — either addressed
+/// directly or matches a subscription pattern. Hot-path helper kept
+/// adjacent to `EventStore` so the visibility rule lives in one place.
+fn event_visible_to(event: &Event, recipient: &str, subscribed_patterns: &[String]) -> bool {
+    if event.to.as_deref() == Some(recipient) {
+        return true;
+    }
+    topic_matches_any(event.topic.as_deref(), subscribed_patterns)
+}
+
+fn topic_matches_any(topic: Option<&str>, patterns: &[String]) -> bool {
+    let Some(t) = topic else {
+        return false;
+    };
+    patterns.iter().any(|p| topic_matches(p, t))
 }
 
 fn now_ms() -> u64 {
@@ -420,7 +481,7 @@ mod tests {
         post_to(&mut store, "e2", "builder", "b", None, None);
         post_to(&mut store, "e3", "reviewer", "c", None, None);
 
-        let mine = store.list_for_recipient("reviewer", false, ProjectFilter::Any);
+        let mine = store.list_for_recipient("reviewer", NO_SUBSCRIPTIONS, false, ProjectFilter::Any);
         let ids: Vec<_> = mine.iter().map(|e| e.id.clone()).collect();
         assert_eq!(ids, vec!["e1", "e3"]);
     }
@@ -430,9 +491,9 @@ mod tests {
         let mut store = EventStore::new();
         post_to(&mut store, "e1", "reviewer", "a", None, None);
         post_to(&mut store, "e2", "reviewer", "b", None, None);
-        store.mark_read("e1", "reviewer", 2000);
+        store.mark_read("e1", "reviewer", NO_SUBSCRIPTIONS, 2000);
 
-        let unread = store.list_for_recipient("reviewer", true, ProjectFilter::Any);
+        let unread = store.list_for_recipient("reviewer", NO_SUBSCRIPTIONS, true, ProjectFilter::Any);
         assert_eq!(unread.len(), 1);
         assert_eq!(unread[0].id, "e2");
     }
@@ -446,13 +507,14 @@ mod tests {
 
         let only_a = store.list_for_recipient(
             "reviewer",
+            NO_SUBSCRIPTIONS,
             false,
             ProjectFilter::Exact(Some("proj-a")),
         );
         assert_eq!(only_a.len(), 1);
         assert_eq!(only_a[0].id, "a");
 
-        let global_only = store.list_for_recipient("reviewer", false, ProjectFilter::Exact(None));
+        let global_only = store.list_for_recipient("reviewer", NO_SUBSCRIPTIONS, false, ProjectFilter::Exact(None));
         assert_eq!(global_only.len(), 1);
         assert_eq!(global_only[0].id, "g");
     }
@@ -500,8 +562,8 @@ mod tests {
     fn mark_read_is_idempotent() {
         let mut store = EventStore::new();
         post_to(&mut store, "e1", "reviewer", "x", None, None);
-        assert!(store.mark_read("e1", "reviewer", 1000));
-        assert!(!store.mark_read("e1", "reviewer", 2000), "second call should report no change");
+        assert!(store.mark_read("e1", "reviewer", NO_SUBSCRIPTIONS, 1000));
+        assert!(!store.mark_read("e1", "reviewer", NO_SUBSCRIPTIONS, 2000), "second call should report no change");
         let state = store.read_state("e1", "reviewer").unwrap();
         assert_eq!(state.read_at, Some(1000), "first read_at should be preserved");
     }
@@ -509,7 +571,7 @@ mod tests {
     #[test]
     fn mark_read_for_unknown_event_is_noop() {
         let mut store = EventStore::new();
-        assert!(!store.mark_read("nope", "reviewer", 1000));
+        assert!(!store.mark_read("nope", "reviewer", NO_SUBSCRIPTIONS, 1000));
         assert!(store.read_state("nope", "reviewer").is_none(), "no orphan state row");
     }
 
@@ -517,7 +579,7 @@ mod tests {
     fn ack_implies_read() {
         let mut store = EventStore::new();
         post_to(&mut store, "e1", "reviewer", "x", None, None);
-        assert!(store.ack("e1", "reviewer", Some("done".into()), 1500));
+        assert!(store.ack("e1", "reviewer", NO_SUBSCRIPTIONS, Some("done".into()), 1500));
         let state = store.read_state("e1", "reviewer").unwrap();
         assert!(state.is_read());
         assert!(state.is_acked());
@@ -530,8 +592,8 @@ mod tests {
     fn ack_after_read_preserves_read_at() {
         let mut store = EventStore::new();
         post_to(&mut store, "e1", "reviewer", "x", None, None);
-        store.mark_read("e1", "reviewer", 1000);
-        assert!(store.ack("e1", "reviewer", None, 2000));
+        store.mark_read("e1", "reviewer", NO_SUBSCRIPTIONS, 1000);
+        assert!(store.ack("e1", "reviewer", NO_SUBSCRIPTIONS, None, 2000));
         let state = store.read_state("e1", "reviewer").unwrap();
         assert_eq!(state.read_at, Some(1000));
         assert_eq!(state.acked_at, Some(2000));
@@ -541,10 +603,10 @@ mod tests {
     fn double_ack_is_noop_unless_result_changes() {
         let mut store = EventStore::new();
         post_to(&mut store, "e1", "reviewer", "x", None, None);
-        store.ack("e1", "reviewer", Some("first".into()), 1000);
-        assert!(!store.ack("e1", "reviewer", None, 2000), "redundant ack returns false");
+        store.ack("e1", "reviewer", NO_SUBSCRIPTIONS, Some("first".into()), 1000);
+        assert!(!store.ack("e1", "reviewer", NO_SUBSCRIPTIONS, None, 2000), "redundant ack returns false");
         // Updating the result is allowed.
-        assert!(store.ack("e1", "reviewer", Some("better".into()), 3000));
+        assert!(store.ack("e1", "reviewer", NO_SUBSCRIPTIONS, Some("better".into()), 3000));
         let state = store.read_state("e1", "reviewer").unwrap();
         assert_eq!(state.acked_at, Some(1000), "acked_at preserved across re-ack");
         assert_eq!(state.ack_result.as_deref(), Some("better"));
@@ -556,9 +618,9 @@ mod tests {
         post_to(&mut store, "e1", "reviewer", "a", None, None);
         post_to(&mut store, "e2", "reviewer", "b", None, None);
         post_to(&mut store, "e3", "builder", "c", None, None);
-        assert_eq!(store.unread_count("reviewer", ProjectFilter::Any), 2);
-        store.mark_read("e1", "reviewer", 1500);
-        assert_eq!(store.unread_count("reviewer", ProjectFilter::Any), 1);
+        assert_eq!(store.unread_count("reviewer", NO_SUBSCRIPTIONS, ProjectFilter::Any), 2);
+        store.mark_read("e1", "reviewer", NO_SUBSCRIPTIONS, 1500);
+        assert_eq!(store.unread_count("reviewer", NO_SUBSCRIPTIONS, ProjectFilter::Any), 1);
     }
 
     #[test]
@@ -567,8 +629,8 @@ mod tests {
         post_to(&mut store, "e1", "reviewer", "a", None, None);
         post_to(&mut store, "e2", "reviewer", "b", None, None);
         post_to(&mut store, "e3", "builder", "c", None, None);
-        store.mark_read("e1", "reviewer", 1000);
-        store.mark_read("e3", "builder", 1000);
+        store.mark_read("e1", "reviewer", NO_SUBSCRIPTIONS, 1000);
+        store.mark_read("e3", "builder", NO_SUBSCRIPTIONS, 1000);
 
         let cleared = store.clear_read("reviewer", ProjectFilter::Any, 5000);
         assert_eq!(cleared, 1);
@@ -581,14 +643,14 @@ mod tests {
 
         // Cleared events drop out of list_for_recipient.
         let visible: Vec<_> = store
-            .list_for_recipient("reviewer", false, ProjectFilter::Any)
+            .list_for_recipient("reviewer", NO_SUBSCRIPTIONS, false, ProjectFilter::Any)
             .iter()
             .map(|e| e.id.clone())
             .collect();
         assert_eq!(visible, vec!["e2"], "e1 cleared, e2 still visible");
 
         // And don't show up as unread either (regression of prior bug).
-        assert_eq!(store.unread_count("reviewer", ProjectFilter::Any), 1);
+        assert_eq!(store.unread_count("reviewer", NO_SUBSCRIPTIONS, ProjectFilter::Any), 1);
 
         // Builder's state is untouched.
         assert!(store.read_state("e3", "builder").is_some());
@@ -600,7 +662,7 @@ mod tests {
     fn capacity_eviction_drops_orphan_read_state() {
         let mut store = EventStore::with_capacity(2, None);
         post_to(&mut store, "e1", "reviewer", "a", None, None);
-        store.mark_read("e1", "reviewer", 500);
+        store.mark_read("e1", "reviewer", NO_SUBSCRIPTIONS, 500);
         post_to(&mut store, "e2", "reviewer", "b", None, None);
         post_to(&mut store, "e3", "reviewer", "c", None, None);
         // e1 should be evicted now; its read_state row should also be gone.
@@ -614,7 +676,7 @@ mod tests {
         let mut store = EventStore::new();
         post_to(&mut store, "e1", "reviewer", "a", Some("me"), None);
         post_to(&mut store, "e2", "builder", "b", Some("me"), None);
-        store.mark_read("e1", "reviewer", 1500);
+        store.mark_read("e1", "reviewer", NO_SUBSCRIPTIONS, 1500);
 
         let sent = store.list_sent_by("me", None, None);
         assert_eq!(sent.len(), 2);
@@ -637,7 +699,7 @@ mod tests {
             .from("me")
             .kind(EventKind::Signal);
         store.post(topic_event, "e1".into(), 1000).unwrap();
-        store.mark_read("e1", "qa", 1500); // qa subscribes to the topic
+        store.mark_read("e1", "qa", NO_SUBSCRIPTIONS, 1500); // qa subscribes to the topic
 
         let sent_qa_view = store.list_sent_by("me", Some("qa"), None);
         assert_eq!(sent_qa_view.len(), 1);
@@ -649,10 +711,10 @@ mod tests {
         let mut store = EventStore::new();
         post_to(&mut store, "e1", "reviewer", "a", Some("me"), None);
         // qa is NOT the addressed recipient — can't fabricate read state.
-        assert!(!store.mark_read("e1", "qa", 1500));
+        assert!(!store.mark_read("e1", "qa", NO_SUBSCRIPTIONS, 1500));
         assert!(store.read_state("e1", "qa").is_none());
         // The actual recipient still works fine.
-        assert!(store.mark_read("e1", "reviewer", 1500));
+        assert!(store.mark_read("e1", "reviewer", NO_SUBSCRIPTIONS, 1500));
     }
 
     #[test]
@@ -660,7 +722,7 @@ mod tests {
         let mut store = EventStore::new();
         post_to(&mut store, "e1", "reviewer", "a", None, None);
         post_to(&mut store, "e2", "reviewer", "b", None, None);
-        store.mark_read("e1", "reviewer", 1000);
+        store.mark_read("e1", "reviewer", NO_SUBSCRIPTIONS, 1000);
 
         let events: Vec<_> = store.events().cloned().collect();
         let states: Vec<_> = store.all_read_state().cloned().collect();
@@ -668,5 +730,121 @@ mod tests {
         assert_eq!(restored.len(), 2);
         assert!(restored.read_state("e1", "reviewer").unwrap().is_read());
         assert!(restored.read_state("e2", "reviewer").is_none());
+    }
+
+    // ── Subscription-aware visibility ──────────────────────────────
+
+    fn post_topic(store: &mut EventStore, id: &str, topic: &str) -> Event {
+        let b = EventBuilder::new("body").topic(topic).kind(EventKind::Signal);
+        store.post(b, id.to_string(), 1000).unwrap()
+    }
+
+    fn post_topic_to(
+        store: &mut EventStore,
+        id: &str,
+        topic: &str,
+        addressed: &str,
+    ) -> Event {
+        let b = EventBuilder::new("body")
+            .to(addressed)
+            .topic(topic)
+            .kind(EventKind::Task);
+        store.post(b, id.to_string(), 1000).unwrap()
+    }
+
+    #[test]
+    fn list_for_recipient_unions_addressed_and_subscribed_topics() {
+        let mut store = EventStore::new();
+        post_to(&mut store, "e1", "auditor", "direct", None, None);
+        post_topic(&mut store, "e2", "repo-a.build.completed");
+        post_topic(&mut store, "e3", "repo-a.build.failed");
+
+        let patterns = vec!["**.completed".to_string()];
+        let events =
+            store.list_for_recipient("auditor", &patterns, false, ProjectFilter::Any);
+        let ids: Vec<_> = events.iter().map(|e| e.id.clone()).collect();
+        // e1 is direct mail, e2 matches the pattern, e3 doesn't.
+        assert_eq!(ids, vec!["e1", "e2"]);
+    }
+
+    #[test]
+    fn list_for_recipient_no_subscriptions_keeps_legacy_semantics() {
+        let mut store = EventStore::new();
+        post_to(&mut store, "e1", "auditor", "direct", None, None);
+        post_topic(&mut store, "e2", "build.completed");
+
+        let events =
+            store.list_for_recipient("auditor", NO_SUBSCRIPTIONS, false, ProjectFilter::Any);
+        let ids: Vec<_> = events.iter().map(|e| e.id.clone()).collect();
+        assert_eq!(ids, vec!["e1"], "no subs → topic event invisible");
+    }
+
+    #[test]
+    fn subscriber_can_mark_read_topic_event() {
+        let mut store = EventStore::new();
+        post_topic(&mut store, "e1", "build.completed");
+
+        let patterns = vec!["**.completed".to_string()];
+        // Subscriber can ack/read.
+        assert!(store.mark_read("e1", "auditor", &patterns, 2000));
+        assert!(store.read_state("e1", "auditor").unwrap().is_read());
+    }
+
+    #[test]
+    fn subscriber_can_mark_read_addressed_topic_event() {
+        // Event is addressed to `reviewer` AND has a topic. Pre-fix,
+        // `auditor` could not write read state because to=reviewer
+        // gatekeeps. With a matching subscription, `auditor` can.
+        let mut store = EventStore::new();
+        post_topic_to(&mut store, "e1", "build.completed", "reviewer");
+
+        let auditor_patterns = vec!["**.completed".to_string()];
+        assert!(store.mark_read("e1", "auditor", &auditor_patterns, 2000));
+        // And the addressed recipient still works without subscriptions.
+        assert!(store.mark_read("e1", "reviewer", NO_SUBSCRIPTIONS, 2000));
+    }
+
+    #[test]
+    fn non_subscriber_still_cannot_mark_read_addressed_event() {
+        let mut store = EventStore::new();
+        post_to(&mut store, "e1", "reviewer", "direct", None, None);
+
+        // `qa` has subscriptions, but none matches this event's (absent) topic.
+        let patterns = vec!["**.completed".to_string()];
+        assert!(!store.mark_read("e1", "qa", &patterns, 2000));
+        assert!(store.read_state("e1", "qa").is_none());
+    }
+
+    #[test]
+    fn unread_count_includes_subscribed_events() {
+        let mut store = EventStore::new();
+        post_to(&mut store, "e1", "auditor", "direct", None, None);
+        post_topic(&mut store, "e2", "build.completed");
+        post_topic(&mut store, "e3", "build.failed");
+
+        let patterns = vec!["**.completed".to_string()];
+        let unread = store.unread_count("auditor", &patterns, ProjectFilter::Any);
+        assert_eq!(unread, 2, "direct (e1) + matching topic (e2)");
+
+        // Read the topic event; unread drops by one.
+        store.mark_read("e2", "auditor", &patterns, 2000);
+        assert_eq!(store.unread_count("auditor", &patterns, ProjectFilter::Any), 1);
+    }
+
+    #[test]
+    fn clear_read_works_for_subscribed_topic_events() {
+        let mut store = EventStore::new();
+        post_topic(&mut store, "e1", "build.completed");
+
+        let patterns = vec!["**.completed".to_string()];
+        store.mark_read("e1", "auditor", &patterns, 1000);
+        let cleared = store.clear_read("auditor", ProjectFilter::Any, 5000);
+        assert_eq!(cleared, 1);
+        assert!(store.read_state("e1", "auditor").unwrap().is_cleared());
+
+        // Cleared topic event drops out of list_for_recipient.
+        let events =
+            store.list_for_recipient("auditor", &patterns, false, ProjectFilter::Any);
+        assert!(events.is_empty());
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -217,12 +217,21 @@ fn main() {
         commands::user_themes::user_themes_dir,
         // pane_state commands are omitted from specta — serde_json::Value
         // produces invalid TypeScript. They're called via raw invoke() instead.
+        // Subscription commands are registered with `invoke_handler!`
+        // only (below). They're hand-typed in `src/lib/types/mailbox.ts`
+        // to mirror the mailbox/aliases pattern.
     ]);
 
     #[cfg(debug_assertions)]
     builder
         .export(specta_typescript::Typescript::default(), "../src/lib/bindings.ts")
         .expect("Failed to export TypeScript bindings");
+
+    // Subscription manager loaded once and shared by both the
+    // MailboxManager (so post() can fan out matches) and AppState (so
+    // the Tauri/CLI/MCP layers can mutate the subscription set). Clone
+    // is cheap — internally an Arc.
+    let subscription_manager = roux_lib::subscriptions::SubscriptionManager::load();
 
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
@@ -245,7 +254,13 @@ fn main() {
             automation_hooks: automation_hooks::AutomationHookManager::new(),
             notification_manager: notifications::NotificationManager::new(),
             alias_manager: roux_lib::aliases::AliasManager::load(),
-            mailbox_manager: roux_lib::mailbox::MailboxManager::load(),
+            // Subscriptions feed into the mailbox manager so topic events
+            // become visible / ack-able to subscribers. The same handle
+            // also lives on AppState so the Tauri/CLI/MCP layers can
+            // mutate the subscription set; clone is cheap (Arc inside).
+            mailbox_manager: roux_lib::mailbox::MailboxManager::load()
+                .with_subscriptions(subscription_manager.clone()),
+            subscription_manager,
             pending_replies: Mutex::new(std::collections::HashMap::new()),
             managed_proxy: services::managed_proxy::ManagedProxyState::new(),
         })
@@ -422,6 +437,9 @@ fn main() {
             commands::mailbox::mailbox_ack,
             commands::mailbox::mailbox_clear_read,
             commands::mailbox::mailbox_deliver_to_pane,
+            commands::subscriptions::subscriptions_list,
+            commands::subscriptions::subscriptions_create,
+            commands::subscriptions::subscriptions_delete,
         ])
         .setup(|app| {
             // Install the roux-cli shim dir (~/.config/roux/bin) with

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -308,6 +308,32 @@ pub struct BusTailParams {
     pub limit: Option<u64>,
 }
 
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct BusSubscribeParams {
+    /// Glob pattern. `*` matches one segment, `**` matches many.
+    pub pattern: String,
+    /// Alias to bind the subscription to. Defaults to the calling
+    /// pane's alias when omitted.
+    pub alias: Option<String>,
+    pub project_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct BusUnsubscribeParams {
+    pub id: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct BusSubscriptionsParams {
+    pub alias: Option<String>,
+    pub project_id: Option<String>,
+    #[serde(default)]
+    pub global: bool,
+}
+
 #[derive(Debug, Clone)]
 pub struct RouxMcpServer;
 
@@ -812,6 +838,66 @@ impl RouxMcpServer {
         }
         call_socket(json!({
             "command": "bus-tail",
+            "args": Value::Object(args),
+        }))
+        .await
+    }
+
+    #[tool(
+        description = "Subscribe an alias to topic events matching a glob pattern. `*` matches one segment, `**` matches many. When `alias` is omitted, defaults to the calling pane's alias. Matched events land in the subscriber's mailbox so subsequent `roux_mailbox_read` returns them."
+    )]
+    async fn roux_bus_subscribe(
+        &self,
+        Parameters(params): Parameters<BusSubscribeParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let mut args = serde_json::Map::new();
+        args.insert("pattern".into(), Value::String(params.pattern));
+        if let Some(a) = params.alias {
+            args.insert("alias".into(), Value::String(a));
+        }
+        if let Some(p) = params.project_id {
+            args.insert("project_id".into(), Value::String(p));
+        }
+        call_socket(json!({
+            "command": "bus-subscribe",
+            "args": Value::Object(args),
+        }))
+        .await
+    }
+
+    #[tool(description = "Remove a bus subscription by id.")]
+    async fn roux_bus_unsubscribe(
+        &self,
+        Parameters(params): Parameters<BusUnsubscribeParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let mut args = serde_json::Map::new();
+        args.insert("id".into(), Value::String(params.id));
+        call_socket(json!({
+            "command": "bus-unsubscribe",
+            "args": Value::Object(args),
+        }))
+        .await
+    }
+
+    #[tool(
+        description = "List bus subscriptions. With `alias`, only that alias's subscriptions; with `projectId` or `global`, scoped accordingly. Without filters, all subscriptions are returned."
+    )]
+    async fn roux_bus_subscriptions(
+        &self,
+        Parameters(params): Parameters<BusSubscriptionsParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let mut args = serde_json::Map::new();
+        if let Some(a) = params.alias {
+            args.insert("alias".into(), Value::String(a));
+        }
+        if let Some(p) = params.project_id {
+            args.insert("project_id".into(), Value::String(p));
+        }
+        if params.global {
+            args.insert("global".into(), Value::Bool(true));
+        }
+        call_socket(json!({
+            "command": "bus-subscriptions",
             "args": Value::Object(args),
         }))
         .await

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -313,9 +313,10 @@ pub struct BusTailParams {
 pub struct BusSubscribeParams {
     /// Glob pattern. `*` matches one segment, `**` matches many.
     pub pattern: String,
-    /// Alias to bind the subscription to. Defaults to the calling
-    /// pane's alias when omitted.
-    pub alias: Option<String>,
+    /// Alias to bind the subscription to. Required for MCP/stdio
+    /// callers — there's no pane context for the implicit fallback the
+    /// CLI uses, so missing alias would silently fail to subscribe.
+    pub alias: String,
     pub project_id: Option<String>,
 }
 
@@ -852,9 +853,7 @@ impl RouxMcpServer {
     ) -> Result<CallToolResult, ErrorData> {
         let mut args = serde_json::Map::new();
         args.insert("pattern".into(), Value::String(params.pattern));
-        if let Some(a) = params.alias {
-            args.insert("alias".into(), Value::String(a));
-        }
+        args.insert("alias".into(), Value::String(params.alias));
         if let Some(p) = params.project_id {
             args.insert("project_id".into(), Value::String(p));
         }

--- a/src-tauri/src/socket.rs
+++ b/src-tauri/src/socket.rs
@@ -204,6 +204,9 @@ async fn handle_request(req: Request, app: &tauri::AppHandle) -> Response {
         "mailbox-sent" => handle_mailbox_sent(req, app).await,
         "bus-publish" => handle_bus_publish(req, app).await,
         "bus-tail" => handle_bus_tail(req, app).await,
+        "bus-subscribe" => handle_bus_subscribe(req, app).await,
+        "bus-unsubscribe" => handle_bus_unsubscribe(req, app).await,
+        "bus-subscriptions" => handle_bus_subscriptions(req, app).await,
         "session-list" => handle_session_list(req, app).await,
         "session-poll" => handle_session_poll(req, app).await,
         "session-panes-list" => handle_session_panes_list(req, app).await,
@@ -1931,6 +1934,65 @@ async fn handle_bus_tail(req: Request, app: &tauri::AppHandle) -> Response {
         None => state.mailbox_manager.list_all(filter, limit),
     };
     Response::success(serde_json::to_value(events).unwrap_or_default())
+}
+
+/// Resolve the alias to subscribe under: explicit `--alias` wins, else
+/// the calling pane's auto-claimed alias. We require *something* to bind
+/// to — anonymous subscriptions can't deliver mail anywhere.
+fn resolve_subscriber_alias(req: &Request, app: &tauri::AppHandle) -> Result<String, String> {
+    if let Some(a) = args_str(req, "alias") {
+        return Ok(a.to_string());
+    }
+    let state: tauri::State<AppState> = app.state();
+    let pane_id = req.pane_id.as_deref().ok_or_else(|| {
+        "no --alias given and no pane context available; pass --alias <name>".to_string()
+    })?;
+    let mut held = state.alias_manager.find_for_pane(pane_id);
+    held.sort_by_key(|a| a.created_at);
+    held.into_iter()
+        .next()
+        .map(|a| a.alias)
+        .ok_or_else(|| {
+            "no --alias given and the calling pane holds no alias; pass --alias <name>".to_string()
+        })
+}
+
+async fn handle_bus_subscribe(req: Request, app: &tauri::AppHandle) -> Response {
+    let pattern = match args_str(&req, "pattern") {
+        Some(p) if !p.trim().is_empty() => p.to_string(),
+        _ => return Response::err("pattern required"),
+    };
+    let alias = match resolve_subscriber_alias(&req, app) {
+        Ok(a) => a,
+        Err(e) => return Response::err(e),
+    };
+    let project_id = args_str(&req, "project_id").map(str::to_string);
+
+    let state: tauri::State<AppState> = app.state();
+    match state.subscription_manager.subscribe(&alias, &pattern, project_id, Some(app)) {
+        Ok(s) => Response::success(serde_json::to_value(s).unwrap_or_default()),
+        Err(e) => Response::err(e.to_string()),
+    }
+}
+
+async fn handle_bus_unsubscribe(req: Request, app: &tauri::AppHandle) -> Response {
+    let id = match args_str(&req, "id") {
+        Some(s) if !s.is_empty() => s.to_string(),
+        _ => return Response::err("subscription id required"),
+    };
+    let state: tauri::State<AppState> = app.state();
+    let removed = state.subscription_manager.unsubscribe(&id, Some(app));
+    Response::success(serde_json::json!({ "removed": removed }))
+}
+
+async fn handle_bus_subscriptions(req: Request, app: &tauri::AppHandle) -> Response {
+    let state: tauri::State<AppState> = app.state();
+    let filter = mailbox_project_filter(args_str(&req, "project_id"), args_bool(&req, "global"));
+    let subs = match args_str(&req, "alias") {
+        Some(a) => state.subscription_manager.for_alias(a, filter),
+        None => state.subscription_manager.list(filter),
+    };
+    Response::success(serde_json::to_value(subs).unwrap_or_default())
 }
 
 fn crypto_random_uuid() -> String {

--- a/src-tauri/src/socket.rs
+++ b/src-tauri/src/socket.rs
@@ -1937,8 +1937,12 @@ async fn handle_bus_tail(req: Request, app: &tauri::AppHandle) -> Response {
 }
 
 /// Resolve the alias to subscribe under: explicit `--alias` wins, else
-/// the calling pane's auto-claimed alias. We require *something* to bind
-/// to — anonymous subscriptions can't deliver mail anywhere.
+/// the calling pane's bound alias. We require *something* to bind to
+/// — anonymous subscriptions can't deliver mail anywhere. When the
+/// pane holds multiple aliases (manual + auto-claim, or several manual
+/// claims) we refuse to guess and return a disambiguation error;
+/// silently picking by `created_at` would route deliveries to the
+/// wrong inbox.
 fn resolve_subscriber_alias(req: &Request, app: &tauri::AppHandle) -> Result<String, String> {
     if let Some(a) = args_str(req, "alias") {
         return Ok(a.to_string());
@@ -1947,14 +1951,20 @@ fn resolve_subscriber_alias(req: &Request, app: &tauri::AppHandle) -> Result<Str
     let pane_id = req.pane_id.as_deref().ok_or_else(|| {
         "no --alias given and no pane context available; pass --alias <name>".to_string()
     })?;
-    let mut held = state.alias_manager.find_for_pane(pane_id);
-    held.sort_by_key(|a| a.created_at);
-    held.into_iter()
-        .next()
-        .map(|a| a.alias)
-        .ok_or_else(|| {
-            "no --alias given and the calling pane holds no alias; pass --alias <name>".to_string()
-        })
+    let held = state.alias_manager.find_for_pane(pane_id);
+    match held.len() {
+        0 => Err(
+            "no --alias given and the calling pane holds no alias; pass --alias <name>"
+                .to_string(),
+        ),
+        1 => Ok(held[0].alias.clone()),
+        _ => {
+            let names: Vec<_> = held.iter().map(|a| a.alias.as_str()).collect();
+            Err(format!(
+                "no --alias given and the calling pane holds multiple aliases ({names:?}); pass --alias <name>"
+            ))
+        }
+    }
 }
 
 async fn handle_bus_subscribe(req: Request, app: &tauri::AppHandle) -> Response {
@@ -1981,8 +1991,10 @@ async fn handle_bus_unsubscribe(req: Request, app: &tauri::AppHandle) -> Respons
         _ => return Response::err("subscription id required"),
     };
     let state: tauri::State<AppState> = app.state();
-    let removed = state.subscription_manager.unsubscribe(&id, Some(app));
-    Response::success(serde_json::json!({ "removed": removed }))
+    match state.subscription_manager.unsubscribe(&id, Some(app)) {
+        Ok(removed) => Response::success(serde_json::json!({ "removed": removed })),
+        Err(e) => Response::err(e.to_string()),
+    }
 }
 
 async fn handle_bus_subscriptions(req: Request, app: &tauri::AppHandle) -> Response {

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -5,6 +5,7 @@ use tokio::sync::oneshot;
 
 use roux_lib::aliases::AliasManager;
 use roux_lib::mailbox::MailboxManager;
+use roux_lib::subscriptions::SubscriptionManager;
 
 use crate::notifications::NotificationManager;
 use crate::pane_service::PaneHandle;
@@ -28,6 +29,7 @@ pub(crate) struct AppState {
     pub(crate) notification_manager: NotificationManager,
     pub(crate) alias_manager: AliasManager,
     pub(crate) mailbox_manager: MailboxManager,
+    pub(crate) subscription_manager: SubscriptionManager,
     pub(crate) pending_replies: PendingReplies,
     pub(crate) managed_proxy: Arc<crate::services::managed_proxy::ManagedProxyState>,
 }

--- a/src-tauri/src/subscriptions/manager.rs
+++ b/src-tauri/src/subscriptions/manager.rs
@@ -1,0 +1,260 @@
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use roux_core::{validate_topic_pattern, BusSubscription, BusSubscriptionEvent};
+use tauri::{AppHandle, Emitter};
+
+use crate::aliases::ProjectFilter;
+
+use super::persistence::{self, load_from_path, save_to_path};
+use super::store::{AddError, SubscriptionStore};
+
+/// Tauri event name emitted on every subscription mutation.
+pub const SUBSCRIPTION_EVENT: &str = "subscription-event";
+
+#[derive(Debug, thiserror::Error)]
+pub enum SubscribeError {
+    #[error("invalid topic pattern: {0}")]
+    InvalidPattern(String),
+    #[error("invalid alias: {0}")]
+    InvalidAlias(String),
+    #[error(transparent)]
+    Store(#[from] AddError),
+}
+
+/// Clonable handle over the subscription store. Persistence runs
+/// synchronously on every mutation — the file is small (typically a few
+/// dozen rows × ~150 bytes) so cost is negligible and the simpler
+/// "save on every change" model avoids stale-state recovery after crash.
+#[derive(Clone)]
+pub struct SubscriptionManager {
+    inner: Arc<Mutex<SubscriptionStore>>,
+    persistence_path: Option<Arc<PathBuf>>,
+}
+
+impl SubscriptionManager {
+    pub fn load() -> Self {
+        Self::load_from(persistence::persistence_path())
+    }
+
+    pub fn load_from(path: PathBuf) -> Self {
+        let entries = load_from_path(&path);
+        Self {
+            inner: Arc::new(Mutex::new(SubscriptionStore::from_entries(entries))),
+            persistence_path: Some(Arc::new(path)),
+        }
+    }
+
+    /// In-memory variant. No load, no persist on mutations. For tests.
+    #[cfg(test)]
+    pub fn in_memory() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(SubscriptionStore::new())),
+            persistence_path: None,
+        }
+    }
+
+    /// Add a subscription. Validates the pattern (and alias format)
+    /// before insertion. Returns the persisted subscription with its id
+    /// stamped.
+    pub fn subscribe(
+        &self,
+        alias: &str,
+        pattern: &str,
+        project_id: Option<String>,
+        app: Option<&AppHandle>,
+    ) -> Result<BusSubscription, SubscribeError> {
+        let canonical_alias = roux_core::validate_alias_name(alias)
+            .map_err(|e| SubscribeError::InvalidAlias(e.to_string()))?;
+        let validated_pattern = validate_topic_pattern(pattern)
+            .map_err(|e| SubscribeError::InvalidPattern(e.to_string()))?;
+
+        let subscription = BusSubscription {
+            id: uuid::Uuid::new_v4().to_string(),
+            alias: canonical_alias,
+            pattern: validated_pattern,
+            project_id,
+            created_at: now_ms(),
+        };
+
+        let inserted = {
+            let mut store = self.inner.lock().expect("subscription store poisoned");
+            store.add(subscription)?
+        };
+        self.persist();
+        if let Some(app) = app {
+            let _ = app.emit(
+                SUBSCRIPTION_EVENT,
+                &BusSubscriptionEvent::Created { subscription: inserted.clone() },
+            );
+        }
+        Ok(inserted)
+    }
+
+    /// Remove by id. Returns `true` when something was deleted.
+    pub fn unsubscribe(&self, id: &str, app: Option<&AppHandle>) -> bool {
+        let removed = {
+            let mut store = self.inner.lock().expect("subscription store poisoned");
+            store.remove(id)
+        };
+        if removed {
+            self.persist();
+            if let Some(app) = app {
+                let _ = app
+                    .emit(SUBSCRIPTION_EVENT, &BusSubscriptionEvent::Removed { id: id.to_string() });
+            }
+        }
+        removed
+    }
+
+    pub fn get(&self, id: &str) -> Option<BusSubscription> {
+        let store = self.inner.lock().expect("subscription store poisoned");
+        store.get(id).cloned()
+    }
+
+    pub fn for_alias(
+        &self,
+        alias: &str,
+        project_filter: ProjectFilter<'_>,
+    ) -> Vec<BusSubscription> {
+        let store = self.inner.lock().expect("subscription store poisoned");
+        store.for_alias(alias, project_filter)
+    }
+
+    pub fn list(&self, project_filter: ProjectFilter<'_>) -> Vec<BusSubscription> {
+        let store = self.inner.lock().expect("subscription store poisoned");
+        store.list(project_filter)
+    }
+
+    /// Subscriptions whose pattern matches `topic` AND whose project
+    /// scope is compatible with `event_project_id`. Hot path on every
+    /// `bus publish`.
+    pub fn matching_topic(
+        &self,
+        topic: &str,
+        event_project_id: Option<&str>,
+    ) -> Vec<BusSubscription> {
+        let store = self.inner.lock().expect("subscription store poisoned");
+        store.matching_topic(topic, event_project_id)
+    }
+
+    /// Patterns subscribed to by `alias` in scopes compatible with
+    /// `event_project_id`. Used by the mailbox layer to extend
+    /// `list_for_recipient` and ack ownership for topic events.
+    pub fn patterns_for_alias(
+        &self,
+        alias: &str,
+        event_project_id: Option<&str>,
+    ) -> Vec<String> {
+        let store = self.inner.lock().expect("subscription store poisoned");
+        store.patterns_for_alias(alias, event_project_id)
+    }
+
+    fn persist(&self) {
+        let Some(path) = self.persistence_path.as_ref() else {
+            return;
+        };
+        let store = self.inner.lock().expect("subscription store poisoned");
+        if let Err(e) = save_to_path(store.entries(), path.as_path()) {
+            eprintln!(
+                "[roux] subscription persistence failed at {}: {e}",
+                path.display(),
+            );
+        }
+    }
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn subscribe_persists_to_disk() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("subscriptions.json");
+        let mgr = SubscriptionManager::load_from(path.clone());
+        let s = mgr.subscribe("auditor", "*.completed", None, None).unwrap();
+
+        let raw = std::fs::read_to_string(&path).unwrap();
+        assert!(raw.contains(&s.id));
+        assert!(raw.contains("auditor"));
+    }
+
+    #[test]
+    fn subscribe_rejects_invalid_pattern() {
+        let mgr = SubscriptionManager::in_memory();
+        let err = mgr.subscribe("auditor", "Bad Pattern!", None, None).unwrap_err();
+        assert!(matches!(err, SubscribeError::InvalidPattern(_)));
+    }
+
+    #[test]
+    fn subscribe_rejects_invalid_alias() {
+        let mgr = SubscriptionManager::in_memory();
+        let err = mgr.subscribe("Bad Alias!", "*", None, None).unwrap_err();
+        assert!(matches!(err, SubscribeError::InvalidAlias(_)));
+    }
+
+    #[test]
+    fn subscribe_canonicalizes_alias_to_lowercase() {
+        let mgr = SubscriptionManager::in_memory();
+        let s = mgr.subscribe("Auditor", "*", None, None).unwrap();
+        assert_eq!(s.alias, "auditor");
+    }
+
+    #[test]
+    fn subscribe_rejects_duplicate_triple() {
+        let mgr = SubscriptionManager::in_memory();
+        mgr.subscribe("auditor", "*.completed", None, None).unwrap();
+        let err = mgr.subscribe("auditor", "*.completed", None, None).unwrap_err();
+        assert!(matches!(err, SubscribeError::Store(AddError::Duplicate { .. })));
+    }
+
+    #[test]
+    fn unsubscribe_returns_false_for_missing_id() {
+        let mgr = SubscriptionManager::in_memory();
+        assert!(!mgr.unsubscribe("ghost", None));
+    }
+
+    #[test]
+    fn unsubscribe_removes_and_persists() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("subscriptions.json");
+        let mgr = SubscriptionManager::load_from(path.clone());
+        let s = mgr.subscribe("auditor", "*", None, None).unwrap();
+        assert!(mgr.unsubscribe(&s.id, None));
+
+        let mgr2 = SubscriptionManager::load_from(path);
+        assert!(mgr2.get(&s.id).is_none());
+    }
+
+    #[test]
+    fn matching_topic_returns_glob_matches() {
+        let mgr = SubscriptionManager::in_memory();
+        mgr.subscribe("a", "repo-a.*", None, None).unwrap();
+        mgr.subscribe("b", "**.completed", None, None).unwrap();
+        let ms = mgr.matching_topic("repo-a.build.completed", None);
+        let aliases: Vec<_> = ms.iter().map(|s| s.alias.clone()).collect();
+        assert_eq!(aliases, vec!["b".to_string()]);
+    }
+
+    #[test]
+    fn for_alias_round_trips_through_disk() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("subscriptions.json");
+        let mgr = SubscriptionManager::load_from(path.clone());
+        mgr.subscribe("auditor", "*.completed", None, None).unwrap();
+        mgr.subscribe("auditor", "**.failed", Some("p1".into()), None).unwrap();
+
+        let mgr2 = SubscriptionManager::load_from(path);
+        let mine = mgr2.for_alias("auditor", ProjectFilter::Any);
+        assert_eq!(mine.len(), 2);
+    }
+}

--- a/src-tauri/src/subscriptions/manager.rs
+++ b/src-tauri/src/subscriptions/manager.rs
@@ -20,6 +20,17 @@ pub enum SubscribeError {
     InvalidAlias(String),
     #[error(transparent)]
     Store(#[from] AddError),
+    /// Disk save failed. The in-memory mutation has been rolled back
+    /// before this error is surfaced — caller need not retry the undo.
+    #[error("persistence failed: {0}")]
+    Persist(String),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum UnsubscribeError {
+    /// Disk save failed; the deletion has been rolled back.
+    #[error("persistence failed: {0}")]
+    Persist(String),
 }
 
 /// Clonable handle over the subscription store. Persistence runs
@@ -81,7 +92,15 @@ impl SubscriptionManager {
             let mut store = self.inner.lock().expect("subscription store poisoned");
             store.add(subscription)?
         };
-        self.persist();
+        // Persist BEFORE emitting — if the disk write fails, roll the
+        // in-memory mutation back and surface the error so the caller
+        // can retry. Otherwise the UI/CLI would observe a "Created"
+        // event that disappears on next restart.
+        if let Err(e) = self.persist() {
+            let mut store = self.inner.lock().expect("subscription store poisoned");
+            store.remove(&inserted.id);
+            return Err(SubscribeError::Persist(e.to_string()));
+        }
         if let Some(app) = app {
             let _ = app.emit(
                 SUBSCRIPTION_EVENT,
@@ -91,20 +110,39 @@ impl SubscriptionManager {
         Ok(inserted)
     }
 
-    /// Remove by id. Returns `true` when something was deleted.
-    pub fn unsubscribe(&self, id: &str, app: Option<&AppHandle>) -> bool {
-        let removed = {
+    /// Remove by id. Returns `Ok(true)` when something was deleted,
+    /// `Ok(false)` when the id was unknown, and an error when the
+    /// disk save failed (in which case the in-memory deletion has
+    /// been rolled back).
+    pub fn unsubscribe(
+        &self,
+        id: &str,
+        app: Option<&AppHandle>,
+    ) -> Result<bool, UnsubscribeError> {
+        let removed_entry = {
             let mut store = self.inner.lock().expect("subscription store poisoned");
-            store.remove(id)
-        };
-        if removed {
-            self.persist();
-            if let Some(app) = app {
-                let _ = app
-                    .emit(SUBSCRIPTION_EVENT, &BusSubscriptionEvent::Removed { id: id.to_string() });
+            let entry = store.get(id).cloned();
+            if entry.is_some() {
+                store.remove(id);
             }
+            entry
+        };
+        let Some(removed) = removed_entry else {
+            return Ok(false);
+        };
+        if let Err(e) = self.persist() {
+            // Roll back: re-insert the entry. We use `add` here because
+            // the duplicate-triple guard won't fire (we just removed the
+            // sole row with this triple).
+            let mut store = self.inner.lock().expect("subscription store poisoned");
+            let _ = store.add(removed);
+            return Err(UnsubscribeError::Persist(e.to_string()));
         }
-        removed
+        if let Some(app) = app {
+            let _ = app
+                .emit(SUBSCRIPTION_EVENT, &BusSubscriptionEvent::Removed { id: id.to_string() });
+        }
+        Ok(true)
     }
 
     pub fn get(&self, id: &str) -> Option<BusSubscription> {
@@ -150,17 +188,14 @@ impl SubscriptionManager {
         store.patterns_for_alias(alias, event_project_id)
     }
 
-    fn persist(&self) {
+    /// Persist the current in-memory state. `Ok(())` when there's no
+    /// configured path (test mode) so callers can chain unconditionally.
+    fn persist(&self) -> std::io::Result<()> {
         let Some(path) = self.persistence_path.as_ref() else {
-            return;
+            return Ok(());
         };
         let store = self.inner.lock().expect("subscription store poisoned");
-        if let Err(e) = save_to_path(store.entries(), path.as_path()) {
-            eprintln!(
-                "[roux] subscription persistence failed at {}: {e}",
-                path.display(),
-            );
-        }
+        save_to_path(store.entries(), path.as_path())
     }
 }
 
@@ -220,7 +255,7 @@ mod tests {
     #[test]
     fn unsubscribe_returns_false_for_missing_id() {
         let mgr = SubscriptionManager::in_memory();
-        assert!(!mgr.unsubscribe("ghost", None));
+        assert!(!mgr.unsubscribe("ghost", None).unwrap());
     }
 
     #[test]
@@ -229,7 +264,7 @@ mod tests {
         let path = dir.path().join("subscriptions.json");
         let mgr = SubscriptionManager::load_from(path.clone());
         let s = mgr.subscribe("auditor", "*", None, None).unwrap();
-        assert!(mgr.unsubscribe(&s.id, None));
+        assert!(mgr.unsubscribe(&s.id, None).unwrap());
 
         let mgr2 = SubscriptionManager::load_from(path);
         assert!(mgr2.get(&s.id).is_none());

--- a/src-tauri/src/subscriptions/mod.rs
+++ b/src-tauri/src/subscriptions/mod.rs
@@ -1,0 +1,18 @@
+//! Persistent bus subscriptions.
+//!
+//! An alias subscribes to a topic glob (`repo-a.*`, `**.completed`); the
+//! mailbox layer delivers matching events into the subscriber's inbox.
+//! Mirrors the `aliases` module split: `store` is in-memory and pure,
+//! `manager` owns persistence and Tauri event emission.
+//!
+//! See `/docs/features/mailbox.md` for the user-facing surface and
+//! [#161](https://github.com/phin-tech/roux/issues/161) for the design
+//! motivation.
+
+pub mod manager;
+pub mod persistence;
+pub mod store;
+
+pub use manager::{SubscriptionManager, SUBSCRIPTION_EVENT};
+pub use persistence::{load_subscriptions, persistence_path, save_subscriptions};
+pub use store::{AddError, SubscriptionStore};

--- a/src-tauri/src/subscriptions/persistence.rs
+++ b/src-tauri/src/subscriptions/persistence.rs
@@ -1,0 +1,128 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use roux_core::BusSubscription;
+use serde::{Deserialize, Serialize};
+
+const SCHEMA_VERSION: u32 = 1;
+
+/// Versioned envelope around the subscription array. Mirrors
+/// `aliases/persistence.rs` so future shape migrations follow a uniform
+/// pattern (the test for unknown future versions still loading the
+/// `data` array applies here too).
+#[derive(Debug, Serialize, Deserialize)]
+struct SubscriptionsFile {
+    version: u32,
+    data: Vec<BusSubscription>,
+}
+
+pub fn persistence_path() -> PathBuf {
+    crate::paths::roux_config_dir().join("subscriptions.json")
+}
+
+pub fn load_subscriptions() -> Vec<BusSubscription> {
+    load_from_path(&persistence_path())
+}
+
+pub fn save_subscriptions(entries: &[BusSubscription]) -> std::io::Result<()> {
+    save_to_path(entries, &persistence_path())
+}
+
+pub(crate) fn load_from_path(path: &Path) -> Vec<BusSubscription> {
+    if !path.exists() {
+        return Vec::new();
+    }
+    let content = match fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(_) => return Vec::new(),
+    };
+
+    if let Ok(file) = serde_json::from_str::<SubscriptionsFile>(&content) {
+        return file.data;
+    }
+
+    // Defensive fallback: bare arrays (hand-edited or pre-versioning).
+    serde_json::from_str::<Vec<BusSubscription>>(&content).unwrap_or_default()
+}
+
+pub(crate) fn save_to_path(entries: &[BusSubscription], path: &Path) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let envelope = SubscriptionsFile { version: SCHEMA_VERSION, data: entries.to_vec() };
+    let json = serde_json::to_string_pretty(&envelope)?;
+    fs::write(path, json)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn fixture(id: &str) -> BusSubscription {
+        BusSubscription {
+            id: id.into(),
+            alias: "auditor".into(),
+            pattern: "*.completed".into(),
+            project_id: None,
+            created_at: 1,
+        }
+    }
+
+    #[test]
+    fn save_then_load_round_trips() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("subscriptions.json");
+        let entries = vec![fixture("a"), fixture("b")];
+        save_to_path(&entries, &path).unwrap();
+        let loaded = load_from_path(&path);
+        assert_eq!(loaded.len(), 2);
+        assert_eq!(loaded[0].id, "a");
+    }
+
+    #[test]
+    fn load_returns_empty_when_file_missing() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("subscriptions.json");
+        assert!(load_from_path(&path).is_empty());
+    }
+
+    #[test]
+    fn load_returns_empty_when_file_is_garbage() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("subscriptions.json");
+        fs::write(&path, "not json").unwrap();
+        assert!(load_from_path(&path).is_empty());
+    }
+
+    #[test]
+    fn load_accepts_bare_array_for_backcompat() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("subscriptions.json");
+        let bare = serde_json::to_string(&[fixture("a")]).unwrap();
+        fs::write(&path, bare).unwrap();
+        let loaded = load_from_path(&path);
+        assert_eq!(loaded.len(), 1);
+    }
+
+    #[test]
+    fn load_envelope_with_unknown_version_still_parses_data() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("subscriptions.json");
+        let envelope = serde_json::json!({ "version": 999, "data": [fixture("a")] });
+        fs::write(&path, envelope.to_string()).unwrap();
+        let loaded = load_from_path(&path);
+        assert_eq!(loaded.len(), 1);
+    }
+
+    #[test]
+    fn save_writes_versioned_envelope() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("subscriptions.json");
+        save_to_path(&[fixture("a")], &path).unwrap();
+        let content = fs::read_to_string(&path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert_eq!(parsed["version"], SCHEMA_VERSION);
+        assert!(parsed["data"].is_array());
+    }
+}

--- a/src-tauri/src/subscriptions/store.rs
+++ b/src-tauri/src/subscriptions/store.rs
@@ -1,0 +1,281 @@
+use roux_core::{topic_matches, BusSubscription};
+
+use crate::aliases::ProjectFilter;
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum AddError {
+    #[error("subscription already exists for alias '{alias}' pattern '{pattern}' in this project scope")]
+    Duplicate { alias: String, pattern: String },
+}
+
+/// In-memory subscription store. Entries are keyed implicitly by `id`
+/// (uuid). Duplicate-prevention triple is `(alias, pattern, project_id)` —
+/// adding the same triple twice is rejected so a chatty agent doesn't
+/// bloat the table.
+///
+/// Persistence and event emission live in `SubscriptionManager` (mirrors
+/// the `AliasStore` / `AliasManager` split).
+pub struct SubscriptionStore {
+    entries: Vec<BusSubscription>,
+}
+
+impl SubscriptionStore {
+    pub fn new() -> Self {
+        Self { entries: Vec::new() }
+    }
+
+    pub fn from_entries(entries: Vec<BusSubscription>) -> Self {
+        Self { entries }
+    }
+
+    pub fn entries(&self) -> &[BusSubscription] {
+        &self.entries
+    }
+
+    /// Add `subscription`. Rejects if `(alias, pattern, project_id)` is
+    /// already present.
+    pub fn add(&mut self, subscription: BusSubscription) -> Result<BusSubscription, AddError> {
+        if self.entries.iter().any(|s| {
+            s.alias == subscription.alias
+                && s.pattern == subscription.pattern
+                && s.project_id == subscription.project_id
+        }) {
+            return Err(AddError::Duplicate {
+                alias: subscription.alias,
+                pattern: subscription.pattern,
+            });
+        }
+        self.entries.push(subscription.clone());
+        Ok(subscription)
+    }
+
+    /// Remove by id. Returns `true` when something was actually removed.
+    pub fn remove(&mut self, id: &str) -> bool {
+        let before = self.entries.len();
+        self.entries.retain(|s| s.id != id);
+        self.entries.len() != before
+    }
+
+    pub fn get(&self, id: &str) -> Option<&BusSubscription> {
+        self.entries.iter().find(|s| s.id == id)
+    }
+
+    /// Subscriptions belonging to `alias` within the given project filter.
+    pub fn for_alias(
+        &self,
+        alias: &str,
+        project_filter: ProjectFilter<'_>,
+    ) -> Vec<BusSubscription> {
+        self.entries
+            .iter()
+            .filter(|s| s.alias == alias)
+            .filter(|s| project_filter.matches(s.project_id.as_deref()))
+            .cloned()
+            .collect()
+    }
+
+    /// All subscriptions matching the given project filter.
+    pub fn list(&self, project_filter: ProjectFilter<'_>) -> Vec<BusSubscription> {
+        self.entries
+            .iter()
+            .filter(|s| project_filter.matches(s.project_id.as_deref()))
+            .cloned()
+            .collect()
+    }
+
+    /// Subscriptions whose pattern matches `topic` AND whose project
+    /// scope is compatible with `event_project_id`. A subscription with
+    /// `project_id = None` is global and matches any event scope; a
+    /// scoped subscription only matches events in the same scope.
+    pub fn matching_topic(
+        &self,
+        topic: &str,
+        event_project_id: Option<&str>,
+    ) -> Vec<BusSubscription> {
+        self.entries
+            .iter()
+            .filter(|s| project_scope_matches(s.project_id.as_deref(), event_project_id))
+            .filter(|s| topic_matches(&s.pattern, topic))
+            .cloned()
+            .collect()
+    }
+
+    /// Patterns subscribed to by `alias` in scopes compatible with
+    /// `event_project_id`. Hot path for `EventStore::list_for_recipient`
+    /// and `recipient_owns` — keep cheap (string clones only).
+    pub fn patterns_for_alias(
+        &self,
+        alias: &str,
+        event_project_id: Option<&str>,
+    ) -> Vec<String> {
+        self.entries
+            .iter()
+            .filter(|s| s.alias == alias)
+            .filter(|s| project_scope_matches(s.project_id.as_deref(), event_project_id))
+            .map(|s| s.pattern.clone())
+            .collect()
+    }
+
+    #[cfg(test)]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    #[cfg(test)]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+impl Default for SubscriptionStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Returns true when a subscription's project scope is compatible with
+/// an event's project scope. A `None` (global) subscription matches any
+/// event scope; a scoped subscription only matches events in the same
+/// scope.
+fn project_scope_matches(sub_scope: Option<&str>, event_scope: Option<&str>) -> bool {
+    match sub_scope {
+        None => true,
+        Some(s) => event_scope == Some(s),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sub(id: &str, alias: &str, pattern: &str, project_id: Option<&str>) -> BusSubscription {
+        BusSubscription {
+            id: id.into(),
+            alias: alias.into(),
+            pattern: pattern.into(),
+            project_id: project_id.map(str::to_string),
+            created_at: 0,
+        }
+    }
+
+    #[test]
+    fn add_then_get_round_trips() {
+        let mut store = SubscriptionStore::new();
+        store.add(sub("s1", "auditor", "*.completed", None)).unwrap();
+        let got = store.get("s1").unwrap();
+        assert_eq!(got.alias, "auditor");
+        assert_eq!(got.pattern, "*.completed");
+    }
+
+    #[test]
+    fn add_rejects_duplicate_triple() {
+        let mut store = SubscriptionStore::new();
+        store.add(sub("s1", "auditor", "*.completed", None)).unwrap();
+        let err = store.add(sub("s2", "auditor", "*.completed", None)).unwrap_err();
+        assert!(matches!(err, AddError::Duplicate { .. }));
+    }
+
+    #[test]
+    fn add_allows_same_pattern_in_different_project_scopes() {
+        let mut store = SubscriptionStore::new();
+        store.add(sub("s1", "auditor", "*.completed", None)).unwrap();
+        store
+            .add(sub("s2", "auditor", "*.completed", Some("p1")))
+            .unwrap();
+        assert_eq!(store.len(), 2);
+    }
+
+    #[test]
+    fn remove_returns_false_for_missing_id() {
+        let mut store = SubscriptionStore::new();
+        assert!(!store.remove("missing"));
+    }
+
+    #[test]
+    fn remove_returns_true_and_drops_entry() {
+        let mut store = SubscriptionStore::new();
+        store.add(sub("s1", "a", "*", None)).unwrap();
+        assert!(store.remove("s1"));
+        assert!(store.get("s1").is_none());
+    }
+
+    #[test]
+    fn for_alias_filters_by_alias_and_project() {
+        let mut store = SubscriptionStore::new();
+        store.add(sub("s1", "auditor", "*.completed", None)).unwrap();
+        store.add(sub("s2", "auditor", "*.failed", Some("p1"))).unwrap();
+        store.add(sub("s3", "builder", "*", None)).unwrap();
+
+        let auditor_any = store.for_alias("auditor", ProjectFilter::Any);
+        assert_eq!(auditor_any.len(), 2);
+
+        let auditor_global = store.for_alias("auditor", ProjectFilter::Exact(None));
+        assert_eq!(auditor_global.len(), 1);
+        assert_eq!(auditor_global[0].pattern, "*.completed");
+
+        let builder = store.for_alias("builder", ProjectFilter::Any);
+        assert_eq!(builder.len(), 1);
+    }
+
+    #[test]
+    fn matching_topic_returns_only_glob_matches() {
+        let mut store = SubscriptionStore::new();
+        store.add(sub("s1", "a", "repo-a.*", None)).unwrap();
+        store.add(sub("s2", "b", "**.completed", None)).unwrap();
+        store.add(sub("s3", "c", "exact.match", None)).unwrap();
+
+        let ms = store.matching_topic("repo-a.build.completed", None);
+        let aliases: Vec<_> = ms.iter().map(|s| s.alias.as_str()).collect();
+        // `repo-a.*` does NOT match three-segment topic; `**.completed` does.
+        assert_eq!(aliases, vec!["b"]);
+    }
+
+    #[test]
+    fn matching_topic_respects_project_scope() {
+        let mut store = SubscriptionStore::new();
+        // Global sub matches any event scope.
+        store.add(sub("s1", "a", "*", None)).unwrap();
+        // Scoped sub only matches events in the same project.
+        store.add(sub("s2", "b", "*", Some("p1"))).unwrap();
+        store.add(sub("s3", "c", "*", Some("p2"))).unwrap();
+
+        // Event in project p1: sub s1 (global) and s2 (p1) match; s3 (p2) doesn't.
+        let ms = store.matching_topic("foo", Some("p1"));
+        let aliases: Vec<_> = ms.iter().map(|s| s.alias.as_str()).collect();
+        assert_eq!(aliases, vec!["a", "b"]);
+
+        // Global event (no project): only the global sub matches.
+        let ms = store.matching_topic("foo", None);
+        let aliases: Vec<_> = ms.iter().map(|s| s.alias.as_str()).collect();
+        assert_eq!(aliases, vec!["a"]);
+    }
+
+    #[test]
+    fn patterns_for_alias_returns_relevant_patterns_only() {
+        let mut store = SubscriptionStore::new();
+        store.add(sub("s1", "auditor", "repo-a.*", None)).unwrap();
+        store.add(sub("s2", "auditor", "**.failed", Some("p1"))).unwrap();
+        store.add(sub("s3", "builder", "*", None)).unwrap();
+
+        // Event in p1 sees both auditor subs (global s1 + scoped s2).
+        let mut got = store.patterns_for_alias("auditor", Some("p1"));
+        got.sort();
+        assert_eq!(got, vec!["**.failed".to_string(), "repo-a.*".to_string()]);
+
+        // Global event only sees the global sub.
+        let got = store.patterns_for_alias("auditor", None);
+        assert_eq!(got, vec!["repo-a.*".to_string()]);
+    }
+
+    #[test]
+    fn list_filters_by_project_scope() {
+        let mut store = SubscriptionStore::new();
+        store.add(sub("s1", "a", "*", None)).unwrap();
+        store.add(sub("s2", "b", "*", Some("p1"))).unwrap();
+
+        assert_eq!(store.list(ProjectFilter::Any).len(), 2);
+        assert_eq!(store.list(ProjectFilter::Exact(None)).len(), 1);
+        assert_eq!(store.list(ProjectFilter::Exact(Some("p1"))).len(), 1);
+        assert_eq!(store.list(ProjectFilter::Exact(Some("p2"))).len(), 0);
+    }
+}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -44,7 +44,7 @@
   } from "$lib/stores/mailbox";
   import {
     hydrateSubscriptions,
-    startSubscriptionEventListener,
+    startSubscriptionEventListenerWithCleanup,
   } from "$lib/stores/subscriptions";
   import { initPtyInventoryPolling } from "$lib/stores/ptyInventory";
   import { initSessionWithProfile, splitPane } from "$lib/panes/actions";
@@ -823,7 +823,7 @@
     // the listener keeps the store in sync without polling.
     await hydrateMailbox();
     await hydrateSubscriptions();
-    await startSubscriptionEventListener();
+    tauriUnlisteners.push(await startSubscriptionEventListenerWithCleanup());
     tauriUnlisteners.push(
       await onMailboxEvent((payload) => applyMailboxEvent(payload)),
     );

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -42,6 +42,10 @@
     applyMailboxEvent,
     applyAliasEvent,
   } from "$lib/stores/mailbox";
+  import {
+    hydrateSubscriptions,
+    startSubscriptionEventListener,
+  } from "$lib/stores/subscriptions";
   import { initPtyInventoryPolling } from "$lib/stores/ptyInventory";
   import { initSessionWithProfile, splitPane } from "$lib/panes/actions";
   import { hasSplitPanes } from "$lib/panes/layout";
@@ -818,6 +822,8 @@
     // cheap (one list-all + one alias-list + per-alias unread counts);
     // the listener keeps the store in sync without polling.
     await hydrateMailbox();
+    await hydrateSubscriptions();
+    await startSubscriptionEventListener();
     tauriUnlisteners.push(
       await onMailboxEvent((payload) => applyMailboxEvent(payload)),
     );

--- a/src/lib/components/MailboxPanel.svelte
+++ b/src/lib/components/MailboxPanel.svelte
@@ -63,9 +63,13 @@
   // Subscription compose form state. Shown only when the Subscriptions
   // tab is active. Pattern is validated server-side; we surface the
   // backend error inline to keep the form concrete-feedback-driven.
+  // Project scope is global-only from the UI for now — the form
+  // doesn't expose a project picker, and silently passing the current
+  // project would surprise users who expect form fields to govern
+  // submitted state. CLI/MCP cover scoped subscriptions until we add
+  // a proper picker.
   let subAlias = $state("");
   let subPattern = $state("");
-  let subProjectId = $state<string | null>(null);
   let subSubmitting = $state(false);
   let subError = $state<string | null>(null);
   let deletingSubId = $state<string | null>(null);
@@ -249,11 +253,7 @@
     subSubmitting = true;
     subError = null;
     try {
-      await createSubscription(
-        subAlias.trim(),
-        subPattern.trim(),
-        subProjectId,
-      );
+      await createSubscription(subAlias.trim(), subPattern.trim(), null);
       // Reset on success — the store updates from the
       // `subscription-event` listener so the new row appears in the list.
       subPattern = "";

--- a/src/lib/components/MailboxPanel.svelte
+++ b/src/lib/components/MailboxPanel.svelte
@@ -14,6 +14,11 @@
     unreadByAlias,
   } from "$lib/stores/mailbox";
   import {
+    createSubscription,
+    deleteSubscription,
+    subscriptions,
+  } from "$lib/stores/subscriptions";
+  import {
     mailboxDeliverToPane,
     mailboxListForRecipient,
     mailboxReadState,
@@ -53,7 +58,17 @@
   let composeKind = $state<EventKind>("task");
   let posting = $state(false);
   let postError = $state<string | null>(null);
-  let view = $state<"mailbox" | "firehose">("mailbox");
+  let view = $state<"mailbox" | "firehose" | "subscriptions">("mailbox");
+
+  // Subscription compose form state. Shown only when the Subscriptions
+  // tab is active. Pattern is validated server-side; we surface the
+  // backend error inline to keep the form concrete-feedback-driven.
+  let subAlias = $state("");
+  let subPattern = $state("");
+  let subProjectId = $state<string | null>(null);
+  let subSubmitting = $state(false);
+  let subError = $state<string | null>(null);
+  let deletingSubId = $state<string | null>(null);
 
   // Hydrate the first time the panel is shown. (`hydrateMailbox` is
   // idempotent, but a guard keeps it from spamming on re-mount.)
@@ -229,6 +244,47 @@
     await clearReadFor(selectedAlias);
   }
 
+  async function handleSubscribe(): Promise<void> {
+    if (subSubmitting) return;
+    subSubmitting = true;
+    subError = null;
+    try {
+      await createSubscription(
+        subAlias.trim(),
+        subPattern.trim(),
+        subProjectId,
+      );
+      // Reset on success — the store updates from the
+      // `subscription-event` listener so the new row appears in the list.
+      subPattern = "";
+    } catch (err) {
+      subError = String(err);
+    } finally {
+      subSubmitting = false;
+    }
+  }
+
+  async function handleUnsubscribe(id: string): Promise<void> {
+    if (deletingSubId) return;
+    deletingSubId = id;
+    try {
+      await deleteSubscription(id);
+    } catch (err) {
+      subError = String(err);
+    } finally {
+      deletingSubId = null;
+    }
+  }
+
+  // Pre-fill the alias field from the current selection so a user
+  // working in the Inbox can switch tabs and see "this alias's
+  // subscriptions" without re-typing.
+  $effect(() => {
+    if (view === "subscriptions" && subAlias === "") {
+      subAlias = selectedAlias === "me" ? "" : selectedAlias;
+    }
+  });
+
   let deliveringId = $state<string | null>(null);
   let deliverError = $state<string | null>(null);
 
@@ -293,6 +349,13 @@
           onclick={() => (view = "firehose")}
           title="Firehose view — every event in the store, newest first"
         >All</button>
+        <button
+          class="rounded px-2 py-0.5 text-[11px] {view === 'subscriptions'
+            ? 'bg-bg-hover text-text-primary'
+            : 'text-text-muted hover:text-text-primary'}"
+          onclick={() => (view = "subscriptions")}
+          title="Bus subscriptions — alias receives matching topic events"
+        >Subs</button>
       </div>
       <button
         class="cursor-pointer rounded border border-transparent bg-transparent px-2 py-0.5 text-[10px] text-text-muted hover:border-border-subtle hover:bg-bg-hover hover:text-text-primary"
@@ -513,7 +576,7 @@
         >clear read</button>
       {/if}
     </div>
-  {:else}
+  {:else if view === "firehose"}
     <!-- Firehose: every event newest first, no per-recipient state -->
     <div class="flex-1 overflow-y-auto p-2">
       {#if firehoseEvents.length === 0}
@@ -548,6 +611,82 @@
             <p class="truncate text-[11px] text-text-secondary">
               {e.subject ?? e.body}
             </p>
+          </article>
+        {/each}
+      {/if}
+    </div>
+  {:else}
+    <!-- Subscriptions: list + create form. The list updates live via
+         the `subscription-event` Tauri channel; mutations here go through
+         the same Tauri commands that CLI/MCP use. -->
+    <form
+      class="flex flex-col gap-1 border-b border-border-subtle bg-bg-surface/30 p-2"
+      onsubmit={(e) => {
+        e.preventDefault();
+        void handleSubscribe();
+      }}
+    >
+      <div class="flex gap-1">
+        <input
+          class="flex-1 rounded border border-border-subtle bg-bg-deep px-2 py-1 text-[11px] text-text-primary placeholder:text-text-muted/60"
+          bind:value={subAlias}
+          placeholder="Alias (e.g. auditor)"
+          list="mailbox-compose-aliases"
+          autocomplete="off"
+          required
+        />
+        <input
+          class="flex-[2] rounded border border-border-subtle bg-bg-deep px-2 py-1 text-[11px] text-text-primary placeholder:text-text-muted/60"
+          bind:value={subPattern}
+          placeholder="Pattern: repo-a.* or **.completed"
+          autocomplete="off"
+          required
+        />
+      </div>
+      <div class="flex items-center gap-2 text-[10px] text-text-muted/80">
+        <span>* matches one segment, ** matches many. Patterns and aliases are lowercase, hyphens allowed.</span>
+        <button
+          type="submit"
+          class="ml-auto cursor-pointer rounded border border-accent-dim bg-accent/20 px-2 py-1 text-[11px] text-text-primary hover:bg-accent/30 disabled:opacity-50"
+          disabled={subSubmitting}
+        >{subSubmitting ? "Adding…" : "Subscribe"}</button>
+      </div>
+      {#if subError}
+        <div class="rounded border border-red-500/40 bg-red-500/10 px-2 py-1 text-[10px] text-red-300">
+          {subError}
+        </div>
+      {/if}
+    </form>
+
+    <div class="flex-1 overflow-y-auto p-2">
+      {#if $subscriptions.length === 0}
+        <div
+          class="flex h-full items-center justify-center text-center text-sm text-text-muted"
+        >No subscriptions yet. Add one above to push topic events into
+          an alias's mailbox.</div>
+      {:else}
+        {#each $subscriptions as s (s.id)}
+          <article
+            class="mb-1 flex items-center gap-2 rounded border border-border-subtle bg-bg-surface/30 px-2 py-1.5"
+          >
+            <span class="rounded bg-bg-hover px-1.5 py-0.5 text-[10px] text-text-primary"
+              >@{s.alias}</span
+            >
+            <code class="text-[11px] text-text-secondary">{s.pattern}</code>
+            {#if s.projectId}
+              <span class="text-[9px] text-text-muted">scope: {s.projectId}</span>
+            {:else}
+              <span class="text-[9px] text-text-muted/70">scope: global</span>
+            {/if}
+            <span class="ml-auto shrink-0 text-[10px] text-text-muted/70"
+              >{formatRelative(s.createdAt)}</span
+            >
+            <button
+              class="cursor-pointer rounded border border-transparent bg-transparent px-1.5 py-0.5 text-[10px] text-text-muted hover:border-border-subtle hover:bg-bg-hover hover:text-text-primary disabled:opacity-50"
+              onclick={() => handleUnsubscribe(s.id)}
+              disabled={deletingSubId === s.id}
+              title="Remove this subscription"
+            >{deletingSubId === s.id ? "…" : "remove"}</button>
           </article>
         {/each}
       {/if}

--- a/src/lib/stores/__tests__/subscriptions.test.ts
+++ b/src/lib/stores/__tests__/subscriptions.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { get } from "svelte/store";
+
+vi.mock("$lib/tauri", () => ({
+  onBusSubscriptionEvent: vi.fn().mockResolvedValue(() => {}),
+  subscriptionsCreate: vi.fn(),
+  subscriptionsDelete: vi.fn(),
+  subscriptionsList: vi.fn().mockResolvedValue([]),
+}));
+
+import {
+  applySubscriptionEvent,
+  subscriptions,
+} from "$lib/stores/subscriptions";
+import type { BusSubscription } from "$lib/tauri";
+
+function fixture(id: string, alias = "auditor", pattern = "*"): BusSubscription {
+  return {
+    id,
+    alias,
+    pattern,
+    projectId: null,
+    createdAt: 1000,
+  };
+}
+
+describe("subscriptions store", () => {
+  beforeEach(() => {
+    subscriptions.set([]);
+  });
+
+  it("created event prepends a new subscription", () => {
+    applySubscriptionEvent({ kind: "created", subscription: fixture("a") });
+    applySubscriptionEvent({ kind: "created", subscription: fixture("b") });
+    const list = get(subscriptions);
+    expect(list.map((s) => s.id)).toEqual(["b", "a"]);
+  });
+
+  it("created event for an existing id replaces in place (idempotent reload)", () => {
+    applySubscriptionEvent({ kind: "created", subscription: fixture("a", "x") });
+    applySubscriptionEvent({
+      kind: "created",
+      subscription: { ...fixture("a", "y"), pattern: "**" },
+    });
+    const list = get(subscriptions);
+    expect(list).toHaveLength(1);
+    expect(list[0].alias).toBe("y");
+    expect(list[0].pattern).toBe("**");
+  });
+
+  it("removed event drops the matching id", () => {
+    applySubscriptionEvent({ kind: "created", subscription: fixture("a") });
+    applySubscriptionEvent({ kind: "created", subscription: fixture("b") });
+    applySubscriptionEvent({ kind: "removed", id: "a" });
+    expect(get(subscriptions).map((s) => s.id)).toEqual(["b"]);
+  });
+
+  it("removed event for unknown id is a no-op", () => {
+    applySubscriptionEvent({ kind: "created", subscription: fixture("a") });
+    applySubscriptionEvent({ kind: "removed", id: "ghost" });
+    expect(get(subscriptions).map((s) => s.id)).toEqual(["a"]);
+  });
+});

--- a/src/lib/stores/subscriptions.ts
+++ b/src/lib/stores/subscriptions.ts
@@ -1,0 +1,79 @@
+import { writable, get } from "svelte/store";
+import {
+  onBusSubscriptionEvent,
+  subscriptionsCreate as tauriCreate,
+  subscriptionsDelete as tauriDelete,
+  subscriptionsList,
+} from "$lib/tauri";
+import type { BusSubscription, BusSubscriptionEvent } from "$lib/tauri";
+
+/**
+ * Authoritative store of all bus subscriptions, latest-first by
+ * createdAt. Hydrated once on app start and kept in sync via the
+ * `subscription-event` Tauri channel.
+ */
+export const subscriptions = writable<BusSubscription[]>([]);
+
+/** Hydrate the store from the backend. Call once on app start. */
+export async function hydrateSubscriptions(): Promise<void> {
+  try {
+    const subs = await subscriptionsList({});
+    subs.sort((a, b) => b.createdAt - a.createdAt);
+    subscriptions.set(subs);
+  } catch (err) {
+    console.error("Failed to hydrate bus subscriptions", err);
+  }
+}
+
+/**
+ * Apply a `subscription-event` payload to the store. Pure function so
+ * tests can exercise it without a Tauri runtime.
+ */
+export function applySubscriptionEvent(event: BusSubscriptionEvent): void {
+  subscriptions.update((current) => {
+    if (event.kind === "created") {
+      // Idempotent: replace any existing row with the same id, otherwise
+      // prepend (newest-first).
+      const without = current.filter((s) => s.id !== event.subscription.id);
+      return [event.subscription, ...without];
+    }
+    return current.filter((s) => s.id !== event.id);
+  });
+}
+
+let unlisten: (() => void) | null = null;
+
+/** Wire the global event listener. Idempotent across hot reloads. */
+export async function startSubscriptionEventListener(): Promise<void> {
+  if (unlisten) return;
+  unlisten = await onBusSubscriptionEvent(applySubscriptionEvent);
+}
+
+export function stopSubscriptionEventListener(): void {
+  if (unlisten) {
+    unlisten();
+    unlisten = null;
+  }
+}
+
+/** Create a new subscription. Throws on backend validation errors. */
+export async function createSubscription(
+  alias: string,
+  pattern: string,
+  projectId: string | null = null,
+): Promise<BusSubscription> {
+  return tauriCreate(alias, pattern, projectId);
+}
+
+/** Delete a subscription by id. Returns true when something was removed. */
+export async function deleteSubscription(id: string): Promise<boolean> {
+  return tauriDelete(id);
+}
+
+/**
+ * Subscriptions for `alias`, sorted newest-first. Useful in templates
+ * that need an alias-scoped view without re-fetching from the backend.
+ */
+export function subscriptionsForAlias(alias: string): BusSubscription[] {
+  return get(subscriptions).filter((s) => s.alias === alias);
+}

--- a/src/lib/stores/subscriptions.ts
+++ b/src/lib/stores/subscriptions.ts
@@ -42,11 +42,24 @@ export function applySubscriptionEvent(event: BusSubscriptionEvent): void {
 }
 
 let unlisten: (() => void) | null = null;
+// Tracks an in-flight listener registration so two near-simultaneous
+// `startSubscriptionEventListener` calls don't both subscribe before
+// the first await resolves (which would leak one unlisten handle and
+// double-handle every future event).
+let listenerInit: Promise<void> | null = null;
 
 /** Wire the global event listener. Idempotent across hot reloads. */
 export async function startSubscriptionEventListener(): Promise<void> {
   if (unlisten) return;
-  unlisten = await onBusSubscriptionEvent(applySubscriptionEvent);
+  if (listenerInit) return listenerInit;
+  listenerInit = onBusSubscriptionEvent(applySubscriptionEvent)
+    .then((fn) => {
+      unlisten = fn;
+    })
+    .finally(() => {
+      listenerInit = null;
+    });
+  return listenerInit;
 }
 
 export function stopSubscriptionEventListener(): void {
@@ -54,6 +67,20 @@ export function stopSubscriptionEventListener(): void {
     unlisten();
     unlisten = null;
   }
+}
+
+/**
+ * Start the listener and return its unlisten function so callers can
+ * drop it through their existing cleanup pipeline (e.g. App.svelte's
+ * `tauriUnlisteners` array). The cleanup wrapper goes through
+ * `stopSubscriptionEventListener` so the module-level handle is
+ * cleared and a later restart gets a fresh subscription.
+ */
+export async function startSubscriptionEventListenerWithCleanup(): Promise<
+  () => void
+> {
+  await startSubscriptionEventListener();
+  return stopSubscriptionEventListener;
 }
 
 /** Create a new subscription. Throws on backend validation errors. */

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1335,6 +1335,8 @@ export async function removePaneRecord(id: string): Promise<void> {
 import type {
   AgentAlias,
   AliasEvent,
+  BusSubscription,
+  BusSubscriptionEvent,
   Event as MailboxEventPayload,
   MailboxEvent,
   ReadState,
@@ -1343,6 +1345,8 @@ import type {
 export type {
   AgentAlias,
   AliasEvent,
+  BusSubscription,
+  BusSubscriptionEvent,
   EventKind,
   MailboxEvent,
   ReadState,
@@ -1510,4 +1514,40 @@ export async function aliasesGet(
 
 export async function aliasesWhoami(sessionId: string): Promise<AgentAlias[]> {
   return invoke("aliases_whoami", { sessionId });
+}
+
+// ── Bus subscriptions ─────────────────────────────────────────────────────────
+
+export function onBusSubscriptionEvent(
+  callback: (payload: BusSubscriptionEvent) => void,
+): Promise<UnlistenFn> {
+  return listen<BusSubscriptionEvent>("subscription-event", (e) =>
+    callback(e.payload),
+  );
+}
+
+export async function subscriptionsList(
+  options: {
+    alias?: string | null;
+    projectId?: string | null;
+    global?: boolean;
+  } = {},
+): Promise<BusSubscription[]> {
+  return invoke("subscriptions_list", {
+    alias: options.alias ?? null,
+    projectId: options.projectId ?? null,
+    global: options.global ?? null,
+  });
+}
+
+export async function subscriptionsCreate(
+  alias: string,
+  pattern: string,
+  projectId: string | null = null,
+): Promise<BusSubscription> {
+  return invoke("subscriptions_create", { alias, pattern, projectId });
+}
+
+export async function subscriptionsDelete(id: string): Promise<boolean> {
+  return invoke("subscriptions_delete", { id });
 }

--- a/src/lib/types/mailbox.ts
+++ b/src/lib/types/mailbox.ts
@@ -62,7 +62,17 @@ export type MailboxEvent =
       recipient: string;
       result: string | null;
     }
-  | { kind: "cleared"; recipient: string; count: number };
+  | { kind: "cleared"; recipient: string; count: number }
+  | {
+      /** Bus subscription matched a published topic event. The event itself
+       *  also fires as `posted`; this variant adds the per-subscriber
+       *  delivery context so the UI can bump the subscriber's unread count
+       *  and surface the delivery without a new mailbox row. */
+      kind: "topicDelivered";
+      eventId: string;
+      recipient: string;
+      subscriptionId: string;
+    };
 
 /**
  * Frontend mirror of `roux_core::AliasEvent`. Tagged with `kind`.
@@ -70,3 +80,22 @@ export type MailboxEvent =
 export type AliasEvent =
   | { kind: "set"; alias: AgentAlias }
   | { kind: "unset"; canonical: string; projectId: string | null };
+
+/**
+ * Frontend mirror of `roux_core::BusSubscription`.
+ */
+export interface BusSubscription {
+  id: string;
+  alias: string;
+  pattern: string;
+  projectId: string | null;
+  createdAt: number;
+}
+
+/**
+ * Frontend mirror of `roux_core::BusSubscriptionEvent`. Tagged with `kind`.
+ * Emitted on the `subscription-event` Tauri channel for every mutation.
+ */
+export type BusSubscriptionEvent =
+  | { kind: "created"; subscription: BusSubscription }
+  | { kind: "removed"; id: string };


### PR DESCRIPTION
## Summary
- Adds persistent bus subscriptions: an alias subscribes to a topic glob (`repo-a.*`, `**.completed`) and matched bus events land in the subscriber's mailbox. \`roux mailbox read\` returns them, the unread badge bumps via \`mailbox-event\`, and the subscriber can mark-read / ack like any other mail. Subscriptions persist to \`subscriptions.json\`.
- MQTT-style globbing: \`*\` matches one segment, \`**\` matches many. Pattern segments use the same alphabet as topics (lowercase, digits, hyphens). Partial-segment globs (\`foo*\`) are rejected at validation.
- Closes the **persistent bus subscriptions** and **glob topic patterns** items from #161.

## Reopened from #163
The original #163 closed automatically when its base branch (\`feature/improve-mailbox\`, the auto-claim PR #162) was deleted on merge. This is a re-creation of the same diff, rebased onto main. The review history is in #163.

## Stack
**#164** (mailbox-watch) is stacked on top of this PR. Review order: this PR first, then #164.

## Surface
- Core: \`topic_glob\` matcher (23 tests including memoization perf regression); \`BusSubscription\` model; \`MailboxEvent::TopicDelivered\` variant.
- Backend: \`subscriptions/\` module mirroring \`aliases/\` (store / persistence / manager). Mailbox store gains pattern-aware \`list_for_recipient\` / \`recipient_owns\` / \`unread_count\`.
- Cross-project authorization is closed: a p2-scoped sub cannot ack p1 events. Persistence failures roll back the in-memory mutation.
- CLI: \`roux bus subscribe\`, \`roux bus unsubscribe\`, \`roux bus subscriptions\`. \`--alias\` defaults to the calling pane's bound alias and errors when ambiguous.
- MCP: \`roux_bus_subscribe\` / \`roux_bus_unsubscribe\` / \`roux_bus_subscriptions\` tools (\`alias\` is required for MCP since there's no pane context).
- Tauri commands: \`subscriptions_list\` / \`subscriptions_create\` / \`subscriptions_delete\`.
- UI: Subs tab in the Mailbox panel with concurrent-init guard + cleanup wired through \`tauriUnlisteners\`.

## Test plan
- [x] \`cargo test --bin roux\` — 478+ tests pass
- [x] \`cargo test --lib --workspace\` — 386+ tests pass
- [x] \`npm run test\` — 1003 pass
- [x] \`npm run check\` — 0 errors
- [x] \`cargo clippy --bin roux --tests\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Persistent bus subscriptions enable reliable topic-based event delivery to aliases
  * Topic glob patterns support `*` (single segment) and `**` (any segments) wildcards for event matching
  * New CLI commands: `bus-subscribe`, `bus-unsubscribe`, `bus-subscriptions`
  * Subscriptions UI panel with create/list/delete capabilities
  * Subscriptions persist to disk and support project-level scoping
  * MCP support for subscription management
  * New mailbox event type for topic-delivered messages

* **Documentation**
  * Added subscriptions guide with pattern matching rules and CLI examples

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phin-tech/roux/pull/165)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Adds persistent bus subscriptions backed by `subscriptions.json`: aliases subscribe to MQTT-style glob patterns (`*` = one segment, `**` = many), and matched `bus publish` events land in the subscriber's mailbox with project-scope authorization enforced end-to-end.
- Introduces `validate_topic` / `validate_topic_pattern` in `roux-core` and an O(P×T) memoized matcher; the mailbox store's `list_for_recipient`, `recipient_owns`, and `unread_count` are extended to respect subscription patterns while keeping cross-project authorization closed.
- `validate_topic` (doc: \"Used by `bus publish`\") is exported but not called in `handle_bus_publish` — topics with invalid characters are stored silently and will never match any subscription pattern, causing missed deliveries.

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Not safe to merge as-is: validate_topic is introduced for bus-publish validation but never called, so malformed topics are silently persisted and deliveries are lost.

Single P1 finding: the validate_topic function is added with explicit doc intent for bus publish but is not wired into handle_bus_publish. Invalid topics produce no error and never match any subscription pattern, silently breaking the core feature. All other logic — memoized matcher, persistence, rollback, authorization — is well-tested and sound.

src-tauri/src/socket.rs — handle_bus_publish must call validate_topic before building the event.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src-tauri/src/socket.rs | Adds bus-subscribe, bus-unsubscribe, bus-subscriptions CLI socket handlers; handle_bus_publish does NOT call validate_topic, so malformed topics are silently stored and never match subscription patterns. |
| crates/roux-core/src/topic_glob.rs | New MQTT-style glob matcher with O(P×T) memoized DP; 23 tests including adversarial multi-** regression. Logic is sound and index arithmetic is overflow-safe. |
| src-tauri/src/mailbox/store.rs | Extended list_for_recipient, unread_count, and recipient_owns with subscription-pattern awareness; project-scoped authorization tested with a dedicated cross-project regression. |
| src-tauri/src/mailbox/manager.rs | Wires SubscriptionManager into the mailbox layer; patterns_for correctly restricts global-view calls to global-only patterns to prevent cross-project leakage. |
| src-tauri/src/subscriptions/manager.rs | Persist-before-emit pattern with rollback on IO failure is correct; minor issue: rollback re-inserts at tail rather than original position, changing observable subscription order. |
| src-tauri/src/subscriptions/store.rs | In-memory subscription store with duplicate-triple guard and project-scope matching; well-tested. project_scope_matches correctly closes cross-project authorization. |
| src/lib/stores/subscriptions.ts | Hydrate + concurrent-init guard pattern mirrors the mailbox store; idempotent applySubscriptionEvent with cleanup wired through tauriUnlisteners. |
| src/lib/components/MailboxPanel.svelte | Adds Subscriptions tab with stale-response guard on async inbox fetch, subscription create/delete handlers, and alias pre-fill from current selection. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI as roux CLI
    participant Socket as socket.rs
    participant MM as MailboxManager
    participant SM as SubscriptionManager
    participant Store as EventStore
    participant Tauri as Tauri Events

    CLI->>Socket: "bus publish {topic, body}"
    Socket->>MM: post(builder, Some(app))
    MM->>Store: store.post(builder, id, now)
    Store-->>MM: Event
    MM->>MM: persist to events.jsonl
    MM->>Tauri: emit mailbox-event(Posted)
    MM->>SM: matching_topic(topic, project_id)
    SM-->>MM: "Vec<BusSubscription>"
    loop for each matching subscription
        MM->>Tauri: emit mailbox-event(TopicDelivered)
    end
    MM-->>Socket: Ok(Event)

    Note over CLI,Socket: bus subscribe {alias, pattern}
    CLI->>Socket: bus subscribe
    Socket->>SM: subscribe(alias, pattern, project_id)
    SM->>SM: validate_alias + validate_topic_pattern
    SM->>SM: persist to subscriptions.json
    SM->>Tauri: emit subscription-event(Created)
    SM-->>Socket: Ok(BusSubscription)
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src-tauri/src/socket.rs`, line 1873-1876 ([link](https://github.com/phin-tech/roux/blob/7bb02140f0861ca50a074744beb9fb13f01ca5cc/src-tauri/src/socket.rs#L1873-L1876)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`validate_topic` introduced but not wired to `bus-publish`**

   The PR adds `validate_topic` with a doc comment explicitly saying it's "Used by `bus publish` to reject malformed topic strings before they hit the store", but `handle_bus_publish` never calls it. A topic like `Repo_A.Build.Completed` (uppercase/underscore) will be accepted and persisted, but will silently fail to match any subscription pattern — deliveries are lost with no error reported to the caller.

   

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src-tauri%2Fsrc%2Fsocket.rs%0ALine%3A%201873-1876%0A%0AComment%3A%0A**%60validate_topic%60%20introduced%20but%20not%20wired%20to%20%60bus-publish%60**%0A%0AThe%20PR%20adds%20%60validate_topic%60%20with%20a%20doc%20comment%20explicitly%20saying%20it's%20%22Used%20by%20%60bus%20publish%60%20to%20reject%20malformed%20topic%20strings%20before%20they%20hit%20the%20store%22%2C%20but%20%60handle_bus_publish%60%20never%20calls%20it.%20A%20topic%20like%20%60Repo_A.Build.Completed%60%20%28uppercase%2Funderscore%29%20will%20be%20accepted%20and%20persisted%2C%20but%20will%20silently%20fail%20to%20match%20any%20subscription%20pattern%20%E2%80%94%20deliveries%20are%20lost%20with%20no%20error%20reported%20to%20the%20caller.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20topic%20%3D%20match%20args_str%28%26req%2C%20%22topic%22%29%20%7B%0A%20%20%20%20%20%20%20%20Some%28s%29%20if%20!s.trim%28%29.is_empty%28%29%20%3D%3E%20match%20roux_core%3A%3Avalidate_topic%28s%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20Ok%28t%29%20%3D%3E%20t%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Err%28e%29%20%3D%3E%20return%20Response%3A%3Aerr%28format!%28%22invalid%20topic%3A%20%7Be%7D%22%29%29%2C%0A%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20_%20%3D%3E%20return%20Response%3A%3Aerr%28%22topic%20required%22%29%2C%0A%20%20%20%20%7D%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=phin-tech%2Froux&pr=165&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22feature%2Fbus-subscriptions%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fbus-subscriptions%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src-tauri%2Fsrc%2Fsocket.rs%0ALine%3A%201873-1876%0A%0AComment%3A%0A**%60validate_topic%60%20introduced%20but%20not%20wired%20to%20%60bus-publish%60**%0A%0AThe%20PR%20adds%20%60validate_topic%60%20with%20a%20doc%20comment%20explicitly%20saying%20it's%20%22Used%20by%20%60bus%20publish%60%20to%20reject%20malformed%20topic%20strings%20before%20they%20hit%20the%20store%22%2C%20but%20%60handle_bus_publish%60%20never%20calls%20it.%20A%20topic%20like%20%60Repo_A.Build.Completed%60%20%28uppercase%2Funderscore%29%20will%20be%20accepted%20and%20persisted%2C%20but%20will%20silently%20fail%20to%20match%20any%20subscription%20pattern%20%E2%80%94%20deliveries%20are%20lost%20with%20no%20error%20reported%20to%20the%20caller.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20topic%20%3D%20match%20args_str%28%26req%2C%20%22topic%22%29%20%7B%0A%20%20%20%20%20%20%20%20Some%28s%29%20if%20!s.trim%28%29.is_empty%28%29%20%3D%3E%20match%20roux_core%3A%3Avalidate_topic%28s%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20Ok%28t%29%20%3D%3E%20t%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Err%28e%29%20%3D%3E%20return%20Response%3A%3Aerr%28format!%28%22invalid%20topic%3A%20%7Be%7D%22%29%29%2C%0A%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20_%20%3D%3E%20return%20Response%3A%3Aerr%28%22topic%20required%22%29%2C%0A%20%20%20%20%7D%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc-tauri%2Fsrc%2Fsocket.rs%3A1873-1876%0A**%60validate_topic%60%20introduced%20but%20not%20wired%20to%20%60bus-publish%60**%0A%0AThe%20PR%20adds%20%60validate_topic%60%20with%20a%20doc%20comment%20explicitly%20saying%20it's%20%22Used%20by%20%60bus%20publish%60%20to%20reject%20malformed%20topic%20strings%20before%20they%20hit%20the%20store%22%2C%20but%20%60handle_bus_publish%60%20never%20calls%20it.%20A%20topic%20like%20%60Repo_A.Build.Completed%60%20%28uppercase%2Funderscore%29%20will%20be%20accepted%20and%20persisted%2C%20but%20will%20silently%20fail%20to%20match%20any%20subscription%20pattern%20%E2%80%94%20deliveries%20are%20lost%20with%20no%20error%20reported%20to%20the%20caller.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20topic%20%3D%20match%20args_str%28%26req%2C%20%22topic%22%29%20%7B%0A%20%20%20%20%20%20%20%20Some%28s%29%20if%20!s.trim%28%29.is_empty%28%29%20%3D%3E%20match%20roux_core%3A%3Avalidate_topic%28s%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20Ok%28t%29%20%3D%3E%20t%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Err%28e%29%20%3D%3E%20return%20Response%3A%3Aerr%28format!%28%22invalid%20topic%3A%20%7Be%7D%22%29%29%2C%0A%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20_%20%3D%3E%20return%20Response%3A%3Aerr%28%22topic%20required%22%29%2C%0A%20%20%20%20%7D%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc-tauri%2Fsrc%2Fsubscriptions%2Fmanager.rs%3A136-139%0A**Rollback%20re-inserts%20at%20end%2C%20changing%20subscription%20order**%0A%0A%60store.add%28removed%29%60%20appends%20the%20rolled-back%20entry%20to%20the%20end%20of%20the%20%60Vec%60%20rather%20than%20restoring%20it%20to%20its%20original%20position.%20After%20a%20failed%20persist%2C%20the%20subscription%20list%20order%20visible%20to%20the%20CLI%2C%20MCP%2C%20and%20UI%20differs%20from%20what%20was%20persisted%20on%20disk.%20While%20not%20a%20correctness%20bug%2C%20it%20can%20cause%20surprising%20reorderings%20on%20the%20next%20listing%20after%20any%20persist%20failure.%0A%0A&repo=phin-tech%2Froux&pr=165&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22feature%2Fbus-subscriptions%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fbus-subscriptions%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc-tauri%2Fsrc%2Fsocket.rs%3A1873-1876%0A**%60validate_topic%60%20introduced%20but%20not%20wired%20to%20%60bus-publish%60**%0A%0AThe%20PR%20adds%20%60validate_topic%60%20with%20a%20doc%20comment%20explicitly%20saying%20it's%20%22Used%20by%20%60bus%20publish%60%20to%20reject%20malformed%20topic%20strings%20before%20they%20hit%20the%20store%22%2C%20but%20%60handle_bus_publish%60%20never%20calls%20it.%20A%20topic%20like%20%60Repo_A.Build.Completed%60%20%28uppercase%2Funderscore%29%20will%20be%20accepted%20and%20persisted%2C%20but%20will%20silently%20fail%20to%20match%20any%20subscription%20pattern%20%E2%80%94%20deliveries%20are%20lost%20with%20no%20error%20reported%20to%20the%20caller.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20topic%20%3D%20match%20args_str%28%26req%2C%20%22topic%22%29%20%7B%0A%20%20%20%20%20%20%20%20Some%28s%29%20if%20!s.trim%28%29.is_empty%28%29%20%3D%3E%20match%20roux_core%3A%3Avalidate_topic%28s%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20Ok%28t%29%20%3D%3E%20t%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Err%28e%29%20%3D%3E%20return%20Response%3A%3Aerr%28format!%28%22invalid%20topic%3A%20%7Be%7D%22%29%29%2C%0A%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20_%20%3D%3E%20return%20Response%3A%3Aerr%28%22topic%20required%22%29%2C%0A%20%20%20%20%7D%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc-tauri%2Fsrc%2Fsubscriptions%2Fmanager.rs%3A136-139%0A**Rollback%20re-inserts%20at%20end%2C%20changing%20subscription%20order**%0A%0A%60store.add%28removed%29%60%20appends%20the%20rolled-back%20entry%20to%20the%20end%20of%20the%20%60Vec%60%20rather%20than%20restoring%20it%20to%20its%20original%20position.%20After%20a%20failed%20persist%2C%20the%20subscription%20list%20order%20visible%20to%20the%20CLI%2C%20MCP%2C%20and%20UI%20differs%20from%20what%20was%20persisted%20on%20disk.%20While%20not%20a%20correctness%20bug%2C%20it%20can%20cause%20surprising%20reorderings%20on%20the%20next%20listing%20after%20any%20persist%20failure.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix: address PR #163 review findings"](https://github.com/phin-tech/roux/commit/7bb02140f0861ca50a074744beb9fb13f01ca5cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31446016)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->