### PR TITLE
[codex] extract terminal env helpers into runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4081,6 +4081,8 @@ dependencies = [
 name = "roux-runtime"
 version = "0.1.0"
 dependencies = [
+ "dirs",
+ "libc",
  "roux-core",
  "serde",
  "serde_json",

--- a/crates/roux-runtime/Cargo.toml
+++ b/crates/roux-runtime/Cargo.toml
@@ -13,6 +13,10 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "sync", "time"] }
+dirs = "6"
 
 [dev-dependencies]
 tempfile = "3"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"

--- a/crates/roux-runtime/src/lib.rs
+++ b/crates/roux-runtime/src/lib.rs
@@ -4,6 +4,8 @@
 //! current Tauri app and, later, by a standalone daemon.
 
 pub mod pane_service;
+pub mod process;
 pub mod project_service;
 pub mod pty_ready_gate;
 pub mod session_service;
+pub mod terminal_env;

--- a/crates/roux-runtime/src/process.rs
+++ b/crates/roux-runtime/src/process.rs
@@ -1,0 +1,88 @@
+/// Look up the current working directory of an OS process by PID.
+///
+/// Returns `None` if the PID does not exist, the caller lacks permission, or
+/// the OS refuses the lookup.
+#[cfg(target_os = "macos")]
+pub fn cwd_for_pid(pid: u32) -> Option<String> {
+    // proc_pidinfo(pid, PROC_PIDVNODEPATHINFO, 0, &mut info, sizeof(info))
+    // fills a proc_vnodepathinfo struct; its pvi_cdir.vip_path is the cwd as
+    // a NUL-terminated C string of length MAXPATHLEN (1024 on Darwin).
+    const MAXPATHLEN: usize = 1024;
+    const VNODE_INFO_SIZE: usize = 152;
+    const VNODE_INFO_PATH_SIZE: usize = VNODE_INFO_SIZE + MAXPATHLEN;
+    const PROC_PIDVNODEPATHINFO: libc::c_int = 9;
+
+    #[repr(C)]
+    struct ProcVnodePathInfo {
+        pvi_cdir: [u8; VNODE_INFO_PATH_SIZE],
+        pvi_rdir: [u8; VNODE_INFO_PATH_SIZE],
+    }
+
+    extern "C" {
+        fn proc_pidinfo(
+            pid: libc::c_int,
+            flavor: libc::c_int,
+            arg: u64,
+            buffer: *mut libc::c_void,
+            buffersize: libc::c_int,
+        ) -> libc::c_int;
+    }
+
+    let mut info = ProcVnodePathInfo {
+        pvi_cdir: [0u8; VNODE_INFO_PATH_SIZE],
+        pvi_rdir: [0u8; VNODE_INFO_PATH_SIZE],
+    };
+    let size = std::mem::size_of::<ProcVnodePathInfo>() as libc::c_int;
+
+    let ret = unsafe {
+        proc_pidinfo(
+            pid as libc::c_int,
+            PROC_PIDVNODEPATHINFO,
+            0,
+            &mut info as *mut _ as *mut libc::c_void,
+            size,
+        )
+    };
+    if ret <= 0 {
+        return None;
+    }
+
+    let path_bytes = &info.pvi_cdir[VNODE_INFO_SIZE..];
+    let nul = path_bytes.iter().position(|&b| b == 0).unwrap_or(path_bytes.len());
+    if nul == 0 {
+        return None;
+    }
+    std::str::from_utf8(&path_bytes[..nul]).ok().map(|s| s.to_string())
+}
+
+#[cfg(target_os = "linux")]
+pub fn cwd_for_pid(pid: u32) -> Option<String> {
+    std::fs::read_link(format!("/proc/{pid}/cwd")).ok().map(|p| p.to_string_lossy().into_owned())
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+pub fn cwd_for_pid(_pid: u32) -> Option<String> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cwd_for_pid_returns_current_process_cwd() {
+        let pid = std::process::id();
+        let cwd = cwd_for_pid(pid).expect("cwd_for_pid should resolve for self");
+        let expected = std::env::current_dir().expect("current_dir");
+        assert_eq!(
+            std::fs::canonicalize(&cwd).unwrap(),
+            std::fs::canonicalize(&expected).unwrap(),
+            "cwd_for_pid(self) should match std::env::current_dir()"
+        );
+    }
+
+    #[test]
+    fn cwd_for_pid_returns_none_for_nonexistent_pid() {
+        assert!(cwd_for_pid(0).is_none());
+    }
+}

--- a/crates/roux-runtime/src/terminal_env.rs
+++ b/crates/roux-runtime/src/terminal_env.rs
@@ -65,6 +65,17 @@ pub struct RouxEnvInputs<'a> {
     pub notes: Option<&'a NotesEnvInputs>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TerminalEnvWarning {
+    ProjectContextPathsJoinFailed { path_count: usize, error: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RouxEnvOutput {
+    pub pairs: Vec<(String, String)>,
+    pub warnings: Vec<TerminalEnvWarning>,
+}
+
 /// Build the PATH value to hand to a PTY child.
 pub fn build_pty_path(user_path: &str, roux_cli_bin_dir: Option<&str>) -> String {
     let Some(bin_dir) = roux_cli_bin_dir else {
@@ -85,6 +96,10 @@ pub fn build_pty_path(user_path: &str, roux_cli_bin_dir: Option<&str>) -> String
 }
 
 pub fn roux_env_pairs(inputs: RouxEnvInputs<'_>) -> Vec<(String, String)> {
+    roux_env_pairs_with_warnings(inputs).pairs
+}
+
+pub fn roux_env_pairs_with_warnings(inputs: RouxEnvInputs<'_>) -> RouxEnvOutput {
     let mut pairs: Vec<(String, String)> = vec![
         (
             "PATH".to_string(),
@@ -113,10 +128,11 @@ pub fn roux_env_pairs(inputs: RouxEnvInputs<'_>) -> Vec<(String, String)> {
     if let Some(wt) = inputs.worktree_path {
         pairs.push(("ROUX_WORKTREE_PATH".to_string(), wt.to_string()));
     }
+    let mut warnings = Vec::new();
     if let Some(n) = inputs.notes {
-        notes_env_pairs(n, &mut pairs);
+        warnings.extend(notes_env_pairs(n, &mut pairs));
     }
-    pairs
+    RouxEnvOutput { pairs, warnings }
 }
 
 /// True for env keys that are meaningful inside a smolvm guest.
@@ -133,7 +149,11 @@ pub fn is_guest_safe_env_key(key: &str) -> bool {
     )
 }
 
-pub fn notes_env_pairs(n: &NotesEnvInputs, pairs: &mut Vec<(String, String)>) {
+pub fn notes_env_pairs(
+    n: &NotesEnvInputs,
+    pairs: &mut Vec<(String, String)>,
+) -> Vec<TerminalEnvWarning> {
+    let mut warnings = Vec::new();
     let root = Path::new(&n.vault_root);
     let global_dir = root.join("global");
     let repo_dir = root.join("repos").join(&n.repo_slug);
@@ -170,16 +190,23 @@ pub fn notes_env_pairs(n: &NotesEnvInputs, pairs: &mut Vec<(String, String)>) {
     }
 
     if !n.context_paths.is_empty() {
-        if let Ok(joined) = std::env::join_paths(n.context_paths.iter().map(Path::new)) {
-            pairs.push((
-                "ROUX_PROJECT_CONTEXT_PATHS".to_string(),
-                joined.to_string_lossy().to_string(),
-            ));
+        match std::env::join_paths(n.context_paths.iter().map(Path::new)) {
+            Ok(joined) => {
+                pairs.push((
+                    "ROUX_PROJECT_CONTEXT_PATHS".to_string(),
+                    joined.to_string_lossy().to_string(),
+                ));
+            }
+            Err(e) => warnings.push(TerminalEnvWarning::ProjectContextPathsJoinFailed {
+                path_count: n.context_paths.len(),
+                error: e.to_string(),
+            }),
         }
     }
     if !n.project_prompt.is_empty() {
         pairs.push(("ROUX_PROJECT_PROMPT".to_string(), n.project_prompt.clone()));
     }
+    warnings
 }
 
 #[cfg(not(windows))]
@@ -274,6 +301,43 @@ mod tests {
         assert!(pairs.contains(&("ROUX_AGENT_ALIAS".to_string(), "agent-a".to_string())));
         assert!(pairs.contains(&("ROUX_PROJECT_PROMPT".to_string(), "Follow the spec".to_string())));
         assert!(pairs.iter().any(|(k, v)| k == "PATH" && v.starts_with("/roux/bin:")));
+    }
+
+    #[test]
+    fn roux_env_pairs_reports_invalid_context_paths() {
+        #[cfg(windows)]
+        let invalid_context_path = "bad;path".to_string();
+        #[cfg(not(windows))]
+        let invalid_context_path = "bad:path".to_string();
+
+        let notes = NotesEnvInputs {
+            vault_root: "/vault".to_string(),
+            session_slug: "session-a".to_string(),
+            repo_slug: "repo-a".to_string(),
+            project_slug: None,
+            context_paths: vec![invalid_context_path],
+            project_prompt: String::new(),
+        };
+
+        let output = roux_env_pairs_with_warnings(RouxEnvInputs {
+            user_path: "/usr/bin",
+            socket_path: "/tmp/roux.sock",
+            cli_shim: None,
+            session_id: None,
+            pane_id: None,
+            pane_alias: None,
+            project_id: None,
+            worktree_path: None,
+            notes: Some(&notes),
+        });
+
+        assert!(!output.pairs.iter().any(|(k, _)| k == "ROUX_PROJECT_CONTEXT_PATHS"));
+        assert_eq!(output.warnings.len(), 1);
+        assert!(matches!(
+            &output.warnings[0],
+            TerminalEnvWarning::ProjectContextPathsJoinFailed { path_count: 1, error }
+                if !error.is_empty()
+        ));
     }
 
     #[test]

--- a/crates/roux-runtime/src/terminal_env.rs
+++ b/crates/roux-runtime/src/terminal_env.rs
@@ -1,0 +1,358 @@
+use std::path::{Path, PathBuf};
+
+/// Nono sandbox configuration for a shell PTY. When present, the shell is
+/// spawned inside `nono run` with the given profile and directory allowances.
+#[derive(Debug, Clone)]
+pub struct NonoConfig {
+    pub profile: String,
+    pub allow_dirs: Vec<String>,
+}
+
+impl NonoConfig {
+    /// Resolve `~` to the user's home directory and relative paths against
+    /// `working_dir`. Nono receives arguments directly, so shell expansion is
+    /// not available at spawn time.
+    pub fn resolved_allow_dirs(&self, working_dir: &str) -> Vec<String> {
+        let home = dirs::home_dir();
+        self.allow_dirs
+            .iter()
+            .filter_map(|d| {
+                if d == "~" {
+                    home.as_ref().map(|h| h.to_string_lossy().into_owned())
+                } else if let Some(tail) = d.strip_prefix("~/") {
+                    home.as_ref().map(|h| h.join(tail).to_string_lossy().into_owned())
+                } else if Path::new(d).is_absolute() {
+                    Some(d.clone())
+                } else {
+                    Some(Path::new(working_dir).join(d).to_string_lossy().into_owned())
+                }
+            })
+            .collect()
+    }
+}
+
+/// Smolvm exec configuration for a shell PTY. When present, the shell is
+/// spawned inside `smolvm machine exec --name <machine_name> -it -- <guest_shell>`.
+#[derive(Debug, Clone)]
+pub struct SmolvmExec {
+    pub binary: PathBuf,
+    pub machine_name: String,
+    pub guest_shell: String,
+}
+
+/// Pre-computed inputs for the `ROUX_*_NOTES_*` env vars. Callers resolve
+/// slugs and project context before handing these values to terminal spawn.
+#[derive(Debug, Clone, Default)]
+pub struct NotesEnvInputs {
+    pub vault_root: String,
+    pub session_slug: String,
+    pub repo_slug: String,
+    pub project_slug: Option<String>,
+    pub context_paths: Vec<String>,
+    pub project_prompt: String,
+}
+
+pub struct RouxEnvInputs<'a> {
+    pub user_path: &'a str,
+    pub socket_path: &'a str,
+    /// `(bin-dir-to-prepend-to-PATH, absolute-roux-cli-path)`.
+    pub cli_shim: Option<(&'a str, &'a str)>,
+    pub session_id: Option<&'a str>,
+    pub pane_id: Option<&'a str>,
+    pub pane_alias: Option<&'a str>,
+    pub project_id: Option<&'a str>,
+    pub worktree_path: Option<&'a str>,
+    pub notes: Option<&'a NotesEnvInputs>,
+}
+
+/// Build the PATH value to hand to a PTY child.
+pub fn build_pty_path(user_path: &str, roux_cli_bin_dir: Option<&str>) -> String {
+    let Some(bin_dir) = roux_cli_bin_dir else {
+        return user_path.to_string();
+    };
+
+    let mut paths: Vec<_> = std::env::split_paths(user_path).collect();
+    let bin_dir_path = PathBuf::from(bin_dir);
+    if paths.iter().any(|path| path == &bin_dir_path) {
+        return user_path.to_string();
+    }
+
+    paths.insert(0, bin_dir_path);
+    std::env::join_paths(paths)
+        .ok()
+        .and_then(|value| value.into_string().ok())
+        .unwrap_or_else(|| user_path.to_string())
+}
+
+pub fn roux_env_pairs(inputs: RouxEnvInputs<'_>) -> Vec<(String, String)> {
+    let mut pairs: Vec<(String, String)> = vec![
+        (
+            "PATH".to_string(),
+            build_pty_path(inputs.user_path, inputs.cli_shim.map(|(bin_dir, _)| bin_dir)),
+        ),
+        ("TERM".to_string(), "xterm-256color".to_string()),
+        ("COLORTERM".to_string(), "truecolor".to_string()),
+        ("ROUX_SESSION".to_string(), "1".to_string()),
+        ("ROUX_SOCKET".to_string(), inputs.socket_path.to_string()),
+    ];
+    if let Some((_, cli_path)) = inputs.cli_shim {
+        pairs.push(("ROUX_CLI".to_string(), cli_path.to_string()));
+    }
+    if let Some(sid) = inputs.session_id {
+        pairs.push(("ROUX_SESSION_ID".to_string(), sid.to_string()));
+    }
+    if let Some(pid) = inputs.pane_id {
+        pairs.push(("ROUX_PANE_ID".to_string(), pid.to_string()));
+    }
+    if let Some(alias) = inputs.pane_alias {
+        pairs.push(("ROUX_AGENT_ALIAS".to_string(), alias.to_string()));
+    }
+    if let Some(pid) = inputs.project_id {
+        pairs.push(("ROUX_PROJECT_ID".to_string(), pid.to_string()));
+    }
+    if let Some(wt) = inputs.worktree_path {
+        pairs.push(("ROUX_WORKTREE_PATH".to_string(), wt.to_string()));
+    }
+    if let Some(n) = inputs.notes {
+        notes_env_pairs(n, &mut pairs);
+    }
+    pairs
+}
+
+/// True for env keys that are meaningful inside a smolvm guest.
+pub fn is_guest_safe_env_key(key: &str) -> bool {
+    matches!(
+        key,
+        "TERM"
+            | "COLORTERM"
+            | "ROUX_SESSION"
+            | "ROUX_SESSION_ID"
+            | "ROUX_PANE_ID"
+            | "ROUX_PROJECT_ID"
+            | "ROUX_AGENT_ALIAS"
+    )
+}
+
+pub fn notes_env_pairs(n: &NotesEnvInputs, pairs: &mut Vec<(String, String)>) {
+    let root = Path::new(&n.vault_root);
+    let global_dir = root.join("global");
+    let repo_dir = root.join("repos").join(&n.repo_slug);
+    let session_dir = root.join("sessions").join(&n.session_slug);
+
+    pairs.push(("ROUX_NOTES_ROOT".to_string(), root.to_string_lossy().to_string()));
+    pairs.push(("ROUX_GLOBAL_NOTES_DIR".to_string(), global_dir.to_string_lossy().to_string()));
+    pairs.push((
+        "ROUX_GLOBAL_NOTES_FILE".to_string(),
+        global_dir.join("notes.md").to_string_lossy().to_string(),
+    ));
+    pairs.push(("ROUX_REPO_SLUG".to_string(), n.repo_slug.clone()));
+    pairs.push(("ROUX_REPO_NOTES_DIR".to_string(), repo_dir.to_string_lossy().to_string()));
+    pairs.push((
+        "ROUX_REPO_NOTES_FILE".to_string(),
+        repo_dir.join("notes.md").to_string_lossy().to_string(),
+    ));
+    pairs.push(("ROUX_SESSION_DIR".to_string(), session_dir.to_string_lossy().to_string()));
+    pairs.push((
+        "ROUX_SESSION_NOTES_FILE".to_string(),
+        session_dir.join("notes.md").to_string_lossy().to_string(),
+    ));
+    if let Some(project_slug) = n.project_slug.as_deref() {
+        let project_dir = root.join("projects").join(project_slug);
+        pairs.push(("ROUX_SESSION_PROJECT".to_string(), project_slug.to_string()));
+        pairs.push((
+            "ROUX_SESSION_PROJECT_NOTES_DIR".to_string(),
+            project_dir.to_string_lossy().to_string(),
+        ));
+        pairs.push((
+            "ROUX_SESSION_PROJECT_NOTES_FILE".to_string(),
+            project_dir.join("notes.md").to_string_lossy().to_string(),
+        ));
+    }
+
+    if !n.context_paths.is_empty() {
+        if let Ok(joined) = std::env::join_paths(n.context_paths.iter().map(Path::new)) {
+            pairs.push((
+                "ROUX_PROJECT_CONTEXT_PATHS".to_string(),
+                joined.to_string_lossy().to_string(),
+            ));
+        }
+    }
+    if !n.project_prompt.is_empty() {
+        pairs.push(("ROUX_PROJECT_PROMPT".to_string(), n.project_prompt.clone()));
+    }
+}
+
+#[cfg(not(windows))]
+pub fn resolve_default_shell_from_sources(
+    setting_shell: Option<&str>,
+    login_shell: Option<&str>,
+    env_shell: Option<&str>,
+) -> String {
+    setting_shell
+        .and_then(nonempty_trimmed)
+        .or_else(|| login_shell.and_then(nonempty_trimmed))
+        .or_else(|| env_shell.and_then(nonempty_trimmed))
+        .unwrap_or("/bin/zsh")
+        .to_string()
+}
+
+pub fn nonempty_trimmed(value: &str) -> Option<&str> {
+    let trimmed = value.trim();
+    (!trimmed.is_empty()).then_some(trimmed)
+}
+
+#[cfg(unix)]
+pub fn login_shell_for_current_user() -> Option<String> {
+    let uid = unsafe { libc::getuid() };
+    let mut result: *mut libc::passwd = std::ptr::null_mut();
+    let mut buf_size = unsafe { libc::sysconf(libc::_SC_GETPW_R_SIZE_MAX) };
+    if buf_size < 1024 {
+        buf_size = 16 * 1024;
+    }
+    let mut buf = vec![0 as libc::c_char; buf_size as usize];
+
+    loop {
+        let mut passwd = std::mem::MaybeUninit::<libc::passwd>::zeroed();
+        let rc = unsafe {
+            libc::getpwuid_r(uid, passwd.as_mut_ptr(), buf.as_mut_ptr(), buf.len(), &mut result)
+        };
+        if rc == libc::ERANGE {
+            buf.resize(buf.len() * 2, 0);
+            continue;
+        }
+        if rc != 0 || result.is_null() {
+            return None;
+        }
+
+        let passwd = unsafe { passwd.assume_init() };
+        if passwd.pw_shell.is_null() {
+            return None;
+        }
+        let shell = unsafe { std::ffi::CStr::from_ptr(passwd.pw_shell) };
+        return shell.to_str().ok().and_then(nonempty_trimmed).map(str::to_string);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_pty_path_prepends_shim_once() {
+        let path = build_pty_path("/usr/bin:/bin", Some("/roux/bin"));
+        assert_eq!(path, "/roux/bin:/usr/bin:/bin");
+
+        let path = build_pty_path(&path, Some("/roux/bin"));
+        assert_eq!(path, "/roux/bin:/usr/bin:/bin");
+    }
+
+    #[test]
+    fn roux_env_pairs_includes_identity_socket_cli_and_notes() {
+        let notes = NotesEnvInputs {
+            vault_root: "/vault".to_string(),
+            session_slug: "session-a".to_string(),
+            repo_slug: "repo-a".to_string(),
+            project_slug: Some("project-a".to_string()),
+            context_paths: vec!["/specs/a.md".to_string(), "/specs/b.md".to_string()],
+            project_prompt: "Follow the spec".to_string(),
+        };
+
+        let pairs = roux_env_pairs(RouxEnvInputs {
+            user_path: "/usr/bin",
+            socket_path: "/tmp/roux.sock",
+            cli_shim: Some(("/roux/bin", "/roux/bin/roux-cli")),
+            session_id: Some("session-a"),
+            pane_id: Some("pane-a"),
+            pane_alias: Some("agent-a"),
+            project_id: Some("project-id"),
+            worktree_path: Some("/repo"),
+            notes: Some(&notes),
+        });
+
+        assert!(pairs.contains(&("ROUX_SOCKET".to_string(), "/tmp/roux.sock".to_string())));
+        assert!(pairs.contains(&("ROUX_CLI".to_string(), "/roux/bin/roux-cli".to_string())));
+        assert!(pairs.contains(&("ROUX_AGENT_ALIAS".to_string(), "agent-a".to_string())));
+        assert!(pairs.contains(&("ROUX_PROJECT_PROMPT".to_string(), "Follow the spec".to_string())));
+        assert!(pairs.iter().any(|(k, v)| k == "PATH" && v.starts_with("/roux/bin:")));
+    }
+
+    #[test]
+    fn guest_safe_env_excludes_host_paths() {
+        assert!(is_guest_safe_env_key("ROUX_SESSION_ID"));
+        assert!(is_guest_safe_env_key("ROUX_AGENT_ALIAS"));
+        assert!(!is_guest_safe_env_key("PATH"));
+        assert!(!is_guest_safe_env_key("ROUX_SOCKET"));
+        assert!(!is_guest_safe_env_key("ROUX_CLI"));
+        assert!(!is_guest_safe_env_key("ROUX_NOTES_ROOT"));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn default_shell_prefers_explicit_setting_over_login_shell_and_env() {
+        let shell = resolve_default_shell_from_sources(
+            Some(" /custom/fish "),
+            Some("/bin/zsh"),
+            Some("/bin/bash"),
+        );
+
+        assert_eq!(shell, "/custom/fish");
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn default_shell_prefers_login_shell_over_env_shell() {
+        let shell = resolve_default_shell_from_sources(
+            None,
+            Some("/opt/homebrew/bin/fish"),
+            Some("/bin/zsh"),
+        );
+
+        assert_eq!(shell, "/opt/homebrew/bin/fish");
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn default_shell_uses_env_shell_when_login_shell_is_unavailable() {
+        let shell = resolve_default_shell_from_sources(None, None, Some("/bin/bash"));
+
+        assert_eq!(shell, "/bin/bash");
+    }
+
+    #[test]
+    fn resolved_allow_dirs_expands_tilde() {
+        let nono = NonoConfig { profile: "test".into(), allow_dirs: vec!["~/data".into()] };
+        let resolved = nono.resolved_allow_dirs("/work");
+        assert!(resolved[0].starts_with('/'), "should be absolute: {}", resolved[0]);
+        assert!(resolved[0].ends_with("/data"), "should end with /data: {}", resolved[0]);
+        assert!(!resolved[0].contains('~'), "should not contain tilde: {}", resolved[0]);
+    }
+
+    #[test]
+    fn resolved_allow_dirs_resolves_relative() {
+        let nono = NonoConfig { profile: "test".into(), allow_dirs: vec!["local/dir".into()] };
+        let resolved = nono.resolved_allow_dirs("/work/project");
+        assert_eq!(resolved[0], "/work/project/local/dir");
+    }
+
+    #[test]
+    fn resolved_allow_dirs_passes_absolute_through() {
+        let nono = NonoConfig { profile: "test".into(), allow_dirs: vec!["/tmp/scratch".into()] };
+        let resolved = nono.resolved_allow_dirs("/work");
+        assert_eq!(resolved[0], "/tmp/scratch");
+    }
+
+    #[test]
+    fn resolved_allow_dirs_handles_bare_tilde() {
+        let nono = NonoConfig { profile: "test".into(), allow_dirs: vec!["~".into()] };
+        let resolved = nono.resolved_allow_dirs("/work");
+        let home = dirs::home_dir().unwrap();
+        assert_eq!(resolved[0], home.to_string_lossy());
+    }
+
+    #[test]
+    fn resolved_allow_dirs_handles_empty() {
+        let nono = NonoConfig { profile: "test".into(), allow_dirs: vec![] };
+        let resolved = nono.resolved_allow_dirs("/work");
+        assert!(resolved.is_empty());
+    }
+}

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -1714,15 +1714,6 @@ fn shell_binary_path_cache() -> &'static Mutex<Option<Option<String>>> {
     CACHE.get_or_init(|| Mutex::new(None))
 }
 
-#[cfg(not(windows))]
-fn resolve_default_shell_from_sources(
-    setting_shell: Option<&str>,
-    login_shell: Option<&str>,
-    env_shell: Option<&str>,
-) -> String {
-    terminal_env::resolve_default_shell_from_sources(setting_shell, login_shell, env_shell)
-}
-
 fn apply_shell_command_flags(cmd: &mut CommandBuilder, shell: &str) {
     #[cfg(windows)]
     {
@@ -1845,7 +1836,7 @@ mod tests {
     #[cfg(not(windows))]
     #[test]
     fn default_shell_prefers_explicit_setting_over_login_shell_and_env() {
-        let shell = resolve_default_shell_from_sources(
+        let shell = terminal_env::resolve_default_shell_from_sources(
             Some(" /custom/fish "),
             Some("/bin/zsh"),
             Some("/bin/bash"),
@@ -1857,7 +1848,7 @@ mod tests {
     #[cfg(not(windows))]
     #[test]
     fn default_shell_prefers_login_shell_over_env_shell() {
-        let shell = resolve_default_shell_from_sources(
+        let shell = terminal_env::resolve_default_shell_from_sources(
             None,
             Some("/opt/homebrew/bin/fish"),
             Some("/bin/zsh"),
@@ -1869,7 +1860,8 @@ mod tests {
     #[cfg(not(windows))]
     #[test]
     fn default_shell_uses_env_shell_when_login_shell_is_unavailable() {
-        let shell = resolve_default_shell_from_sources(None, None, Some("/bin/bash"));
+        let shell =
+            terminal_env::resolve_default_shell_from_sources(None, None, Some("/bin/bash"));
 
         assert_eq!(shell, "/bin/bash");
     }

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -1562,7 +1562,7 @@ fn roux_env_pairs(
     // `roux alias whoami`.
     let pane_alias = pane_id.and_then(lookup_pane_alias);
 
-    terminal_env::roux_env_pairs(terminal_env::RouxEnvInputs {
+    let output = terminal_env::roux_env_pairs_with_warnings(terminal_env::RouxEnvInputs {
         user_path,
         socket_path: &socket_path,
         cli_shim: cli_shim.as_ref().map(|(bin_dir, cli_path)| (bin_dir.as_str(), cli_path.as_str())),
@@ -1572,7 +1572,19 @@ fn roux_env_pairs(
         project_id,
         worktree_path,
         notes,
-    })
+    });
+    for warning in &output.warnings {
+        let terminal_env::TerminalEnvWarning::ProjectContextPathsJoinFailed {
+            path_count,
+            error,
+        } = warning;
+        rlog!(
+            "notes_env_pairs: failed to encode ROUX_PROJECT_CONTEXT_PATHS ({} paths): {}",
+            path_count,
+            error
+        );
+    }
+    output.pairs
 }
 
 /// True for env keys that are meaningful inside a smolvm guest. Host

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -1,7 +1,6 @@
 use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
 use std::collections::{HashMap, VecDeque};
 use std::io::Read;
-use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
@@ -17,6 +16,9 @@ use crate::platform;
 use crate::pty_ready_gate::ShellReadyGate;
 
 pub use roux_core::{PtyInfo, PtyRole, PtyStatus};
+pub use roux_runtime::process::cwd_for_pid;
+pub use roux_runtime::terminal_env::{NonoConfig, NotesEnvInputs, SmolvmExec};
+use roux_runtime::terminal_env;
 
 type PtyWriter = Arc<Mutex<Box<dyn std::io::Write + Send>>>;
 type ReadyGate = Arc<Mutex<ShellReadyGate>>;
@@ -533,144 +535,6 @@ pub enum PtyError {
         #[source]
         source: anyhow::Error,
     },
-}
-
-/// Look up the current working directory of an OS process by PID.
-///
-/// Used to report live cwd for shell panes at save time so reconnecting a
-/// session restores the user's actual directory (after `cd`s), not just the
-/// directory the shell was originally spawned in. The kernel tracks cwd on
-/// the shell process itself, so this pulls directly from OS-level process
-/// info — no shell integration or OSC 7 cooperation required.
-///
-/// Returns `None` if the PID doesn't exist, the caller lacks permission, or
-/// the OS refuses.
-#[cfg(target_os = "macos")]
-pub fn cwd_for_pid(pid: u32) -> Option<String> {
-    // proc_pidinfo(pid, PROC_PIDVNODEPATHINFO, 0, &mut info, sizeof(info))
-    // fills a proc_vnodepathinfo struct; its pvi_cdir.vip_path is the cwd as
-    // a NUL-terminated C string of length MAXPATHLEN (1024 on Darwin).
-    //
-    // We only need the cwd byte range, not the full struct layout, so we
-    // define a minimally-sufficient stand-in whose size matches the real
-    // struct. proc_vnodepathinfo is two vnode_info_path structs back-to-back;
-    // the first is pvi_cdir (what we want). Each vnode_info_path is
-    // sizeof(vnode_info) + MAXPATHLEN; vnode_info is 152 bytes on Darwin.
-    const MAXPATHLEN: usize = 1024;
-    const VNODE_INFO_SIZE: usize = 152;
-    const VNODE_INFO_PATH_SIZE: usize = VNODE_INFO_SIZE + MAXPATHLEN;
-    const PROC_PIDVNODEPATHINFO: libc::c_int = 9;
-
-    #[repr(C)]
-    struct ProcVnodePathInfo {
-        pvi_cdir: [u8; VNODE_INFO_PATH_SIZE],
-        pvi_rdir: [u8; VNODE_INFO_PATH_SIZE],
-    }
-
-    extern "C" {
-        fn proc_pidinfo(
-            pid: libc::c_int,
-            flavor: libc::c_int,
-            arg: u64,
-            buffer: *mut libc::c_void,
-            buffersize: libc::c_int,
-        ) -> libc::c_int;
-    }
-
-    let mut info = ProcVnodePathInfo {
-        pvi_cdir: [0u8; VNODE_INFO_PATH_SIZE],
-        pvi_rdir: [0u8; VNODE_INFO_PATH_SIZE],
-    };
-    let size = std::mem::size_of::<ProcVnodePathInfo>() as libc::c_int;
-
-    let ret = unsafe {
-        proc_pidinfo(
-            pid as libc::c_int,
-            PROC_PIDVNODEPATHINFO,
-            0,
-            &mut info as *mut _ as *mut libc::c_void,
-            size,
-        )
-    };
-    if ret <= 0 {
-        return None;
-    }
-
-    // vip_path starts at offset VNODE_INFO_SIZE within vnode_info_path and is
-    // a C string (MAXPATHLEN bytes, NUL-terminated).
-    let path_bytes = &info.pvi_cdir[VNODE_INFO_SIZE..];
-    let nul = path_bytes.iter().position(|&b| b == 0).unwrap_or(path_bytes.len());
-    if nul == 0 {
-        return None;
-    }
-    std::str::from_utf8(&path_bytes[..nul]).ok().map(|s| s.to_string())
-}
-
-#[cfg(target_os = "linux")]
-pub fn cwd_for_pid(pid: u32) -> Option<String> {
-    std::fs::read_link(format!("/proc/{}/cwd", pid)).ok().map(|p| p.to_string_lossy().into_owned())
-}
-
-#[cfg(not(any(target_os = "macos", target_os = "linux")))]
-pub fn cwd_for_pid(_pid: u32) -> Option<String> {
-    None
-}
-
-/// Nono sandbox configuration for a shell PTY. When present, the shell
-/// is spawned inside `nono run` with the given profile and directory
-/// allowances.
-#[derive(Debug, Clone)]
-pub struct NonoConfig {
-    pub profile: String,
-    pub allow_dirs: Vec<String>,
-}
-
-/// Smolvm exec configuration for a shell PTY. When present, the shell is
-/// spawned inside `smolvm machine exec --name <machine_name> -it -- <guest_shell>`
-/// instead of directly on the host. Mutually exclusive with `NonoConfig`
-/// — nono is host-side and doesn't exist inside a guest VM unless the
-/// image installs it; the spawn path silently skips nono when smolvm is
-/// set.
-#[derive(Debug, Clone)]
-pub struct SmolvmExec {
-    /// Resolved `smolvm` binary path, from
-    /// [`crate::services::smolvm::resolve_smolvm_binary`]. Owning this
-    /// (rather than re-resolving in the spawn path) means a smolvm
-    /// uninstall after the session was bound surfaces as a clean failure
-    /// at the caller, not a confusing "command not found" mid-spawn.
-    pub binary: PathBuf,
-    pub machine_name: String,
-    /// Guest shell path. v1 hardcodes `/bin/sh` at the call site;
-    /// future Smolfile-derived override will plug in here.
-    pub guest_shell: String,
-}
-
-impl NonoConfig {
-    /// Resolve `~` to the user's home directory and relative paths
-    /// against `working_dir`. Nono receives arguments via CommandBuilder
-    /// (no shell expansion), so tilde must be expanded here.
-    ///
-    /// Uses `Path::is_absolute()` for portability: on Windows this
-    /// correctly treats `C:\foo` as absolute. Falls back to silently
-    /// dropping `~`-prefixed entries when `HOME` is unavailable rather
-    /// than emitting a bogus `--allow-dir` with a relative path.
-    pub fn resolved_allow_dirs(&self, working_dir: &str) -> Vec<String> {
-        let home = dirs::home_dir();
-        self.allow_dirs
-            .iter()
-            .filter_map(|d| {
-                if d == "~" {
-                    home.as_ref().map(|h| h.to_string_lossy().into_owned())
-                } else if let Some(tail) = d.strip_prefix("~/") {
-                    home.as_ref().map(|h| h.join(tail).to_string_lossy().into_owned())
-                } else if std::path::Path::new(d).is_absolute() {
-                    Some(d.clone())
-                } else {
-                    Some(std::path::Path::new(working_dir).join(d).to_string_lossy().into_owned())
-                }
-            })
-            .collect()
-    }
 }
 
 pub struct PtyManager {
@@ -1655,28 +1519,6 @@ fn roux_cli_shim() -> Option<(String, String)> {
         .clone()
 }
 
-/// Build the PATH value to hand to a PTY child. Prepends the roux-cli shim
-/// directory (if available) to the user's login-shell PATH so scripts
-/// running inside any Roux pane can invoke `roux notify`, `roux-cli focus`,
-/// etc. without a separate install step.
-fn build_pty_path(user_path: &str) -> String {
-    let Some((bin_dir, _)) = roux_cli_shim() else {
-        return user_path.to_string();
-    };
-
-    let mut paths: Vec<_> = std::env::split_paths(user_path).collect();
-    let bin_dir_path = std::path::PathBuf::from(&bin_dir);
-    if paths.iter().any(|path| path == &bin_dir_path) {
-        return user_path.to_string();
-    }
-
-    paths.insert(0, bin_dir_path);
-    std::env::join_paths(paths)
-        .ok()
-        .and_then(|value| value.into_string().ok())
-        .unwrap_or_else(|| user_path.to_string())
-}
-
 /// Apply the common Roux env vars to a `CommandBuilder`: PATH with shim dir
 /// prepended, `ROUX_CLI` pointing at the absolute roux-cli path, and the
 /// standard `ROUX_*` markers. Called by every `spawn_*` method so the three
@@ -1686,29 +1528,6 @@ fn build_pty_path(user_path: &str) -> String {
 /// PTY hosts `ROUX_SESSION_ID` and `ROUX_PANE_ID` in its env unconditionally.
 /// Hooks and `roux notify` read them to route events back to the correct
 /// pane without cwd heuristics.
-/// Pre-computed inputs for the `ROUX_*_NOTES_*` env vars. Built by the
-/// session-creation layer (which has access to `NotesService` + settings)
-/// and threaded through the PTY spawn calls. Every string has already been
-/// resolved through `NotesService::resolve_target` so the slugs here are
-/// the same ones the Tauri commands and the frontend panel will see.
-#[derive(Debug, Clone, Default)]
-pub(crate) struct NotesEnvInputs {
-    pub(crate) vault_root: String,
-    pub(crate) session_slug: String,
-    pub(crate) repo_slug: String,
-    pub(crate) project_slug: Option<String>,
-    /// External docs/specs paths attached to this session's project.
-    /// Surfaced to the PTY child as `ROUX_PROJECT_CONTEXT_PATHS` (colon-
-    /// separated like `PATH`), and only when the session is associated
-    /// with a project that has at least one path configured.
-    pub(crate) context_paths: Vec<String>,
-    /// Free-form text exposed as `ROUX_PROJECT_PROMPT`. The frontend
-    /// profile runner additionally splices this into the agent CLI's
-    /// startup command (`--append-system-prompt` for Claude,
-    /// `-c instructions=…` for Codex). Empty string = unset.
-    pub(crate) project_prompt: String,
-}
-
 fn apply_roux_env(
     cmd: &mut CommandBuilder,
     user_path: &str,
@@ -1736,41 +1555,24 @@ fn roux_env_pairs(
     worktree_path: Option<&str>,
     notes: Option<&NotesEnvInputs>,
 ) -> Vec<(String, String)> {
-    let mut pairs: Vec<(String, String)> = vec![
-        ("PATH".to_string(), build_pty_path(user_path)),
-        ("TERM".to_string(), "xterm-256color".to_string()),
-        ("COLORTERM".to_string(), "truecolor".to_string()),
-        ("ROUX_SESSION".to_string(), "1".to_string()),
-        ("ROUX_SOCKET".to_string(), socket_path_str()),
-    ];
-    if let Some((_, cli_path)) = roux_cli_shim() {
-        pairs.push(("ROUX_CLI".to_string(), cli_path));
-    }
-    if let Some(sid) = session_id {
-        pairs.push(("ROUX_SESSION_ID".to_string(), sid.to_string()));
-    }
-    if let Some(pid) = pane_id {
-        pairs.push(("ROUX_PANE_ID".to_string(), pid.to_string()));
-        // Snapshot any alias bound to this pane at spawn time. The lookup
-        // hits the persisted `aliases.json` directly so we don't have to
-        // plumb `AliasManager` through the PtyManager. If the alias is
-        // auto-claimed AFTER spawn (pane rename / auto-claim from name),
-        // the env stays stale until the next respawn — agents should
-        // prefer `roux alias whoami` for live state.
-        if let Some(alias) = lookup_pane_alias(pid) {
-            pairs.push(("ROUX_AGENT_ALIAS".to_string(), alias));
-        }
-    }
-    if let Some(pid) = project_id {
-        pairs.push(("ROUX_PROJECT_ID".to_string(), pid.to_string()));
-    }
-    if let Some(wt) = worktree_path {
-        pairs.push(("ROUX_WORKTREE_PATH".to_string(), wt.to_string()));
-    }
-    if let Some(n) = notes {
-        notes_env_pairs(n, &mut pairs);
-    }
-    pairs
+    let socket_path = socket_path_str();
+    let cli_shim = roux_cli_shim();
+    // Snapshot any alias bound to this pane at spawn time. The lookup hits
+    // persisted `aliases.json`; live alias state remains available through
+    // `roux alias whoami`.
+    let pane_alias = pane_id.and_then(lookup_pane_alias);
+
+    terminal_env::roux_env_pairs(terminal_env::RouxEnvInputs {
+        user_path,
+        socket_path: &socket_path,
+        cli_shim: cli_shim.as_ref().map(|(bin_dir, cli_path)| (bin_dir.as_str(), cli_path.as_str())),
+        session_id,
+        pane_id,
+        pane_alias: pane_alias.as_deref(),
+        project_id,
+        worktree_path,
+        notes,
+    })
 }
 
 /// True for env keys that are meaningful inside a smolvm guest. Host
@@ -1779,16 +1581,7 @@ fn roux_env_pairs(
 /// locations. Forwarding them would mislead shell-rc scripts that test
 /// for them.
 fn is_guest_safe_env_key(key: &str) -> bool {
-    matches!(
-        key,
-        "TERM"
-            | "COLORTERM"
-            | "ROUX_SESSION"
-            | "ROUX_SESSION_ID"
-            | "ROUX_PANE_ID"
-            | "ROUX_PROJECT_ID"
-            | "ROUX_AGENT_ALIAS"
-    )
+    terminal_env::is_guest_safe_env_key(key)
 }
 
 /// Best-effort lookup: which alias is bound to `pane_id` right now?
@@ -1823,73 +1616,6 @@ fn ensure_machine_running(binary: &std::path::Path, name: &str) -> Result<(), St
     }
     rlog!("smol machine '{}' is '{}', auto-starting before exec", name, m.state);
     roux_smolvm::start_machine(binary, name).map_err(|e| e.to_string())
-}
-
-/// Collect notes-related env pairs for forwarding into a child process.
-/// Used by `roux_env_pairs` (host-side `cmd.env`) and the smolvm wrap
-/// (`-e KEY=VAL` flags). Project-context vars are deliberately omitted
-/// when their inputs are empty so shell idioms like
-/// `${ROUX_SESSION_PROJECT:-no-project}` keep working.
-fn notes_env_pairs(n: &NotesEnvInputs, pairs: &mut Vec<(String, String)>) {
-    use std::path::Path;
-    let root = Path::new(&n.vault_root);
-    let global_dir = root.join("global");
-    let repo_dir = root.join("repos").join(&n.repo_slug);
-    let session_dir = root.join("sessions").join(&n.session_slug);
-
-    pairs.push(("ROUX_NOTES_ROOT".to_string(), root.to_string_lossy().to_string()));
-    pairs.push((
-        "ROUX_GLOBAL_NOTES_DIR".to_string(),
-        global_dir.to_string_lossy().to_string(),
-    ));
-    pairs.push((
-        "ROUX_GLOBAL_NOTES_FILE".to_string(),
-        global_dir.join("notes.md").to_string_lossy().to_string(),
-    ));
-    pairs.push(("ROUX_REPO_SLUG".to_string(), n.repo_slug.clone()));
-    pairs.push(("ROUX_REPO_NOTES_DIR".to_string(), repo_dir.to_string_lossy().to_string()));
-    pairs.push((
-        "ROUX_REPO_NOTES_FILE".to_string(),
-        repo_dir.join("notes.md").to_string_lossy().to_string(),
-    ));
-    pairs.push(("ROUX_SESSION_DIR".to_string(), session_dir.to_string_lossy().to_string()));
-    pairs.push((
-        "ROUX_SESSION_NOTES_FILE".to_string(),
-        session_dir.join("notes.md").to_string_lossy().to_string(),
-    ));
-    if let Some(project_slug) = n.project_slug.as_deref() {
-        let project_dir = root.join("projects").join(project_slug);
-        pairs.push(("ROUX_SESSION_PROJECT".to_string(), project_slug.to_string()));
-        pairs.push((
-            "ROUX_SESSION_PROJECT_NOTES_DIR".to_string(),
-            project_dir.to_string_lossy().to_string(),
-        ));
-        pairs.push((
-            "ROUX_SESSION_PROJECT_NOTES_FILE".to_string(),
-            project_dir.join("notes.md").to_string_lossy().to_string(),
-        ));
-    }
-
-    if !n.context_paths.is_empty() {
-        match std::env::join_paths(n.context_paths.iter().map(std::path::Path::new)) {
-            Ok(joined) => {
-                pairs.push((
-                    "ROUX_PROJECT_CONTEXT_PATHS".to_string(),
-                    joined.to_string_lossy().to_string(),
-                ));
-            }
-            Err(e) => {
-                rlog!(
-                    "notes_env_pairs: failed to encode ROUX_PROJECT_CONTEXT_PATHS ({} paths): {}",
-                    n.context_paths.len(),
-                    e
-                );
-            }
-        }
-    }
-    if !n.project_prompt.is_empty() {
-        pairs.push(("ROUX_PROJECT_PROMPT".to_string(), n.project_prompt.clone()));
-    }
 }
 
 /// Get the user's login shell PATH by invoking the same shell Roux would use
@@ -1954,9 +1680,9 @@ fn resolve_default_shell() -> String {
 
     #[cfg(not(windows))]
     {
-        resolve_default_shell_from_sources(
+        terminal_env::resolve_default_shell_from_sources(
             shell_binary_path.as_deref(),
-            login_shell_for_current_user().as_deref(),
+            terminal_env::login_shell_for_current_user().as_deref(),
             std::env::var("SHELL").ok().as_deref(),
         )
     }
@@ -1964,7 +1690,8 @@ fn resolve_default_shell() -> String {
 
 pub(crate) fn set_shell_binary_path_override(path: Option<String>) {
     let cache = shell_binary_path_cache();
-    *cache.lock().unwrap() = Some(path.as_deref().and_then(nonempty_trimmed).map(str::to_string));
+    *cache.lock().unwrap() =
+        Some(path.as_deref().and_then(terminal_env::nonempty_trimmed).map(str::to_string));
 }
 
 fn shell_binary_path_override() -> Option<String> {
@@ -1975,7 +1702,7 @@ fn shell_binary_path_override() -> Option<String> {
             crate::settings::load_settings()
                 .shell_binary_path
                 .as_deref()
-                .and_then(nonempty_trimmed)
+                .and_then(terminal_env::nonempty_trimmed)
                 .map(str::to_string),
         );
     }
@@ -1993,49 +1720,7 @@ fn resolve_default_shell_from_sources(
     login_shell: Option<&str>,
     env_shell: Option<&str>,
 ) -> String {
-    setting_shell
-        .and_then(nonempty_trimmed)
-        .or_else(|| login_shell.and_then(nonempty_trimmed))
-        .or_else(|| env_shell.and_then(nonempty_trimmed))
-        .unwrap_or("/bin/zsh")
-        .to_string()
-}
-
-fn nonempty_trimmed(value: &str) -> Option<&str> {
-    let trimmed = value.trim();
-    (!trimmed.is_empty()).then_some(trimmed)
-}
-
-#[cfg(unix)]
-fn login_shell_for_current_user() -> Option<String> {
-    let uid = unsafe { libc::getuid() };
-    let mut result: *mut libc::passwd = std::ptr::null_mut();
-    let mut buf_size = unsafe { libc::sysconf(libc::_SC_GETPW_R_SIZE_MAX) };
-    if buf_size < 1024 {
-        buf_size = 16 * 1024;
-    }
-    let mut buf = vec![0 as libc::c_char; buf_size as usize];
-
-    loop {
-        let mut passwd = std::mem::MaybeUninit::<libc::passwd>::zeroed();
-        let rc = unsafe {
-            libc::getpwuid_r(uid, passwd.as_mut_ptr(), buf.as_mut_ptr(), buf.len(), &mut result)
-        };
-        if rc == libc::ERANGE {
-            buf.resize(buf.len() * 2, 0);
-            continue;
-        }
-        if rc != 0 || result.is_null() {
-            return None;
-        }
-
-        let passwd = unsafe { passwd.assume_init() };
-        if passwd.pw_shell.is_null() {
-            return None;
-        }
-        let shell = unsafe { std::ffi::CStr::from_ptr(passwd.pw_shell) };
-        return shell.to_str().ok().and_then(nonempty_trimmed).map(str::to_string);
-    }
+    terminal_env::resolve_default_shell_from_sources(setting_shell, login_shell, env_shell)
 }
 
 fn apply_shell_command_flags(cmd: &mut CommandBuilder, shell: &str) {


### PR DESCRIPTION
## Summary
- move PTY cwd lookup, terminal env construction, nono/smolvm config types, and notes env inputs into roux-runtime
- keep src-tauri/src/pty.rs as the Tauri adapter for socket paths, CLI shims, aliases, and CommandBuilder application
- add runtime tests for process cwd lookup, env-pair construction, guest-safe env filtering, shell selection, and nono allow-dir resolution

## Verification
- cargo test -p roux-runtime
- cargo clippy -p roux-runtime -- -D warnings
- CI=1 cargo check -p roux --lib
- git diff --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts PTY-related helpers — `cwd_for_pid`, terminal env construction, `NonoConfig`/`SmolvmExec`/`NotesEnvInputs` types, shell resolution, and guest-safe env filtering — from `src-tauri/src/pty.rs` into the platform-agnostic `roux-runtime` crate. The Tauri adapter in `pty.rs` is kept thin, delegating to `terminal_env::roux_env_pairs_with_warnings` and re-exporting the moved types via `pub use`.

- `crates/roux-runtime/src/process.rs` is a new module with platform-specific `cwd_for_pid` (macOS `proc_pidinfo` FFI, Linux `/proc/{pid}/cwd` symlink, no-op fallback) and a test suite covering self-PID and nonexistent-PID cases.
- `crates/roux-runtime/src/terminal_env.rs` is a new module with all env-pair construction logic; the previous silent drop of `join_paths` failures is replaced by `TerminalEnvWarning::ProjectContextPathsJoinFailed`, and `pty.rs` logs the warning via `rlog!`.
- `pty.rs` is reduced by ~350 lines to a thin Tauri adapter; the local `roux_env_pairs` wrapper correctly extracts socket path, CLI shim, and pane alias from global state before delegating.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all logic is a direct extraction with no behavioral changes; the one observable improvement is that join_paths failures now emit a logged warning instead of silently disappearing.

The moved code is a faithful copy of the originals in pty.rs: cwd_for_pid struct layout, env-pair construction, shell resolution, and guest-safe filtering are all bit-for-bit equivalent. The only deliberate behavioral change — surfacing join_paths failures as TerminalEnvWarning and logging them — is strictly better than the old silent drop. Tests cover the new public surface.

process.rs — the magic constant VNODE_INFO_SIZE=152 lost its Darwin-layout explanation and would benefit from a brief comment tying it to the Darwin proc_info.h struct.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/roux-runtime/src/process.rs | New file extracting cwd_for_pid from pty.rs. Functionally identical across macOS (proc_pidinfo FFI), Linux (/proc/pid/cwd symlink), and unsupported OS (None). Magic constants VNODE_INFO_SIZE=152 lost their Darwin-layout explanation from the original code. |
| crates/roux-runtime/src/terminal_env.rs | New file consolidating env-building helpers. The join_paths failure is now surfaced via TerminalEnvWarning (an improvement over the old silent drop). Shell resolution, guest-safe filtering, and nono allow-dir expansion are all behaviorally equivalent to pty.rs originals. |
| src-tauri/src/pty.rs | Tauri adapter correctly delegates to roux-runtime; local roux_env_pairs still extracts socket/cli/alias from global state and routes warnings to rlog!. The pane_alias logic (only resolved when pane_id is Some) is preserved via .and_then. |
| crates/roux-runtime/Cargo.toml | Adds dirs = "6" (unconditional) and libc = "0.2" (unix-only target dependency) needed by the new terminal_env and process modules. |
| crates/roux-runtime/src/lib.rs | Trivial: adds pub mod process and pub mod terminal_env to crate root. |
| Cargo.lock | Lock file updated to add dirs and libc to roux-runtime's dependency list, consistent with Cargo.toml changes. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["pty.rs\napply_roux_env()"] --> B["local roux_env_pairs()\n(collects socket, shim, alias\nfrom global state)"]
    B --> C["terminal_env::roux_env_pairs_with_warnings()\nRouxEnvInputs"]
    C --> D["build_pty_path()\nPrepend shim dir to PATH"]
    C --> E["notes_env_pairs()\nROUX_NOTES_* vars"]
    E --> F{join_paths ok?}
    F -- Ok --> G["ROUX_PROJECT_CONTEXT_PATHS set"]
    F -- Err --> H["TerminalEnvWarning\n::ProjectContextPathsJoinFailed"]
    H --> I["pty.rs: rlog! warning"]
    C --> J["RouxEnvOutput\n{pairs, warnings}"]
    B --> K["output.pairs → CommandBuilder"]
    L["resolve_default_shell()"] --> M["terminal_env::\nresolve_default_shell_from_sources()"]
    M --> N["terminal_env::\nlogin_shell_for_current_user()"]
    O["cwd_for_pid()"] --> P{OS?}
    P -- macOS --> Q["proc_pidinfo FFI"]
    P -- Linux --> R["/proc/pid/cwd symlink"]
    P -- other --> S["None"]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src-tauri/src/pty.rs`, line 1717-1724 ([link](https://github.com/phin-tech/roux/blob/4e812915b793682fb23b22f5a26e9ad48822aef1/src-tauri/src/pty.rs#L1717-L1724)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **Dead local wrapper `resolve_default_shell_from_sources`**

   `resolve_default_shell()` now calls `terminal_env::resolve_default_shell_from_sources` directly (line 1683), but this local wrapper was kept. Its only callers are the test helpers below it (lines 1848–1872); those could call `terminal_env::resolve_default_shell_from_sources` directly instead. As-is the wrapper adds an indirection that's easy to miss when the two functions diverge in the future.

   

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src-tauri%2Fsrc%2Fpty.rs%0ALine%3A%201717-1724%0A%0AComment%3A%0A**Dead%20local%20wrapper%20%60resolve_default_shell_from_sources%60**%0A%0A%60resolve_default_shell%28%29%60%20now%20calls%20%60terminal_env%3A%3Aresolve_default_shell_from_sources%60%20directly%20%28line%201683%29%2C%20but%20this%20local%20wrapper%20was%20kept.%20Its%20only%20callers%20are%20the%20test%20helpers%20below%20it%20%28lines%201848%E2%80%931872%29%3B%20those%20could%20call%20%60terminal_env%3A%3Aresolve_default_shell_from_sources%60%20directly%20instead.%20As-is%20the%20wrapper%20adds%20an%20indirection%20that's%20easy%20to%20miss%20when%20the%20two%20functions%20diverge%20in%20the%20future.%0A%0A%60%60%60suggestion%0A%2F%2F%20Local%20alias%20kept%20for%20the%20test%20helpers%20below%3B%20delegates%20to%20roux-runtime.%0A%23%5Bcfg%28not%28windows%29%29%5D%0Afn%20resolve_default_shell_from_sources%28%0A%20%20%20%20setting_shell%3A%20Option%3C%26str%3E%2C%0A%20%20%20%20login_shell%3A%20Option%3C%26str%3E%2C%0A%20%20%20%20env_shell%3A%20Option%3C%26str%3E%2C%0A%29%20-%3E%20String%20%7B%0A%20%20%20%20terminal_env%3A%3Aresolve_default_shell_from_sources%28setting_shell%2C%20login_shell%2C%20env_shell%29%0A%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=phin-tech%2Froux&pr=180&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22feature%2Fextract-terminal-runtime%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fextract-terminal-runtime%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src-tauri%2Fsrc%2Fpty.rs%0ALine%3A%201717-1724%0A%0AComment%3A%0A**Dead%20local%20wrapper%20%60resolve_default_shell_from_sources%60**%0A%0A%60resolve_default_shell%28%29%60%20now%20calls%20%60terminal_env%3A%3Aresolve_default_shell_from_sources%60%20directly%20%28line%201683%29%2C%20but%20this%20local%20wrapper%20was%20kept.%20Its%20only%20callers%20are%20the%20test%20helpers%20below%20it%20%28lines%201848%E2%80%931872%29%3B%20those%20could%20call%20%60terminal_env%3A%3Aresolve_default_shell_from_sources%60%20directly%20instead.%20As-is%20the%20wrapper%20adds%20an%20indirection%20that's%20easy%20to%20miss%20when%20the%20two%20functions%20diverge%20in%20the%20future.%0A%0A%60%60%60suggestion%0A%2F%2F%20Local%20alias%20kept%20for%20the%20test%20helpers%20below%3B%20delegates%20to%20roux-runtime.%0A%23%5Bcfg%28not%28windows%29%29%5D%0Afn%20resolve_default_shell_from_sources%28%0A%20%20%20%20setting_shell%3A%20Option%3C%26str%3E%2C%0A%20%20%20%20login_shell%3A%20Option%3C%26str%3E%2C%0A%20%20%20%20env_shell%3A%20Option%3C%26str%3E%2C%0A%29%20-%3E%20String%20%7B%0A%20%20%20%20terminal_env%3A%3Aresolve_default_shell_from_sources%28setting_shell%2C%20login_shell%2C%20env_shell%29%0A%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Froux-runtime%2Fsrc%2Fprocess.rs%3A57-60%0A**Magic%20constants%20lost%20their%20Darwin-layout%20explanation**%0A%0A%60VNODE_INFO_SIZE%20%3D%20152%60%20was%20derived%20from%20the%20real%20%60vnode_info%60%20struct%20in%20%60%3Csys%2Fproc_info.h%3E%60%2C%20and%20the%20original%20%60pty.rs%60%20had%20a%20detailed%20comment%20explaining%20that%20%60proc_vnodepathinfo%60%20is%20two%20%60vnode_info_path%60%20structs%20back-to-back%2C%20that%20each%20%60vnode_info_path%60%20is%20%60sizeof%28vnode_info%29%20%2B%20MAXPATHLEN%60%2C%20and%20that%20%60vnode_info%60%20is%20152%20bytes%20on%20Darwin.%20Without%20that%20comment%2C%20a%20future%20reader%20has%20no%20way%20to%20cross-check%20the%20constant%20or%20notice%20if%20it%20diverges%20from%20a%20future%20Darwin%20ABI%20change.%20The%20comment%20was%20the%20only%20documentation%20tying%20this%20to%20a%20verifiable%20source.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Froux-runtime%2Fsrc%2Fterminal_env.rs%3A179-182%0A**%60SmolvmExec%60%20field%20rationale%20stripped%20on%20move**%0A%0A%60SmolvmExec.binary%60%20and%20%60SmolvmExec.guest_shell%60%20had%20field-level%20doc-comments%20in%20%60pty.rs%60%20explaining%20the%20design%20intent%20%E2%80%94%20specifically%20that%20owning%20the%20resolved%20binary%20path%20%28rather%20than%20re-resolving%20it%20at%20spawn%20time%29%20surfaces%20a%20clean%20failure%20when%20%60smolvm%60%20is%20uninstalled%20after%20the%20session%20is%20bound%2C%20instead%20of%20a%20confusing%20%22command%20not%20found%22%20mid-spawn.%20The%20%60guest_shell%60%20comment%20noted%20that%20v1%20hardcodes%20%60%2Fbin%2Fsh%60%20and%20a%20future%20Smolfile-derived%20override%20will%20plug%20in%20here.%20Both%20rationales%20are%20useful%20for%20maintaining%20correctness%20when%20this%20struct%20evolves.%0A%0A&repo=phin-tech%2Froux&pr=180&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22feature%2Fextract-terminal-runtime%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fextract-terminal-runtime%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Froux-runtime%2Fsrc%2Fprocess.rs%3A57-60%0A**Magic%20constants%20lost%20their%20Darwin-layout%20explanation**%0A%0A%60VNODE_INFO_SIZE%20%3D%20152%60%20was%20derived%20from%20the%20real%20%60vnode_info%60%20struct%20in%20%60%3Csys%2Fproc_info.h%3E%60%2C%20and%20the%20original%20%60pty.rs%60%20had%20a%20detailed%20comment%20explaining%20that%20%60proc_vnodepathinfo%60%20is%20two%20%60vnode_info_path%60%20structs%20back-to-back%2C%20that%20each%20%60vnode_info_path%60%20is%20%60sizeof%28vnode_info%29%20%2B%20MAXPATHLEN%60%2C%20and%20that%20%60vnode_info%60%20is%20152%20bytes%20on%20Darwin.%20Without%20that%20comment%2C%20a%20future%20reader%20has%20no%20way%20to%20cross-check%20the%20constant%20or%20notice%20if%20it%20diverges%20from%20a%20future%20Darwin%20ABI%20change.%20The%20comment%20was%20the%20only%20documentation%20tying%20this%20to%20a%20verifiable%20source.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Froux-runtime%2Fsrc%2Fterminal_env.rs%3A179-182%0A**%60SmolvmExec%60%20field%20rationale%20stripped%20on%20move**%0A%0A%60SmolvmExec.binary%60%20and%20%60SmolvmExec.guest_shell%60%20had%20field-level%20doc-comments%20in%20%60pty.rs%60%20explaining%20the%20design%20intent%20%E2%80%94%20specifically%20that%20owning%20the%20resolved%20binary%20path%20%28rather%20than%20re-resolving%20it%20at%20spawn%20time%29%20surfaces%20a%20clean%20failure%20when%20%60smolvm%60%20is%20uninstalled%20after%20the%20session%20is%20bound%2C%20instead%20of%20a%20confusing%20%22command%20not%20found%22%20mid-spawn.%20The%20%60guest_shell%60%20comment%20noted%20that%20v1%20hardcodes%20%60%2Fbin%2Fsh%60%20and%20a%20future%20Smolfile-derived%20override%20will%20plug%20in%20here.%20Both%20rationales%20are%20useful%20for%20maintaining%20correctness%20when%20this%20struct%20evolves.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["preserve terminal env diagnostics"](https://github.com/phin-tech/roux/commit/4342ce8c8e955e6c902134fa054ecf5ff3833993) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33239686)</sub>

<!-- /greptile_comment -->