### PR TITLE
feat(mailbox): thread inbox events by correlation_id

### DIFF
--- a/docs/features/mailbox.md
+++ b/docs/features/mailbox.md
@@ -168,6 +168,14 @@ threads:
 roux mailbox reply <event_id> "looking now, will get back in 10"
 ```
 
+The Mailbox panel's Inbox view groups events sharing a `correlation_id`
+into threads — replies render indented under their root with a `↳`
+prefix, so a long back-and-forth reads as one conversation instead of
+N flat rows. Per-event actions (mark read, ack, dismiss, deliver) work
+on each event independently. When the original isn't visible (e.g.
+you've dismissed it but kept the replies), the earliest visible
+reply becomes the visual root.
+
 ### Sender's view
 
 ```sh

--- a/src/lib/components/MailboxPanel.svelte
+++ b/src/lib/components/MailboxPanel.svelte
@@ -6,6 +6,7 @@
     ackEvent,
     clearReadFor,
     events,
+    groupIntoThreads,
     hydrateMailbox,
     mailboxMutationTick,
     markRead,
@@ -166,6 +167,11 @@
   function eventReadState(id: string): ReadState | null {
     return recipientReadStates.get(id) ?? null;
   }
+
+  // Group inbox events into threads by `correlationId` so replies
+  // render nested under their root. Singletons (no correlation) are
+  // 1-event threads, visually identical to a flat row.
+  let recipientThreads = $derived(groupIntoThreads(recipientEvents));
 
   let firehoseEvents = $derived(visible ? $events : []);
 
@@ -512,83 +518,97 @@
       {/each}
     </div>
 
+    {#snippet eventCard(e: MailboxEventPayload, isReply: boolean)}
+      {@const state = eventReadState(e.id)}
+      {@const isRead = state?.readAt != null}
+      {@const isAcked = state?.ackedAt != null}
+      <article
+        class="flex flex-col gap-1 rounded-lg border border-border-subtle bg-bg-surface/30 px-2 py-1.5 {isRead
+          ? 'opacity-60'
+          : ''} {isReply
+          ? 'ml-3 border-l-2 border-l-accent-dim/40 bg-bg-surface/20'
+          : ''}"
+      >
+        <header class="flex items-center gap-2">
+          {#if isReply}
+            <span class="text-[10px] text-text-muted/70" title="Reply">↳</span>
+          {/if}
+          <span
+            class="inline-block h-2 w-2 shrink-0 rounded-full {kindColor(
+              e.kind,
+            )}"
+          ></span>
+          <span class="text-[10px] uppercase tracking-wider text-text-muted"
+            >{e.kind}</span
+          >
+          {#if e.from}
+            <span class="truncate text-[10px] text-text-muted"
+              >from {e.from}</span
+            >
+          {/if}
+          {#if isAcked}
+            <span class="text-[10px] text-green" title={state?.ackResult ?? "Acked"}
+              >✓ ack{state?.ackResult ? `: ${state.ackResult}` : ""}</span
+            >
+          {:else if isRead}
+            <span class="text-[10px] text-text-muted">read</span>
+          {/if}
+          <span class="ml-auto shrink-0 text-[10px] text-text-muted/70"
+            >{formatRelative(e.createdAt)}</span
+          >
+        </header>
+        {#if e.subject}
+          <h4 class="text-[11px] font-medium text-text-primary">
+            {e.subject}
+          </h4>
+        {/if}
+        <p class="whitespace-pre-wrap text-[11px] text-text-secondary">
+          {e.body}
+        </p>
+        {#if e.topic}
+          <span class="text-[9px] text-text-muted">topic: {e.topic}</span>
+        {/if}
+        <footer class="flex flex-wrap gap-1">
+          <button
+            class="cursor-pointer rounded border border-transparent bg-transparent px-1.5 py-0.5 text-[10px] text-text-muted hover:border-border-subtle hover:bg-bg-hover hover:text-text-primary disabled:opacity-40"
+            onclick={() => handleMarkRead(e.id)}
+            disabled={isRead}
+          >mark read</button>
+          <button
+            class="cursor-pointer rounded border border-transparent bg-transparent px-1.5 py-0.5 text-[10px] text-text-muted hover:border-border-subtle hover:bg-bg-hover hover:text-text-primary disabled:opacity-40"
+            onclick={() => handleAck(e.id)}
+            disabled={isAcked}
+          >ack</button>
+          <button
+            class="cursor-pointer rounded border border-transparent bg-transparent px-1.5 py-0.5 text-[10px] text-text-muted hover:border-border-subtle hover:bg-bg-hover hover:text-text-primary"
+            onclick={() => handleDismiss(e.id)}
+            title="Hide this event from your inbox view. The event itself is preserved; other recipients keep seeing it."
+          >dismiss</button>
+          {#if recipientHasPane(e.to, e.projectId)}
+            <button
+              class="cursor-pointer rounded border border-accent-dim/60 bg-accent/10 px-1.5 py-0.5 text-[10px] text-accent hover:bg-accent/20 disabled:opacity-50"
+              onclick={() => handleDeliver(e.id)}
+              disabled={deliveringId === e.id}
+              title="Type this message into the recipient's pane and ack it. Bypasses the agent's drain step — use when you want immediate delivery."
+            >{deliveringId === e.id ? "delivering…" : "deliver →"}</button>
+          {/if}
+        </footer>
+      </article>
+    {/snippet}
+
     <div class="flex-1 overflow-y-auto p-2">
-      {#if recipientEvents.length === 0}
+      {#if recipientThreads.length === 0}
         <div
           class="flex h-full items-center justify-center text-sm text-text-muted"
         >No {unreadOnly ? "unread" : ""} mail for {selectedAlias}</div>
       {:else}
-        {#each recipientEvents as e (e.id)}
-          {@const state = eventReadState(e.id)}
-          {@const isRead = state?.readAt != null}
-          {@const isAcked = state?.ackedAt != null}
-          <article
-            class="mb-2 flex flex-col gap-1 rounded-lg border border-border-subtle bg-bg-surface/30 px-2 py-1.5 {isRead
-              ? 'opacity-60'
-              : ''}"
-          >
-            <header class="flex items-center gap-2">
-              <span
-                class="inline-block h-2 w-2 shrink-0 rounded-full {kindColor(
-                  e.kind,
-                )}"
-              ></span>
-              <span class="text-[10px] uppercase tracking-wider text-text-muted"
-                >{e.kind}</span
-              >
-              {#if e.from}
-                <span class="truncate text-[10px] text-text-muted"
-                  >from {e.from}</span
-                >
-              {/if}
-              {#if isAcked}
-                <span class="text-[10px] text-green" title={state?.ackResult ?? "Acked"}
-                  >✓ ack{state?.ackResult ? `: ${state.ackResult}` : ""}</span
-                >
-              {:else if isRead}
-                <span class="text-[10px] text-text-muted">read</span>
-              {/if}
-              <span class="ml-auto shrink-0 text-[10px] text-text-muted/70"
-                >{formatRelative(e.createdAt)}</span
-              >
-            </header>
-            {#if e.subject}
-              <h4 class="text-[11px] font-medium text-text-primary">
-                {e.subject}
-              </h4>
-            {/if}
-            <p class="whitespace-pre-wrap text-[11px] text-text-secondary">
-              {e.body}
-            </p>
-            {#if e.topic}
-              <span class="text-[9px] text-text-muted">topic: {e.topic}</span>
-            {/if}
-            <footer class="flex flex-wrap gap-1">
-              <button
-                class="cursor-pointer rounded border border-transparent bg-transparent px-1.5 py-0.5 text-[10px] text-text-muted hover:border-border-subtle hover:bg-bg-hover hover:text-text-primary disabled:opacity-40"
-                onclick={() => handleMarkRead(e.id)}
-                disabled={isRead}
-              >mark read</button>
-              <button
-                class="cursor-pointer rounded border border-transparent bg-transparent px-1.5 py-0.5 text-[10px] text-text-muted hover:border-border-subtle hover:bg-bg-hover hover:text-text-primary disabled:opacity-40"
-                onclick={() => handleAck(e.id)}
-                disabled={isAcked}
-              >ack</button>
-              <button
-                class="cursor-pointer rounded border border-transparent bg-transparent px-1.5 py-0.5 text-[10px] text-text-muted hover:border-border-subtle hover:bg-bg-hover hover:text-text-primary"
-                onclick={() => handleDismiss(e.id)}
-                title="Hide this event from your inbox view. The event itself is preserved; other recipients keep seeing it."
-              >dismiss</button>
-              {#if recipientHasPane(e.to, e.projectId)}
-                <button
-                  class="cursor-pointer rounded border border-accent-dim/60 bg-accent/10 px-1.5 py-0.5 text-[10px] text-accent hover:bg-accent/20 disabled:opacity-50"
-                  onclick={() => handleDeliver(e.id)}
-                  disabled={deliveringId === e.id}
-                  title="Type this message into the recipient's pane and ack it. Bypasses the agent's drain step — use when you want immediate delivery."
-                >{deliveringId === e.id ? "delivering…" : "deliver →"}</button>
-              {/if}
-            </footer>
-          </article>
+        {#each recipientThreads as thread (thread.id)}
+          <div class="mb-2 flex flex-col gap-1">
+            {@render eventCard(thread.root, false)}
+            {#each thread.replies as reply (reply.id)}
+              {@render eventCard(reply, true)}
+            {/each}
+          </div>
         {/each}
       {/if}
     </div>

--- a/src/lib/stores/__tests__/mailboxThreading.test.ts
+++ b/src/lib/stores/__tests__/mailboxThreading.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import { groupIntoThreads } from "$lib/stores/mailbox";
+import type { MailboxEventPayload } from "$lib/tauri";
+
+function event(
+  id: string,
+  createdAt: number,
+  partial: Partial<MailboxEventPayload> = {},
+): MailboxEventPayload {
+  return {
+    id,
+    createdAt,
+    to: "reviewer",
+    topic: null,
+    from: "me",
+    kind: "task",
+    correlationId: null,
+    projectId: null,
+    subject: null,
+    body: `event ${id}`,
+    structured: null,
+    retractedAt: null,
+    ...partial,
+  };
+}
+
+describe("groupIntoThreads", () => {
+  it("returns an empty array for an empty input", () => {
+    expect(groupIntoThreads([])).toEqual([]);
+  });
+
+  it("treats events without correlationId as singleton threads", () => {
+    const a = event("a", 1);
+    const b = event("b", 2);
+    const threads = groupIntoThreads([a, b]);
+    expect(threads).toHaveLength(2);
+    expect(threads[0].root.id).toBe("a");
+    expect(threads[0].replies).toEqual([]);
+    expect(threads[1].root.id).toBe("b");
+  });
+
+  it("groups correlated events under the root whose id matches correlationId", () => {
+    const root = event("root-1", 100);
+    const reply1 = event("r1", 110, { correlationId: "root-1" });
+    const reply2 = event("r2", 120, { correlationId: "root-1" });
+    const threads = groupIntoThreads([reply2, root, reply1]);
+    expect(threads).toHaveLength(1);
+    expect(threads[0].id).toBe("root-1");
+    expect(threads[0].root.id).toBe("root-1");
+    // Replies oldest → newest.
+    expect(threads[0].replies.map((e) => e.id)).toEqual(["r1", "r2"]);
+  });
+
+  it("falls back to earliest event when the correlationId root isn't in the slice", () => {
+    // Original was clipped/dismissed; we only see the replies.
+    const reply1 = event("r1", 110, { correlationId: "missing-root" });
+    const reply2 = event("r2", 120, { correlationId: "missing-root" });
+    const threads = groupIntoThreads([reply2, reply1]);
+    expect(threads).toHaveLength(1);
+    expect(threads[0].id).toBe("missing-root");
+    expect(threads[0].root.id).toBe("r1"); // earliest visible
+    expect(threads[0].replies.map((e) => e.id)).toEqual(["r2"]);
+  });
+
+  it("orders threads by root createdAt ascending (oldest thread first)", () => {
+    const oldRoot = event("old", 100);
+    const newRoot = event("new", 500);
+    const newReply = event("new-r", 510, { correlationId: "new" });
+    const threads = groupIntoThreads([newRoot, newReply, oldRoot]);
+    expect(threads.map((t) => t.id)).toEqual(["old", "new"]);
+  });
+
+  it("breaks ordering ties on root createdAt with thread id (deterministic)", () => {
+    const a = event("a", 100);
+    const b = event("b", 100);
+    const threads = groupIntoThreads([b, a]);
+    expect(threads.map((t) => t.id)).toEqual(["a", "b"]);
+  });
+
+  it("keeps singletons and threads interleaved by createdAt", () => {
+    const single1 = event("s1", 50);
+    const root = event("root", 100);
+    const reply = event("r", 200, { correlationId: "root" });
+    const single2 = event("s2", 300);
+    const threads = groupIntoThreads([single2, single1, reply, root]);
+    expect(threads.map((t) => t.id)).toEqual(["s1", "root", "s2"]);
+    const rootThread = threads.find((t) => t.id === "root")!;
+    expect(rootThread.replies).toHaveLength(1);
+    expect(rootThread.replies[0].id).toBe("r");
+  });
+
+  it("self-correlated event (correlationId === id) is a 1-event thread", () => {
+    // Defensive: backend's `mailbox reply` seeds correlationId to the
+    // original event id, but a malformed sender could set it to its
+    // own id. Should not duplicate the root into replies.
+    const e = event("loop", 100, { correlationId: "loop" });
+    const threads = groupIntoThreads([e]);
+    expect(threads).toHaveLength(1);
+    expect(threads[0].root.id).toBe("loop");
+    expect(threads[0].replies).toEqual([]);
+  });
+});

--- a/src/lib/stores/mailbox.ts
+++ b/src/lib/stores/mailbox.ts
@@ -261,3 +261,65 @@ export async function clearReadFor(recipient: string): Promise<number> {
 export function getEventSnapshot(id: string): MailboxEventPayload | undefined {
   return get(events).find((e) => e.id === id);
 }
+
+// ── Threading ──────────────────────────────────────────────────────────────
+
+/**
+ * One thread in the inbox view. A thread groups events sharing the same
+ * `correlationId`; events without a correlation are 1-event threads
+ * (visually identical to a flat row).
+ *
+ * Resolution rules:
+ * - The root is the event whose `id === correlationId` (the original
+ *   message that seeded the thread). If that event isn't in the
+ *   provided slice (clipped, dismissed, retracted) the earliest event
+ *   in the group becomes the visual root.
+ * - Replies are sorted oldest → newest so the conversation reads
+ *   top-to-bottom.
+ */
+export interface MailboxThread {
+  /** Stable id for keyed rendering. Equals `correlationId` when set,
+   *  else the singleton's event id. */
+  id: string;
+  root: MailboxEventPayload;
+  replies: MailboxEventPayload[];
+}
+
+/**
+ * Group a flat event list into threads by `correlationId`. Threads are
+ * ordered by their root's `createdAt` ascending, matching the flat
+ * drain order ("oldest first") the inbox already used. Pure function;
+ * exported so it can be unit-tested without a Tauri runtime.
+ */
+export function groupIntoThreads(
+  events: MailboxEventPayload[],
+): MailboxThread[] {
+  const buckets = new Map<string, MailboxEventPayload[]>();
+  for (const e of events) {
+    const key = e.correlationId ?? e.id;
+    const bucket = buckets.get(key);
+    if (bucket) bucket.push(e);
+    else buckets.set(key, [e]);
+  }
+
+  const threads: MailboxThread[] = [];
+  for (const [key, group] of buckets) {
+    group.sort((a, b) => a.createdAt - b.createdAt);
+    // Prefer the event whose id matches the correlationId — that's
+    // the original. Fall back to the earliest visible event when the
+    // root isn't in this slice.
+    const rootIdx = group.findIndex((e) => e.id === key);
+    const root = rootIdx >= 0 ? group[rootIdx] : group[0];
+    const replies = group.filter((e) => e.id !== root.id);
+    threads.push({ id: key, root, replies });
+  }
+
+  // Stable thread order: oldest root first. Ties broken by id so the
+  // result is deterministic across hot reloads.
+  threads.sort((a, b) => {
+    const byTime = a.root.createdAt - b.root.createdAt;
+    if (byTime !== 0) return byTime;
+    return a.id.localeCompare(b.id);
+  });
+  return threads;
+}


### PR DESCRIPTION
## Summary
The Mailbox panel's Inbox view groups events sharing a \`correlation_id\` into visual threads — root event renders normally, replies render indented under it with a \`↳\` prefix and a left accent border. Long back-and-forths now read as one conversation instead of N flat rows.

Closes the **threading by correlation_id in the UI** item from #161.

## Surface
- **\`groupIntoThreads\`** in \`src/lib/stores/mailbox.ts\` — pure function, exported so it's unit-testable without a Tauri runtime. Returns \`MailboxThread[]\` of \`{ id, root, replies }\`.
- **MailboxPanel** uses a Svelte snippet (\`eventCard(e, isReply)\`) so root and reply markup share one template; reply mode toggles the indent + ↳ prefix.

## Resolution rules
- Root = the event whose \`id === correlationId\` (the original message that seeded the thread). When that event isn't in the slice (clipped, dismissed, retracted), the earliest visible event becomes the visual root.
- Replies sort oldest → newest within the thread.
- Threads sort by root \`createdAt\` ascending (matches the existing flat drain order). Ties broken by id for determinism.
- Self-correlation (\`correlationId === id\`) is a 1-event thread; the root isn't duplicated into replies.

## Backend
None. The backend already records \`correlation_id\` on every \`mailbox reply\` since the original mailbox PR (#160).

## Test plan
- [x] \`npm run test -- mailboxThreading\` — 8 new tests (singletons, correlated thread, missing root fallback, ordering, ties, interleaving, self-correlation)
- [x] \`npm run check\` — 0 errors
- [x] \`npm run test\` — 1011 pass (was 1003)
- [x] \`cargo test --bin roux\` — 486 pass (no backend changes)
- [ ] Manual: \`mailbox post --to me "main"\`, \`mailbox reply <id> "follow up"\`. Open the panel; confirm the reply renders indented under the root with the ↳ prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inbox now groups related events into threaded conversations with visual indentation and reply prefixes.
  * Per-event actions (mark read, acknowledge, dismiss, deliver) operate independently within threads.
  * When the root event is hidden, the earliest visible reply becomes the visual thread root.

* **Documentation**
  * Updated Mailbox feature documentation to explain threaded conversation grouping behavior.

* **Tests**
  * Added comprehensive test coverage for threaded conversation grouping logic.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phin-tech/roux/pull/170)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Introduces `groupIntoThreads` in `mailbox.ts` — a pure function that buckets `MailboxEventPayload[]` by `correlationId`, resolves the root event (with a fallback to earliest-visible when the original is absent), and sorts threads oldest-first with deterministic tie-breaking.
- `MailboxPanel` now iterates `recipientThreads` (a `$derived` of the above) instead of the flat `recipientEvents`, rendering replies indented with a `↳` prefix via a shared `{#snippet eventCard}`.
- Eight new Vitest unit tests cover all documented resolution rules; no backend changes required.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; only P2 style findings with no impact on correctness or runtime behaviour

Logic is sound and all documented resolution rules are covered by tests. Two P2 issues found: the `events` parameter name shadows the module-level store (harmless today, potential footgun for future edits), and the per-reply sort lacks a tie-breaker that the thread-level sort already applies. No P0 or P1 issues.

src/lib/stores/mailbox.ts — minor naming and sort-stability nits
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/stores/mailbox.ts | Adds `MailboxThread` interface and `groupIntoThreads` pure function; logic is correct for root resolution, self-correlation, and fallback; minor: parameter `events` shadows module-level store, per-reply sort lacks a tie-breaker |
| src/lib/components/MailboxPanel.svelte | Replaces flat `{#each}` over events with a two-level `{#each}` over threads using a reusable `{#snippet eventCard}`; correct Svelte 5 rune usage and keying; reply indent/styling applied via `isReply` flag |
| src/lib/stores/__tests__/mailboxThreading.test.ts | Eight focused unit tests cover empty input, singletons, correlated threads, missing-root fallback, ordering, tie-breaking, interleaving, and self-correlation; all paths documented in the PR description are exercised |
| docs/features/mailbox.md | Adds a short paragraph documenting the new threading UI behaviour and the missing-root fallback rule |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Input[Flat event list] --> Bucket[Bucket by correlationId]
    Bucket --> Sort[Sort each bucket by createdAt]
    Sort --> RootCheck{Root event present?}
    RootCheck -- yes --> UseRoot[root = event whose id matches key]
    RootCheck -- no --> Fallback[root = earliest event in bucket]
    UseRoot --> Build[Build MailboxThread]
    Fallback --> Build
    Build --> ThreadSort[Sort threads by root createdAt]
    ThreadSort --> Output[MailboxThread list]
    Output --> RenderRoot[Render root card no indent]
    Output --> RenderReply[Render reply cards indented with prefix]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Flib%2Fstores%2Fmailbox.ts%3A294-296%0A**Parameter%20%60events%60%20shadows%20module-level%20store**%0A%0AThe%20function%20parameter%20is%20named%20%60events%60%2C%20which%20shadows%20the%20module-level%20%60export%20const%20events%20%3D%20writable%3CMailboxEventPayload%5B%5D%3E%28%5B%5D%29%60%20declared%20at%20line%2036.%20Inside%20the%20function%20body%20there's%20no%20actual%20reference%20to%20the%20store%2C%20so%20there's%20no%20runtime%20bug%20%E2%80%94%20but%20a%20future%20maintainer%20adding%20a%20store%20read%20inside%20this%20function%20would%20silently%20get%20the%20parameter%20instead.%20Renaming%20the%20parameter%20to%20%60rawEvents%60%20or%20%60eventList%60%20avoids%20the%20ambiguity.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Flib%2Fstores%2Fmailbox.ts%3A307%0A**No%20tie-breaker%20on%20per-reply%20sort**%0A%0A%60group.sort%28%28a%2C%20b%29%20%3D%3E%20a.createdAt%20-%20b.createdAt%29%60%20breaks%20no%20ties%2C%20so%20two%20replies%20with%20identical%20millisecond%20timestamps%20can%20appear%20in%20non-deterministic%20order%20across%20renders.%20The%20thread-level%20sort%20%28line%20319%29%20already%20uses%20%60id.localeCompare%60%20as%20a%20tiebreaker%20%E2%80%94%20applying%20the%20same%20pattern%20here%20keeps%20the%20whole%20output%20stable%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20group.sort%28%28a%2C%20b%29%20%3D%3E%20a.createdAt%20-%20b.createdAt%20%7C%7C%20a.id.localeCompare%28b.id%29%29%3B%0A%60%60%60%0A%0A&repo=phin-tech%2Froux&pr=170&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22feature%2Fmailbox-threading%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fmailbox-threading%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Flib%2Fstores%2Fmailbox.ts%3A294-296%0A**Parameter%20%60events%60%20shadows%20module-level%20store**%0A%0AThe%20function%20parameter%20is%20named%20%60events%60%2C%20which%20shadows%20the%20module-level%20%60export%20const%20events%20%3D%20writable%3CMailboxEventPayload%5B%5D%3E%28%5B%5D%29%60%20declared%20at%20line%2036.%20Inside%20the%20function%20body%20there's%20no%20actual%20reference%20to%20the%20store%2C%20so%20there's%20no%20runtime%20bug%20%E2%80%94%20but%20a%20future%20maintainer%20adding%20a%20store%20read%20inside%20this%20function%20would%20silently%20get%20the%20parameter%20instead.%20Renaming%20the%20parameter%20to%20%60rawEvents%60%20or%20%60eventList%60%20avoids%20the%20ambiguity.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Flib%2Fstores%2Fmailbox.ts%3A307%0A**No%20tie-breaker%20on%20per-reply%20sort**%0A%0A%60group.sort%28%28a%2C%20b%29%20%3D%3E%20a.createdAt%20-%20b.createdAt%29%60%20breaks%20no%20ties%2C%20so%20two%20replies%20with%20identical%20millisecond%20timestamps%20can%20appear%20in%20non-deterministic%20order%20across%20renders.%20The%20thread-level%20sort%20%28line%20319%29%20already%20uses%20%60id.localeCompare%60%20as%20a%20tiebreaker%20%E2%80%94%20applying%20the%20same%20pattern%20here%20keeps%20the%20whole%20output%20stable%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20group.sort%28%28a%2C%20b%29%20%3D%3E%20a.createdAt%20-%20b.createdAt%20%7C%7C%20a.id.localeCompare%28b.id%29%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(mailbox): thread inbox events by co..."](https://github.com/phin-tech/roux/commit/f3a50525ebc72d31b601f568a939883c64d54abc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31496826)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->