### PR TITLE
feat(mailbox): unsend (sender retract) + dismiss (recipient hide)

### DIFF
--- a/crates/roux-core/src/models/event.rs
+++ b/crates/roux-core/src/models/event.rs
@@ -77,6 +77,24 @@ pub struct Event {
     /// `{ task, context, expectsReply }` but nothing is enforced.
     #[serde(default)]
     pub structured: Option<Value>,
+
+    // ── Lifecycle ───────────────────────────────────────────────────
+    /// Set when the sender retracts (unsends) this event before any
+    /// recipient has acked. Retracted events are filtered out of
+    /// recipient inbox views and the firehose but stay in
+    /// `events.jsonl` for audit (a retract marker row is applied at
+    /// load time). The sender's `mailbox sent` view still surfaces
+    /// them with this timestamp visible.
+    #[serde(default)]
+    pub retracted_at: Option<u64>,
+}
+
+impl Event {
+    /// True when the sender has unsent this event. Retracted events
+    /// are filtered out of inbox/firehose views.
+    pub fn is_retracted(&self) -> bool {
+        self.retracted_at.is_some()
+    }
 }
 
 /// Per-recipient mutable state for an event. Split from `Event` so a
@@ -165,6 +183,13 @@ pub enum MailboxEvent {
         recipient: String,
         subscription_id: String,
     },
+    /// Sender unsent the event. Recipients should drop it from their
+    /// inbox view; the row stays in `events.jsonl` for audit.
+    Retracted { event_id: String },
+    /// Recipient dismissed a single event from their inbox without
+    /// having read it (or after, doesn't matter). The event itself is
+    /// preserved; only this recipient's view loses it.
+    Dismissed { event_id: String, recipient: String },
 }
 
 /// Builder for new events. Validates at construction so callers get a
@@ -253,6 +278,7 @@ impl EventBuilder {
             subject: self.subject,
             body: self.body,
             structured: self.structured,
+            retracted_at: None,
         })
     }
 }

--- a/docs/features/mailbox.md
+++ b/docs/features/mailbox.md
@@ -178,6 +178,34 @@ roux mailbox sent --to reviewer       # only stuff I sent to reviewer
 Each row pairs the event with the recipient's read/ack state, so you can
 tell whether the reviewer saw your mail and what they did with it.
 
+### Unsend (retract)
+
+```sh
+roux mailbox unsend <event_id>        # default: --alias = my pane's alias
+roux mailbox unsend <event_id> --alias me
+```
+
+Marks the event as retracted: it disappears from recipient inbox views
+and the firehose. Allowed only **before any recipient has acked** —
+once anyone confirmed delivery, retraction is rejected so the audit
+trail stays honest. Your `mailbox sent` view still surfaces retracted
+events with the `retractedAt` timestamp visible.
+
+The events log is append-only; retraction is recorded as a marker row
+in `events.jsonl` and applied to the event at load time.
+
+### Dismiss (recipient-side hide)
+
+```sh
+roux mailbox dismiss <event_id>       # default: --alias = my pane's alias
+```
+
+Hides a single event from your inbox view (read or unread). The event
+itself is preserved; other recipients keep seeing it. Use this when an
+agent has been chatty or you want to drop one specific item without
+clearing your whole read backlog. The Mailbox panel exposes this as a
+`dismiss` button on each inbox row.
+
 ## Bus
 
 When you want to publish "this happened" without addressing a specific

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -251,6 +251,23 @@ enum MailboxAction {
         #[arg(long, conflicts_with = "project")]
         global: bool,
     },
+    /// Unsend an event you posted. Only works if no recipient has
+    /// acked yet — once anyone confirmed delivery the audit trail is
+    /// preserved.
+    Unsend {
+        event_id: String,
+        /// Sender alias to retract on behalf of (default: calling
+        /// pane's bound alias).
+        #[arg(short = 'a', long)]
+        alias: Option<String>,
+    },
+    /// Dismiss a single event from your inbox view (read or unread).
+    /// The event itself is preserved; only your view loses it.
+    Dismiss {
+        event_id: String,
+        #[arg(short = 'a', long)]
+        alias: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1349,6 +1366,32 @@ fn main() {
                 }
                 run_streaming_command(serde_json::json!({
                     "command": "mailbox-watch",
+                    "session_id": get_session_id(),
+                    "pane_id": get_pane_id(),
+                    "args": Value::Object(args),
+                }));
+            }
+            MailboxAction::Unsend { event_id, alias } => {
+                let mut args = serde_json::Map::new();
+                args.insert("event_id".into(), Value::String(event_id));
+                if let Some(a) = alias {
+                    args.insert("alias".into(), Value::String(a));
+                }
+                run_socket_command(serde_json::json!({
+                    "command": "mailbox-retract",
+                    "session_id": get_session_id(),
+                    "pane_id": get_pane_id(),
+                    "args": Value::Object(args),
+                }));
+            }
+            MailboxAction::Dismiss { event_id, alias } => {
+                let mut args = serde_json::Map::new();
+                args.insert("event_id".into(), Value::String(event_id));
+                if let Some(a) = alias {
+                    args.insert("alias".into(), Value::String(a));
+                }
+                run_socket_command(serde_json::json!({
+                    "command": "mailbox-dismiss",
                     "session_id": get_session_id(),
                     "pane_id": get_pane_id(),
                     "args": Value::Object(args),

--- a/src-tauri/src/commands/mailbox.rs
+++ b/src-tauri/src/commands/mailbox.rs
@@ -204,6 +204,29 @@ pub async fn mailbox_clear_read(
     ) as u32)
 }
 
+#[tauri::command]
+pub async fn mailbox_retract(
+    event_id: String,
+    sender: String,
+    state: tauri::State<'_, AppState>,
+    app: tauri::AppHandle,
+) -> Result<Event, String> {
+    state
+        .mailbox_manager
+        .retract(&event_id, &sender, Some(&app))
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn mailbox_dismiss(
+    event_id: String,
+    recipient: String,
+    state: tauri::State<'_, AppState>,
+    app: tauri::AppHandle,
+) -> Result<bool, String> {
+    Ok(state.mailbox_manager.dismiss(&event_id, &recipient, Some(&app)))
+}
+
 /// Deliver a mailbox event to the recipient's pane by writing the body
 /// (plus a trailing CR) into its PTY. Acks the event with a "delivered
 /// via UI" marker so the sender's `mailbox sent` view shows it landed.

--- a/src-tauri/src/mailbox/manager.rs
+++ b/src-tauri/src/mailbox/manager.rs
@@ -9,9 +9,10 @@ use crate::aliases::ProjectFilter;
 use crate::subscriptions::SubscriptionManager;
 
 use super::persistence::{
-    self, append_event_to, load_events_from, load_read_state_from, save_read_state_to,
+    self, append_event_to, append_retract_to, load_events_from, load_read_state_from,
+    save_read_state_to,
 };
-use super::store::{EventStore, PostError};
+use super::store::{EventStore, PostError, RetractError};
 
 /// Tauri event name emitted on every mailbox mutation. Frontend listens
 /// here to update the inbox / firehose without polling.
@@ -283,6 +284,79 @@ impl MailboxManager {
             }
         }
         cleared
+    }
+
+    /// Sender-side unsend. Sets `retracted_at` on the event in memory,
+    /// appends a retract marker row to `events.jsonl` (audit log
+    /// stays append-only), and emits `MailboxEvent::Retracted` so UIs
+    /// drop the event from inbox views. Roll back the in-memory
+    /// retraction on persist failure to keep on-disk + memory state
+    /// in sync — symmetric with `post`'s rollback.
+    pub fn retract(
+        &self,
+        event_id: &str,
+        caller: &str,
+        app: Option<&AppHandle>,
+    ) -> Result<Event, RetractError> {
+        let now = now_ms();
+        let event = {
+            let mut store = self.inner.lock().expect("event store poisoned");
+            store.retract(event_id, caller, now)?
+        };
+        if let Some(paths) = self.paths.as_ref() {
+            if let Err(e) = append_retract_to(&paths.events, &event.id, now) {
+                let mut store = self.inner.lock().expect("event store poisoned");
+                // Roll back: the event still exists; just clear the flag.
+                if let Some(ev) = store.events_mut_find(&event.id) {
+                    ev.retracted_at = None;
+                }
+                eprintln!(
+                    "[roux] retract persistence failed at {}: {e}",
+                    paths.events.display()
+                );
+                return Err(RetractError::NotFound(format!(
+                    "persistence error rolled back: {e}"
+                )));
+            }
+        }
+        let evt = MailboxEvent::Retracted { event_id: event.id.clone() };
+        self.broadcast(&evt);
+        if let Some(app) = app {
+            let _ = app.emit(MAILBOX_EVENT, &evt);
+        }
+        Ok(event)
+    }
+
+    /// Recipient-side single-event hide. Sets `cleared_at` on the
+    /// (event_id, recipient) ReadState regardless of read state and
+    /// persists the read_state file. Returns true on state change.
+    pub fn dismiss(
+        &self,
+        event_id: &str,
+        recipient: &str,
+        app: Option<&AppHandle>,
+    ) -> bool {
+        let now = now_ms();
+        let patterns = self
+            .get(event_id)
+            .map(|e| self.patterns_for_event(recipient, &e))
+            .unwrap_or_default();
+        let changed = {
+            let mut store = self.inner.lock().expect("event store poisoned");
+            store.dismiss(event_id, recipient, &patterns, now)
+        };
+        if changed {
+            self.persist_read_state();
+            let evt = MailboxEvent::Dismissed {
+                event_id: event_id.to_string(),
+                recipient: recipient.to_string(),
+            };
+            self.broadcast(&evt);
+            if let Some(app) = app {
+                let _ = app.emit(MAILBOX_EVENT, &evt);
+            }
+        }
+        changed
     }
 
     pub fn list_for_recipient(
@@ -701,5 +775,80 @@ mod tests {
         mgr.post(task("hi"), None).unwrap();
         assert!(matches!(rx_a.recv().await.unwrap(), MailboxEvent::Posted { .. }));
         assert!(matches!(rx_b.recv().await.unwrap(), MailboxEvent::Posted { .. }));
+    }
+
+    // ── Retract / Dismiss ──────────────────────────────────────────
+
+    #[test]
+    fn retract_round_trips_through_disk_reload() {
+        let dir = tempdir().unwrap();
+        let (e, r) = paths(dir.path());
+        let mgr = MailboxManager::load_from(e.clone(), r.clone());
+        let event = mgr.post(task("ephemeral"), None).unwrap();
+        let retracted = mgr.retract(&event.id, "me", None).unwrap();
+        assert!(retracted.is_retracted());
+
+        // Reload from disk — retract marker must reapply.
+        let mgr2 = MailboxManager::load_from(e, r);
+        let inbox = mgr2.list_for_recipient("reviewer", false, ProjectFilter::Any);
+        assert!(inbox.is_empty(), "retracted event must not appear after reload");
+        let raw = mgr2.get(&event.id).unwrap();
+        assert!(raw.is_retracted());
+    }
+
+    #[tokio::test]
+    async fn retract_broadcasts_retracted_event() {
+        let mgr = MailboxManager::in_memory();
+        let event = mgr.post(task("oops"), None).unwrap();
+        let mut rx = mgr.subscribe_events();
+        mgr.retract(&event.id, "me", None).unwrap();
+        // Skip the (Posted) which was emitted before subscribe; the
+        // broadcaster only delivers events after subscribe_events.
+        let frame = rx.recv().await.unwrap();
+        match frame {
+            MailboxEvent::Retracted { event_id } => assert_eq!(event_id, event.id),
+            other => panic!("expected Retracted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dismiss_round_trips_through_disk_reload() {
+        let dir = tempdir().unwrap();
+        let (e, r) = paths(dir.path());
+        let mgr = MailboxManager::load_from(e.clone(), r.clone());
+        let event = mgr.post(task("noisy"), None).unwrap();
+        assert!(mgr.dismiss(&event.id, "reviewer", None));
+
+        let mgr2 = MailboxManager::load_from(e, r);
+        let inbox = mgr2.list_for_recipient("reviewer", false, ProjectFilter::Any);
+        assert!(
+            inbox.is_empty(),
+            "dismissed event must not reappear after reload"
+        );
+    }
+
+    #[tokio::test]
+    async fn dismiss_broadcasts_dismissed_event() {
+        let mgr = MailboxManager::in_memory();
+        let event = mgr.post(task("noise"), None).unwrap();
+        let mut rx = mgr.subscribe_events();
+        mgr.dismiss(&event.id, "reviewer", None);
+        let frame = rx.recv().await.unwrap();
+        match frame {
+            MailboxEvent::Dismissed { event_id, recipient } => {
+                assert_eq!(event_id, event.id);
+                assert_eq!(recipient, "reviewer");
+            }
+            other => panic!("expected Dismissed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn retract_rejected_after_ack() {
+        let mgr = MailboxManager::in_memory();
+        let event = mgr.post(task("x"), None).unwrap();
+        mgr.ack(&event.id, "reviewer", Some("done".into()), None);
+        let err = mgr.retract(&event.id, "me", None).unwrap_err();
+        assert!(matches!(err, RetractError::AlreadyAcked(_)));
     }
 }

--- a/src-tauri/src/mailbox/manager.rs
+++ b/src-tauri/src/mailbox/manager.rs
@@ -310,12 +310,9 @@ impl MailboxManager {
                 if let Some(ev) = store.events_mut_find(&event.id) {
                     ev.retracted_at = None;
                 }
-                eprintln!(
-                    "[roux] retract persistence failed at {}: {e}",
+                return Err(RetractError::Persist(format!(
+                    "events.jsonl append failed at {}: {e}",
                     paths.events.display()
-                );
-                return Err(RetractError::NotFound(format!(
-                    "persistence error rolled back: {e}"
                 )));
             }
         }

--- a/src-tauri/src/mailbox/persistence.rs
+++ b/src-tauri/src/mailbox/persistence.rs
@@ -154,13 +154,12 @@ pub(crate) fn load_events_from(path: &Path) -> Vec<Event> {
             }
         }
     }
-    // Apply retract markers. Order matters: events with multiple
-    // markers (shouldn't happen in normal use, but defensive) take
-    // the most recent timestamp.
+    // Apply retract markers. Earliest retract wins on duplicates —
+    // the first retract is authoritative; later markers (which only
+    // appear on corruption or hand-edited files in normal use) are
+    // ignored. The matching test is `earliest_retract_wins_when_duplicated`.
     for (id, at) in retracts {
         if let Some(e) = events.iter_mut().find(|e| e.id == id) {
-            // Earliest retract wins — the first retract is the
-            // authoritative one; later duplicates are redundant.
             if e.retracted_at.is_none() {
                 e.retracted_at = Some(at);
             }

--- a/src-tauri/src/mailbox/persistence.rs
+++ b/src-tauri/src/mailbox/persistence.rs
@@ -29,6 +29,23 @@ struct EventRowV1 {
     event: Event,
 }
 
+/// Append-only retract marker. Written when a sender unsends an
+/// event; the loader detects rows with `rowType: "retract"` and
+/// applies `retracted_at` to the matching event so the audit log
+/// stays append-only (we don't rewrite previously-written rows).
+#[derive(Debug, Serialize, Deserialize)]
+struct RetractRowV1 {
+    #[serde(rename = "schemaVersion", default = "default_schema_version")]
+    schema_version: u32,
+    /// Tag used by the loader to disambiguate from event rows.
+    #[serde(rename = "rowType")]
+    row_type: String,
+    #[serde(rename = "eventId")]
+    event_id: String,
+    #[serde(rename = "retractedAt")]
+    retracted_at: u64,
+}
+
 fn default_schema_version() -> u32 {
     EVENT_SCHEMA_VERSION
 }
@@ -59,6 +76,10 @@ pub fn append_event(event: &Event) -> io::Result<()> {
     append_event_to(&events_path(), event)
 }
 
+pub fn append_retract(event_id: &str, retracted_at: u64) -> io::Result<()> {
+    append_retract_to(&events_path(), event_id, retracted_at)
+}
+
 pub fn save_read_state(states: &[ReadState]) -> io::Result<()> {
     save_read_state_to(&read_state_path(), states)
 }
@@ -67,6 +88,10 @@ pub fn save_read_state(states: &[ReadState]) -> io::Result<()> {
 /// (logged via stderr). Rows whose `schemaVersion` is greater than the
 /// version this binary understands are skipped at load time but retained
 /// on disk by virtue of being append-only.
+///
+/// Retract marker rows (`rowType: "retract"`) are detected here and
+/// applied to the matching event's `retracted_at` field — the audit log
+/// stays append-only and the in-memory store reflects the retraction.
 pub(crate) fn load_events_from(path: &Path) -> Vec<Event> {
     if !path.exists() {
         return Vec::new();
@@ -76,7 +101,8 @@ pub(crate) fn load_events_from(path: &Path) -> Vec<Event> {
         Err(_) => return Vec::new(),
     };
     let reader = BufReader::new(file);
-    let mut out = Vec::new();
+    let mut events: Vec<Event> = Vec::new();
+    let mut retracts: Vec<(String, u64)> = Vec::new();
     for (lineno, line) in reader.lines().enumerate() {
         let Ok(line) = line else { continue };
         if line.trim().is_empty() {
@@ -105,8 +131,21 @@ pub(crate) fn load_events_from(path: &Path) -> Vec<Event> {
             );
             continue;
         }
+        // Retract marker — collect; apply after all events are loaded.
+        if value.get("rowType").and_then(|v| v.as_str()) == Some("retract") {
+            match serde_json::from_value::<RetractRowV1>(value) {
+                Ok(row) => retracts.push((row.event_id, row.retracted_at)),
+                Err(e) => {
+                    eprintln!(
+                        "[roux] events.jsonl:{}: malformed retract row: {e}",
+                        lineno + 1
+                    );
+                }
+            }
+            continue;
+        }
         match serde_json::from_value::<EventRowV1>(value) {
-            Ok(row) => out.push(row.event),
+            Ok(row) => events.push(row.event),
             Err(e) => {
                 eprintln!(
                     "[roux] events.jsonl:{}: row failed to deserialize: {e}",
@@ -115,7 +154,19 @@ pub(crate) fn load_events_from(path: &Path) -> Vec<Event> {
             }
         }
     }
-    out
+    // Apply retract markers. Order matters: events with multiple
+    // markers (shouldn't happen in normal use, but defensive) take
+    // the most recent timestamp.
+    for (id, at) in retracts {
+        if let Some(e) = events.iter_mut().find(|e| e.id == id) {
+            // Earliest retract wins — the first retract is the
+            // authoritative one; later duplicates are redundant.
+            if e.retracted_at.is_none() {
+                e.retracted_at = Some(at);
+            }
+        }
+    }
+    events
 }
 
 pub(crate) fn append_event_to(path: &Path, event: &Event) -> io::Result<()> {
@@ -123,6 +174,26 @@ pub(crate) fn append_event_to(path: &Path, event: &Event) -> io::Result<()> {
         fs::create_dir_all(parent)?;
     }
     let row = EventRowV1 { schema_version: EVENT_SCHEMA_VERSION, event: event.clone() };
+    let json = serde_json::to_string(&row)?;
+    let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+    writeln!(file, "{}", json)?;
+    Ok(())
+}
+
+pub(crate) fn append_retract_to(
+    path: &Path,
+    event_id: &str,
+    retracted_at: u64,
+) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let row = RetractRowV1 {
+        schema_version: EVENT_SCHEMA_VERSION,
+        row_type: "retract".to_string(),
+        event_id: event_id.to_string(),
+        retracted_at,
+    };
     let json = serde_json::to_string(&row)?;
     let mut file = OpenOptions::new().create(true).append(true).open(path)?;
     writeln!(file, "{}", json)?;
@@ -303,5 +374,57 @@ mod tests {
         let path = dir.path().join("nested").join("read_state.json");
         save_read_state_to(&path, &[]).unwrap();
         assert!(path.exists());
+    }
+
+    // ── Retract marker rows ────────────────────────────────────────
+
+    #[test]
+    fn append_retract_then_load_applies_retracted_at() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("events.jsonl");
+        append_event_to(&path, &sample_event("e1", "x")).unwrap();
+        append_retract_to(&path, "e1", 9999).unwrap();
+        let loaded = load_events_from(&path);
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].retracted_at, Some(9999));
+    }
+
+    #[test]
+    fn retract_marker_for_missing_event_is_silent_noop() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("events.jsonl");
+        append_event_to(&path, &sample_event("e1", "x")).unwrap();
+        // Marker references an event that never existed (or was
+        // evicted). Loader doesn't fail; just doesn't apply.
+        append_retract_to(&path, "ghost", 5000).unwrap();
+        let loaded = load_events_from(&path);
+        assert_eq!(loaded.len(), 1);
+        assert!(loaded[0].retracted_at.is_none());
+    }
+
+    #[test]
+    fn earliest_retract_wins_when_duplicated() {
+        // Defensive: if two retract markers somehow appear for the
+        // same id (e.g. corruption, ill-behaved external editor), the
+        // first one is authoritative.
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("events.jsonl");
+        append_event_to(&path, &sample_event("e1", "x")).unwrap();
+        append_retract_to(&path, "e1", 1000).unwrap();
+        append_retract_to(&path, "e1", 9000).unwrap();
+        let loaded = load_events_from(&path);
+        assert_eq!(loaded[0].retracted_at, Some(1000));
+    }
+
+    #[test]
+    fn append_retract_writes_row_type_tag() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("events.jsonl");
+        append_retract_to(&path, "e1", 5).unwrap();
+        let raw = fs::read_to_string(&path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(raw.trim()).unwrap();
+        assert_eq!(parsed["rowType"], "retract");
+        assert_eq!(parsed["eventId"], "e1");
+        assert_eq!(parsed["retractedAt"], 5);
     }
 }

--- a/src-tauri/src/mailbox/store.rs
+++ b/src-tauri/src/mailbox/store.rs
@@ -48,6 +48,12 @@ pub enum RetractError {
     /// manager surfaces this so callers don't double-emit Tauri events.
     #[error("event {0} already retracted")]
     AlreadyRetracted(String),
+    /// Disk persistence failed after the in-memory retract was
+    /// applied. The manager rolls the in-memory state back before
+    /// returning this so the UI doesn't observe a "Retracted" that
+    /// disappears on restart. Symmetric with `PostError::Persist`.
+    #[error("retract persistence failed: {0}")]
+    Persist(String),
 }
 
 /// Append-only event store with per-recipient read/ack state. Events are

--- a/src-tauri/src/mailbox/store.rs
+++ b/src-tauri/src/mailbox/store.rs
@@ -29,6 +29,27 @@ pub enum PostError {
     Persist(String),
 }
 
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum RetractError {
+    /// No event with that id exists in the store.
+    #[error("event not found: {0}")]
+    NotFound(String),
+    /// Only the original sender may retract a posted event. Anyone
+    /// else trying to unsend is blocked here.
+    #[error("only the sender ({event_sender:?}) can retract event {event_id}; got {caller:?}")]
+    NotSender { event_id: String, event_sender: Option<String>, caller: String },
+    /// At least one recipient has acked the event. Retraction is only
+    /// allowed before delivery is confirmed — once anyone acked, the
+    /// audit trail must reflect that they saw it.
+    #[error("event {0} already acked by a recipient; retraction blocked")]
+    AlreadyAcked(String),
+    /// The event was already retracted. Idempotent retract isn't
+    /// useful (no state changes) so the second call is rejected; the
+    /// manager surfaces this so callers don't double-emit Tauri events.
+    #[error("event {0} already retracted")]
+    AlreadyRetracted(String),
+}
+
 /// Append-only event store with per-recipient read/ack state. Events are
 /// keyed by `id`; `ReadState` is keyed by `(recipient, event_id)` so a
 /// single broadcast event can have N independent cursors without
@@ -193,6 +214,9 @@ impl EventStore {
     ) -> Vec<Event> {
         self.events
             .iter()
+            // Retracted events disappear from recipient inboxes — the
+            // sender unsent them before any ack confirmed delivery.
+            .filter(|e| !e.is_retracted())
             .filter(|e| event_visible_to(e, recipient, subscribed_patterns))
             .filter(|e| project_filter.matches(e.project_id.as_deref()))
             .filter(|e| !self.is_cleared_by(&e.id, recipient))
@@ -202,22 +226,28 @@ impl EventStore {
     }
 
     /// Events on `topic` (exact match in Phase 2; glob support is a
-    /// follow-up). Includes events that also have `to` set.
+    /// follow-up). Includes events that also have `to` set. Retracted
+    /// events are filtered out — see `list_for_recipient`.
     pub fn list_for_topic(&self, topic: &str, project_filter: ProjectFilter<'_>) -> Vec<Event> {
         self.events
             .iter()
+            .filter(|e| !e.is_retracted())
             .filter(|e| e.topic.as_deref() == Some(topic))
             .filter(|e| project_filter.matches(e.project_id.as_deref()))
             .cloned()
             .collect()
     }
 
-    /// Firehose view: every event matching the project filter, newest first.
+    /// Firehose view: every event matching the project filter, newest
+    /// first. Retracted events are skipped — `list_sent_by` is the
+    /// only view that surfaces them, since the sender wants to know
+    /// what they unsent.
     pub fn list_all(&self, project_filter: ProjectFilter<'_>, limit: Option<usize>) -> Vec<Event> {
         let iter = self
             .events
             .iter()
             .rev()
+            .filter(|e| !e.is_retracted())
             .filter(|e| project_filter.matches(e.project_id.as_deref()));
         match limit {
             Some(n) => iter.take(n).cloned().collect(),
@@ -351,6 +381,7 @@ impl EventStore {
     ) -> usize {
         self.events
             .iter()
+            .filter(|e| !e.is_retracted())
             .filter(|e| event_visible_to(e, recipient, subscribed_patterns))
             .filter(|e| project_filter.matches(e.project_id.as_deref()))
             .filter(|e| !self.is_cleared_by(&e.id, recipient))
@@ -399,6 +430,91 @@ impl EventStore {
             }
         }
         cleared
+    }
+
+    /// Retract (unsend) `event_id` on behalf of `caller`. Only the
+    /// original sender may retract, and only before any recipient has
+    /// acked. Sets `retracted_at = Some(now_ms)` on the in-memory
+    /// event and returns the updated copy.
+    pub fn retract(
+        &mut self,
+        event_id: &str,
+        caller: &str,
+        now_ms: u64,
+    ) -> Result<Event, RetractError> {
+        // Look up the event first; emit a precise error before any
+        // mutation so the manager can persist or skip cleanly.
+        let any_acked = self
+            .read_state
+            .iter()
+            .any(|((_, eid), s)| eid == event_id && s.acked_at.is_some());
+        let event = self
+            .events
+            .iter_mut()
+            .find(|e| e.id == event_id)
+            .ok_or_else(|| RetractError::NotFound(event_id.to_string()))?;
+        if event.from.as_deref() != Some(caller) {
+            return Err(RetractError::NotSender {
+                event_id: event_id.to_string(),
+                event_sender: event.from.clone(),
+                caller: caller.to_string(),
+            });
+        }
+        if event.is_retracted() {
+            return Err(RetractError::AlreadyRetracted(event_id.to_string()));
+        }
+        if any_acked {
+            return Err(RetractError::AlreadyAcked(event_id.to_string()));
+        }
+        event.retracted_at = Some(now_ms);
+        Ok(event.clone())
+    }
+
+    /// Apply a retracted_at timestamp to an existing event without
+    /// any caller/ack checks. Used by the persistence loader to
+    /// replay retract marker rows. Returns true when the event
+    /// existed and was updated; false silently when the event isn't
+    /// in memory (the marker was for an evicted-from-RAM event).
+    pub fn apply_retract_marker(&mut self, event_id: &str, retracted_at: u64) -> bool {
+        if let Some(event) = self.events.iter_mut().find(|e| e.id == event_id) {
+            event.retracted_at = Some(retracted_at);
+            return true;
+        }
+        false
+    }
+
+    /// Mutable lookup by id. Used by the manager to roll back an
+    /// in-memory retract when the persistence write fails.
+    pub fn events_mut_find(&mut self, event_id: &str) -> Option<&mut Event> {
+        self.events.iter_mut().find(|e| e.id == event_id)
+    }
+
+    /// Dismiss `event_id` from `recipient`'s inbox view. Unlike
+    /// `clear_read` (which acts on a project-scoped batch of *read*
+    /// rows), this targets a single event regardless of read state.
+    /// `recipient_owns` still gatekeeps so a stranger can't fabricate
+    /// a ReadState row that `list_sent_by` would surface back to the
+    /// sender.
+    ///
+    /// Returns `true` when the cleared_at flag flipped (false when
+    /// already cleared, when the recipient doesn't own the event,
+    /// or when the event itself doesn't exist).
+    pub fn dismiss(
+        &mut self,
+        event_id: &str,
+        recipient: &str,
+        subscribed_patterns: &[String],
+        now_ms: u64,
+    ) -> bool {
+        if !self.recipient_owns(event_id, recipient, subscribed_patterns) {
+            return false;
+        }
+        let state = self.read_state_mut_or_insert(event_id, recipient);
+        if state.cleared_at.is_some() {
+            return false;
+        }
+        state.cleared_at = Some(now_ms);
+        true
     }
 }
 
@@ -846,5 +962,150 @@ mod tests {
         let events =
             store.list_for_recipient("auditor", &patterns, false, ProjectFilter::Any);
         assert!(events.is_empty());
+    }
+
+    // ── Retract (unsend) ───────────────────────────────────────────
+
+    #[test]
+    fn retract_sets_retracted_at_when_caller_is_sender() {
+        let mut store = EventStore::new();
+        post_to(&mut store, "e1", "reviewer", "x", Some("me"), None);
+        let updated = store.retract("e1", "me", 5000).unwrap();
+        assert_eq!(updated.retracted_at, Some(5000));
+        assert!(store.get("e1").unwrap().is_retracted());
+    }
+
+    #[test]
+    fn retract_rejects_non_sender() {
+        let mut store = EventStore::new();
+        post_to(&mut store, "e1", "reviewer", "x", Some("me"), None);
+        let err = store.retract("e1", "stranger", 5000).unwrap_err();
+        assert!(matches!(err, RetractError::NotSender { .. }));
+        assert!(!store.get("e1").unwrap().is_retracted());
+    }
+
+    #[test]
+    fn retract_rejects_already_acked() {
+        let mut store = EventStore::new();
+        post_to(&mut store, "e1", "reviewer", "x", Some("me"), None);
+        // Reviewer acks → sender can no longer unsend.
+        store.ack("e1", "reviewer", NO_SUBSCRIPTIONS, Some("done".into()), 1000);
+        let err = store.retract("e1", "me", 5000).unwrap_err();
+        assert!(matches!(err, RetractError::AlreadyAcked(_)));
+        assert!(!store.get("e1").unwrap().is_retracted());
+    }
+
+    #[test]
+    fn retract_idempotent_returns_already_retracted() {
+        let mut store = EventStore::new();
+        post_to(&mut store, "e1", "reviewer", "x", Some("me"), None);
+        store.retract("e1", "me", 5000).unwrap();
+        let err = store.retract("e1", "me", 6000).unwrap_err();
+        assert!(matches!(err, RetractError::AlreadyRetracted(_)));
+    }
+
+    #[test]
+    fn retract_rejects_missing_event() {
+        let mut store = EventStore::new();
+        let err = store.retract("ghost", "me", 5000).unwrap_err();
+        assert!(matches!(err, RetractError::NotFound(_)));
+    }
+
+    #[test]
+    fn retracted_event_disappears_from_recipient_inbox() {
+        let mut store = EventStore::new();
+        post_to(&mut store, "e1", "reviewer", "live", Some("me"), None);
+        post_to(&mut store, "e2", "reviewer", "to-retract", Some("me"), None);
+        store.retract("e2", "me", 5000).unwrap();
+        let inbox = store.list_for_recipient("reviewer", NO_SUBSCRIPTIONS, false, ProjectFilter::Any);
+        let ids: Vec<_> = inbox.iter().map(|e| e.id.clone()).collect();
+        assert_eq!(ids, vec!["e1"]);
+    }
+
+    #[test]
+    fn retracted_event_excluded_from_unread_count_and_firehose() {
+        let mut store = EventStore::new();
+        post_to(&mut store, "e1", "reviewer", "live", Some("me"), None);
+        post_to(&mut store, "e2", "reviewer", "to-retract", Some("me"), None);
+        store.retract("e2", "me", 5000).unwrap();
+        assert_eq!(store.unread_count("reviewer", NO_SUBSCRIPTIONS, ProjectFilter::Any), 1);
+        let firehose = store.list_all(ProjectFilter::Any, None);
+        let ids: Vec<_> = firehose.iter().map(|e| e.id.clone()).collect();
+        assert_eq!(ids, vec!["e1"]);
+    }
+
+    #[test]
+    fn list_sent_by_still_surfaces_retracted_for_sender() {
+        // The sender wants to know what they unsent. list_sent_by
+        // intentionally ignores the retract filter.
+        let mut store = EventStore::new();
+        post_to(&mut store, "e1", "reviewer", "to-retract", Some("me"), None);
+        store.retract("e1", "me", 5000).unwrap();
+        let sent = store.list_sent_by("me", None, None);
+        assert_eq!(sent.len(), 1);
+        assert!(sent[0].0.is_retracted());
+    }
+
+    #[test]
+    fn apply_retract_marker_idempotently_sets_timestamp() {
+        let mut store = EventStore::new();
+        post_to(&mut store, "e1", "reviewer", "x", Some("me"), None);
+        assert!(store.apply_retract_marker("e1", 5000));
+        assert_eq!(store.get("e1").unwrap().retracted_at, Some(5000));
+        // Marker for an evicted/missing event is a silent no-op.
+        assert!(!store.apply_retract_marker("ghost", 5000));
+    }
+
+    // ── Dismiss (per-event recipient-side hide) ────────────────────
+
+    #[test]
+    fn dismiss_sets_cleared_at_for_unread_event() {
+        let mut store = EventStore::new();
+        post_to(&mut store, "e1", "reviewer", "x", None, None);
+        assert!(store.dismiss("e1", "reviewer", NO_SUBSCRIPTIONS, 5000));
+        assert!(store.read_state("e1", "reviewer").unwrap().is_cleared());
+    }
+
+    #[test]
+    fn dismissed_event_disappears_from_inbox() {
+        let mut store = EventStore::new();
+        post_to(&mut store, "e1", "reviewer", "x", None, None);
+        post_to(&mut store, "e2", "reviewer", "y", None, None);
+        store.dismiss("e1", "reviewer", NO_SUBSCRIPTIONS, 5000);
+        let ids: Vec<_> = store
+            .list_for_recipient("reviewer", NO_SUBSCRIPTIONS, false, ProjectFilter::Any)
+            .iter()
+            .map(|e| e.id.clone())
+            .collect();
+        assert_eq!(ids, vec!["e2"]);
+    }
+
+    #[test]
+    fn dismiss_rejects_non_recipient() {
+        let mut store = EventStore::new();
+        post_to(&mut store, "e1", "reviewer", "x", None, None);
+        // qa is not the addressed recipient and has no subscription —
+        // can't fabricate a ReadState row.
+        assert!(!store.dismiss("e1", "qa", NO_SUBSCRIPTIONS, 5000));
+        assert!(store.read_state("e1", "qa").is_none());
+    }
+
+    #[test]
+    fn dismiss_idempotent_returns_false_on_repeat() {
+        let mut store = EventStore::new();
+        post_to(&mut store, "e1", "reviewer", "x", None, None);
+        assert!(store.dismiss("e1", "reviewer", NO_SUBSCRIPTIONS, 5000));
+        assert!(!store.dismiss("e1", "reviewer", NO_SUBSCRIPTIONS, 6000));
+    }
+
+    #[test]
+    fn dismiss_works_after_read_without_overwriting_read_at() {
+        let mut store = EventStore::new();
+        post_to(&mut store, "e1", "reviewer", "x", None, None);
+        store.mark_read("e1", "reviewer", NO_SUBSCRIPTIONS, 1000);
+        assert!(store.dismiss("e1", "reviewer", NO_SUBSCRIPTIONS, 5000));
+        let state = store.read_state("e1", "reviewer").unwrap();
+        assert_eq!(state.read_at, Some(1000), "prior read_at preserved");
+        assert_eq!(state.cleared_at, Some(5000));
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -439,6 +439,8 @@ fn main() {
             commands::mailbox::mailbox_mark_read,
             commands::mailbox::mailbox_ack,
             commands::mailbox::mailbox_clear_read,
+            commands::mailbox::mailbox_retract,
+            commands::mailbox::mailbox_dismiss,
             commands::mailbox::mailbox_deliver_to_pane,
             commands::subscriptions::subscriptions_list,
             commands::subscriptions::subscriptions_create,

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -251,6 +251,23 @@ pub struct MailboxAckParams {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
+pub struct MailboxRetractParams {
+    pub event_id: String,
+    /// Sender alias to retract on behalf of. Required for MCP/stdio
+    /// (no pane context for the implicit fallback the CLI uses).
+    pub alias: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MailboxDismissParams {
+    pub event_id: String,
+    /// Recipient alias whose view to dismiss from. Required for MCP.
+    pub alias: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct MailboxCountParams {
     pub alias: Option<String>,
     pub project_id: Option<String>,
@@ -697,6 +714,40 @@ impl RouxMcpServer {
         }
         call_socket(json!({
             "command": "mailbox-ack",
+            "args": Value::Object(args),
+        }))
+        .await
+    }
+
+    #[tool(
+        description = "Unsend an event you posted. Allowed only when no recipient has acked yet — once anyone confirmed delivery, retraction is rejected to keep the audit trail intact."
+    )]
+    async fn roux_mailbox_unsend(
+        &self,
+        Parameters(params): Parameters<MailboxRetractParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let mut args = serde_json::Map::new();
+        args.insert("event_id".into(), Value::String(params.event_id));
+        args.insert("alias".into(), Value::String(params.alias));
+        call_socket(json!({
+            "command": "mailbox-retract",
+            "args": Value::Object(args),
+        }))
+        .await
+    }
+
+    #[tool(
+        description = "Dismiss a single event from a recipient's inbox view (read or unread). The event itself is preserved; only this recipient's view loses it."
+    )]
+    async fn roux_mailbox_dismiss(
+        &self,
+        Parameters(params): Parameters<MailboxDismissParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let mut args = serde_json::Map::new();
+        args.insert("event_id".into(), Value::String(params.event_id));
+        args.insert("alias".into(), Value::String(params.alias));
+        call_socket(json!({
+            "command": "mailbox-dismiss",
             "args": Value::Object(args),
         }))
         .await

--- a/src-tauri/src/socket.rs
+++ b/src-tauri/src/socket.rs
@@ -270,6 +270,8 @@ async fn handle_request(req: Request, app: &tauri::AppHandle) -> Response {
         "mailbox-peek" => handle_mailbox_peek(req, app).await,
         "mailbox-read" => handle_mailbox_read(req, app).await,
         "mailbox-ack" => handle_mailbox_ack(req, app).await,
+        "mailbox-retract" => handle_mailbox_retract(req, app).await,
+        "mailbox-dismiss" => handle_mailbox_dismiss(req, app).await,
         "mailbox-count" => handle_mailbox_count(req, app).await,
         "mailbox-clear" => handle_mailbox_clear(req, app).await,
         "mailbox-reply" => handle_mailbox_reply(req, app).await,
@@ -1885,6 +1887,39 @@ async fn handle_mailbox_ack(req: Request, app: &tauri::AppHandle) -> Response {
     };
     let result = args_str(&req, "result").map(String::from);
     let changed = state.mailbox_manager.ack(&event_id, &alias, result, Some(app));
+    Response::success(serde_json::json!({ "changed": changed }))
+}
+
+async fn handle_mailbox_retract(req: Request, app: &tauri::AppHandle) -> Response {
+    let event_id = match args_str(&req, "event_id") {
+        Some(s) => s.to_string(),
+        None => return Response::err("event_id required"),
+    };
+    let state: tauri::State<AppState> = app.state();
+    // Retract is a sender-side action: caller must be the alias that
+    // sent the event. Use `args.alias` if given, else the calling
+    // pane's bound alias.
+    let alias = match resolve_recipient_alias(&state, &req, args_str(&req, "alias")) {
+        Ok(a) => a,
+        Err(e) => return Response::err(e),
+    };
+    match state.mailbox_manager.retract(&event_id, &alias, Some(app)) {
+        Ok(event) => Response::success(serde_json::to_value(event).unwrap_or_default()),
+        Err(e) => Response::err(e.to_string()),
+    }
+}
+
+async fn handle_mailbox_dismiss(req: Request, app: &tauri::AppHandle) -> Response {
+    let event_id = match args_str(&req, "event_id") {
+        Some(s) => s.to_string(),
+        None => return Response::err("event_id required"),
+    };
+    let state: tauri::State<AppState> = app.state();
+    let alias = match resolve_recipient_alias(&state, &req, args_str(&req, "alias")) {
+        Ok(a) => a,
+        Err(e) => return Response::err(e),
+    };
+    let changed = state.mailbox_manager.dismiss(&event_id, &alias, Some(app));
     Response::success(serde_json::json!({ "changed": changed }))
 }
 

--- a/src/lib/components/MailboxPanel.svelte
+++ b/src/lib/components/MailboxPanel.svelte
@@ -20,8 +20,10 @@
   } from "$lib/stores/subscriptions";
   import {
     mailboxDeliverToPane,
+    mailboxDismiss,
     mailboxListForRecipient,
     mailboxReadState,
+    mailboxRetract,
   } from "$lib/tauri";
   import type {
     AgentAlias,
@@ -246,6 +248,35 @@
 
   async function handleClearRead() {
     await clearReadFor(selectedAlias);
+  }
+
+  async function handleDismiss(eventId: string) {
+    try {
+      await mailboxDismiss(eventId, selectedAlias);
+    } catch (err) {
+      // Mirrors handleDeliver's error-surface pattern for consistency.
+      deliverError = `Dismiss failed: ${String(err)}`;
+    }
+  }
+
+  let retractError = $state<string | null>(null);
+  let retractingId = $state<string | null>(null);
+
+  async function handleRetract(event: MailboxEventPayload) {
+    if (retractingId) return;
+    if (!event.from) {
+      retractError = "Cannot retract — event has no sender alias.";
+      return;
+    }
+    retractingId = event.id;
+    retractError = null;
+    try {
+      await mailboxRetract(event.id, event.from);
+    } catch (err) {
+      retractError = String(err);
+    } finally {
+      retractingId = null;
+    }
   }
 
   async function handleSubscribe(): Promise<void> {
@@ -543,6 +574,11 @@
                 onclick={() => handleAck(e.id)}
                 disabled={isAcked}
               >ack</button>
+              <button
+                class="cursor-pointer rounded border border-transparent bg-transparent px-1.5 py-0.5 text-[10px] text-text-muted hover:border-border-subtle hover:bg-bg-hover hover:text-text-primary"
+                onclick={() => handleDismiss(e.id)}
+                title="Hide this event from your inbox view. The event itself is preserved; other recipients keep seeing it."
+              >dismiss</button>
               {#if recipientHasPane(e.to, e.projectId)}
                 <button
                   class="cursor-pointer rounded border border-accent-dim/60 bg-accent/10 px-1.5 py-0.5 text-[10px] text-accent hover:bg-accent/20 disabled:opacity-50"
@@ -611,10 +647,25 @@
             <p class="truncate text-[11px] text-text-secondary">
               {e.subject ?? e.body}
             </p>
+            {#if e.retractedAt != null}
+              <span class="text-[9px] text-text-muted/70 italic">retracted</span>
+            {:else if e.from === "me"}
+              <button
+                class="self-start cursor-pointer rounded border border-transparent bg-transparent px-1.5 py-0 text-[9px] text-text-muted hover:border-border-subtle hover:bg-bg-hover hover:text-text-primary disabled:opacity-50"
+                onclick={() => handleRetract(e)}
+                disabled={retractingId === e.id}
+                title="Unsend this event. Allowed only if no recipient has acked yet."
+              >{retractingId === e.id ? "unsending…" : "unsend"}</button>
+            {/if}
           </article>
         {/each}
       {/if}
     </div>
+    {#if retractError}
+      <div class="shrink-0 border-t border-red-500/40 bg-red-500/10 px-2 py-1 text-[10px] text-red-300">
+        {retractError}
+      </div>
+    {/if}
   {:else}
     <!-- Subscriptions: list + create form. The list updates live via
          the `subscription-event` Tauri channel; mutations here go through

--- a/src/lib/components/MailboxPanel.svelte
+++ b/src/lib/components/MailboxPanel.svelte
@@ -649,7 +649,7 @@
             </p>
             {#if e.retractedAt != null}
               <span class="text-[9px] text-text-muted/70 italic">retracted</span>
-            {:else if e.from === "me"}
+            {:else if e.from === selectedAlias}
               <button
                 class="self-start cursor-pointer rounded border border-transparent bg-transparent px-1.5 py-0 text-[9px] text-text-muted hover:border-border-subtle hover:bg-bg-hover hover:text-text-primary disabled:opacity-50"
                 onclick={() => handleRetract(e)}

--- a/src/lib/stores/mailbox.ts
+++ b/src/lib/stores/mailbox.ts
@@ -167,10 +167,33 @@ export function applyMailboxEvent(event: MailboxEvent): void {
     }
     case "read":
     case "acked":
-    case "cleared": {
+    case "cleared":
+    case "dismissed": {
       // Read-state-only mutations don't change the events array. The
       // Tauri payload doesn't carry projectId — refresh every known
       // scope for that recipient (fan-out is small in practice).
+      void refreshUnreadCount(event.recipient, undefined);
+      break;
+    }
+    case "retracted": {
+      // Mark the event row retracted in-place so the firehose / sent
+      // view can render it as such; recipient inbox queries hit the
+      // backend (which already filters retracted) so they refresh
+      // through the existing mailboxMutationTick effect.
+      events.update((list) =>
+        list.map((e) =>
+          e.id === event.eventId
+            ? { ...e, retractedAt: e.retractedAt ?? Date.now() }
+            : e,
+        ),
+      );
+      // Bump every alias's unread count — the retracted event might
+      // have been counted somewhere we can't pinpoint without scanning.
+      void refreshAllUnreadCounts();
+      break;
+    }
+    case "topicDelivered": {
+      // Bump the subscriber's unread count.
       void refreshUnreadCount(event.recipient, undefined);
       break;
     }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1481,6 +1481,30 @@ export async function mailboxClearRead(recipient: string): Promise<number> {
 }
 
 /**
+ * Sender-side unsend. Sets retracted_at on the event so recipients drop
+ * it from their inbox views. Allowed only when no recipient has acked
+ * yet — once anyone confirmed delivery the audit trail is preserved.
+ */
+export async function mailboxRetract(
+  eventId: string,
+  sender: string,
+): Promise<MailboxEventPayload> {
+  return invoke("mailbox_retract", { eventId, sender });
+}
+
+/**
+ * Recipient-side single-event hide. Sets cleared_at on the
+ * (eventId, recipient) ReadState regardless of read state. The event
+ * itself is preserved; only this recipient's view loses it.
+ */
+export async function mailboxDismiss(
+  eventId: string,
+  recipient: string,
+): Promise<boolean> {
+  return invoke("mailbox_dismiss", { eventId, recipient });
+}
+
+/**
  * Type a mailbox event's body into the recipient's pane (plus trailing CR
  * so Claude/Codex see it as submitted input). Backend looks up
  * recipient → alias → pane_id → pty_id and writes via the existing PTY

--- a/src/lib/types/mailbox.ts
+++ b/src/lib/types/mailbox.ts
@@ -22,6 +22,10 @@ export interface Event {
   body: string;
   /** Free-form structured payload. May be any JSON value. */
   structured: unknown | null;
+  /** Set when the sender retracted the event. Recipients hide it from
+   *  inbox views; the sender's `mailbox sent` view still surfaces it
+   *  with this timestamp. */
+  retractedAt: number | null;
 }
 
 export interface ReadState {
@@ -88,6 +92,19 @@ export type MailboxEvent =
       eventId: string;
       recipient: string;
       subscriptionId: string;
+    }
+  | {
+      /** Sender unsent the event. UIs should drop it from inbox views;
+       *  the sender's "sent" view should mark it as retracted. */
+      kind: "retracted";
+      eventId: string;
+    }
+  | {
+      /** Recipient dismissed a single event from their inbox view.
+       *  Other recipients are unaffected. */
+      kind: "dismissed";
+      eventId: string;
+      recipient: string;
     };
 
 /**


### PR DESCRIPTION
## Summary
Two new lifecycle operations that close the "no way to delete a message" gap without breaking the append-only audit log.

- **Unsend** — \`roux mailbox unsend <event_id>\`. Sender retracts their own posted event. Sets \`retractedAt\` so recipient inbox views + the firehose hide it; sender's \`mailbox sent\` view still surfaces it with the timestamp. Allowed only before any recipient has acked — once anyone confirmed delivery, retraction is rejected so the audit trail stays honest.
- **Dismiss** — \`roux mailbox dismiss <event_id>\`. Recipient hides a single event from their own view (read or unread). Other recipients are unaffected.
- Closes the question raised in chat about message deletion. (3) hard-delete from the audit log was deliberately not implemented — these two cover the actual user needs without breaking the append-only invariant.

## Stack
This PR is **stacked on top of #167** (\`feature/group-aliases\`). Base is \`feature/group-aliases\`; the diff shows only the unsend/dismiss work. Once #167 lands, this auto-rebases onto main.

## Surface
- **Core**: \`Event.retracted_at\`; \`MailboxEvent::Retracted\` / \`MailboxEvent::Dismissed\` variants on the Tauri channel.
- **Store**: \`retract(id, sender)\` / \`dismiss(id, recipient)\` / \`apply_retract_marker\`. \`list_*\` and \`unread_count\` filter retracted out; \`list_sent_by\` intentionally surfaces them so the sender sees what they unsent.
- **Persistence**: append \`{rowType: "retract", eventId, retractedAt}\` marker row to \`events.jsonl\`; loader applies it. Append-only audit log preserved. Earliest retract wins on duplicates.
- **Manager**: \`retract\` (rolls back in-memory on persist failure, symmetric with \`post\`), \`dismiss\`.
- **CLI**: \`roux mailbox unsend\` / \`roux mailbox dismiss\`.
- **MCP**: \`roux_mailbox_unsend\` / \`roux_mailbox_dismiss\` tools (alias is required — no pane fallback for stdio).
- **Socket**: \`mailbox-retract\` / \`mailbox-dismiss\`.
- **Tauri commands**: \`mailbox_retract\` / \`mailbox_dismiss\` + frontend bindings.
- **UI**: \`dismiss\` button on each inbox row alongside mark-read/ack/deliver. \`unsend\` button on firehose rows where \`event.from === "me"\`. Retracted firehose rows render italicized "retracted" instead of the unsend button.

## Test plan
- [x] \`cargo test --bin roux\` — 486 pass
- [x] \`cargo test --lib --workspace\` — 167 + 195 + ... = 427+ pass across crates
- [x] 12 store tests (retract sender check, ack-block, idempotent, list/unread filtering; dismiss happy path, gatekeeping, idempotent, post-read)
- [x] 4 persistence tests (round-trip, missing-event marker is silent, earliest-wins, rowType tag)
- [x] 5 manager tests (disk reload, broadcast, retract-after-ack rejection)
- [x] \`cargo clippy --bin roux --tests\` — clean
- [x] \`npm run check\` — 0 errors
- [x] \`npm run test\` — 1003 pass
- [ ] Manual end-to-end:
  - Post a task. Reload Roux. Confirm it's still there.
  - Unsend it. Reload. Confirm the recipient inbox is empty AND the sender's \`mailbox sent\` shows it as retracted.
  - Post another task. Mark it read. Confirm it's still in the inbox (greyed). Click dismiss. Confirm it's gone. Reload. Confirm it's still gone.
  - Post a task, ack it from the recipient, then try to unsend — confirm rejection error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Adds sender-retract (`unsend`) and recipient-hide (`dismiss`) lifecycle operations to the mailbox system; the append-only audit log is preserved via a `{rowType: "retract"}` marker row in `events.jsonl`, with earliest-wins semantics on duplicate markers.
- `RetractError::Persist` is correctly defined and used in the rollback path (symmetric with `PostError::Persist`), and the unsend button in the firehose is now gated on `e.from === selectedAlias` rather than the hardcoded `"me"` string.
- One minor inconsistency: `apply_retract_marker` on `EventStore` always overwrites `retracted_at` while the persistence loader applies an `is_none()` guard; these should be aligned to prevent divergence if the method is used in a future replay path.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; only a minor P2 finding (missing is_none() guard in a currently-dead method).

All three previously-flagged issues from earlier review rounds are resolved: the persistence comment is fixed, RetractError::Persist is correctly defined and used, and the 'me' hardcode is replaced with selectedAlias. The implementation is thoroughly tested (12 store + 4 persistence + 5 manager tests). The single remaining finding is a style/maintenance inconsistency in a public but currently uncalled method.

src-tauri/src/mailbox/store.rs — apply_retract_marker is missing the is_none() guard that the persistence loader has.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src-tauri/src/mailbox/store.rs | Adds RetractError (with correct Persist variant), retract, dismiss, apply_retract_marker, and events_mut_find; well-tested, but apply_retract_marker is missing the is_none() guard present in the persistence loader. |
| src-tauri/src/mailbox/manager.rs | Adds retract (with correct rollback on persist failure using RetractError::Persist) and dismiss to MailboxManager; symmetric with existing post rollback pattern and well-tested including ack-block and broadcast tests. |
| src-tauri/src/mailbox/persistence.rs | Adds RetractRowV1, append_retract_to, and applies retract markers in load_events_from with correct earliest-wins semantics; four new tests cover round-trip, missing-event no-op, duplicate priority, and row-type tag. |
| src/lib/components/MailboxPanel.svelte | Adds handleDismiss, handleRetract, dismiss button on inbox rows, and unsend/retracted display on firehose rows; unsend button correctly gated on e.from === selectedAlias (not the previously-flagged hardcoded 'me'). |
| src/lib/stores/mailbox.ts | Handles retracted (in-place event update + refreshAllUnreadCounts) and dismissed (grouped with cleared for refreshUnreadCount); mailboxMutationTick increments on all events so inbox lists also refresh. |
| crates/roux-core/src/models/event.rs | Adds retracted_at: Option<u64> to Event with #[serde(default)], is_retracted() helper, and two new MailboxEvent variants (Retracted, Dismissed); clean and consistent with existing patterns. |
| src-tauri/src/socket.rs | Adds handle_mailbox_retract and handle_mailbox_dismiss handlers; both use resolve_recipient_alias consistent with existing handlers. |
| src-tauri/src/commands/mailbox.rs | Thin Tauri command adapters for mailbox_retract and mailbox_dismiss, consistent with the existing command style. |
| src-tauri/src/mcp.rs | Adds roux_mailbox_unsend / roux_mailbox_dismiss MCP tools; alias is String (required) since MCP has no pane context for implicit fallback. |
| src-tauri/src/cli.rs | Adds Unsend and Dismiss subcommands routing through the socket with mailbox-retract / mailbox-dismiss; consistent with existing CLI handlers. |
| src-tauri/src/main.rs | Registers two new Tauri commands (mailbox_retract, mailbox_dismiss); no issues. |
| src/lib/tauri.ts | Adds typed mailboxRetract and mailboxDismiss wrappers; consistent with existing invoke conventions. |
| src/lib/types/mailbox.ts | Adds retractedAt: number | null to Event and retracted / dismissed discriminated union members to MailboxEvent; types are consistent with Rust serialization. |
| docs/features/mailbox.md | Adds docs for roux mailbox unsend and roux mailbox dismiss with accurate descriptions of the ack-block constraint and append-only audit log. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as MailboxPanel
    participant TC as TauriCommand
    participant MGR as MailboxManager
    participant STORE as EventStore
    participant DISK as events.jsonl

    Note over UI,DISK: Unsend (retract) flow
    UI->>TC: mailbox_retract(event_id, sender)
    TC->>MGR: retract(event_id, caller, app)
    MGR->>STORE: retract(event_id, caller, now_ms)
    Note over STORE: NotFound / NotSender / AlreadyRetracted / AlreadyAcked checks
    STORE-->>MGR: Ok(event) retracted_at set in memory
    MGR->>DISK: append_retract_to(event_id, now)
    alt disk write fails
        DISK-->>MGR: Err(io)
        MGR->>STORE: "rollback retracted_at=None"
        MGR-->>TC: Err(RetractError::Persist)
    else disk write succeeds
        MGR->>UI: broadcast MailboxEvent::Retracted
        MGR-->>TC: Ok(event)
    end

    Note over UI,DISK: Dismiss flow
    UI->>TC: mailbox_dismiss(event_id, recipient)
    TC->>MGR: dismiss(event_id, recipient, app)
    MGR->>STORE: dismiss(event_id, recipient, patterns, now)
    Note over STORE: recipient_owns check then sets cleared_at
    STORE-->>MGR: bool changed
    alt changed is true
        MGR->>DISK: persist_read_state()
        MGR->>UI: broadcast MailboxEvent::Dismissed
    end
    MGR-->>TC: bool
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src-tauri/src/mailbox/manager.rs`, line 235-238 ([link](https://github.com/phin-tech/roux/blob/b373feafded2d82cc2feca73795447b8a2a0344e/src-tauri/src/mailbox/manager.rs#L235-L238)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Wrong error variant used for persistence failure**

   When `append_retract_to` fails, the code correctly rolls back in-memory state but then returns `RetractError::NotFound(...)`. `NotFound` has the format string `"event not found: {0}"`, so callers (the socket handler and the Tauri command both call `.to_string()`) will surface: `"event not found: persistence error rolled back: <io error>"` — a completely wrong diagnosis. By contrast, `PostError` next to it already has a `Persist(String)` variant for exactly this case.

   `RetractError` is missing a `Persist` variant; the workaround of misusing `NotFound` leaks through to user-visible error messages and any caller that pattern-matches on the variant.

   ```rust
   // Add to RetractError in store.rs:
   /// Disk persistence failed; in-memory retraction was rolled back.
   #[error("retract persistence failed: {0}")]
   Persist(String),
   ```

   Then in manager.rs:
   ```rust
   return Err(RetractError::Persist(format!(
       "persistence error rolled back: {e}"
   )));
   ```

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src-tauri%2Fsrc%2Fmailbox%2Fmanager.rs%0ALine%3A%20235-238%0A%0AComment%3A%0A**Wrong%20error%20variant%20used%20for%20persistence%20failure**%0A%0AWhen%20%60append_retract_to%60%20fails%2C%20the%20code%20correctly%20rolls%20back%20in-memory%20state%20but%20then%20returns%20%60RetractError%3A%3ANotFound%28...%29%60.%20%60NotFound%60%20has%20the%20format%20string%20%60%22event%20not%20found%3A%20%7B0%7D%22%60%2C%20so%20callers%20%28the%20socket%20handler%20and%20the%20Tauri%20command%20both%20call%20%60.to_string%28%29%60%29%20will%20surface%3A%20%60%22event%20not%20found%3A%20persistence%20error%20rolled%20back%3A%20%3Cio%20error%3E%22%60%20%E2%80%94%20a%20completely%20wrong%20diagnosis.%20By%20contrast%2C%20%60PostError%60%20next%20to%20it%20already%20has%20a%20%60Persist%28String%29%60%20variant%20for%20exactly%20this%20case.%0A%0A%60RetractError%60%20is%20missing%20a%20%60Persist%60%20variant%3B%20the%20workaround%20of%20misusing%20%60NotFound%60%20leaks%20through%20to%20user-visible%20error%20messages%20and%20any%20caller%20that%20pattern-matches%20on%20the%20variant.%0A%0A%60%60%60rust%0A%2F%2F%20Add%20to%20RetractError%20in%20store.rs%3A%0A%2F%2F%2F%20Disk%20persistence%20failed%3B%20in-memory%20retraction%20was%20rolled%20back.%0A%23%5Berror%28%22retract%20persistence%20failed%3A%20%7B0%7D%22%29%5D%0APersist%28String%29%2C%0A%60%60%60%0A%0AThen%20in%20manager.rs%3A%0A%60%60%60rust%0Areturn%20Err%28RetractError%3A%3APersist%28format!%28%0A%20%20%20%20%22persistence%20error%20rolled%20back%3A%20%7Be%7D%22%0A%29%29%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=phin-tech%2Froux&pr=168&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22feature%2Fmailbox-retract%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fmailbox-retract%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src-tauri%2Fsrc%2Fmailbox%2Fmanager.rs%0ALine%3A%20235-238%0A%0AComment%3A%0A**Wrong%20error%20variant%20used%20for%20persistence%20failure**%0A%0AWhen%20%60append_retract_to%60%20fails%2C%20the%20code%20correctly%20rolls%20back%20in-memory%20state%20but%20then%20returns%20%60RetractError%3A%3ANotFound%28...%29%60.%20%60NotFound%60%20has%20the%20format%20string%20%60%22event%20not%20found%3A%20%7B0%7D%22%60%2C%20so%20callers%20%28the%20socket%20handler%20and%20the%20Tauri%20command%20both%20call%20%60.to_string%28%29%60%29%20will%20surface%3A%20%60%22event%20not%20found%3A%20persistence%20error%20rolled%20back%3A%20%3Cio%20error%3E%22%60%20%E2%80%94%20a%20completely%20wrong%20diagnosis.%20By%20contrast%2C%20%60PostError%60%20next%20to%20it%20already%20has%20a%20%60Persist%28String%29%60%20variant%20for%20exactly%20this%20case.%0A%0A%60RetractError%60%20is%20missing%20a%20%60Persist%60%20variant%3B%20the%20workaround%20of%20misusing%20%60NotFound%60%20leaks%20through%20to%20user-visible%20error%20messages%20and%20any%20caller%20that%20pattern-matches%20on%20the%20variant.%0A%0A%60%60%60rust%0A%2F%2F%20Add%20to%20RetractError%20in%20store.rs%3A%0A%2F%2F%2F%20Disk%20persistence%20failed%3B%20in-memory%20retraction%20was%20rolled%20back.%0A%23%5Berror%28%22retract%20persistence%20failed%3A%20%7B0%7D%22%29%5D%0APersist%28String%29%2C%0A%60%60%60%0A%0AThen%20in%20manager.rs%3A%0A%60%60%60rust%0Areturn%20Err%28RetractError%3A%3APersist%28format!%28%0A%20%20%20%20%22persistence%20error%20rolled%20back%3A%20%7Be%7D%22%0A%29%29%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc-tauri%2Fsrc%2Fmailbox%2Fstore.rs%3A682-688%0A**%60apply_retract_marker%60%20silently%20breaks%20the%20earliest-wins%20invariant**%0A%0AThe%20persistence%20loader%20enforces%20earliest-wins%20with%20an%20%60is_none%28%29%60%20guard%20before%20writing%2C%20but%20%60apply_retract_marker%60%20always%20overwrites%20%60retracted_at%60%20unconditionally.%20The%20docstring%20says%20this%20method%20is%20%22used%20by%20the%20persistence%20loader%20to%20replay%20retract%20marker%20rows%22%20%E2%80%94%20but%20the%20loader%20doesn't%20call%20it%3B%20it%20applies%20the%20same%20pattern%20inline%20with%20the%20guard.%20If%20%60apply_retract_marker%60%20is%20ever%20wired%20into%20a%20replay%20or%20migration%20path%2C%20it%20will%20silently%20produce%20latest-wins%20semantics%20instead%20of%20earliest-wins%2C%20contradicting%20the%20%60earliest_retract_wins_when_duplicated%60%20test%20and%20the%20persistence%20contract.%0A%0A%60%60%60suggestion%0A%20%20%20%20pub%20fn%20apply_retract_marker%28%26mut%20self%2C%20event_id%3A%20%26str%2C%20retracted_at%3A%20u64%29%20-%3E%20bool%20%7B%0A%20%20%20%20%20%20%20%20if%20let%20Some%28event%29%20%3D%20self.events.iter_mut%28%29.find%28%7Ce%7C%20e.id%20%3D%3D%20event_id%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20event.retracted_at.is_none%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20event.retracted_at%20%3D%20Some%28retracted_at%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20true%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20false%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=phin-tech%2Froux&pr=168&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22feature%2Fmailbox-retract%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fmailbox-retract%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc-tauri%2Fsrc%2Fmailbox%2Fstore.rs%3A682-688%0A**%60apply_retract_marker%60%20silently%20breaks%20the%20earliest-wins%20invariant**%0A%0AThe%20persistence%20loader%20enforces%20earliest-wins%20with%20an%20%60is_none%28%29%60%20guard%20before%20writing%2C%20but%20%60apply_retract_marker%60%20always%20overwrites%20%60retracted_at%60%20unconditionally.%20The%20docstring%20says%20this%20method%20is%20%22used%20by%20the%20persistence%20loader%20to%20replay%20retract%20marker%20rows%22%20%E2%80%94%20but%20the%20loader%20doesn't%20call%20it%3B%20it%20applies%20the%20same%20pattern%20inline%20with%20the%20guard.%20If%20%60apply_retract_marker%60%20is%20ever%20wired%20into%20a%20replay%20or%20migration%20path%2C%20it%20will%20silently%20produce%20latest-wins%20semantics%20instead%20of%20earliest-wins%2C%20contradicting%20the%20%60earliest_retract_wins_when_duplicated%60%20test%20and%20the%20persistence%20contract.%0A%0A%60%60%60suggestion%0A%20%20%20%20pub%20fn%20apply_retract_marker%28%26mut%20self%2C%20event_id%3A%20%26str%2C%20retracted_at%3A%20u64%29%20-%3E%20bool%20%7B%0A%20%20%20%20%20%20%20%20if%20let%20Some%28event%29%20%3D%20self.events.iter_mut%28%29.find%28%7Ce%7C%20e.id%20%3D%3D%20event_id%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20event.retracted_at.is_none%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20event.retracted_at%20%3D%20Some%28retracted_at%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20true%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20false%0A%20%20%20%20%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<sub>Reviews (4): Last reviewed commit: ["fix: address late-arriving #168 review f..."](https://github.com/phin-tech/roux/commit/ed2063f4fa8834940fcd81303c68443b932857cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31492047)</sub>

<!-- /greptile_comment -->