### PR TITLE
feat(session): kill, rename, --from, --prompt, --pane-type; fix --working-dir precedence (#175)

### DIFF
--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -422,6 +422,11 @@ enum SessionAction {
         /// Create a new worktree from this branch. Uses --working-dir (or cwd) as the repo to branch from.
         #[arg(long)]
         worktree_branch: Option<String>,
+        /// Git ref to branch the new worktree from (e.g. "main", "origin/main", "abc123").
+        /// Refs starting with "origin/" trigger a `git fetch origin` first.
+        /// Ignored when --worktree-branch is not set.
+        #[arg(long)]
+        from: Option<String>,
         /// Spawn profile id (e.g. "claude", "plain-shell", "codex", user profile id). Default: claude
         #[arg(short = 'P', long)]
         profile: Option<String>,
@@ -434,6 +439,11 @@ enum SessionAction {
         /// Extra directory to allow under nono (repeatable)
         #[arg(long = "nono-allow-dir")]
         nono_allow_dirs: Vec<String>,
+        /// Text to send to the session's primary PTY immediately after it starts
+        /// (with a trailing Enter). Handy for kicking off an agent task at
+        /// creation time without a separate `session send` call.
+        #[arg(long)]
+        prompt: Option<String>,
     },
     /// Send text to a session's PTY (appends \r by default; use --no-enter for raw)
     Send {
@@ -442,9 +452,13 @@ enum SessionAction {
         /// Session id (falls back to $ROUX_SESSION_ID)
         #[arg(short, long)]
         session: Option<String>,
-        /// Pane id (falls back to $ROUX_PANE_ID)
+        /// Pane id (falls back to $ROUX_PANE_ID). Takes priority over --pane-type.
         #[arg(short, long)]
         pane: Option<String>,
+        /// Target the first pane of this type in the session (e.g. shell, claude, command).
+        /// Ignored when --pane is given.
+        #[arg(long)]
+        pane_type: Option<String>,
         /// Send raw text without appending \r (Enter). By default Enter is sent.
         #[arg(long = "no-enter")]
         no_enter: bool,
@@ -457,6 +471,22 @@ enum SessionAction {
     },
     /// List all sessions (JSON)
     List,
+    /// Rename a session (sets a name override that takes precedence over
+    /// the branch-derived label in the UI).
+    Rename {
+        /// New name. Pass an empty string to clear the override.
+        #[arg(short, long)]
+        name: String,
+        /// Session id (falls back to $ROUX_SESSION_ID)
+        #[arg(short, long)]
+        session: Option<String>,
+    },
+    /// Archive (soft-kill) a session — kills its PTYs and moves it to history.
+    Kill {
+        /// Session id (falls back to $ROUX_SESSION_ID)
+        #[arg(short, long)]
+        session: Option<String>,
+    },
     /// Pane commands for a session
     Panes {
         #[command(subcommand)]
@@ -1501,10 +1531,12 @@ fn main() {
                 name,
                 working_dir,
                 worktree_branch,
+                from,
                 profile,
                 flags,
                 nono_profile,
                 nono_allow_dirs,
+                prompt,
             } => {
                 // Default working_dir to the current directory when the caller
                 // is not already inside a Roux session (which lets the backend
@@ -1525,6 +1557,9 @@ fn main() {
                 if let Some(b) = worktree_branch {
                     args.insert("worktree_branch".into(), Value::String(b));
                 }
+                if let Some(sp) = from {
+                    args.insert("start_point".into(), Value::String(sp));
+                }
                 if let Some(p) = profile {
                     args.insert("profile".into(), Value::String(p));
                 }
@@ -1543,6 +1578,9 @@ fn main() {
                         Value::Array(nono_allow_dirs.into_iter().map(Value::String).collect()),
                     );
                 }
+                if let Some(p) = prompt {
+                    args.insert("prompt".into(), Value::String(p));
+                }
                 run_socket_command(serde_json::json!({
                     "command": "session-create",
                     "session_id": get_session_id(),
@@ -1550,14 +1588,20 @@ fn main() {
                     "args": args,
                 }));
             }
-            SessionAction::Send { text, session, pane, no_enter } => {
+            SessionAction::Send { text, session, pane, pane_type, no_enter } => {
                 let (session_id, pane_id) =
                     resolve_target(session, pane, get_session_id(), get_pane_id());
+                let mut args = serde_json::json!({ "text": text, "enter": !no_enter });
+                if pane_id.is_none() {
+                    if let Some(pt) = pane_type {
+                        args["pane_type"] = serde_json::Value::String(pt);
+                    }
+                }
                 run_socket_command(serde_json::json!({
                     "command": "send",
                     "session_id": session_id,
                     "pane_id": pane_id,
-                    "args": { "text": text, "enter": !no_enter },
+                    "args": args,
                 }));
             }
             SessionAction::Poll { session } => {
@@ -1569,6 +1613,19 @@ fn main() {
             SessionAction::List => {
                 run_socket_command(serde_json::json!({
                     "command": "session-list",
+                }));
+            }
+            SessionAction::Rename { name, session } => {
+                run_socket_command(serde_json::json!({
+                    "command": "session-rename",
+                    "session_id": session.or_else(get_session_id),
+                    "args": { "name": name },
+                }));
+            }
+            SessionAction::Kill { session } => {
+                run_socket_command(serde_json::json!({
+                    "command": "session-kill",
+                    "session_id": session.or_else(get_session_id),
                 }));
             }
             SessionAction::Panes { action } => match action {
@@ -2114,20 +2171,132 @@ mod tests {
                     SessionAction::Create {
                         name,
                         worktree_branch,
+                        from,
                         profile,
                         flags,
                         nono_profile,
                         nono_allow_dirs,
                         working_dir,
+                        prompt,
                     },
             } => {
                 assert_eq!(name.as_deref(), Some("feat-x"));
                 assert_eq!(worktree_branch.as_deref(), Some("feat/x"));
+                assert!(from.is_none());
                 assert_eq!(profile.as_deref(), Some("claude"));
                 assert_eq!(flags, vec!["--debug", "--model=opus"]);
                 assert_eq!(nono_profile.as_deref(), Some("strict"));
                 assert_eq!(nono_allow_dirs, vec!["~/work", "/tmp"]);
                 assert!(working_dir.is_none());
+                assert!(prompt.is_none());
+            }
+            _ => panic!("expected Session::Create"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_session_kill() {
+        let cli = Cli::try_parse_from(["roux-cli", "session", "kill", "--session", "sid-1"])
+            .unwrap();
+        match cli.command {
+            Commands::Session { action: SessionAction::Kill { session } } => {
+                assert_eq!(session.as_deref(), Some("sid-1"));
+            }
+            _ => panic!("expected Session::Kill"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_session_send_with_pane_type() {
+        let cli = Cli::try_parse_from([
+            "roux-cli", "session", "send", "ls", "--session", "sid-1", "--pane-type", "shell",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Session {
+                action: SessionAction::Send { text, pane_type, pane, .. },
+            } => {
+                assert_eq!(text, "ls");
+                assert_eq!(pane_type.as_deref(), Some("shell"));
+                assert!(pane.is_none());
+            }
+            _ => panic!("expected Session::Send"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_session_create_with_prompt() {
+        let cli = Cli::try_parse_from([
+            "roux-cli",
+            "session",
+            "create",
+            "--working-dir",
+            "/tmp/repo",
+            "--prompt",
+            "fix the bug",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Session {
+                action: SessionAction::Create { working_dir, prompt, .. },
+            } => {
+                assert_eq!(working_dir.as_deref(), Some("/tmp/repo"));
+                assert_eq!(prompt.as_deref(), Some("fix the bug"));
+            }
+            _ => panic!("expected Session::Create"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_session_rename() {
+        let cli = Cli::try_parse_from([
+            "roux-cli",
+            "session",
+            "rename",
+            "--session",
+            "sid-1",
+            "--name",
+            "new name",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Session {
+                action: SessionAction::Rename { name, session },
+            } => {
+                assert_eq!(name, "new name");
+                assert_eq!(session.as_deref(), Some("sid-1"));
+            }
+            _ => panic!("expected Session::Rename"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_session_create_with_from() {
+        let cli = Cli::try_parse_from([
+            "roux-cli",
+            "session",
+            "create",
+            "--working-dir",
+            "/path/to/repo-b",
+            "--worktree-branch",
+            "feat/x",
+            "--from",
+            "origin/main",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Session {
+                action:
+                    SessionAction::Create {
+                        working_dir,
+                        worktree_branch,
+                        from,
+                        ..
+                    },
+            } => {
+                assert_eq!(working_dir.as_deref(), Some("/path/to/repo-b"));
+                assert_eq!(worktree_branch.as_deref(), Some("feat/x"));
+                assert_eq!(from.as_deref(), Some("origin/main"));
             }
             _ => panic!("expected Session::Create"),
         }

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -1589,10 +1589,15 @@ fn main() {
                 }));
             }
             SessionAction::Send { text, session, pane, pane_type, no_enter } => {
+                let explicit_pane = pane.is_some();
+                // When --pane-type is given without an explicit --pane, suppress the
+                // env-inherited $ROUX_PANE_ID so the server's pane-type resolver runs.
+                let env_pane =
+                    if pane_type.is_some() && !explicit_pane { None } else { get_pane_id() };
                 let (session_id, pane_id) =
-                    resolve_target(session, pane, get_session_id(), get_pane_id());
+                    resolve_target(session, pane, get_session_id(), env_pane);
                 let mut args = serde_json::json!({ "text": text, "enter": !no_enter });
-                if pane_id.is_none() {
+                if !explicit_pane {
                     if let Some(pt) = pane_type {
                         args["pane_type"] = serde_json::Value::String(pt);
                     }

--- a/src-tauri/src/commands/sessions.rs
+++ b/src-tauri/src/commands/sessions.rs
@@ -284,16 +284,14 @@ pub(crate) fn get_pty_cwd(id: String, state: tauri::State<AppState>) -> Option<S
     state.pty_manager.get_cwd(&id)
 }
 
-/// Archive a session (soft-delete). The frontend command name is retained
-/// for backward-compat, but the record is kept on disk and shown in the
-/// sessions-history pane until the user permanently deletes it.
-#[tauri::command]
-#[specta::specta]
-pub(crate) async fn kill_session(
-    id: String,
-    state: tauri::State<'_, AppState>,
+/// Archive a session (soft-delete) and run the surrounding hook +
+/// watch-cleanup work. Shared by the Tauri command and the CLI/socket
+/// handler so both code paths get identical lifecycle behavior.
+pub(crate) async fn archive_session_with_hooks(
+    state: &AppState,
+    id: &str,
 ) -> Result<(), String> {
-    let session = state.session_handle.get(&id).await.map_err(|e| e.to_string())?;
+    let session = state.session_handle.get(id).await.map_err(|e| e.to_string())?;
     if let Some(session) = session.as_ref() {
         let context = crate::automation_hooks::HookContext {
             repo_path: Some(session.repo_root.clone()),
@@ -313,12 +311,12 @@ pub(crate) async fn kill_session(
             .await
             .map_err(|e| e.to_string())?;
     }
-    svc::kill_session(&state.pty_manager, &state.session_handle, &id)
+    svc::kill_session(&state.pty_manager, &state.session_handle, id)
         .await
         .map_err(|e| e.to_string())?;
     // Stop session-scoped recurring watches (e.g. PR pollers) so they
     // don't outlive the archived session and keep firing forever.
-    state.watch_manager.remove_watches_for_session(&id).await;
+    state.watch_manager.remove_watches_for_session(id).await;
     if let Some(session) = session {
         let context = crate::automation_hooks::HookContext {
             repo_path: Some(session.repo_root.clone()),
@@ -337,6 +335,18 @@ pub(crate) async fn kill_session(
             .spawn_background(crate::automation_hooks::HookEvent::PostSessionClose, context);
     }
     Ok(())
+}
+
+/// Archive a session (soft-delete). The frontend command name is retained
+/// for backward-compat, but the record is kept on disk and shown in the
+/// sessions-history pane until the user permanently deletes it.
+#[tauri::command]
+#[specta::specta]
+pub(crate) async fn kill_session(
+    id: String,
+    state: tauri::State<'_, AppState>,
+) -> Result<(), String> {
+    archive_session_with_hooks(&state, &id).await
 }
 
 /// Bring an archived session back to the active list.

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -72,6 +72,10 @@ pub struct CreateSessionParams {
     pub name: Option<String>,
     pub working_dir: Option<String>,
     pub worktree_branch: Option<String>,
+    /// Git ref to branch a newly-created worktree from (e.g. "main",
+    /// "origin/main", "abc123"). Refs starting with "origin/" trigger a
+    /// `git fetch origin` first. Ignored when `worktree_branch` is not set.
+    pub start_point: Option<String>,
     pub profile: Option<String>,
     pub nono_profile: Option<String>,
     #[serde(default)]
@@ -387,7 +391,7 @@ impl RouxMcpServer {
     }
 
     #[tool(
-        description = "Create a Roux session. workingDir or an existing session context is required by Roux."
+        description = "Create a Roux session. workingDir or an existing session context is required by Roux. Use worktreeBranch + startPoint to spin a fresh worktree (e.g. startPoint=\"origin/main\")."
     )]
     async fn roux_create_session(
         &self,
@@ -1055,6 +1059,9 @@ fn build_create_session_request(params: CreateSessionParams) -> Value {
     }
     if let Some(worktree_branch) = params.worktree_branch {
         args.insert("worktree_branch".into(), Value::String(worktree_branch));
+    }
+    if let Some(start_point) = params.start_point {
+        args.insert("start_point".into(), Value::String(start_point));
     }
     if let Some(profile) = params.profile {
         args.insert("profile".into(), Value::String(profile));

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -80,6 +80,9 @@ pub struct CreateSessionParams {
     pub nono_profile: Option<String>,
     #[serde(default)]
     pub nono_allow_dirs: Vec<String>,
+    /// Text to send to the session's primary PTY immediately after it starts
+    /// (with a trailing Enter). CLI-equivalent: `--prompt`.
+    pub prompt: Option<String>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -1074,6 +1077,9 @@ fn build_create_session_request(params: CreateSessionParams) -> Value {
             "nono_allow_dirs".into(),
             Value::Array(params.nono_allow_dirs.into_iter().map(Value::String).collect()),
         );
+    }
+    if let Some(prompt) = params.prompt {
+        args.insert("prompt".into(), Value::String(prompt));
     }
     json!({ "command": "session-create", "args": args })
 }

--- a/src-tauri/src/pane_service.rs
+++ b/src-tauri/src/pane_service.rs
@@ -22,6 +22,7 @@ pub struct PaneDescriptor {
     pub nono_allow_dirs: Option<Vec<String>>,
     pub notes_scope: Option<String>,
     pub notes_view_mode: Option<String>,
+    pub session_id: Option<String>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
@@ -42,6 +43,7 @@ pub struct PaneRecord {
     pub nono_allow_dirs: Option<Vec<String>>,
     pub notes_scope: Option<String>,
     pub notes_view_mode: Option<String>,
+    pub session_id: Option<String>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
@@ -68,6 +70,7 @@ impl PaneRecord {
             nono_allow_dirs: self.nono_allow_dirs.clone(),
             notes_scope: self.notes_scope.clone(),
             notes_view_mode: self.notes_view_mode.clone(),
+            session_id: self.session_id.clone(),
         }
     }
 }
@@ -167,7 +170,14 @@ async fn service_loop(mut rx: mpsc::UnboundedReceiver<PaneMsg>) {
                 let prefix = format!("{}-", session_id);
                 let records = panes
                     .values()
-                    .filter(|r| r.id.starts_with(&prefix))
+                    .filter(|r| {
+                        // Prefer the explicit session_id field when present (populated by
+                        // the frontend for both socket-created and frontend-created panes);
+                        // fall back to the legacy id-prefix heuristic for older records
+                        // that predate this field.
+                        r.session_id.as_deref() == Some(&session_id)
+                            || (r.session_id.is_none() && r.id.starts_with(&prefix))
+                    })
                     .cloned()
                     .collect();
                 let _ = reply.send(records);
@@ -196,6 +206,7 @@ mod tests {
             nono_allow_dirs: None,
             notes_scope: None,
             notes_view_mode: None,
+            session_id: None,
         }
     }
 

--- a/src-tauri/src/pane_service.rs
+++ b/src-tauri/src/pane_service.rs
@@ -85,6 +85,10 @@ enum PaneMsg {
         ids: Vec<String>,
         reply: oneshot::Sender<Vec<PaneRecord>>,
     },
+    ListBySession {
+        session_id: String,
+        reply: oneshot::Sender<Vec<PaneRecord>>,
+    },
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -118,6 +122,19 @@ impl PaneHandle {
         self.send(PaneMsg::ListByIds { ids, reply: reply_tx })?;
         reply_rx.await.map_err(|_| ServiceError)
     }
+
+    /// Return all panes whose id starts with `{session_id}-`.
+    pub async fn list_by_session(
+        &self,
+        session_id: &str,
+    ) -> Result<Vec<PaneRecord>, ServiceError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.send(PaneMsg::ListBySession {
+            session_id: session_id.to_string(),
+            reply: reply_tx,
+        })?;
+        reply_rx.await.map_err(|_| ServiceError)
+    }
 }
 
 pub fn spawn() -> (PaneHandle, JoinHandle<()>) {
@@ -143,6 +160,15 @@ async fn service_loop(mut rx: mpsc::UnboundedReceiver<PaneMsg>) {
                 let records = ids
                     .into_iter()
                     .filter_map(|id| panes.get(&id).cloned())
+                    .collect();
+                let _ = reply.send(records);
+            }
+            PaneMsg::ListBySession { session_id, reply } => {
+                let prefix = format!("{}-", session_id);
+                let records = panes
+                    .values()
+                    .filter(|r| r.id.starts_with(&prefix))
+                    .cloned()
                     .collect();
                 let _ = reply.send(records);
             }

--- a/src-tauri/src/pane_state.rs
+++ b/src-tauri/src/pane_state.rs
@@ -765,6 +765,7 @@ mod tests {
             nono_allow_dirs: None,
             notes_scope: None,
             notes_view_mode: None,
+            session_id: None,
         }];
 
         save_live_to(
@@ -822,6 +823,7 @@ mod tests {
             nono_allow_dirs: None,
             notes_scope: None,
             notes_view_mode: None,
+            session_id: None,
         }];
 
         save_live_to(

--- a/src-tauri/src/socket.rs
+++ b/src-tauri/src/socket.rs
@@ -283,6 +283,8 @@ async fn handle_request(req: Request, app: &tauri::AppHandle) -> Response {
         "bus-subscriptions" => handle_bus_subscriptions(req, app).await,
         "session-list" => handle_session_list(req, app).await,
         "session-poll" => handle_session_poll(req, app).await,
+        "session-kill" => handle_session_kill(req, app).await,
+        "session-rename" => handle_session_rename(req, app).await,
         "session-panes-list" => handle_session_panes_list(req, app).await,
         "session-panes-create" => handle_session_panes_create(req, app).await,
         "mcp-enabled" => handle_mcp_enabled(app),
@@ -468,6 +470,61 @@ async fn handle_session_poll(req: Request, app: &tauri::AppHandle) -> Response {
         Ok(None) => Response::err("session not found"),
         Err(e) => Response::err(format!("{}", e)),
     }
+}
+
+async fn handle_session_rename(req: Request, app: &tauri::AppHandle) -> Response {
+    let session_id = match req.session_id.as_deref() {
+        Some(id) => id.to_string(),
+        None => return Response::err("session_id required (set $ROUX_SESSION_ID or pass --session)"),
+    };
+    let raw = match req.args.get("name").and_then(|n| n.as_str()) {
+        Some(n) => n.to_string(),
+        None => return Response::err("name required"),
+    };
+    // Empty / whitespace-only name clears the override (matches the
+    // GUI's clearSessionNameOverride path).
+    let name_override =
+        if raw.trim().is_empty() { None } else { Some(raw.trim().to_string()) };
+
+    let state: tauri::State<AppState> = app.state();
+    if let Err(e) = state.session_handle.set_name_override(&session_id, name_override.clone()).await
+    {
+        return Response::err(format!("{}", e));
+    }
+
+    use tauri::Emitter;
+    let cmd = roux_core::RouxCommand::new("session-renamed").session_id(&session_id);
+    if let Err(e) = app.emit("roux-command", &cmd) {
+        rlog!("Warning: failed to emit session-renamed event: {}", e);
+    }
+
+    Response::success(serde_json::json!({
+        "session_id": session_id,
+        "name_override": name_override,
+    }))
+}
+
+async fn handle_session_kill(req: Request, app: &tauri::AppHandle) -> Response {
+    let session_id = match req.session_id.as_deref() {
+        Some(id) => id.to_string(),
+        None => {
+            return Response::err(
+                "session_id required (set $ROUX_SESSION_ID or pass --session)",
+            )
+        }
+    };
+    let state: tauri::State<AppState> = app.state();
+    if let Err(e) =
+        crate::commands::sessions::archive_session_with_hooks(&state, &session_id).await
+    {
+        return Response::err(e);
+    }
+    use tauri::Emitter;
+    let cmd = roux_core::RouxCommand::new("session-killed").session_id(&session_id);
+    if let Err(e) = app.emit("roux-command", &cmd) {
+        rlog!("Warning: failed to emit session-killed event: {}", e);
+    }
+    Response::success(serde_json::json!({ "session_id": session_id }))
 }
 
 /// Register a pending-reply oneshot channel and return its request_id + receiver.
@@ -799,6 +856,9 @@ async fn handle_session_create(req: Request, app: &tauri::AppHandle) -> Response
     let working_dir = req.args.get("working_dir").and_then(|d| d.as_str()).map(|s| s.to_string());
     let worktree_branch =
         req.args.get("worktree_branch").and_then(|d| d.as_str()).map(|s| s.to_string());
+    let start_point =
+        req.args.get("start_point").and_then(|d| d.as_str()).map(|s| s.to_string());
+    let prompt = req.args.get("prompt").and_then(|d| d.as_str()).map(|s| s.to_string());
     let profile = req.args.get("profile").and_then(|p| p.as_str()).unwrap_or("claude").to_string();
     let flags: Vec<String> = req
         .args
@@ -814,13 +874,16 @@ async fn handle_session_create(req: Request, app: &tauri::AppHandle) -> Response
         .map(|a| a.iter().filter_map(|v| v.as_str().map(String::from)).collect())
         .unwrap_or_default();
 
-    // Resolve repo_path: use the requesting session's repo_root, or the working_dir
-    let repo_path = match req.session_id.as_deref() {
-        Some(id) => match handle.get(id).await {
+    // Resolve repo_path: explicit working_dir wins so a caller inside another
+    // session can target a different repo. Fall back to the caller session's
+    // repo_root only when working_dir is not provided.
+    let repo_path = match (working_dir.clone(), req.session_id.as_deref()) {
+        (Some(d), _) => d,
+        (None, Some(id)) => match handle.get(id).await {
             Ok(Some(session)) => session.repo_root.clone(),
-            _ => working_dir.clone().unwrap_or_default(),
+            _ => String::new(),
         },
-        None => working_dir.clone().unwrap_or_default(),
+        (None, None) => String::new(),
     };
 
     if repo_path.is_empty() {
@@ -835,8 +898,15 @@ async fn handle_session_create(req: Request, app: &tauri::AppHandle) -> Response
 
     // Build the session target. worktree_branch wins; else treat a distinct
     // working_dir as an existing worktree; else use the repo directly.
+    // For new worktrees, fetch first when the start_point references an
+    // origin ref so it resolves to an up-to-date commit.
     let target = if let Some(branch) = worktree_branch.as_deref() {
-        SessionTarget::NewWorktree { branch, start_point: None, fetch_first: false }
+        let fetch_first = start_point.as_deref().is_some_and(|sp| sp.starts_with("origin/"));
+        SessionTarget::NewWorktree {
+            branch,
+            start_point: start_point.as_deref(),
+            fetch_first,
+        }
     } else {
         match &working_dir {
             Some(dir) if dir != &repo_path => SessionTarget::ExistingWorktree { path: dir },
@@ -883,6 +953,16 @@ async fn handle_session_create(req: Request, app: &tauri::AppHandle) -> Response
     };
 
     let session_id = session.id.clone();
+
+    // Write the initial prompt to the primary PTY before notifying the
+    // frontend so the text is in the PTY buffer when the pane attaches.
+    if let Some(ref text) = prompt {
+        let mut bytes = text.as_bytes().to_vec();
+        bytes.push(b'\r');
+        if let Err(e) = state.pty_manager.write(&session_id, &bytes) {
+            rlog!("Warning: failed to write prompt to session {}: {}", session_id, e);
+        }
+    }
 
     use tauri::Emitter;
     let mut cmd = roux_core::RouxCommand::new("session-created").session_id(&session_id);
@@ -1139,11 +1219,16 @@ fn format_send_data(text: &str, enter: bool) -> String {
 /// when the caller passes a pane_id we have to look it up via the pane
 /// service rather than treating it as a pty_id directly. When no pane_id
 /// is given, fall back to the session's primary PTY.
+///
+/// `pane_type` is an optional filter: when set and `pane_id` is absent,
+/// resolves to the first registered pane of that type in the session
+/// (e.g. "shell" targets a non-agent shell pane).
 async fn resolve_send_pty_id(
     pane_handle: &crate::pane_service::PaneHandle,
     session_handle: &crate::session_service::SessionHandle,
     session_id: &str,
     pane_id: Option<&str>,
+    pane_type: Option<&str>,
 ) -> Result<String, String> {
     if let Some(pane_id) = pane_id {
         let records = pane_handle
@@ -1160,6 +1245,20 @@ async fn resolve_send_pty_id(
             return Err(format!("pane {} does not belong to session {}", pane_id, session_id));
         }
         return Ok(record.pty_id);
+    }
+
+    if let Some(pt) = pane_type {
+        let mut records = pane_handle
+            .list_by_session(session_id)
+            .await
+            .map_err(|e| format!("pane lookup failed: {}", e))?;
+        // Stable order: sort by id so repeated calls return the same pane.
+        records.sort_by(|a, b| a.id.cmp(&b.id));
+        return records
+            .into_iter()
+            .find(|r| r.pane_type == pt)
+            .map(|r| r.pty_id)
+            .ok_or_else(|| format!("no '{}' pane found in session {}", pt, session_id));
     }
 
     match session_handle.get(session_id).await {
@@ -1202,7 +1301,7 @@ async fn resolve_latest_output_pty_id(
     }
 
     if let Some(session_id) = session_id {
-        return resolve_send_pty_id(pane_handle, session_handle, session_id, None).await;
+        return resolve_send_pty_id(pane_handle, session_handle, session_id, None, None).await;
     }
 
     Err("session_id or pane_id required".to_string())
@@ -1286,9 +1385,16 @@ async fn prepare_send(
 
     let session_id = req.session_id.as_deref().ok_or_else(|| "session_id required".to_string())?;
 
+    let pane_type = req.args.get("pane_type").and_then(|v| v.as_str());
     let pty_id =
-        resolve_send_pty_id(pane_handle, session_handle, session_id, req.pane_id.as_deref())
-            .await?;
+        resolve_send_pty_id(
+            pane_handle,
+            session_handle,
+            session_id,
+            req.pane_id.as_deref(),
+            pane_type,
+        )
+        .await?;
 
     let cr = req.args.get("enter").and_then(|v| v.as_bool()).unwrap_or(true);
     let data = format_send_data(&text, cr).into_bytes();
@@ -2637,6 +2743,35 @@ mod tests {
         assert_eq!(req.args["nono_allow_dirs"].as_array().unwrap().len(), 2);
     }
 
+    #[test]
+    fn request_session_create_with_start_point_deserializes() {
+        let json = r#"{
+            "command": "session-create",
+            "args": {
+                "working_dir": "/path/to/repo-b",
+                "worktree_branch": "feat/x",
+                "start_point": "origin/main"
+            }
+        }"#;
+        let req: Request = serde_json::from_str(json).unwrap();
+        assert_eq!(req.args["working_dir"], "/path/to/repo-b");
+        assert_eq!(req.args["worktree_branch"], "feat/x");
+        assert_eq!(req.args["start_point"], "origin/main");
+    }
+
+    #[test]
+    fn request_session_rename_deserializes() {
+        let json = r#"{
+            "command": "session-rename",
+            "session_id": "sid-1",
+            "args": { "name": "renamed" }
+        }"#;
+        let req: Request = serde_json::from_str(json).unwrap();
+        assert_eq!(req.command, "session-rename");
+        assert_eq!(req.session_id.as_deref(), Some("sid-1"));
+        assert_eq!(req.args["name"], "renamed");
+    }
+
     // ── resolve_send_pty_id ──────────────────────────────────
 
     fn pane_record(id: &str, pty_id: &str) -> crate::pane_service::PaneRecord {
@@ -2694,7 +2829,7 @@ mod tests {
         panes.upsert(pane_record("sid-1-main", "sid-1")).await.unwrap();
 
         let pty_id =
-            resolve_send_pty_id(&panes, &sessions, "sid-1", Some("sid-1-main")).await.unwrap();
+            resolve_send_pty_id(&panes, &sessions, "sid-1", Some("sid-1-main"), None).await.unwrap();
         assert_eq!(pty_id, "sid-1");
     }
 
@@ -2709,7 +2844,7 @@ mod tests {
             dir.path().join("sessions.json"),
         );
 
-        let pty_id = resolve_send_pty_id(&panes, &sessions, "sid-1", None).await.unwrap();
+        let pty_id = resolve_send_pty_id(&panes, &sessions, "sid-1", None, None).await.unwrap();
         assert_eq!(pty_id, "sid-1");
     }
 
@@ -2727,7 +2862,7 @@ mod tests {
         );
 
         let err =
-            resolve_send_pty_id(&panes, &sessions, "sid-2", Some("sid-1-main")).await.unwrap_err();
+            resolve_send_pty_id(&panes, &sessions, "sid-2", Some("sid-1-main"), None).await.unwrap_err();
         assert!(err.contains("pane not found"), "got: {}", err);
     }
 
@@ -2748,7 +2883,7 @@ mod tests {
         panes.upsert(pane_record("sid-B-main", "sid-B")).await.unwrap();
 
         let err =
-            resolve_send_pty_id(&panes, &sessions, "sid-B", Some("sid-A-main")).await.unwrap_err();
+            resolve_send_pty_id(&panes, &sessions, "sid-B", Some("sid-A-main"), None).await.unwrap_err();
         assert!(err.contains("does not belong to session"), "got: {}", err);
     }
 
@@ -2759,7 +2894,7 @@ mod tests {
         let (sessions, _sjoin) =
             crate::session_service::spawn_with_path(vec![], dir.path().join("sessions.json"));
 
-        let err = resolve_send_pty_id(&panes, &sessions, "missing-sid", None).await.unwrap_err();
+        let err = resolve_send_pty_id(&panes, &sessions, "missing-sid", None, None).await.unwrap_err();
         assert!(err.contains("session not found"), "got: {}", err);
     }
 
@@ -2777,8 +2912,57 @@ mod tests {
             dir.path().join("sessions.json"),
         );
 
-        let pty_id = resolve_send_pty_id(&panes, &sessions, "sid-1", None).await.unwrap();
+        let pty_id = resolve_send_pty_id(&panes, &sessions, "sid-1", None, None).await.unwrap();
         assert_eq!(pty_id, "sid-1");
+    }
+
+    #[tokio::test]
+    async fn resolve_send_pty_id_pane_type_picks_first_matching_pane() {
+        let (panes, _pjoin) = crate::pane_service::spawn();
+        let dir = tempfile::tempdir().unwrap();
+        let (sessions, _sjoin) =
+            crate::session_service::spawn_with_path(vec![], dir.path().join("sessions.json"));
+        // Claude pane (the main PTY) + two shell panes.
+        let mut claude = pane_record("sid-1-main", "sid-1");
+        claude.pane_type = "claude".into();
+        let mut shell_a = pane_record("sid-1-leaf-a", "pty-shell-a");
+        shell_a.pane_type = "shell".into();
+        let mut shell_b = pane_record("sid-1-leaf-b", "pty-shell-b");
+        shell_b.pane_type = "shell".into();
+        panes.upsert(claude).await.unwrap();
+        panes.upsert(shell_a).await.unwrap();
+        panes.upsert(shell_b).await.unwrap();
+
+        // Asking for "shell" returns the lexically-first shell pane.
+        let pty_id =
+            resolve_send_pty_id(&panes, &sessions, "sid-1", None, Some("shell")).await.unwrap();
+        assert_eq!(pty_id, "pty-shell-a");
+
+        // Asking for a type with no match errors cleanly.
+        let err =
+            resolve_send_pty_id(&panes, &sessions, "sid-1", None, Some("command")).await.unwrap_err();
+        assert!(err.contains("no 'command' pane found"), "got: {}", err);
+    }
+
+    #[test]
+    fn request_session_kill_deserializes() {
+        let json =
+            r#"{"command": "session-kill", "session_id": "sid-1"}"#;
+        let req: Request = serde_json::from_str(json).unwrap();
+        assert_eq!(req.command, "session-kill");
+        assert_eq!(req.session_id.as_deref(), Some("sid-1"));
+    }
+
+    #[test]
+    fn request_send_with_pane_type_deserializes() {
+        let json = r#"{
+            "command": "send",
+            "session_id": "sid-1",
+            "args": { "text": "ls", "enter": true, "pane_type": "shell" }
+        }"#;
+        let req: Request = serde_json::from_str(json).unwrap();
+        assert_eq!(req.args["pane_type"], "shell");
+        assert_eq!(req.args["text"], "ls");
     }
 
     #[tokio::test]

--- a/src-tauri/src/socket.rs
+++ b/src-tauri/src/socket.rs
@@ -2790,6 +2790,7 @@ mod tests {
             nono_allow_dirs: None,
             notes_scope: None,
             notes_view_mode: None,
+            session_id: None,
         }
     }
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -34,7 +34,7 @@
   } from "$lib/stores/commandSurface";
   import { runStartupCheck, runManualCheck } from "$lib/stores/updater";
   import { initSettings, settings } from "$lib/stores/settings";
-  import { addSession, setActiveSession, sessionState, updateSessionStatus } from "$lib/stores/sessions";
+  import { addSession, removeSession, setActiveSession, sessionState, updateSessionStatus } from "$lib/stores/sessions";
   import { addOrUpdateWatch, watchState, ghAvailable as ghAvailableStore, flashSession } from "$lib/stores/watches";
   import { hydrateNotifications, applyNotificationEvent } from "$lib/stores/notifications";
   import {
@@ -717,6 +717,10 @@
           }
           break;
         }
+        case "session-killed": {
+          if (cmd.sessionId) removeSession(cmd.sessionId);
+          break;
+        }
         case "focus": {
           if (cmd.sessionId) {
             setActiveSession(cmd.sessionId);
@@ -724,6 +728,25 @@
           if (cmd.paneId) {
             setLogicalFocus(cmd.paneId);
           }
+          break;
+        }
+        case "session-renamed": {
+          // CLI / external renamed a session — pick up the new
+          // nameOverride from the authoritative backend state.
+          const sessionId = cmd.sessionId;
+          if (!sessionId) break;
+          listSessions().then((sessions) => {
+            const updated = sessions.find((s) => s.id === sessionId);
+            if (!updated) return;
+            sessionState.update((state) => ({
+              ...state,
+              sessions: state.sessions.map((s) =>
+                s.id === sessionId
+                  ? { ...s, nameOverride: updated.nameOverride, name: updated.name }
+                  : s,
+              ),
+            }));
+          }).catch((e) => logError("session-renamed: listSessions failed", e));
           break;
         }
         case "panes-list-request": {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -47,7 +47,7 @@
     startSubscriptionEventListenerWithCleanup,
   } from "$lib/stores/subscriptions";
   import { initPtyInventoryPolling } from "$lib/stores/ptyInventory";
-  import { initSessionWithProfile, splitPane } from "$lib/panes/actions";
+  import { initSessionWithProfile, splitPane, closeSessionPanes } from "$lib/panes/actions";
   import { hasSplitPanes } from "$lib/panes/layout";
   import { setLogicalFocus, focusedPaneId } from "$lib/panes/focus";
   import { getTerminalController } from "$lib/panes/terminalRuntime";
@@ -718,7 +718,10 @@
           break;
         }
         case "session-killed": {
-          if (cmd.sessionId) removeSession(cmd.sessionId);
+          if (cmd.sessionId) {
+            closeSessionPanes(cmd.sessionId);
+            removeSession(cmd.sessionId);
+          }
           break;
         }
         case "focus": {

--- a/src/lib/components/NewSessionDialog.svelte
+++ b/src/lib/components/NewSessionDialog.svelte
@@ -74,6 +74,11 @@
   let worktreePickOpen = $state(true);
   let worktreeActiveIndex = $state(0);
   let selectedWorktree = $state<Worktree | null>(null);
+  // Per-session override for the new-worktree start point. Empty = use the
+  // `worktreeDefaultBase` setting. Refs starting with "origin/" trigger
+  // `git fetch origin` before resolving the ref (matches the CLI / socket
+  // behavior).
+  let startPointInput = $state("");
   let error = $state("");
   let creating = $state(false);
   let rootRepoPaths = $state<string[]>([]);
@@ -730,6 +735,10 @@
    * and existing-worktree paths, so passing these unconditionally is safe).
    */
   function resolveDefaultBase(): { base: string | null; fetchFirst: boolean } {
+    const override = startPointInput.trim();
+    if (override) {
+      return { base: override, fetchFirst: override.startsWith("origin/") };
+    }
     switch ($settings.worktreeDefaultBase ?? "currentBranch") {
       case "main":
         return { base: "main", fetchFirst: false };
@@ -966,6 +975,7 @@
     worktreeFilterInput = "";
     worktreePickOpen = true;
     worktreeActiveIndex = 0;
+    startPointInput = "";
     onclose();
   }
 </script>
@@ -1188,6 +1198,23 @@
                   {/if}
                 </div>
               {/if}
+            </div>
+            <div class="flex flex-col gap-1">
+              <label
+                for="new-session-start-point"
+                class="text-[10px] font-semibold uppercase tracking-wider text-text-muted"
+              >
+                Start from <span class="font-normal normal-case text-text-muted/70">(optional)</span>
+              </label>
+              <input
+                id="new-session-start-point"
+                bind:value={startPointInput}
+                placeholder="e.g. origin/main, main, abc123"
+                class={pickerInputClass}
+              />
+              <p class="text-[10px] text-text-muted/80">
+                Only used when creating a new branch. <code>origin/</code> refs trigger a fetch first.
+              </p>
             </div>
           </fieldset>
         {/if}

--- a/src/lib/panes/actions.ts
+++ b/src/lib/panes/actions.ts
@@ -71,6 +71,7 @@ export function initSessionWithProfile(
       providerSessionId: extras?.providerSessionId,
       nonoProfile: extras?.nonoProfile,
       nonoAllowDirs: extras?.nonoAllowDirs,
+      sessionId,
     });
   }
   initSessionLayout(sessionId, mainPaneId);
@@ -83,7 +84,7 @@ export function splitPane(
   direction: SplitDirection,
   opts: CreatePaneOpts
 ): string | null {
-  const newPaneId = createPane(opts);
+  const newPaneId = createPane({ ...opts, sessionId: opts.sessionId ?? sessionId });
 
   let inserted = false;
   sessionLayouts.update((m) => {

--- a/src/lib/panes/instances.ts
+++ b/src/lib/panes/instances.ts
@@ -72,6 +72,10 @@ export interface PaneInstance {
   // Notes-pane state
   notesScope?: NotesScope;
   notesViewMode?: "edit" | "read";
+
+  // Session this pane belongs to — used by the backend's list_by_session
+  // query so --pane-type resolution works for panes with random UUIDs.
+  sessionId?: string;
 }
 
 export interface CreatePaneOpts {
@@ -89,6 +93,7 @@ export interface CreatePaneOpts {
   nonoAllowDirs?: string[];
   notesScope?: NotesScope;
   notesViewMode?: "edit" | "read";
+  sessionId?: string;
 }
 
 // ── Store ──────────────────────────────────────────────────
@@ -117,6 +122,7 @@ function toPaneRecord(instance: PaneInstance): PaneRecordPayload {
     nonoAllowDirs: instance.nonoAllowDirs,
     notesScope: instance.notesScope,
     notesViewMode: instance.notesViewMode,
+    sessionId: instance.sessionId,
   };
 }
 
@@ -153,7 +159,8 @@ function paneRecordChanged(before: PaneInstance, after: PaneInstance): boolean {
     before.nonoProfile !== after.nonoProfile ||
     before.notesScope !== after.notesScope ||
     before.notesViewMode !== after.notesViewMode ||
-    !stringArraysEqual(before.nonoAllowDirs, after.nonoAllowDirs)
+    !stringArraysEqual(before.nonoAllowDirs, after.nonoAllowDirs) ||
+    before.sessionId !== after.sessionId
   );
 }
 
@@ -199,6 +206,7 @@ export function createPane(opts: CreatePaneOpts): string {
     elapsedTimer: null,
     notesScope: opts.notesScope,
     notesViewMode: opts.notesViewMode,
+    sessionId: opts.sessionId,
   };
   paneInstances.update((map) => {
     const next = new Map(map);

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1323,6 +1323,7 @@ export interface PaneDescriptorPayload {
   nonoAllowDirs?: string[];
   notesScope?: NotesScope;
   notesViewMode?: "edit" | "read";
+  sessionId?: string;
 }
 
 export type PaneRecordPayload = PaneDescriptorPayload;


### PR DESCRIPTION
## Summary

- **Fixes #175** — `session create --worktree-branch` was ignoring `--working-dir` when called from inside another session; explicit `--working-dir` now always wins over the calling session's repo root.
- **`session kill [--session ID]`** — archive and tear down a session, running its PreSessionClose / PostSessionClose hooks. Delegates to the new `archive_session_with_hooks` helper extracted from the Tauri `kill_session` command.
- **`session rename --name NAME [--session ID]`** — set a display-name override for a session.
- **`session create --from <ref>`** — branch a new worktree from any git ref (e.g. `origin/main`, `abc1234`). Refs starting with `origin/` trigger an auto-fetch. Wired through CLI, MCP (`CreateSessionParams.startPoint`), and the GUI worktree picker (NewSessionDialog "Start from" input).
- **`session create --prompt <text>`** — send initial text to the session's primary PTY immediately after it starts (trailing Enter included). Avoids a separate `session send` call for automation.
- **`session send --pane-type <type>`** — target the first pane of a given type (`shell`, `claude`, etc.) in the session without needing an explicit pane ID. Backed by the new `PaneHandle::list_by_session` method (prefix filter on `{session_id}-`).

## Test plan

- [ ] `cargo test -p roux` — all Rust unit tests pass (497)
- [ ] `npm run test` — all Vitest tests pass (1030)
- [ ] `npm run check` — no Svelte type errors
- [ ] Manual: `session create --worktree-branch X --working-dir /path/to/repo` uses the supplied dir, not caller's cwd
- [ ] Manual: `session kill`, `session rename`, `session create --from origin/main`, `session create --prompt "ls"`, `session send --pane-type shell "echo hi"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `session rename` and `session kill` CLI subcommands for session management
  * Extended `session create` with `--from` flag to specify a git ref and `--prompt` to send initial text
  * Extended `session send` with `--pane-type` flag to target specific pane types
  * Added "Start from (optional)" field in session creation dialog for specifying git refs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phin-tech/roux/pull/176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds five new session management capabilities — `session kill`, `session rename`, `--from <ref>`, `--prompt <text>`, and `--pane-type <type>` — and fixes the `--working-dir` precedence bug (#175) so an explicit path always wins over the caller session's repo root. The previous review finding about `--pane-type` being silently discarded when `$ROUX_PANE_ID` was set in the environment is correctly addressed by suppressing `env_pane` when `pane_type` is requested without an explicit `--pane`.

- **`session kill` / `session rename`**: Both CLI and socket handlers are added, with `archive_session_with_hooks` correctly extracted as a shared helper so the Tauri command and the new socket path get identical lifecycle behaviour (hooks + watch cleanup). The frontend reacts to `session-killed` and `session-renamed` events.
- **`--from` / `--prompt`**: Both are wired through CLI, MCP (`CreateSessionParams`), and the socket `session-create` handler; the GUI gains a \"Start from\" field in `NewSessionDialog`. The `session_id` field is added to `PaneDescriptor`/`PaneRecord` as an `Option<String>` so `list_by_session` can resolve panes by type without relying solely on the `{session_id}-` ID-prefix heuristic for newly-created panes.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all new features are additive, the --working-dir fix is correct, and the --pane-type env-suppression fix from the previous review thread is properly implemented.

Changes are well-scoped: new CLI subcommands and flags, an extracted helper, and backward-compatible struct additions. The working-dir precedence fix is straightforward and well-tested. No data-loss or lifecycle-leak paths are introduced.

No files require special attention. The socket.rs prompt-write ordering and the cli.rs --from/--worktree-branch interaction are minor usability gaps, not correctness bugs.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src-tauri/src/cli.rs | Adds --from, --prompt, --pane-type args and Kill/Rename subcommands. The env-pane suppression fix for --pane-type is correct. New CLI tests cover all new flags. |
| src-tauri/src/commands/sessions.rs | Extracts archive_session_with_hooks as a pub(crate) helper shared by the Tauri command and the new socket handler; logic is unchanged from the original kill_session. |
| src-tauri/src/socket.rs | Adds session-kill and session-rename socket handlers; extends handle_session_create with start_point/prompt; fixes --working-dir precedence; adds pane_type routing in prepare_send. |
| src-tauri/src/pane_service.rs | Adds session_id Option<String> to PaneDescriptor/PaneRecord (backward-compatible) and list_by_session method that uses explicit session_id first, falling back to the id-prefix heuristic for legacy records. |
| src/App.svelte | Handles session-killed (close panes + remove session) and session-renamed (async listSessions refresh) events from the backend. |
| src/lib/components/NewSessionDialog.svelte | Adds startPointInput state and 'Start from' UI input; wires it into resolveDefaultBase(); resets on close. |
| src/lib/panes/actions.ts | Propagates sessionId through initSessionWithProfile and splitPane so backend list_by_session can identify panes without the id-prefix heuristic. |
| src/lib/panes/instances.ts | Adds sessionId to PaneInstance and CreatePaneOpts, includes it in toPaneRecord, and adds it to the change-detection predicate. |
| src/lib/tauri.ts | Adds sessionId?: string to PaneDescriptorPayload to match the backend struct addition. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI as roux CLI
    participant Sock as socket.rs
    participant Sess as session_svc
    participant PTY as pty_manager
    participant FE as Frontend (App.svelte)

    note over CLI,FE: session create --worktree-branch feat/x --from origin/main --prompt "ls"
    CLI->>Sock: "session-create {working_dir, worktree_branch, start_point, prompt}"
    Sock->>Sock: resolve repo_path (explicit working_dir wins)
    Sock->>Sess: "create_session_shell(NewWorktree{branch, start_point, fetch_first})"
    Sess-->>Sock: "session (id = session_id)"
    Sock->>PTY: write(session_id, "ls\r")
    Sock->>FE: emit(roux-command, session-created)

    note over CLI,FE: session send --pane-type shell "echo hi"
    CLI->>CLI: pane_type set, suppress $ROUX_PANE_ID
    CLI->>Sock: "send {session_id, pane_id:null, args:{pane_type:shell}}"
    Sock->>Sock: "resolve_send_pty_id(pane_id=None, pane_type=shell)"
    Sock->>Sock: "list_by_session -> find first shell pane"
    Sock->>PTY: write(shell_pty_id, "echo hi\r")

    note over CLI,FE: session kill --session sid-1
    CLI->>Sock: "session-kill {session_id:sid-1}"
    Sock->>Sess: archive_session_with_hooks (hooks + watch cleanup)
    Sock->>FE: emit(roux-command, session-killed)
    FE->>FE: closeSessionPanes + removeSession

    note over CLI,FE: session rename --name "new name" --session sid-1
    CLI->>Sock: "session-rename {session_id, args:{name:new name}}"
    Sock->>Sess: set_name_override
    Sock->>FE: emit(roux-command, session-renamed)
    FE->>FE: "listSessions() -> update sessionState"
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc-tauri%2Fsrc%2Fcli.rs%3A1560-1562%0AWhen%20%60--from%60%20is%20provided%20without%20%60--worktree-branch%60%2C%20the%20%60start_point%60%20arg%20is%20silently%20inserted%20into%20%60args%60%20and%20then%20ignored%20by%20the%20backend%20%28which%20only%20reads%20it%20inside%20the%20%60if%20let%20Some%28branch%29%20%3D%20worktree_branch%60%20branch%29.%20A%20user%20who%20types%20%60roux%20session%20create%20--from%20origin%2Fmain%60%20%28forgetting%20%60--worktree-branch%60%29%20gets%20no%20feedback%20that%20their%20%60--from%60%20was%20a%20no-op.%20Emitting%20a%20warning%20here%20keeps%20the%20help%20text's%20%22Ignored%20when%20--worktree-branch%20is%20not%20set%22%20visible%20at%20runtime.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20let%20Some%28sp%29%20%3D%20from%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20worktree_branch.is_none%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20eprintln!%28%22Warning%3A%20--from%20is%20ignored%20when%20--worktree-branch%20is%20not%20set%22%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20args.insert%28%22start_point%22.into%28%29%2C%20Value%3A%3AString%28sp%29%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc-tauri%2Fsrc%2Fsocket.rs%3A969-977%0A**Prompt%20written%20before%20PTY%20process%20is%20ready%20to%20accept%20input**%0A%0A%60pty_manager.write%60%20is%20called%20immediately%20after%20%60create_session_shell%60%20returns%2C%20before%20the%20spawned%20process%20%28e.g.%20Claude%20Code%29%20has%20necessarily%20started%20its%20read%20loop.%20The%20bytes%20land%20in%20the%20kernel%20PTY%20buffer%20and%20will%20be%20delivered%20correctly%20once%20the%20process%20reads%20%E2%80%94%20this%20is%20the%20expected%20behaviour.%20The%20one%20edge%20case%20to%20be%20aware%20of%3A%20if%20%60create_session_shell%60%20spawns%20the%20process%20asynchronously%20and%20the%20PTY%20write%20races%20with%20process%20startup%2C%20the%20%60rlog!%60%20warning%20is%20the%20only%20signal%20that%20the%20prompt%20was%20dropped.%20A%20dropped%20prompt%20has%20no%20retry%2C%20so%20users%20relying%20on%20%60--prompt%60%20for%20automation%20may%20see%20silent%20failures.%20Worth%20documenting%20this%20limitation%20in%20the%20%60--prompt%60%20help%20text%20or%20adding%20a%20caller-side%20check.%0A%0A&repo=phin-tech%2Froux&pr=176&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22feature%2Fsession-cli-improvements%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fsession-cli-improvements%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc-tauri%2Fsrc%2Fcli.rs%3A1560-1562%0AWhen%20%60--from%60%20is%20provided%20without%20%60--worktree-branch%60%2C%20the%20%60start_point%60%20arg%20is%20silently%20inserted%20into%20%60args%60%20and%20then%20ignored%20by%20the%20backend%20%28which%20only%20reads%20it%20inside%20the%20%60if%20let%20Some%28branch%29%20%3D%20worktree_branch%60%20branch%29.%20A%20user%20who%20types%20%60roux%20session%20create%20--from%20origin%2Fmain%60%20%28forgetting%20%60--worktree-branch%60%29%20gets%20no%20feedback%20that%20their%20%60--from%60%20was%20a%20no-op.%20Emitting%20a%20warning%20here%20keeps%20the%20help%20text's%20%22Ignored%20when%20--worktree-branch%20is%20not%20set%22%20visible%20at%20runtime.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20let%20Some%28sp%29%20%3D%20from%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20worktree_branch.is_none%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20eprintln!%28%22Warning%3A%20--from%20is%20ignored%20when%20--worktree-branch%20is%20not%20set%22%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20args.insert%28%22start_point%22.into%28%29%2C%20Value%3A%3AString%28sp%29%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc-tauri%2Fsrc%2Fsocket.rs%3A969-977%0A**Prompt%20written%20before%20PTY%20process%20is%20ready%20to%20accept%20input**%0A%0A%60pty_manager.write%60%20is%20called%20immediately%20after%20%60create_session_shell%60%20returns%2C%20before%20the%20spawned%20process%20%28e.g.%20Claude%20Code%29%20has%20necessarily%20started%20its%20read%20loop.%20The%20bytes%20land%20in%20the%20kernel%20PTY%20buffer%20and%20will%20be%20delivered%20correctly%20once%20the%20process%20reads%20%E2%80%94%20this%20is%20the%20expected%20behaviour.%20The%20one%20edge%20case%20to%20be%20aware%20of%3A%20if%20%60create_session_shell%60%20spawns%20the%20process%20asynchronously%20and%20the%20PTY%20write%20races%20with%20process%20startup%2C%20the%20%60rlog!%60%20warning%20is%20the%20only%20signal%20that%20the%20prompt%20was%20dropped.%20A%20dropped%20prompt%20has%20no%20retry%2C%20so%20users%20relying%20on%20%60--prompt%60%20for%20automation%20may%20see%20silent%20failures.%20Worth%20documenting%20this%20limitation%20in%20the%20%60--prompt%60%20help%20text%20or%20adding%20a%20caller-side%20check.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix: address PR review findings"](https://github.com/phin-tech/roux/commit/1151378e652e967a0322b1ffef13fc6632d1c79a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33148175)</sub>

<!-- /greptile_comment -->