### PR TITLE
[codex] Add project prompt template variables

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -8,6 +8,7 @@ Roux is a terminal-first workspace for running agent sessions, shells, notes, wa
 - [Multiline Editor](editor.md) — docked terminal input editor with selection seeding, command corrections, and context chips.
 - [Sessions](sessions.md) — create, reconnect, archive, restore, and group agent workflows.
 - [Projects](projects.md) — group sessions across repos, save session blueprints, and inject project context.
+- [Project Prompt Templates](project-prompt-templates.md) — Minijinja variables for branch, worktree, model, and sibling-session context.
 - [Layouts](layouts.md) — start sessions from KDL templates and spawn profiles.
 - [Worktrees](worktrees.md) — manage isolated git checkouts for session work.
 - [Smol Machines](smol-machines.md) — run sessions inside local libkrun / KVM VMs for OS-level isolation.

--- a/docs/features/project-prompt-templates.md
+++ b/docs/features/project-prompt-templates.md
@@ -1,0 +1,108 @@
+# Project Prompt Templates
+
+Project prompts support [Minijinja](https://github.com/mitsuhiko/minijinja)-style variables. Roux stores the prompt as a raw template, then renders it each time a supported agent profile starts.
+
+Rendered prompts are appended automatically for:
+
+| Provider | Startup injection |
+|---|---|
+| Claude | `--append-system-prompt` |
+| Codex | `-c instructions=...` |
+
+Other profiles are not modified automatically. They can still read `ROUX_PROJECT_PROMPT`, which contains the saved project prompt text.
+
+## Preview
+
+The New/Edit Project dialog has a manual **Preview** button under the project prompt field. Pick a session blueprint, then preview to render the template with that blueprint's repo, branch, worktree, and profile values.
+
+Preview uses these fallback values before a real session exists:
+
+| Value | Preview fallback |
+|---|---|
+| `session.id` | `preview` |
+| `session.worktree_path` | blueprint `worktreePath`, otherwise blueprint `repoRoot` |
+| `session.worktree_name` | last path segment of `session.worktree_path` |
+| `session.branch` | blueprint `branch`, otherwise `null` |
+| `other_sessions` | current live sessions in the same project |
+
+## Variables
+
+| Variable | Description |
+|---|---|
+| `project.id` | Project id, or `null` in a new unsaved project preview |
+| `project.name` | Project name |
+| `project.repo_roots` | Repository roots configured on the project |
+| `project.context_paths` | Project context paths |
+| `session.id` | Roux session id |
+| `session.name` | Session name |
+| `session.repo_root` | Repository root for the session |
+| `session.worktree_path` | Directory where the agent starts |
+| `session.worktree_name` | Last path segment of `session.worktree_path` |
+| `session.branch` | Branch or worktree name when known |
+| `session.is_worktree` | `true` when the session uses a worktree |
+| `session.blueprint_id` | Project blueprint id when spawned from a blueprint |
+| `profile.id` | Spawn profile id |
+| `profile.name` | Spawn profile display name |
+| `profile.provider` | `claude`, `codex`, or `null` |
+| `model.name` | Roux's configured default model, or `null` |
+| `model.family` | Same provider family as `profile.provider` |
+| `paths.sessions_folder` | Current session worktree directory |
+| `other_sessions` | Live sessions in the same project, excluding the current session |
+
+Each item in `other_sessions` has the same fields as `session`.
+
+## Examples
+
+Full context sample:
+
+```jinja
+Project: {{ project.name }}
+Session: {{ session.name }}
+Branch: {{ session.branch or "none" }}
+Worktree: {{ session.worktree_name }}
+Folder: {{ paths.sessions_folder }}
+Model: {{ model.name or "default" }} / {{ model.family or "unknown" }}
+
+Other sessions:
+{% for s in other_sessions %}
+- {{ s.name }} on {{ s.branch or "none" }} in {{ s.worktree_name }}
+{% else %}
+- none
+{% endfor %}
+```
+
+Branch-aware instructions:
+
+```jinja
+You are working on {{ session.branch or "the current branch" }}.
+Workspace: {{ session.worktree_path }}
+Model: {{ model.name or "default" }} ({{ model.family or "unknown family" }})
+```
+
+Coordinate with sibling sessions:
+
+```jinja
+Other live sessions in this project:
+{% for s in other_sessions %}
+- {{ s.name }} on {{ s.branch or "unknown branch" }} at {{ s.worktree_path }}
+{% else %}
+- No other sessions are running.
+{% endfor %}
+```
+
+Use project context paths:
+
+```jinja
+Project context:
+{% for path in project.context_paths %}
+- {{ path }}
+{% else %}
+- No project context paths configured.
+{% endfor %}
+```
+
+## Errors
+
+Malformed templates block profile startup instead of sending raw template text to the agent. Use **Preview** before saving when adding loops or conditionals.
+
+Changing a project prompt does not rewrite already-running agent commands. Spawn a new session, reconnect, or re-run the profile to use the updated template.

--- a/docs/features/project-prompt-templates.md
+++ b/docs/features/project-prompt-templates.md
@@ -103,6 +103,6 @@ Project context:
 
 ## Errors
 
-Malformed templates block profile startup instead of sending raw template text to the agent. Use **Preview** before saving when adding loops or conditionals.
+Malformed templates and missing or misspelled variables block profile startup instead of sending raw template text to the agent. Use **Preview** before saving when adding loops, conditionals, or new variables.
 
 Changing a project prompt does not rewrite already-running agent commands. Spawn a new session, reconnect, or re-run the profile to use the updated template.

--- a/docs/features/projects.md
+++ b/docs/features/projects.md
@@ -45,7 +45,7 @@ The sidebar suppresses the blueprint row while its live session is active, so th
 
 ## Project Prompts
 
-The project prompt is free-form text injected when supported agent profiles start.
+The project prompt is free-form text injected when supported agent profiles start. It can include Minijinja variables for the model family, worktree path, branch, same-project sessions, and other spawn-time context.
 
 Supported providers:
 
@@ -57,6 +57,8 @@ Supported providers:
 Other profiles are left unchanged. The prompt is still exposed as `ROUX_PROJECT_PROMPT`, so custom profiles can opt into it manually.
 
 Prompt injection happens at spawn time. Changing a project prompt does not rewrite already-running agent commands; spawn a new session to pick up the new prompt.
+
+See [Project Prompt Templates](project-prompt-templates.md) for the variable reference, examples, preview behavior, and template error handling.
 
 ## Context Paths
 

--- a/src-tauri/src/commands/projects.rs
+++ b/src-tauri/src/commands/projects.rs
@@ -1,6 +1,6 @@
 use crate::services::projects as svc;
 use crate::state::AppState;
-use minijinja::Environment;
+use minijinja::{AutoEscape, Environment, UndefinedBehavior};
 use roux_core::{Project, ProjectUpdate};
 use serde_json::Value;
 
@@ -88,10 +88,15 @@ pub(crate) fn render_project_prompt_template_inner(
     template: &str,
     context: Value,
 ) -> Result<String, String> {
-    let env = Environment::new();
+    let mut env = Environment::new();
+    env.set_auto_escape_callback(|_| AutoEscape::None);
+    env.set_undefined_behavior(UndefinedBehavior::Strict);
     env.render_str(template, &context).map_err(|e| e.to_string())
 }
 
+// No #[specta::specta]: serde_json::Value produces invalid generated
+// TypeScript for this dynamic Minijinja context. The frontend uses a
+// manually typed wrapper in src/lib/tauri.ts instead.
 #[tauri::command]
 pub(crate) async fn render_project_prompt_template(
     template: String,
@@ -143,6 +148,15 @@ mod template_tests {
         let err = render_project_prompt_template_inner("{% for s in other_sessions %}", json!({}))
             .unwrap_err();
 
-        assert!(err.contains("unexpected end of template") || err.contains("unknown block"));
+        assert!(!err.is_empty());
+    }
+
+    #[test]
+    fn missing_variables_return_error() {
+        let err =
+            render_project_prompt_template_inner("{{ session.missing }}", json!({ "session": {} }))
+                .unwrap_err();
+
+        assert!(err.contains("undefined value"));
     }
 }

--- a/src-tauri/src/commands/projects.rs
+++ b/src-tauri/src/commands/projects.rs
@@ -1,6 +1,8 @@
 use crate::services::projects as svc;
 use crate::state::AppState;
+use minijinja::Environment;
 use roux_core::{Project, ProjectUpdate};
+use serde_json::Value;
 
 #[tauri::command]
 #[specta::specta]
@@ -80,4 +82,67 @@ pub(crate) async fn set_session_project(
     svc::set_session_project(&state.session_handle, &session_id, project_id)
         .await
         .map_err(|e| e.to_string())
+}
+
+pub(crate) fn render_project_prompt_template_inner(
+    template: &str,
+    context: Value,
+) -> Result<String, String> {
+    let env = Environment::new();
+    env.render_str(template, &context).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub(crate) async fn render_project_prompt_template(
+    template: String,
+    context: Value,
+) -> Result<String, String> {
+    render_project_prompt_template_inner(&template, context)
+}
+
+#[cfg(test)]
+mod template_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn renders_project_prompt_scalars() {
+        let rendered = render_project_prompt_template_inner(
+            "Model {{ model.name }} on {{ session.branch }} in {{ session.worktree_name }}",
+            json!({
+                "model": { "name": "claude-opus-4-6" },
+                "session": {
+                    "branch": "feature/templates",
+                    "worktree_name": "repo-feature"
+                }
+            }),
+        )
+        .unwrap();
+
+        assert_eq!(rendered, "Model claude-opus-4-6 on feature/templates in repo-feature");
+    }
+
+    #[test]
+    fn renders_other_sessions_loop() {
+        let rendered = render_project_prompt_template_inner(
+            "{% for s in other_sessions %}{{ s.name }}:{{ s.branch }};{% else %}none{% endfor %}",
+            json!({
+                "other_sessions": [
+                    { "name": "api", "branch": "api-work" },
+                    { "name": "web", "branch": "web-work" }
+                ]
+            }),
+        )
+        .unwrap();
+
+        assert_eq!(rendered, "api:api-work;web:web-work;");
+    }
+
+    #[test]
+    fn malformed_template_returns_error() {
+        let err = render_project_prompt_template_inner("{% for s in other_sessions %}", json!({}))
+            .unwrap_err();
+
+        assert!(err.contains("unexpected end of template") || err.contains("unknown block"));
+    }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -382,6 +382,7 @@ fn main() {
             commands::projects::rename_project,
             commands::projects::update_project,
             commands::projects::set_session_project,
+            commands::projects::render_project_prompt_template,
             commands::notes::notes_read,
             commands::notes::notes_write,
             commands::notes::notes_append,

--- a/src/lib/__tests__/projectPromptTemplates.test.ts
+++ b/src/lib/__tests__/projectPromptTemplates.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_SETTINGS, type Project, type Session, type SessionBlueprint } from "$lib/types";
+import type { SpawnProfile } from "$lib/panes/profiles";
+import {
+  buildProjectPromptContext,
+  buildProjectPromptPreviewContext,
+} from "$lib/projectPromptTemplates";
+
+function project(overrides: Partial<Project> = {}): Project {
+  return {
+    id: "proj-1",
+    name: "Template Vars",
+    repoRoots: ["/Users/sam/src/roux"],
+    contextPaths: ["/Users/sam/spec.md"],
+    sessionBlueprints: [],
+    projectPrompt: "",
+    ...overrides,
+  };
+}
+
+function session(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "s1",
+    name: "api",
+    repoRoot: "/Users/sam/src/roux",
+    worktreePath: "/Users/sam/src/roux-api",
+    branch: "feature/api",
+    isWorktree: true,
+    status: "idle",
+    model: null,
+    cost: null,
+    createdAt: 1,
+    projectId: "proj-1",
+    isGitRepo: true,
+    nameOverride: null,
+    primaryPtyId: "s1",
+    archived: false,
+    endedAt: null,
+    blueprintId: "bp-api",
+    pinnedPrUrl: null,
+    smolMachineName: null,
+    ...overrides,
+  };
+}
+
+function blueprint(overrides: Partial<SessionBlueprint> = {}): SessionBlueprint {
+  return {
+    id: "bp-api",
+    name: "api",
+    repoRoot: "/Users/sam/src/roux",
+    branch: "feature/api",
+    worktreePath: null,
+    spawnProfile: "claude",
+    base: null,
+    fetchFirst: false,
+    nonoProfile: null,
+    nonoAllowDirs: [],
+    ...overrides,
+  };
+}
+
+function profile(overrides: Partial<SpawnProfile> = {}): SpawnProfile {
+  return {
+    id: "claude",
+    name: "Claude",
+    setupCommand: null,
+    startupCommand: "claude",
+    startupBehavior: null,
+    env: null,
+    cwdOverride: null,
+    icon: null,
+    provider: "claude",
+    nonoProfile: null,
+    nonoAllowDirs: null,
+    source: "builtin",
+    ...overrides,
+  };
+}
+
+describe("project prompt template context", () => {
+  it("builds session, model, path, and same-project session variables", () => {
+    const ctx = buildProjectPromptContext({
+      project: project(),
+      session: session(),
+      profile: profile(),
+      settings: { ...DEFAULT_SETTINGS, defaultModel: "claude-opus-4-6" },
+      sessions: [
+        session(),
+        session({
+          id: "s2",
+          name: "web",
+          worktreePath: "/Users/sam/src/roux-web",
+          branch: "feature/web",
+          blueprintId: "bp-web",
+        }),
+        session({
+          id: "s3",
+          name: "other-project",
+          projectId: "proj-2",
+        }),
+      ],
+    });
+
+    expect(ctx.session.worktree_name).toBe("roux-api");
+    expect(ctx.paths.sessions_folder).toBe("/Users/sam/src/roux-api");
+    expect(ctx.model).toEqual({ name: "claude-opus-4-6", family: "claude" });
+    expect(ctx.other_sessions).toHaveLength(1);
+    expect(ctx.other_sessions[0]).toMatchObject({
+      id: "s2",
+      name: "web",
+      branch: "feature/web",
+      worktree_name: "roux-web",
+    });
+  });
+
+  it("builds preview context from the selected blueprint", () => {
+    const ctx = buildProjectPromptPreviewContext({
+      project: {
+        id: "proj-1",
+        name: "Template Vars",
+        repoRoots: ["/Users/sam/src/roux"],
+        contextPaths: [],
+      },
+      blueprint: blueprint({
+        worktreePath: "/Users/sam/src/roux-preview",
+      }),
+      profile: profile({ id: "codex", name: "Codex", provider: "codex" }),
+      settings: { ...DEFAULT_SETTINGS, defaultModel: null },
+      sessions: [session({ id: "s2", name: "existing" })],
+    });
+
+    expect(ctx.session).toMatchObject({
+      id: "preview",
+      name: "api",
+      worktree_path: "/Users/sam/src/roux-preview",
+      worktree_name: "roux-preview",
+      branch: "feature/api",
+      is_worktree: true,
+      blueprint_id: "bp-api",
+    });
+    expect(ctx.model).toEqual({ name: null, family: "codex" });
+    expect(ctx.other_sessions.map((s) => s.id)).toEqual(["s2"]);
+  });
+});

--- a/src/lib/__tests__/projectPromptTemplates.test.ts
+++ b/src/lib/__tests__/projectPromptTemplates.test.ts
@@ -98,6 +98,11 @@ describe("project prompt template context", () => {
           name: "other-project",
           projectId: "proj-2",
         }),
+        session({
+          id: "s4",
+          name: "archived",
+          archived: true,
+        }),
       ],
     });
 
@@ -140,5 +145,23 @@ describe("project prompt template context", () => {
     });
     expect(ctx.model).toEqual({ name: null, family: "codex" });
     expect(ctx.other_sessions.map((s) => s.id)).toEqual(["s2"]);
+  });
+
+  it("treats branch-only blueprint previews as worktree sessions", () => {
+    const ctx = buildProjectPromptPreviewContext({
+      project: {
+        id: "proj-1",
+        name: "Template Vars",
+        repoRoots: ["/Users/sam/src/roux"],
+        contextPaths: [],
+      },
+      blueprint: blueprint({ worktreePath: null }),
+      profile: profile(),
+      settings: DEFAULT_SETTINGS,
+      sessions: [],
+    });
+
+    expect(ctx.session.worktree_path).toBe("/Users/sam/src/roux");
+    expect(ctx.session.is_worktree).toBe(true);
   });
 });

--- a/src/lib/commands/panes.ts
+++ b/src/lib/commands/panes.ts
@@ -21,6 +21,7 @@ import {
   type SpawnProfileRef,
 } from "$lib/panes/profiles";
 import { runProfileInPane } from "$lib/panes/profileRunner";
+import { renderProjectPromptForSession } from "$lib/projectPromptTemplates";
 import { spawnShell, spawnTask, listDocs, notificationsPush, listSessionPtys, killPty, setPtyName } from "$lib/tauri";
 import { attachPtyToPane } from "$lib/panes/attach";
 import { openCustomProfileEditor } from "$lib/stores/customProfileModal";
@@ -93,7 +94,12 @@ async function spawnShellPaneWithProfile(
   // already in the tree and the shell is alive, so we surface a
   // notification instead of tearing the pane down.
   try {
+    const appendSystemPrompt = await renderProjectPromptForSession(
+      session,
+      profile,
+    );
     await runProfileInPane(ptyId, profile, {
+      ...(appendSystemPrompt.trim() ? { appendSystemPrompt } : {}),
       smolMachineName: session.smolMachineName ?? null,
     });
   } catch (e) {

--- a/src/lib/components/NewProjectDialog.svelte
+++ b/src/lib/components/NewProjectDialog.svelte
@@ -11,9 +11,14 @@
   import type { Project, SessionBlueprint } from "$lib/types";
   import { logError } from "$lib/logging";
   import { settings } from "$lib/stores/settings";
+  import { sessionState } from "$lib/stores/sessions";
   import { listGitReposInRoots } from "$lib/tauri";
   import RepoAutoComplete from "./RepoAutoComplete.svelte";
   import { buildQuickPickOptions, type RepoQuickPickOption } from "$lib/repos/quickPick";
+  import {
+    buildProjectPromptPreviewContext,
+    renderProjectPromptTemplate,
+  } from "$lib/projectPromptTemplates";
 
   interface Props {
     visible: boolean;
@@ -30,6 +35,10 @@
   let contextPaths = $state<string[]>([]);
   let blueprints = $state<SessionBlueprint[]>([]);
   let projectPrompt = $state("");
+  let promptPreviewBlueprintId = $state("");
+  let promptPreview = $state("");
+  let promptPreviewError = $state("");
+  let promptPreviewing = $state(false);
   let error = $state("");
   let saving = $state(false);
   let confirmDelete = $state(false);
@@ -91,6 +100,10 @@
     contextPaths = [...(project?.contextPaths ?? [])];
     blueprints = (project?.sessionBlueprints ?? []).map((bp) => ({ ...bp }));
     projectPrompt = project?.projectPrompt ?? "";
+    promptPreviewBlueprintId = "";
+    promptPreview = "";
+    promptPreviewError = "";
+    promptPreviewing = false;
     error = "";
     saving = false;
     repoDraft = "";
@@ -145,6 +158,25 @@
   const profiles: SpawnProfile[] = $derived($profileList);
   const defaultProfileId = $derived(profiles[0]?.id ?? "claude");
   const effectiveDefaultProfile = $derived(defaultProfileChoice || defaultProfileId);
+  const selectedPreviewBlueprint = $derived(
+    blueprints.find((bp) => bp.id === promptPreviewBlueprintId) ?? blueprints[0] ?? null,
+  );
+
+  $effect(() => {
+    const hasSelection = blueprints.some((bp) => bp.id === promptPreviewBlueprintId);
+    if (!hasSelection) promptPreviewBlueprintId = blueprints[0]?.id ?? "";
+  });
+
+  $effect(() => {
+    projectPrompt;
+    promptPreviewBlueprintId;
+    name;
+    repoRoots;
+    contextPaths;
+    blueprints;
+    promptPreview = "";
+    promptPreviewError = "";
+  });
 
   // Last segment of a repo path → human-friendly handle for the name
   // template. Mirrors how SessionTabs and the existing repo-grouping logic
@@ -276,6 +308,41 @@
 
   function updateBlueprint(id: string, patch: Partial<SessionBlueprint>) {
     blueprints = blueprints.map((bp) => (bp.id === id ? { ...bp, ...patch } : bp));
+  }
+
+  async function previewProjectPrompt() {
+    if (!projectPrompt.trim()) {
+      promptPreview = "";
+      promptPreviewError = "";
+      return;
+    }
+
+    const blueprint = selectedPreviewBlueprint;
+    const profileId = blueprint?.spawnProfile ?? effectiveDefaultProfile;
+    const profile = profiles.find((p) => p.id === profileId) ?? null;
+    const context = buildProjectPromptPreviewContext({
+      project: {
+        id: project?.id ?? null,
+        name: name.trim(),
+        repoRoots,
+        contextPaths,
+      },
+      blueprint,
+      profile,
+      settings: $settings,
+      sessions: $sessionState.sessions,
+    });
+
+    promptPreviewing = true;
+    promptPreviewError = "";
+    try {
+      promptPreview = await renderProjectPromptTemplate(projectPrompt, context);
+    } catch (e) {
+      promptPreview = "";
+      promptPreviewError = e instanceof Error ? e.message : String(e);
+    } finally {
+      promptPreviewing = false;
+    }
   }
 
   function validate(): string | null {
@@ -643,6 +710,43 @@
               placeholder="Extra instructions to inject at the top of every spawned agent's system prompt"
               rows="4"
             ></textarea>
+            {#if projectPrompt.trim()}
+              <div class="rounded-md border border-border-subtle/70 bg-bg-deep/60 p-2">
+                <div class="flex flex-wrap items-center gap-2">
+                  {#if blueprints.length > 1}
+                    <select
+                      class={smallInput + " max-w-[240px]"}
+                      bind:value={promptPreviewBlueprintId}
+                      disabled={promptPreviewing}
+                    >
+                      {#each blueprints as bp (bp.id)}
+                        <option value={bp.id}>{bp.name || "Untitled session"}</option>
+                      {/each}
+                    </select>
+                  {:else if selectedPreviewBlueprint}
+                    <span class="truncate text-[11px] text-text-muted">
+                      Preview: {selectedPreviewBlueprint.name || "Untitled session"}
+                    </span>
+                  {:else}
+                    <span class="truncate text-[11px] text-text-muted">Preview: draft project</span>
+                  {/if}
+                  <button
+                    class={ghostBtn}
+                    onclick={previewProjectPrompt}
+                    disabled={promptPreviewing}
+                  >
+                    {promptPreviewing ? "Previewing…" : "Preview"}
+                  </button>
+                  <span class="text-[11px] text-text-muted">Minijinja variables</span>
+                </div>
+                {#if promptPreviewError}
+                  <p class="mt-2 whitespace-pre-wrap text-[11px] text-red">{promptPreviewError}</p>
+                {/if}
+                {#if promptPreview}
+                  <pre class="mt-2 max-h-40 overflow-auto whitespace-pre-wrap rounded-md border border-border-subtle/60 bg-bg-surface/60 p-2 font-mono text-[11px] leading-relaxed text-text-primary">{promptPreview}</pre>
+                {/if}
+              </div>
+            {/if}
           </div>
 
           <!-- Context paths -->

--- a/src/lib/components/PaneShell.svelte
+++ b/src/lib/components/PaneShell.svelte
@@ -11,7 +11,7 @@
   import { closePane } from "$lib/panes/actions";
   import { resolveProfileRef } from "$lib/panes/profiles";
   import { runProfileInPane } from "$lib/panes/profileRunner";
-  import { getProjectPrompt } from "$lib/stores/projects";
+  import { renderProjectPromptForSession } from "$lib/projectPromptTemplates";
   import { createResizeScheduler } from "$lib/panes/resizeScheduler";
   import {
     resizeSession,
@@ -147,8 +147,11 @@
     if (!instance || !activeProfile) return;
     log(`Re-running profile "${activeProfile.id}" in pane ${paneId}`);
     try {
+      const appendSystemPrompt = session
+        ? await renderProjectPromptForSession(session, activeProfile)
+        : "";
       await runProfileInPane(instance.ptyId, activeProfile, {
-        appendSystemPrompt: getProjectPrompt(session?.projectId),
+        ...(appendSystemPrompt.trim() ? { appendSystemPrompt } : {}),
         smolMachineName: session?.smolMachineName ?? null,
       });
     } catch (e) {

--- a/src/lib/panes/__tests__/restore.test.ts
+++ b/src/lib/panes/__tests__/restore.test.ts
@@ -25,8 +25,8 @@ vi.mock("$lib/panes/profiles", async () => {
   };
 });
 
-vi.mock("$lib/stores/projects", () => ({
-  getProjectPrompt: vi.fn().mockReturnValue(""),
+vi.mock("$lib/projectPromptTemplates", () => ({
+  renderProjectPromptForSession: vi.fn().mockResolvedValue(""),
 }));
 
 vi.mock("$lib/logging", () => ({

--- a/src/lib/panes/layoutRunner.ts
+++ b/src/lib/panes/layoutRunner.ts
@@ -7,6 +7,7 @@ import { sessionLayouts, type LayoutNode, type SplitDirection } from "./layout";
 import { setLogicalFocus } from "./focus";
 import { spawnShell, killPty } from "$lib/tauri";
 import { runProfileInPane } from "./profileRunner";
+import { renderProjectPromptForSession } from "$lib/projectPromptTemplates";
 
 // ── Public types ────────────────────────────────────────────────────────────
 
@@ -284,7 +285,12 @@ export async function applyLayoutToSession(
   // inherits the same `smolMachineName` from the session record.
   for (const leaf of leaves) {
     try {
+      const appendSystemPrompt = await renderProjectPromptForSession(
+        session,
+        leaf.profile,
+      );
       await runProfileInPane(leaf.ptyId, leaf.profile, {
+        ...(appendSystemPrompt.trim() ? { appendSystemPrompt } : {}),
         smolMachineName: session.smolMachineName ?? null,
       });
     } catch (e) {

--- a/src/lib/panes/restore.ts
+++ b/src/lib/panes/restore.ts
@@ -8,7 +8,7 @@ import { log } from "$lib/logging";
 import { resolveProfileRef, type SpawnProfile, type SpawnProfileRef } from "./profiles";
 import { runProfileInPane } from "./profileRunner";
 import { spawnShell } from "$lib/tauri";
-import { getProjectPrompt } from "$lib/stores/projects";
+import { renderProjectPromptForSession } from "$lib/projectPromptTemplates";
 
 export interface RestoreSessionPanesOptions {
   initTerminal: (paneId: string) => void;
@@ -137,8 +137,12 @@ export async function restoreSessionPanes(
       }
       if (respawn.profile) {
         try {
+          const appendSystemPrompt = await renderProjectPromptForSession(
+            session,
+            respawn.profile,
+          );
           await runProfileInPane(respawn.ptyId, respawn.profile, {
-            appendSystemPrompt: getProjectPrompt(session.projectId),
+            ...(appendSystemPrompt.trim() ? { appendSystemPrompt } : {}),
           });
         } catch (e) {
           log(`restoreSessionPanes(${session.id}): profile replay failed for ${d.id}: ${e}`);

--- a/src/lib/projectPromptTemplates.ts
+++ b/src/lib/projectPromptTemplates.ts
@@ -97,7 +97,7 @@ function sameProjectSessions(
 ): ProjectPromptTemplateSession[] {
   if (!projectId) return [];
   return sessions
-    .filter((s) => s.projectId === projectId && s.id !== excludeSessionId)
+    .filter((s) => s.projectId === projectId && s.id !== excludeSessionId && !s.archived)
     .map(sessionTemplateContext);
 }
 
@@ -150,6 +150,8 @@ export function buildProjectPromptPreviewContext({
     worktree_path: worktreePath,
     worktree_name: lastPathSegment(worktreePath),
     branch: blueprint?.branch ?? null,
+    // Project blueprints map a branch-only target to SessionTarget::NewWorktree
+    // when the session is created, so preview should expose worktree semantics.
     is_worktree: Boolean(blueprint?.branch || blueprint?.worktreePath),
     blueprint_id: blueprint?.id ?? null,
   };

--- a/src/lib/projectPromptTemplates.ts
+++ b/src/lib/projectPromptTemplates.ts
@@ -1,0 +1,208 @@
+import { get } from "svelte/store";
+import type { Project, RouxSettings, Session, SessionBlueprint } from "$lib/types";
+import type { SpawnProfile } from "$lib/panes/profiles";
+import { renderProjectPromptTemplate as renderProjectPromptTemplateRaw } from "$lib/tauri";
+import { getProjectById } from "$lib/stores/projects";
+import { sessionState } from "$lib/stores/sessions";
+import { settings } from "$lib/stores/settings";
+
+export interface ProjectPromptTemplateSession {
+  id: string;
+  name: string;
+  repo_root: string;
+  worktree_path: string;
+  worktree_name: string;
+  branch: string | null;
+  is_worktree: boolean;
+  blueprint_id: string | null;
+}
+
+export interface ProjectPromptTemplateContext {
+  project: {
+    id: string | null;
+    name: string;
+    repo_roots: string[];
+    context_paths: string[];
+  };
+  session: ProjectPromptTemplateSession;
+  profile: {
+    id: string | null;
+    name: string | null;
+    provider: string | null;
+  };
+  model: {
+    name: string | null;
+    family: string | null;
+  };
+  paths: {
+    sessions_folder: string;
+  };
+  other_sessions: ProjectPromptTemplateSession[];
+}
+
+interface BuildProjectPromptContextOptions {
+  project: Project;
+  session: Session;
+  profile: SpawnProfile | null;
+  settings: RouxSettings;
+  sessions: Session[];
+}
+
+interface ProjectPromptPreviewProject {
+  id: string | null;
+  name: string;
+  repoRoots: string[];
+  contextPaths: string[];
+}
+
+interface BuildProjectPromptPreviewContextOptions {
+  project: ProjectPromptPreviewProject;
+  blueprint: SessionBlueprint | null;
+  profile: SpawnProfile | null;
+  settings: RouxSettings;
+  sessions: Session[];
+}
+
+function lastPathSegment(path: string): string {
+  const parts = path.replaceAll("\\", "/").split("/").filter(Boolean);
+  return parts[parts.length - 1] ?? path;
+}
+
+function providerFamily(profile: SpawnProfile | null): string | null {
+  return profile?.provider ?? null;
+}
+
+function modelName(settings: RouxSettings): string | null {
+  const value = settings.defaultModel?.trim();
+  return value ? value : null;
+}
+
+function sessionTemplateContext(session: Session): ProjectPromptTemplateSession {
+  return {
+    id: session.id,
+    name: session.name,
+    repo_root: session.repoRoot,
+    worktree_path: session.worktreePath,
+    worktree_name: lastPathSegment(session.worktreePath),
+    branch: session.branch || null,
+    is_worktree: session.isWorktree,
+    blueprint_id: session.blueprintId ?? null,
+  };
+}
+
+function sameProjectSessions(
+  sessions: Session[],
+  projectId: string | null | undefined,
+  excludeSessionId: string,
+): ProjectPromptTemplateSession[] {
+  if (!projectId) return [];
+  return sessions
+    .filter((s) => s.projectId === projectId && s.id !== excludeSessionId)
+    .map(sessionTemplateContext);
+}
+
+export function buildProjectPromptContext({
+  project,
+  session,
+  profile,
+  settings,
+  sessions,
+}: BuildProjectPromptContextOptions): ProjectPromptTemplateContext {
+  const family = providerFamily(profile);
+  return {
+    project: {
+      id: project.id,
+      name: project.name,
+      repo_roots: project.repoRoots ?? [],
+      context_paths: project.contextPaths ?? [],
+    },
+    session: sessionTemplateContext(session),
+    profile: {
+      id: profile?.id ?? null,
+      name: profile?.name ?? null,
+      provider: family,
+    },
+    model: {
+      name: modelName(settings),
+      family,
+    },
+    paths: {
+      sessions_folder: session.worktreePath,
+    },
+    other_sessions: sameProjectSessions(sessions, project.id, session.id),
+  };
+}
+
+export function buildProjectPromptPreviewContext({
+  project,
+  blueprint,
+  profile,
+  settings,
+  sessions,
+}: BuildProjectPromptPreviewContextOptions): ProjectPromptTemplateContext {
+  const repoRoot = blueprint?.repoRoot ?? project.repoRoots[0] ?? "";
+  const worktreePath = blueprint?.worktreePath || repoRoot;
+  const family = providerFamily(profile);
+  const previewSession: ProjectPromptTemplateSession = {
+    id: "preview",
+    name: blueprint?.name || project.name || "Preview",
+    repo_root: repoRoot,
+    worktree_path: worktreePath,
+    worktree_name: lastPathSegment(worktreePath),
+    branch: blueprint?.branch ?? null,
+    is_worktree: Boolean(blueprint?.branch || blueprint?.worktreePath),
+    blueprint_id: blueprint?.id ?? null,
+  };
+
+  return {
+    project: {
+      id: project.id,
+      name: project.name,
+      repo_roots: project.repoRoots,
+      context_paths: project.contextPaths,
+    },
+    session: previewSession,
+    profile: {
+      id: profile?.id ?? null,
+      name: profile?.name ?? null,
+      provider: family,
+    },
+    model: {
+      name: modelName(settings),
+      family,
+    },
+    paths: {
+      sessions_folder: previewSession.worktree_path,
+    },
+    other_sessions: sameProjectSessions(sessions, project.id, previewSession.id),
+  };
+}
+
+export async function renderProjectPromptTemplate(
+  template: string,
+  context: ProjectPromptTemplateContext,
+): Promise<string> {
+  if (!template.trim()) return "";
+  return renderProjectPromptTemplateRaw(template, context);
+}
+
+export async function renderProjectPromptForSession(
+  session: Session,
+  profile: SpawnProfile | null,
+  projectOverride?: Project | null,
+): Promise<string> {
+  const project = projectOverride ?? getProjectById(session.projectId);
+  const template = project?.projectPrompt ?? "";
+  if (!project || !template.trim()) return "";
+
+  return renderProjectPromptTemplate(
+    template,
+    buildProjectPromptContext({
+      project,
+      session,
+      profile,
+      settings: get(settings),
+      sessions: get(sessionState).sessions,
+    }),
+  );
+}

--- a/src/lib/sessions/reconnect.ts
+++ b/src/lib/sessions/reconnect.ts
@@ -7,7 +7,7 @@ import { sessionLayouts, collectLeafIds, type LayoutNode } from "$lib/panes/layo
 import { loadPaneState, stripCommandPanes, type PaneDescriptor, type PaneStatePayload } from "$lib/panes/persistence";
 import { resolveProfileRef, type SpawnProfile, type SpawnProfileRef } from "$lib/panes/profiles";
 import { runProfileInPane } from "$lib/panes/profileRunner";
-import { getProjectPrompt } from "$lib/stores/projects";
+import { renderProjectPromptForSession } from "$lib/projectPromptTemplates";
 import { log } from "$lib/logging";
 import { setLogicalFocus } from "$lib/panes/focus";
 
@@ -382,8 +382,12 @@ async function reconnectPrimaryPaneOnly(
     const flags = flagsForIntent(intent, instance ?? null, profile, extraFlags);
     const effectiveProfile = profileWithFlags(profile, flags);
     try {
+      const appendSystemPrompt = await renderProjectPromptForSession(
+        session,
+        effectiveProfile,
+      );
       await runProfileInPane(session.id, effectiveProfile, {
-        appendSystemPrompt: getProjectPrompt(session.projectId),
+        ...(appendSystemPrompt.trim() ? { appendSystemPrompt } : {}),
         smolMachineName: session.smolMachineName ?? null,
       });
     } catch (e) {
@@ -410,8 +414,12 @@ async function replayRestoredPaneProfile(
   const flags = flagsForIntent(intent, instance, profile);
   const effectiveProfile = profileWithFlags(profile, flags);
   try {
+    const appendSystemPrompt = await renderProjectPromptForSession(
+      session,
+      effectiveProfile,
+    );
     await runProfileInPane(instance.ptyId, effectiveProfile, {
-      appendSystemPrompt: getProjectPrompt(session.projectId),
+      ...(appendSystemPrompt.trim() ? { appendSystemPrompt } : {}),
       smolMachineName: session.smolMachineName ?? null,
     });
   } catch (e) {

--- a/src/lib/sessions/spawnBlueprint.ts
+++ b/src/lib/sessions/spawnBlueprint.ts
@@ -6,6 +6,7 @@ import {
 import { addSession } from "$lib/stores/sessions";
 import { initSessionWithProfile } from "$lib/panes/actions";
 import type { SpawnProfileRef } from "$lib/panes/profiles";
+import { renderProjectPromptForSession } from "$lib/projectPromptTemplates";
 
 export interface SpawnBlueprintOptions {
   /**
@@ -78,8 +79,13 @@ export async function spawnBlueprintForProject(
   const { connectPaneTerminal } = await import("$lib/panes/terminals");
   await connectPaneTerminal(mainPaneId);
   if (profile) {
+    const appendSystemPrompt = await renderProjectPromptForSession(
+      newSession,
+      profile,
+      project,
+    );
     await runProfileInPane(newSession.id, profile, {
-      appendSystemPrompt: project.projectPrompt ?? "",
+      ...(appendSystemPrompt.trim() ? { appendSystemPrompt } : {}),
       smolMachineName: newSession.smolMachineName ?? null,
     });
   }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1,6 +1,7 @@
 import { Channel, invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import type { SpawnProfileRef } from "$lib/panes/profiles";
+import type { ProjectPromptTemplateContext } from "$lib/projectPromptTemplates";
 import type {
   Session,
   Project,
@@ -874,6 +875,13 @@ export async function updateProject(
   patch: ProjectUpdate,
 ): Promise<Project> {
   return invoke("update_project", { id, patch });
+}
+
+export async function renderProjectPromptTemplate(
+  template: string,
+  context: ProjectPromptTemplateContext,
+): Promise<string> {
+  return invoke("render_project_prompt_template", { template, context });
 }
 
 export async function setSessionProject(


### PR DESCRIPTION
## Summary

Adds Minijinja rendering for project prompts at agent profile startup, with a shared frontend context builder for project/session/profile/model/worktree data and same-project sibling sessions.

Also adds a manual Project Prompt preview in the New/Edit Project dialog, plus docs for available variables and examples.

## Impact

- Project prompts can reference values such as `project.name`, `session.branch`, `session.worktree_name`, `paths.sessions_folder`, `model.family`, and `other_sessions`.
- Malformed templates fail before the profile startup command is typed instead of silently sending raw template text.
- The saved project prompt remains the raw template.

## Validation

- `npm run check`
- `npm run test`

Rust targeted verification was attempted earlier with `cargo test render_project_prompt_template --manifest-path src-tauri/Cargo.toml`, but the Tauri build script is blocked in this checkout because `src-tauri/binaries/roux-cli-aarch64-apple-darwin` is missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Introduced Project Prompt Templates that support dynamic variables (branch, model, worktree, session context) for customized agent startup prompts
* Added live preview in the Project dialog to see rendered prompts before saving
* Project prompts now render dynamically at agent startup with template variable substitution

**Documentation**
* Added comprehensive Project Prompt Templates documentation with examples, supported variables, and preview behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phin-tech/roux/pull/171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces Minijinja template rendering for project prompts, rendering them at agent profile startup instead of sending raw text. A shared context builder populates `project`, `session`, `profile`, `model`, `paths`, and `other_sessions` variables, and a manual Preview button is added to the New/Edit Project dialog.

- **Template rendering**: A new Rust command (`render_project_prompt_template`) backed by Minijinja with `UndefinedBehavior::Strict` ensures malformed templates or unknown variables fail fast before the agent starts, rather than silently sending unrendered text.
- **Caller integration**: The rendering call is wired into all profile-startup paths — `spawnBlueprint.ts`, `layoutRunner.ts`, `restore.ts`, `reconnect.ts`, `commands/panes.ts`, and `PaneShell.svelte` — with varying error-handling strategies per site.
- **Preview**: `buildProjectPromptPreviewContext` synthesizes a fake session from a selected blueprint so users can render the template in the dialog before saving.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the rendering pipeline is well-tested and the fail-fast Strict undefined behavior is intentional and correct.

The core template rendering path is straightforward: context is built from live stores, passed to the Rust Minijinja renderer, and the result is threaded into runProfileInPane. Rust unit tests cover scalar rendering, loops, malformed templates, and undefined variables. The only naming concern is paths.sessions_folder being an alias for session.worktree_path, which could mislead template authors but does not affect runtime correctness.

No files require special attention; the context-builder and Minijinja renderer are the most logic-dense new additions and both have unit test coverage.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/projectPromptTemplates.ts | New module building Minijinja context objects; `paths.sessions_folder` is set to `session.worktreePath` (same value as `session.worktree_path`), making it a redundant alias with a confusing name. |
| src-tauri/src/commands/projects.rs | Adds `render_project_prompt_template` Tauri command backed by Minijinja with Strict undefined behavior; omits `#[specta::specta]` intentionally (documented in comment) due to `serde_json::Value` incompatibility with specta TS codegen. |
| src/lib/sessions/spawnBlueprint.ts | Adds template rendering before `runProfileInPane`; if rendering throws the error propagates uncaught — session is created but agent never starts, caller in NewProjectDialog only logs silently. |
| src/lib/panes/restore.ts | Template rendering wired into the respawn path; errors are caught and only written to the backend log, so a template failure silently leaves the respawned pane without a running agent. |
| src/lib/sessions/reconnect.ts | Template rendering added to both reconnect paths; errors are caught-and-logged with no user-visible signal. |
| src/lib/commands/panes.ts | Template rendering correctly placed inside the existing try/catch; failure surfaces as a user-visible notification with the Minijinja error in the body. |
| src/lib/components/NewProjectDialog.svelte | Adds preview rendering using `buildProjectPromptPreviewContext`; template errors shown inline; preview correctly uses the selected blueprint's repo/branch/profile values. |
| src/lib/tauri.ts | Adds a manually typed `renderProjectPromptTemplate` wrapper for the Tauri command, bypassing specta as documented; types correctly match the new Rust command signature. |
| src/lib/__tests__/projectPromptTemplates.test.ts | Unit tests for both context builders; covers sibling-session filtering, archived-session exclusion, preview fallback values, and branch-only worktree detection. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Agent Profile Starts] --> B{Has project prompt?}
    B -- No --> C[runProfileInPane as-is]
    B -- Yes --> D[buildProjectPromptContext]
    D --> E[renderProjectPromptTemplate Rust/Minijinja]
    E -- Success --> F[runProfileInPane with appendSystemPrompt]
    E -- Template Error --> G{Caller}
    G -- PaneShell/panes.ts --> H[User notification shown]
    G -- restore.ts/reconnect.ts --> I[backend log only, no agent started]
    G -- layoutRunner.ts --> J[warning collected, no agent started]
    G -- spawnBlueprint.ts --> K[error propagates, caller logs silently]

    subgraph Preview
        L[NewProjectDialog Preview button] --> M[buildProjectPromptPreviewContext]
        M --> N[renderProjectPromptTemplate]
        N -- Error --> O[inline error shown in dialog]
        N -- Success --> P[rendered text shown in dialog]
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/lib/panes/restore.ts`, line 139-149 ([link](https://github.com/phin-tech/roux/blob/1755ddcbb0860a864cdf13b6a89374ca5081efc0/src/lib/panes/restore.ts#L139-L149)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=8" align="top"></a> **Template error silently drops profile startup on restore**

   When `renderProjectPromptForSession` rejects (e.g., a previously-valid template references a renamed variable, or the IPC call fails), the rejection is caught by this same `catch` block and only logged — `runProfileInPane` is never called. The session appears restored in the UI but the agent profile never starts, with no user-visible indication beyond a backend log entry. This same pattern applies in `reconnect.ts` (`reconnectPrimaryPaneOnly` and `replayRestoredPaneProfile`).

   Previously `getProjectPrompt` could only fail synchronously and the raw prompt string was always passed through, so the agent at least started. Consider either falling back to `runProfileInPane` without a prompt when rendering fails, or surfacing the template error as a user-visible notification so the user knows to fix the template before the session starts.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Flib%2Fpanes%2Frestore.ts%0ALine%3A%20139-149%0A%0AComment%3A%0A**Template%20error%20silently%20drops%20profile%20startup%20on%20restore**%0A%0AWhen%20%60renderProjectPromptForSession%60%20rejects%20%28e.g.%2C%20a%20previously-valid%20template%20references%20a%20renamed%20variable%2C%20or%20the%20IPC%20call%20fails%29%2C%20the%20rejection%20is%20caught%20by%20this%20same%20%60catch%60%20block%20and%20only%20logged%20%E2%80%94%20%60runProfileInPane%60%20is%20never%20called.%20The%20session%20appears%20restored%20in%20the%20UI%20but%20the%20agent%20profile%20never%20starts%2C%20with%20no%20user-visible%20indication%20beyond%20a%20backend%20log%20entry.%20This%20same%20pattern%20applies%20in%20%60reconnect.ts%60%20%28%60reconnectPrimaryPaneOnly%60%20and%20%60replayRestoredPaneProfile%60%29.%0A%0APreviously%20%60getProjectPrompt%60%20could%20only%20fail%20synchronously%20and%20the%20raw%20prompt%20string%20was%20always%20passed%20through%2C%20so%20the%20agent%20at%20least%20started.%20Consider%20either%20falling%20back%20to%20%60runProfileInPane%60%20without%20a%20prompt%20when%20rendering%20fails%2C%20or%20surfacing%20the%20template%20error%20as%20a%20user-visible%20notification%20so%20the%20user%20knows%20to%20fix%20the%20template%20before%20the%20session%20starts.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=phin-tech%2Froux&pr=171&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22feature%2Ftemplate-vars-in-projects%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Ftemplate-vars-in-projects%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Flib%2Fpanes%2Frestore.ts%0ALine%3A%20139-149%0A%0AComment%3A%0A**Template%20error%20silently%20drops%20profile%20startup%20on%20restore**%0A%0AWhen%20%60renderProjectPromptForSession%60%20rejects%20%28e.g.%2C%20a%20previously-valid%20template%20references%20a%20renamed%20variable%2C%20or%20the%20IPC%20call%20fails%29%2C%20the%20rejection%20is%20caught%20by%20this%20same%20%60catch%60%20block%20and%20only%20logged%20%E2%80%94%20%60runProfileInPane%60%20is%20never%20called.%20The%20session%20appears%20restored%20in%20the%20UI%20but%20the%20agent%20profile%20never%20starts%2C%20with%20no%20user-visible%20indication%20beyond%20a%20backend%20log%20entry.%20This%20same%20pattern%20applies%20in%20%60reconnect.ts%60%20%28%60reconnectPrimaryPaneOnly%60%20and%20%60replayRestoredPaneProfile%60%29.%0A%0APreviously%20%60getProjectPrompt%60%20could%20only%20fail%20synchronously%20and%20the%20raw%20prompt%20string%20was%20always%20passed%20through%2C%20so%20the%20agent%20at%20least%20started.%20Consider%20either%20falling%20back%20to%20%60runProfileInPane%60%20without%20a%20prompt%20when%20rendering%20fails%2C%20or%20surfacing%20the%20template%20error%20as%20a%20user-visible%20notification%20so%20the%20user%20knows%20to%20fix%20the%20template%20before%20the%20session%20starts.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Flib%2FprojectPromptTemplates.ts%3A129-131%0A%60paths.sessions_folder%60%20is%20set%20to%20%60session.worktreePath%60%2C%20making%20it%20identical%20to%20%60session.worktree_path%60%20in%20every%20context.%20The%20name%20strongly%20implies%20%22the%20directory%20that%20contains%20all%20session%20worktrees%22%20%28i.e.%2C%20the%20parent%20of%20all%20worktrees%29%2C%20but%20it%20actually%20returns%20the%20current%20session's%20own%20worktree%20path.%20Since%20both%20render%20the%20same%20string%2C%20the%20variable%20is%20a%20redundant%20alias%20that%20may%20confuse%20template%20authors%20expecting%20a%20parent-level%20folder%20path.%20Consider%20renaming%20it%20to%20%60paths.worktree_path%60%20%28making%20the%20duplication%20with%20%60session.worktree_path%60%20obvious%20and%20intentional%29%20or%20pointing%20it%20at%20the%20parent%20directory%20if%20a%20%22folder%20containing%20all%20worktrees%22%20is%20the%20intended%20semantic.%0A%0A%60%60%60suggestion%0A%20%20%20%20paths%3A%20%7B%0A%20%20%20%20%20%20worktree_path%3A%20session.worktreePath%2C%0A%20%20%20%20%7D%2C%0A%60%60%60%0A%0A&repo=phin-tech%2Froux&pr=171&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22feature%2Ftemplate-vars-in-projects%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Ftemplate-vars-in-projects%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Flib%2FprojectPromptTemplates.ts%3A129-131%0A%60paths.sessions_folder%60%20is%20set%20to%20%60session.worktreePath%60%2C%20making%20it%20identical%20to%20%60session.worktree_path%60%20in%20every%20context.%20The%20name%20strongly%20implies%20%22the%20directory%20that%20contains%20all%20session%20worktrees%22%20%28i.e.%2C%20the%20parent%20of%20all%20worktrees%29%2C%20but%20it%20actually%20returns%20the%20current%20session's%20own%20worktree%20path.%20Since%20both%20render%20the%20same%20string%2C%20the%20variable%20is%20a%20redundant%20alias%20that%20may%20confuse%20template%20authors%20expecting%20a%20parent-level%20folder%20path.%20Consider%20renaming%20it%20to%20%60paths.worktree_path%60%20%28making%20the%20duplication%20with%20%60session.worktree_path%60%20obvious%20and%20intentional%29%20or%20pointing%20it%20at%20the%20parent%20directory%20if%20a%20%22folder%20containing%20all%20worktrees%22%20is%20the%20intended%20semantic.%0A%0A%60%60%60suggestion%0A%20%20%20%20paths%3A%20%7B%0A%20%20%20%20%20%20worktree_path%3A%20session.worktreePath%2C%0A%20%20%20%20%7D%2C%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix: address project prompt template rev..."](https://github.com/phin-tech/roux/commit/51a37a1acb010b38f7ef7ce32f9a3f9ea58c6c2e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32797727)</sub>

<!-- /greptile_comment -->