### PR TITLE
fix(terminal): self-heal WebGL glyph-atlas corruption during streaming

### DIFF
--- a/src/lib/panes/__tests__/xtermController.test.ts
+++ b/src/lib/panes/__tests__/xtermController.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { writable } from "svelte/store";
 
 import { DEFAULT_SETTINGS } from "$lib/types";
@@ -15,9 +15,12 @@ const mocks = vi.hoisted(() => {
     webglDispose: vi.fn(),
     webglOnContextLoss: vi.fn(),
     webglClearTextureAtlas: vi.fn(),
+    webglOnAddTextureAtlasCanvas: vi.fn(),
     contextLossSubDispose: vi.fn(),
+    atlasAddSubDispose: vi.fn(),
     nextWebglShouldThrow: false,
     lastWebglContextLossHandler: null as (() => void) | null,
+    lastWebglAtlasAddHandler: null as (() => void) | null,
   };
 });
 
@@ -110,6 +113,11 @@ vi.mock("@xterm/addon-webgl", () => ({
       mocks.webglOnContextLoss(handler);
       return { dispose: mocks.contextLossSubDispose };
     };
+    this.onAddTextureAtlasCanvas = (handler: () => void) => {
+      mocks.lastWebglAtlasAddHandler = handler;
+      mocks.webglOnAddTextureAtlasCanvas(handler);
+      return { dispose: mocks.atlasAddSubDispose };
+    };
   }),
 }));
 
@@ -125,8 +133,11 @@ beforeEach(() => {
   mocks.webglDispose.mockClear();
   mocks.webglOnContextLoss.mockClear();
   mocks.webglClearTextureAtlas.mockClear();
+  mocks.webglOnAddTextureAtlasCanvas.mockClear();
   mocks.contextLossSubDispose.mockClear();
+  mocks.atlasAddSubDispose.mockClear();
   mocks.lastWebglContextLossHandler = null;
+  mocks.lastWebglAtlasAddHandler = null;
   mocks.nextWebglShouldThrow = false;
   mocks.settingsStore.set({ ...DEFAULT_SETTINGS });
 });
@@ -152,6 +163,10 @@ describe("XtermTerminalController renderer setup", () => {
     expect(mocks.terminalOpen).toHaveBeenCalledWith(container);
     expect(raf).not.toHaveBeenCalled();
     expect(mocks.fitAddonFit).not.toHaveBeenCalled();
+
+    // dispose() cancels the throttled atlas-refresh timer attach() schedules,
+    // so it cannot leak into a later test.
+    controller.dispose();
   });
 
   it("clears the WebGL texture atlas after a successful fit", () => {
@@ -311,5 +326,98 @@ describe("XtermTerminalController renderer setup", () => {
 
     expect(terminal.input).toHaveBeenCalledWith("\r", undefined);
     expect(terminal.paste).toHaveBeenCalledWith("echo hi");
+  });
+});
+
+describe("XtermTerminalController WebGL atlas refresh", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("subscribes to onAddTextureAtlasCanvas when WebGL is active", () => {
+    mocks.settingsStore.set({ ...DEFAULT_SETTINGS, gpuAcceleration: "auto" });
+
+    createXtermTerminalController();
+
+    expect(mocks.webglOnAddTextureAtlasCanvas).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not subscribe to onAddTextureAtlasCanvas when gpuAcceleration is 'off'", () => {
+    mocks.settingsStore.set({ ...DEFAULT_SETTINGS, gpuAcceleration: "off" });
+
+    createXtermTerminalController();
+
+    expect(mocks.webglOnAddTextureAtlasCanvas).not.toHaveBeenCalled();
+  });
+
+  it("clears the texture atlas on a throttled delay after a page is added", () => {
+    mocks.settingsStore.set({ ...DEFAULT_SETTINGS, gpuAcceleration: "auto" });
+    createXtermTerminalController();
+
+    mocks.lastWebglAtlasAddHandler?.();
+    // Throttled: nothing happens synchronously on the page-add event.
+    expect(mocks.webglClearTextureAtlas).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(250);
+    expect(mocks.webglClearTextureAtlas).toHaveBeenCalledTimes(1);
+  });
+
+  it("coalesces a burst of page-add events into a single clear", () => {
+    mocks.settingsStore.set({ ...DEFAULT_SETTINGS, gpuAcceleration: "auto" });
+    createXtermTerminalController();
+
+    for (let i = 0; i < 5; i++) {
+      mocks.lastWebglAtlasAddHandler?.();
+    }
+
+    vi.advanceTimersByTime(250);
+    expect(mocks.webglClearTextureAtlas).toHaveBeenCalledTimes(1);
+  });
+
+  it("schedules a throttled atlas refresh on attach", () => {
+    mocks.settingsStore.set({ ...DEFAULT_SETTINGS, gpuAcceleration: "auto" });
+    const controller = createXtermTerminalController();
+
+    controller.attach(document.createElement("div"));
+    expect(mocks.webglClearTextureAtlas).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(250);
+    expect(mocks.webglClearTextureAtlas).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels a pending atlas refresh when the controller is disposed", () => {
+    mocks.settingsStore.set({ ...DEFAULT_SETTINGS, gpuAcceleration: "auto" });
+    const controller = createXtermTerminalController();
+
+    mocks.lastWebglAtlasAddHandler?.();
+    controller.dispose();
+
+    expect(() => vi.advanceTimersByTime(250)).not.toThrow();
+    expect(mocks.webglClearTextureAtlas).not.toHaveBeenCalled();
+  });
+
+  it("disposes the onAddTextureAtlasCanvas subscription on dispose", () => {
+    mocks.settingsStore.set({ ...DEFAULT_SETTINGS, gpuAcceleration: "auto" });
+    const controller = createXtermTerminalController();
+
+    expect(mocks.atlasAddSubDispose).not.toHaveBeenCalled();
+
+    controller.dispose();
+
+    expect(mocks.atlasAddSubDispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores a page-add event that fires after the controller is disposed", () => {
+    mocks.settingsStore.set({ ...DEFAULT_SETTINGS, gpuAcceleration: "auto" });
+    const controller = createXtermTerminalController();
+    controller.dispose();
+
+    expect(() => mocks.lastWebglAtlasAddHandler?.()).not.toThrow();
+    vi.advanceTimersByTime(250);
+    expect(mocks.webglClearTextureAtlas).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/panes/xtermController.ts
+++ b/src/lib/panes/xtermController.ts
@@ -21,11 +21,20 @@ interface CreateTerminalControllerOptions {
   allowKeyboardEvent?: (event: KeyboardEvent) => boolean;
 }
 
+// Trailing-edge throttle for WebGL texture-atlas refreshes. Above one animation
+// frame so a streaming output burst never causes per-frame re-rasterization,
+// and sub-second so any glyph-atlas corruption reads as a brief flicker rather
+// than a stuck frame.
+const ATLAS_REFRESH_THROTTLE_MS = 250;
+
 class XtermTerminalController implements TerminalController {
   private readonly terminal: Terminal;
   private readonly fitAddon: FitAddon;
   private webglAddon: WebglAddon | null = null;
   private webglContextLossSub: { dispose(): void } | null = null;
+  private webglAtlasSub: { dispose(): void } | null = null;
+  private atlasRefreshTimer: ReturnType<typeof setTimeout> | null = null;
+  private atlasRefreshPending = false;
   private watchDecorations: XtermWatchDecorationsHandle | null = null;
 
   constructor(options?: CreateTerminalControllerOptions) {
@@ -68,17 +77,48 @@ class XtermTerminalController implements TerminalController {
       const webgl = new WebglAddon();
       this.terminal.loadAddon(webgl);
       this.webglAddon = webgl;
+      // A new atlas page (allocation or merge) rewrites glyph page indices and
+      // UVs; cells outside the dirty range keep stale coordinates and render
+      // garbled. clearTextureAtlas() forces a full atlas + model rebuild, so
+      // refresh (throttled) whenever the atlas grows — this is decoupled from
+      // resize, which is why streaming output could corrupt without recovery.
+      this.webglAtlasSub = webgl.onAddTextureAtlasCanvas(() => {
+        this.scheduleAtlasRefresh();
+      });
       this.webglContextLossSub = webgl.onContextLoss(() => {
         // Guard against the handler firing twice (xterm hands us an event
         // disposable, not a one-shot) or after the controller is disposed.
         // Null the ref before dispose() so a re-entrant call is a no-op.
         if (this.webglAddon !== webgl) return;
         this.webglAddon = null;
+        this.cancelAtlasRefresh();
+        this.webglAtlasSub?.dispose();
+        this.webglAtlasSub = null;
         webgl.dispose();
       });
     } catch {
       this.webglAddon = null;
     }
+  }
+
+  private scheduleAtlasRefresh(): void {
+    if (!this.webglAddon) return;
+    this.atlasRefreshPending = true;
+    if (this.atlasRefreshTimer !== null) return;
+    this.atlasRefreshTimer = setTimeout(() => {
+      this.atlasRefreshTimer = null;
+      if (!this.atlasRefreshPending) return;
+      this.atlasRefreshPending = false;
+      this.webglAddon?.clearTextureAtlas();
+    }, ATLAS_REFRESH_THROTTLE_MS);
+  }
+
+  private cancelAtlasRefresh(): void {
+    if (this.atlasRefreshTimer !== null) {
+      clearTimeout(this.atlasRefreshTimer);
+      this.atlasRefreshTimer = null;
+    }
+    this.atlasRefreshPending = false;
   }
 
   attach(container: HTMLElement): void {
@@ -93,6 +133,11 @@ class XtermTerminalController implements TerminalController {
     } else if (!container.contains(this.terminal.element)) {
       container.appendChild(this.terminal.element);
     }
+    // A pane keeps receiving write() while detached (display:none), so its
+    // model can hold stale atlas coordinates from a page merge triggered by
+    // another pane. Refresh the atlas on (re)attach so it cannot surface
+    // corruption when the pane becomes visible again.
+    this.scheduleAtlasRefresh();
   }
 
   detach(): void {
@@ -105,6 +150,9 @@ class XtermTerminalController implements TerminalController {
   dispose(): void {
     this.watchDecorations?.dispose();
     this.watchDecorations = null;
+    this.cancelAtlasRefresh();
+    this.webglAtlasSub?.dispose();
+    this.webglAtlasSub = null;
     this.webglContextLossSub?.dispose();
     this.webglContextLossSub = null;
     this.webglAddon?.dispose();


### PR DESCRIPTION
## Problem

Terminal text could spontaneously render garbled — glyphs drawn at wrong positions, overlapping/smearing — **while Claude Code output was streaming**, with no window resize or pane interaction. It **persisted until the user manually resized or switched tabs**, which forced a redraw.

## Root cause

The renderer is `@xterm/addon-webgl` (`gpuAcceleration` defaults to `auto`). xterm's WebGL `TextureAtlas` grows lazily as new glyph variants are rasterized (Claude Code's TUI generates a huge variant count). When the atlas allocates or **merges a texture page**, every affected glyph's page index and UV coordinates are rewritten — and cells outside the current dirty line range keep **stale page/UV coordinates**, so they sample glyphs from the wrong atlas page.

The prior fix (`a9a2bf7`) added `clearTextureAtlas()` inside `fit()`. That only recovers on **resize** — page allocation is driven by glyph-variant volume, not by resize — so corruption that happened mid-stream had no recovery path. That's exactly why manually interacting (which triggers `fit()`) "fixed" it.

## Fix

`src/lib/panes/xtermController.ts`:

- Subscribe to `WebglAddon.onAddTextureAtlasCanvas` — fires exactly when a texture page is added/merged, i.e. the moment stale coordinates become possible. On that event, schedule a **throttled (250ms, trailing-edge)** `clearTextureAtlas()` that forces a full atlas + model rebuild. A burst of page-adds during streaming coalesces into one clear; steady-state output (once the glyph working set is rasterized) triggers none.
- `attach()` also schedules a refresh, so a pane corrupted while detached (background panes keep receiving `write()`) self-heals when it becomes visible again.
- The existing `fit()`-based clear is left unchanged (covers the resize/DPR path).
- The throttle timer and the event subscription are torn down in both `dispose()` and the context-loss handler — no leaked timers/listeners.

**Cross-pane note:** the WebGL atlas is shared across same-theme panes (`CharAtlasCache` is a module global). `onAddTextureAtlasCanvas` is forwarded to every renderer sharing that atlas, so one busy pane's page merge triggers a self-heal in every pane it could have corrupted.

## Why not prevent it

The true bug is in `@xterm/addon-webgl@0.19.0`'s partial-model-update path; fixing it upstream would need an addon fork, and no stable addon upgrade exists (only `0.20.0-beta.*`). Fast, automatic recovery is the correct minimal fix.

## Testing

- `src/lib/panes/__tests__/xtermController.test.ts` — extended the `@xterm/addon-webgl` mock with `onAddTextureAtlasCanvas`; added 8 tests (subscription gating by `gpuAcceleration`, throttled clear, burst coalescing, attach-triggered refresh, timer cancellation + subscription disposal on `dispose()`). Written red-first, then implemented.
- `npm run test` — 1027 passed, 2 skipped (pre-existing), 0 failed.
- `npm run check` — 0 errors, 0 warnings.

Runtime verification still recommended: `task dev`, stream long Claude Code TUI output across several panes, confirm corruption no longer persists and any transient glitch self-clears within ~250ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of GPU-accelerated terminal rendering through automatic recovery from rendering glitches.

* **Tests**
  * Enhanced test coverage for GPU-accelerated rendering scenarios, including event handling and cleanup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phin-tech/roux/pull/173?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a self-healing path for WebGL glyph-atlas corruption that occurs during streaming output, complementing the existing resize-triggered `clearTextureAtlas()` call.

- **Core mechanism**: subscribes to `onAddTextureAtlasCanvas` (fires exactly when the atlas allocates or merges a page) and runs a trailing-edge throttled (250 ms) `clearTextureAtlas()` — bursts of page-adds during a streaming session coalesce into one clear.
- **Background-pane healing**: `attach()` now schedules a refresh so a pane that accumulated stale atlas coordinates while detached (`display:none`) self-heals as soon as it becomes visible.
- **Lifecycle hygiene**: both `dispose()` and the context-loss handler cancel the pending timer and dispose the `webglAtlasSub` subscription; 8 new tests (fake-timer, red-first per AGENTS.md TDD protocol) cover gating, coalescing, attach refresh, and teardown.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The change is narrowly scoped to WebGL atlas lifecycle management, all new state is properly torn down in every exit path, and the test suite explicitly covers post-disposal stale-event safety.

The throttle implementation correctly coalesces bursts via a single timer + pending flag, the !this.webglAddon guard prevents spurious refreshes after context loss or disposal, and both the context-loss handler and dispose() cancel the timer and dispose the subscription. No logic gaps were found across the new code paths.

No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/panes/xtermController.ts | Adds throttled atlas-refresh mechanism (scheduleAtlasRefresh/cancelAtlasRefresh), onAddTextureAtlasCanvas subscription, and attach()-triggered refresh; teardown is correct in both dispose() and context-loss paths. |
| src/lib/panes/__tests__/xtermController.test.ts | Extends WebGL mock with onAddTextureAtlasCanvas; adds 8 tests covering subscription gating, coalescing, attach-triggered refresh, and subscription/timer teardown on dispose. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant XTC as XtermTerminalController
    participant WebGL as WebglAddon
    participant Atlas as TextureAtlas
    participant Timer as setTimeout

    Note over XTC,Atlas: setupRenderer()
    XTC->>WebGL: loadAddon(webgl)
    XTC->>WebGL: onAddTextureAtlasCanvas(handler) → webglAtlasSub
    XTC->>WebGL: onContextLoss(handler) → webglContextLossSub

    Note over XTC,Timer: Streaming output (page allocation/merge)
    Atlas-->>WebGL: _createNewPage() fires onAddTextureAtlasCanvas
    WebGL-->>XTC: handler()
    XTC->>XTC: scheduleAtlasRefresh()
    XTC->>Timer: setTimeout(250ms) [if no timer running]

    Note over XTC,Timer: Burst coalescing
    Atlas-->>WebGL: onAddTextureAtlasCanvas (x4 more)
    WebGL-->>XTC: handler() × 4
    XTC->>XTC: "atlasRefreshPending = true (timer already running, no-op)"

    Timer-->>XTC: callback fires
    XTC->>WebGL: clearTextureAtlas()

    Note over XTC,Timer: attach() — background pane becoming visible
    XTC->>XTC: scheduleAtlasRefresh()
    XTC->>Timer: setTimeout(250ms)
    Timer-->>XTC: callback fires
    XTC->>WebGL: clearTextureAtlas()

    Note over XTC,Timer: dispose() / context loss
    XTC->>XTC: cancelAtlasRefresh() [clears timer]
    XTC->>XTC: webglAtlasSub.dispose()
    XTC->>WebGL: dispose()
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/lib/panes/__tests__/xtermController.test.ts`, line 231-240 ([link](https://github.com/phin-tech/roux/blob/f5388a969533b1a645b421c3fa4b464ae95c7d74/src/lib/panes/__tests__/xtermController.test.ts#L231-L240)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **Context-loss test doesn't verify atlas-subscription and timer teardown**

   The new context-loss handler also calls `cancelAtlasRefresh()` and disposes `webglAtlasSub`, but the existing test only asserts on `webglDispose`. A regression in those two lines (e.g., calling them in the wrong order or accidentally removing one) would still pass all tests. Consider adding an assertion on `atlasAddSubDispose` here, and a paired test that fires context loss while an atlas-refresh timer is pending and then advances the clock to confirm `webglClearTextureAtlas` is never called.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Flib%2Fpanes%2F__tests__%2FxtermController.test.ts%0ALine%3A%20231-240%0A%0AComment%3A%0A**Context-loss%20test%20doesn't%20verify%20atlas-subscription%20and%20timer%20teardown**%0A%0AThe%20new%20context-loss%20handler%20also%20calls%20%60cancelAtlasRefresh%28%29%60%20and%20disposes%20%60webglAtlasSub%60%2C%20but%20the%20existing%20test%20only%20asserts%20on%20%60webglDispose%60.%20A%20regression%20in%20those%20two%20lines%20%28e.g.%2C%20calling%20them%20in%20the%20wrong%20order%20or%20accidentally%20removing%20one%29%20would%20still%20pass%20all%20tests.%20Consider%20adding%20an%20assertion%20on%20%60atlasAddSubDispose%60%20here%2C%20and%20a%20paired%20test%20that%20fires%20context%20loss%20while%20an%20atlas-refresh%20timer%20is%20pending%20and%20then%20advances%20the%20clock%20to%20confirm%20%60webglClearTextureAtlas%60%20is%20never%20called.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=phin-tech%2Froux&pr=173&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22fix%2Fweird-rendering-issue%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fweird-rendering-issue%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Flib%2Fpanes%2F__tests__%2FxtermController.test.ts%0ALine%3A%20231-240%0A%0AComment%3A%0A**Context-loss%20test%20doesn't%20verify%20atlas-subscription%20and%20timer%20teardown**%0A%0AThe%20new%20context-loss%20handler%20also%20calls%20%60cancelAtlasRefresh%28%29%60%20and%20disposes%20%60webglAtlasSub%60%2C%20but%20the%20existing%20test%20only%20asserts%20on%20%60webglDispose%60.%20A%20regression%20in%20those%20two%20lines%20%28e.g.%2C%20calling%20them%20in%20the%20wrong%20order%20or%20accidentally%20removing%20one%29%20would%20still%20pass%20all%20tests.%20Consider%20adding%20an%20assertion%20on%20%60atlasAddSubDispose%60%20here%2C%20and%20a%20paired%20test%20that%20fires%20context%20loss%20while%20an%20atlas-refresh%20timer%20is%20pending%20and%20then%20advances%20the%20clock%20to%20confirm%20%60webglClearTextureAtlas%60%20is%20never%20called.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/weird-rende..."](https://github.com/phin-tech/roux/commit/374c26e5851ed2736e457c8888cbde07424fe092) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32814288)</sub>

<!-- /greptile_comment -->