### PR TITLE
Add prerelease docs publishing

### DIFF
--- a/.github/workflows/docs-prerelease.yml
+++ b/.github/workflows/docs-prerelease.yml
@@ -1,10 +1,16 @@
-name: Republish docs version
+name: Publish prerelease docs
 
 on:
+  push:
+    tags:
+      - "v*-pre.*"
+      - "v*-alpha.*"
+      - "v*-beta.*"
+      - "v*-rc.*"
   workflow_dispatch:
     inputs:
       version:
-        description: "Docs version to overwrite (e.g. 0.5.0 or v0.5.0)"
+        description: "Prerelease docs version to publish (e.g. 0.5.4-pre.1 or v0.5.4-pre.1)"
         required: true
         type: string
       source_ref:
@@ -12,11 +18,6 @@ on:
         required: false
         default: main
         type: string
-      update_latest:
-        description: "Also move the latest alias and default version"
-        required: false
-        default: true
-        type: boolean
 
 permissions:
   contents: write
@@ -31,25 +32,43 @@ jobs:
   build:
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.version.outputs.version }}
+      prerelease_url: ${{ steps.release.outputs.prerelease_url }}
+    env:
+      PRERELEASE_ALIAS: pre-releases
     steps:
-      - name: Checkout selected ref
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.source_ref }}
-          fetch-depth: 0
-
-      - name: Normalize version
-        id: version
+      - name: Resolve prerelease version
+        id: release
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_SOURCE_REF: ${{ inputs.source_ref }}
         run: |
           set -euo pipefail
-          VERSION="${{ inputs.version }}"
-          VERSION="${VERSION#v}"
+          if [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+            SOURCE_REF="${GITHUB_REF_NAME}"
+          else
+            VERSION="${INPUT_VERSION#v}"
+            SOURCE_REF="${INPUT_SOURCE_REF:-main}"
+          fi
+
           if [[ -z "$VERSION" ]]; then
             echo "Version cannot be empty." >&2
             exit 1
           fi
+          if [[ ! "$VERSION" =~ -[0-9A-Za-z][0-9A-Za-z.-]*$ ]]; then
+            echo "Version must be a prerelease with a hyphen suffix, got: $VERSION" >&2
+            exit 1
+          fi
+
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "source_ref=$SOURCE_REF" >> "$GITHUB_OUTPUT"
+          echo "prerelease_url=https://phin-tech.github.io/roux/${PRERELEASE_ALIAS}/" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout selected ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.release.outputs.source_ref }}
+          fetch-depth: 0
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
@@ -57,7 +76,7 @@ jobs:
           enable-cache: true
           cache-dependency-glob: docs/uv.lock
 
-      - name: Install dependencies
+      - name: Install docs dependencies
         run: |
           uv sync --project docs --frozen
           echo "$GITHUB_WORKSPACE/docs/.venv/bin" >> "$GITHUB_PATH"
@@ -67,26 +86,21 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
 
-      - name: Fetch existing versioned docs
+      - name: Fetch existing published docs
         run: |
           if git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
             git fetch origin gh-pages:gh-pages --depth=1
           fi
 
-      - name: Republish versioned docs
+      - name: Publish prerelease docs
         env:
-          VERSION: ${{ steps.version.outputs.version }}
-          UPDATE_LATEST: ${{ inputs.update_latest }}
+          VERSION: ${{ steps.release.outputs.version }}
+          PRERELEASE_ALIAS: ${{ env.PRERELEASE_ALIAS }}
         run: |
           set -euo pipefail
-          if [[ "$UPDATE_LATEST" == "true" ]]; then
-            mike deploy --update-aliases "$VERSION" latest
-            mike set-default latest
-          else
-            mike deploy "$VERSION"
-          fi
+          mike deploy --branch gh-pages --update-aliases "$VERSION" "$PRERELEASE_ALIAS"
 
-      - name: Archive versioned site
+      - name: Archive published site
         run: |
           rm -rf site
           mkdir -p site
@@ -123,7 +137,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: ${{ needs.build.outputs.prerelease_url }}
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/docs-prerelease.yml
+++ b/.github/workflows/docs-prerelease.yml
@@ -31,8 +31,6 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    outputs:
-      prerelease_url: ${{ steps.release.outputs.prerelease_url }}
     env:
       PRERELEASE_ALIAS: pre-releases
     steps:
@@ -62,7 +60,6 @@ jobs:
 
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "source_ref=$SOURCE_REF" >> "$GITHUB_OUTPUT"
-          echo "prerelease_url=https://phin-tech.github.io/roux/${PRERELEASE_ALIAS}/" >> "$GITHUB_OUTPUT"
 
       - name: Checkout selected ref
         uses: actions/checkout@v4
@@ -95,7 +92,6 @@ jobs:
       - name: Publish prerelease docs
         env:
           VERSION: ${{ steps.release.outputs.version }}
-          PRERELEASE_ALIAS: ${{ env.PRERELEASE_ALIAS }}
         run: |
           set -euo pipefail
           mike deploy --branch gh-pages --update-aliases "$VERSION" "$PRERELEASE_ALIAS"
@@ -105,6 +101,11 @@ jobs:
           rm -rf site
           mkdir -p site
           git archive gh-pages | tar -x -C site
+
+      - name: Checkout primary site source
+        run: |
+          git fetch origin main --depth=1
+          git checkout --detach FETCH_HEAD
 
       - name: Build primary docs site
         run: mkdocs build --site-dir site/docs --strict
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: github-pages
-      url: ${{ needs.build.outputs.prerelease_url }}
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Fetch existing published docs
         run: |
           if git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
-            git fetch origin gh-pages --depth=1
+            git fetch origin gh-pages:gh-pages --depth=1
           fi
 
       - name: Publish preview docs
@@ -62,6 +62,21 @@ jobs:
           rm -rf site
           mkdir -p site
           git archive gh-pages | tar -x -C site
+
+      - name: Build primary docs site
+        run: mkdocs build --site-dir site/docs --strict
+
+      - name: Overlay landing site
+        run: |
+          cp -R docs/landing/. site/
+          VERSION_TAG="$(git tag --list 'v*' --sort=-v:refname | grep -Ev '-' | head -n1 || true)"
+          if [[ -n "$VERSION_TAG" ]]; then
+            VERSION="${VERSION_TAG#v}"
+            sed -i \
+              -e "s|<span data-version-issue>LATEST</span>|<span data-version-issue>${VERSION}</span>|g" \
+              -e "s|<span data-version-tag>v0.LATEST</span>|<span data-version-tag>${VERSION_TAG}</span>|g" \
+              site/index.html
+          fi
 
       - name: Push gh-pages history
         run: git push origin gh-pages

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -63,6 +63,11 @@ jobs:
           mkdir -p site
           git archive gh-pages | tar -x -C site
 
+      - name: Checkout primary site source
+        run: |
+          git fetch origin main --depth=1
+          git checkout --detach FETCH_HEAD
+
       - name: Build primary docs site
         run: mkdocs build --site-dir site/docs --strict
 

--- a/.github/workflows/docs-republish.yml
+++ b/.github/workflows/docs-republish.yml
@@ -92,6 +92,11 @@ jobs:
           mkdir -p site
           git archive gh-pages | tar -x -C site
 
+      - name: Checkout primary site source
+        run: |
+          git fetch origin main --depth=1
+          git checkout --detach FETCH_HEAD
+
       - name: Build primary docs site
         run: mkdocs build --site-dir site/docs --strict
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,6 +22,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.ref_type != 'tag' || !contains(github.ref_name, '-')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -40,6 +41,15 @@ jobs:
           uv sync --project docs --frozen
           echo "$GITHUB_WORKSPACE/docs/.venv/bin" >> $GITHUB_PATH
 
+      - name: Restore versioned docs
+        run: |
+          rm -rf site
+          mkdir -p site
+          if git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
+            git fetch origin gh-pages --depth=1
+            git archive FETCH_HEAD | tar -x -C site
+          fi
+
       - name: Build docs
         run: mkdocs build --site-dir site/docs --strict
 
@@ -51,11 +61,11 @@ jobs:
 
           # Stamp the latest release version into the masthead (as the "issue
           # number") and the download link. On a tag push, use that tag;
-          # otherwise fall back to the most recent reachable tag.
+          # otherwise fall back to the most recent reachable stable tag.
           if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
             VERSION_TAG="${GITHUB_REF_NAME}"
           else
-            VERSION_TAG="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+            VERSION_TAG="$(git tag --list 'v*' --sort=-v:refname | grep -Ev '-' | head -n1 || true)"
           fi
           if [[ -n "$VERSION_TAG" ]]; then
             VERSION="${VERSION_TAG#v}"

--- a/README.md
+++ b/README.md
@@ -115,3 +115,9 @@ Or do signing and publishing together:
 ```bash
 task publish:op
 ```
+
+Publish the current prerelease docs alias after a prerelease tag exists:
+
+```bash
+task docs:prerelease VERSION=0.5.4-pre.1
+```

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -569,6 +569,8 @@ tasks:
     desc: "Publish prerelease docs to https://phin-tech.github.io/roux/pre-releases/. Usage: task docs:prerelease VERSION=0.5.4-pre.1 [SOURCE_REF=v0.5.4-pre.1]"
     requires:
       vars: [VERSION]
+    vars:
+      SOURCE_REF_ARG: '{{default "" .SOURCE_REF}}'
     preconditions:
       - sh: "command -v gh >/dev/null 2>&1"
         msg: "GitHub CLI 'gh' is required"
@@ -576,19 +578,27 @@ tasks:
       - |
         set -euo pipefail
         VERSION="{{.VERSION}}"
-        SOURCE_REF="{{.SOURCE_REF}}"
+        SOURCE_REF="{{.SOURCE_REF_ARG}}"
         if [ -z "$SOURCE_REF" ]; then
           SOURCE_REF="v${VERSION#v}"
         fi
 
         echo "Dispatching prerelease docs publish (VERSION=${VERSION}, SOURCE_REF=${SOURCE_REF})..."
+        DISPATCHED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
         gh workflow run docs-prerelease.yml \
           --ref main \
           -f version="${VERSION}" \
           -f source_ref="${SOURCE_REF}"
         sleep 2
-        RUN_ID=$(gh run list --workflow=docs-prerelease.yml --event=workflow_dispatch --limit=1 --json databaseId --jq '.[0].databaseId')
-        if [ -z "${RUN_ID}" ]; then
+        RUN_ID=$(gh run list \
+          --workflow=docs-prerelease.yml \
+          --event=workflow_dispatch \
+          --branch main \
+          --created ">${DISPATCHED_AT}" \
+          --limit=10 \
+          --json databaseId,createdAt \
+          --jq 'sort_by(.createdAt) | reverse | .[0].databaseId // ""')
+        if [ -z "${RUN_ID}" ] || [ "${RUN_ID}" = "null" ]; then
           echo "Dispatched, but could not resolve the run ID. Check https://github.com/phin-tech/roux/actions" >&2
           exit 0
         fi

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -565,6 +565,36 @@ tasks:
     cmds:
       - uv run --project docs mkdocs build --strict
 
+  docs:prerelease:
+    desc: "Publish prerelease docs to https://phin-tech.github.io/roux/pre-releases/. Usage: task docs:prerelease VERSION=0.5.4-pre.1 [SOURCE_REF=v0.5.4-pre.1]"
+    requires:
+      vars: [VERSION]
+    preconditions:
+      - sh: "command -v gh >/dev/null 2>&1"
+        msg: "GitHub CLI 'gh' is required"
+    cmds:
+      - |
+        set -euo pipefail
+        VERSION="{{.VERSION}}"
+        SOURCE_REF="{{.SOURCE_REF}}"
+        if [ -z "$SOURCE_REF" ]; then
+          SOURCE_REF="v${VERSION#v}"
+        fi
+
+        echo "Dispatching prerelease docs publish (VERSION=${VERSION}, SOURCE_REF=${SOURCE_REF})..."
+        gh workflow run docs-prerelease.yml \
+          --ref main \
+          -f version="${VERSION}" \
+          -f source_ref="${SOURCE_REF}"
+        sleep 2
+        RUN_ID=$(gh run list --workflow=docs-prerelease.yml --event=workflow_dispatch --limit=1 --json databaseId --jq '.[0].databaseId')
+        if [ -z "${RUN_ID}" ]; then
+          echo "Dispatched, but could not resolve the run ID. Check https://github.com/phin-tech/roux/actions" >&2
+          exit 0
+        fi
+        echo "Watching run ${RUN_ID}..."
+        gh run watch "${RUN_ID}" --exit-status
+
   docs:landing:
     desc: "Serve the retro landing page locally at http://127.0.0.1:8765/"
     dir: docs/landing

--- a/docs/features/mailbox.md
+++ b/docs/features/mailbox.md
@@ -312,7 +312,7 @@ When a pane is hosting an agent, Roux injects these:
 
 ## How agents discover the mailbox
 
-Roux ships a Claude Code [skill](../sessions.md#skills) (auto-installed at
+Roux ships a Claude Code skill (auto-installed at
 `~/.claude/skills/roux/SKILL.md`) that teaches agents:
 
 - `$ROUX_SESSION=1` ⇒ they're in Roux

--- a/docs/install.md
+++ b/docs/install.md
@@ -30,6 +30,8 @@ Roux has a built-in auto-updater. When a new version is published, Roux checks f
 
 You can also switch between **Stable** and **Pre-release (Alpha)** in **Settings** → **Advanced**. The prerelease channel follows the newest published prerelease build; switching back to Stable takes effect on the next stable release at or above your current version.
 
+Docs for the current prerelease channel are published at [phin-tech.github.io/roux/pre-releases/](https://phin-tech.github.io/roux/pre-releases/). Version-specific prerelease docs remain available at paths like `https://phin-tech.github.io/roux/0.5.4-pre.1/`.
+
 Updates are signed and verified on device before they're installed.
 
 After you click **Install and restart**, Roux downloads the new version, verifies the signature, and replaces the app bundle in place. In most cases it will then relaunch itself into the new version automatically. Occasionally — on macOS, after the bundle has just been swapped on disk — the automatic relaunch fails. When that happens the banner changes to **"Update installed. Quit and reopen Roux to finish."** with a **Quit Roux** button. Click it (or quit the app yourself) and reopen Roux from Launchpad or Spotlight — you'll be on the new version.

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -4,6 +4,7 @@ version = "0"
 description = "Build environment for the Roux documentation site (mkdocs-material + mike)."
 requires-python = ">=3.12"
 dependencies = [
+    "mike>=2.2.0",
     "mkdocs-material==9.5.39",
 ]
 

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -229,6 +229,23 @@ wheels = [
 ]
 
 [[package]]
+name = "mike"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "mkdocs" },
+    { name = "pyparsing" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "verspec" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/47/fa87e9d56bef16cdfe34b059a437e8c6f7ec6f1b9c378871c3cf95ebea9c/mike-2.2.0.tar.gz", hash = "sha256:1e3858e32c0f125aac14432fc7848434358f9ae0962c5c5cde387ad47f6ad25e", size = 38450, upload-time = "2026-04-14T04:59:03.944Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/8e/56ccb09c7232a55403a7637caa21922f3b65901a37f5e8bdb405d0de0946/mike-2.2.0-py3-none-any.whl", hash = "sha256:e1f4981c1152eec7c2490a3401142292cc47d686194188416db2648fdfe1d040", size = 34026, upload-time = "2026-04-14T04:59:02.602Z" },
+]
+
+[[package]]
 name = "mkdocs"
 version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -353,6 +370,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
 ]
 
 [[package]]
@@ -533,11 +559,15 @@ name = "roux-docs"
 version = "0"
 source = { virtual = "." }
 dependencies = [
+    { name = "mike" },
     { name = "mkdocs-material" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "mkdocs-material", specifier = "==9.5.39" }]
+requires-dist = [
+    { name = "mike", specifier = ">=2.2.0" },
+    { name = "mkdocs-material", specifier = "==9.5.39" },
+]
 
 [[package]]
 name = "six"
@@ -555,6 +585,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "verspec"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/44/8126f9f0c44319b2efc65feaad589cadef4d77ece200ae3c9133d58464d0/verspec-0.1.0.tar.gz", hash = "sha256:c4504ca697b2056cdb4bfa7121461f5a0e81809255b41c03dda4ba823637c01e", size = 27123, upload-time = "2020-11-30T02:24:09.646Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/ce/3b6fee91c85626eaf769d617f1be9d2e15c1cca027bbdeb2e0d751469355/verspec-0.1.0-py3-none-any.whl", hash = "sha256:741877d5633cc9464c45a469ae2a31e801e6dbbaa85b9675d481cda100f11c31", size = 19640, upload-time = "2020-11-30T02:24:08.387Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- add a dedicated prerelease docs publisher for /pre-releases/
- install mike in the docs uv environment and fix stale docs republish dependencies
- preserve versioned docs while deploying the primary landing and /docs/ site
- add a Taskfile helper for manual prerelease docs publishes

## Verification

- uv run --project docs mkdocs build --strict
- simulated Pages artifact layout from gh-pages + /docs + landing
- Ruby YAML parse for touched workflows
- task --list

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a dedicated prerelease docs publishing pipeline (`docs-prerelease.yml`) that uses `mike` to deploy versioned docs under a `pre-releases/` alias, while preserving the primary landing and `/docs/` paths by overlaying them on top of the archived `gh-pages` content. It also migrates the republish workflow from `pip+requirements.txt` to `uv`, and applies the same landing-overlay + primary-docs build pattern to the preview and republish workflows for consistency.

- **New `docs-prerelease.yml`**: triggers on prerelease tag patterns (`v*-pre.*`, `-alpha`, `-beta`, `-rc`) or `workflow_dispatch`, validates version format, runs `mike deploy --update-aliases` to set the `pre-releases` alias, then rebuilds and overlays the primary site before uploading the Pages artifact.
- **`docs.yml` guard + versioned-docs restore**: a job-level `if` skips the stable build on prerelease tags; a new \"Restore versioned docs\" step extracts the existing `gh-pages` tree into `site/` before `mkdocs build` so that mike-managed versioned paths survive stable publishes.
- **Dependency + tooling updates**: `mike>=2.2.0` added to `docs/pyproject.toml` (with locked dependencies in `uv.lock`); a `docs:prerelease` Taskfile task dispatches the workflow and watches the run.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the new prerelease workflow, the versioned-docs restore step in the stable workflow, and the landing-overlay pattern in all four workflows are logically sound and consistent with each other.

The versioning, push-order, concurrency-group usage, permissions, and tag-trigger guard are all correctly implemented. The docs.yml restore step correctly uses FETCH_HEAD (no local-branch mapping needed since mike is not called there), while the mike-using workflows correctly map gh-pages:gh-pages so the local branch is available. The Taskfile run-ID lookup uses a pre-dispatch timestamp filter plus JSON sort, making it robust. No correctness issues were found across the changed files.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/docs-prerelease.yml | New workflow correctly validates version format, uses mike to publish versioned prerelease docs, then overlays the primary mkdocs build and landing page before deploying the artifact. Concurrency group, permissions, and tag-trigger patterns are all correct. |
| .github/workflows/docs.yml | Job-level guard correctly skips stable build for prerelease tags; new "Restore versioned docs" step preserves mike-managed versioned paths before mkdocs overwrites site/docs/; version-tag lookup switched from git describe to explicit stable-only filter. |
| .github/workflows/docs-republish.yml | Migrates from pip+requirements.txt to uv; adds primary-site build and landing overlay steps that match the new prerelease workflow pattern; fetch mapping fix (gh-pages:gh-pages) is consistent with other workflows. |
| .github/workflows/docs-preview.yml | Applies the same landing-overlay + primary-docs build pattern; fetch mapping fix included; PR-specific docs remain accessible at their versioned path while /docs/ always reflects main. |
| Taskfile.yml | New docs:prerelease task dispatches the workflow and resolves the run ID using a pre-dispatch timestamp filter + JSON sort rather than a blind --limit=1, making it robust to concurrent dispatches. |
| docs/pyproject.toml | Adds mike>=2.2.0 as a required dependency for the docs build environment; lockfile updated accordingly. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub Actions
    participant GHP as gh-pages branch
    participant Pages as GitHub Pages

    Dev->>GH: "Push prerelease tag (v*-pre.*)"
    GH->>GH: "Resolve version & source_ref"
    GH->>GH: "Checkout tag (fetch-depth=0)"
    GH->>GH: uv sync (install mike + mkdocs-material)
    GH->>GHP: git fetch origin gh-pages:gh-pages
    GH->>GHP: mike deploy --update-aliases VERSION pre-releases
    Note over GH,GHP: Versioned docs committed to local gh-pages
    GH->>GH: git archive gh-pages → site/
    GH->>GH: git fetch origin main + checkout
    GH->>GH: mkdocs build → site/docs/
    GH->>GH: cp docs/landing → site/ (stamp stable version)
    GH->>GHP: git push origin gh-pages
    GH->>Pages: upload-pages-artifact (site/)
    GH->>Pages: deploy-pages (artifact)
    Pages-->>Dev: phin-tech.github.io/roux/pre-releases/
```

<sub>Reviews (2): Last reviewed commit: ["fix: address prerelease docs review"](https://github.com/phin-tech/roux/commit/4cbf71f809e53fb9eed388158a12f1a6f0586ec1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32815157)</sub>

<!-- /greptile_comment -->