### PR TITLE
[codex] extract pty lifecycle contracts

### DIFF
--- a/crates/roux-runtime/src/lib.rs
+++ b/crates/roux-runtime/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod pane_service;
 pub mod process;
 pub mod project_service;
+pub mod pty_lifecycle;
 pub mod pty_ready_gate;
 pub mod session_service;
 pub mod terminal_env;

--- a/crates/roux-runtime/src/pty_lifecycle.rs
+++ b/crates/roux-runtime/src/pty_lifecycle.rs
@@ -1,0 +1,118 @@
+use std::sync::mpsc;
+
+/// Events that can occur during a PTY's lifecycle.
+#[derive(Debug, Clone, PartialEq)]
+#[allow(dead_code)] // Variants reserved for future detach tracking
+pub enum PtyLifecycleEvent {
+    /// PTY process exited.
+    Exited {
+        pty_id: String,
+        session_id: Option<String>,
+        code: Option<u32>,
+        reason: ExitReason,
+        generation: u64,
+    },
+    /// Output arrived while PTY was detached.
+    OutputWhileDetached { pty_id: String },
+    /// Bell (BEL character) arrived while PTY was detached.
+    BellWhileDetached { pty_id: String },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ExitReason {
+    Exit,
+    IoError,
+    Killed,
+}
+
+impl From<ExitReason> for roux_core::SessionExitReason {
+    fn from(r: ExitReason) -> Self {
+        match r {
+            ExitReason::Exit => roux_core::SessionExitReason::Exit,
+            ExitReason::IoError => roux_core::SessionExitReason::IoError,
+            ExitReason::Killed => roux_core::SessionExitReason::Killed,
+        }
+    }
+}
+
+/// Sender half of the lifecycle bus. Clone and pass to flusher threads.
+pub type LifecycleTx<Message> = mpsc::Sender<Message>;
+
+/// Receiver half of the lifecycle bus. Owned by the bus handler thread.
+pub type LifecycleRx<Message> = mpsc::Receiver<Message>;
+
+/// Create a new lifecycle bus channel pair.
+pub fn channel<Message>() -> (LifecycleTx<Message>, LifecycleRx<Message>) {
+    mpsc::channel()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exit_reason_converts_to_core_type() {
+        assert_eq!(
+            roux_core::SessionExitReason::from(ExitReason::Exit),
+            roux_core::SessionExitReason::Exit
+        );
+        assert_eq!(
+            roux_core::SessionExitReason::from(ExitReason::IoError),
+            roux_core::SessionExitReason::IoError
+        );
+        assert_eq!(
+            roux_core::SessionExitReason::from(ExitReason::Killed),
+            roux_core::SessionExitReason::Killed
+        );
+    }
+
+    #[test]
+    fn channel_can_send_and_receive_events() {
+        let (tx, rx) = channel::<PtyLifecycleEvent>();
+
+        tx.send(PtyLifecycleEvent::Exited {
+            pty_id: "pty-1".to_string(),
+            session_id: Some("session-1".to_string()),
+            code: Some(0),
+            reason: ExitReason::Exit,
+            generation: 1,
+        })
+        .unwrap();
+
+        tx.send(PtyLifecycleEvent::OutputWhileDetached { pty_id: "pty-2".to_string() })
+            .unwrap();
+
+        let evt1 = rx.recv().unwrap();
+        assert!(matches!(evt1, PtyLifecycleEvent::Exited { pty_id, .. } if pty_id == "pty-1"));
+
+        let evt2 = rx.recv().unwrap();
+        assert!(
+            matches!(evt2, PtyLifecycleEvent::OutputWhileDetached { pty_id } if pty_id == "pty-2")
+        );
+    }
+
+    #[test]
+    fn lifecycle_tx_is_clone() {
+        let (tx, rx) = channel::<PtyLifecycleEvent>();
+        let tx2 = tx.clone();
+
+        tx.send(PtyLifecycleEvent::BellWhileDetached { pty_id: "pty-1".to_string() })
+            .unwrap();
+
+        tx2.send(PtyLifecycleEvent::BellWhileDetached { pty_id: "pty-2".to_string() })
+            .unwrap();
+
+        drop(tx);
+        drop(tx2);
+
+        let mut ids = vec![];
+        while let Ok(evt) = rx.recv() {
+            if let PtyLifecycleEvent::BellWhileDetached { pty_id } = evt {
+                ids.push(pty_id);
+            }
+        }
+        assert_eq!(ids.len(), 2);
+        assert!(ids.contains(&"pty-1".to_string()));
+        assert!(ids.contains(&"pty-2".to_string()));
+    }
+}

--- a/src-tauri/src/pty_lifecycle.rs
+++ b/src-tauri/src/pty_lifecycle.rs
@@ -10,23 +10,7 @@
 use std::sync::{mpsc, Arc};
 use std::thread;
 
-/// Events that can occur during a PTY's lifecycle.
-#[derive(Debug, Clone, PartialEq)]
-#[allow(dead_code)] // Variants reserved for future detach tracking
-pub enum PtyLifecycleEvent {
-    /// PTY process exited.
-    Exited {
-        pty_id: String,
-        session_id: Option<String>,
-        code: Option<u32>,
-        reason: ExitReason,
-        generation: u64,
-    },
-    /// Output arrived while PTY was detached.
-    OutputWhileDetached { pty_id: String },
-    /// Bell (BEL character) arrived while PTY was detached.
-    BellWhileDetached { pty_id: String },
-}
+pub use roux_runtime::pty_lifecycle::{ExitReason, PtyLifecycleEvent};
 
 pub enum PtyLifecycleCommand {
     Register {
@@ -98,23 +82,6 @@ impl std::fmt::Debug for PtyLifecycleMessage {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum ExitReason {
-    Exit,
-    IoError,
-    Killed,
-}
-
-impl From<ExitReason> for roux_core::SessionExitReason {
-    fn from(r: ExitReason) -> Self {
-        match r {
-            ExitReason::Exit => roux_core::SessionExitReason::Exit,
-            ExitReason::IoError => roux_core::SessionExitReason::IoError,
-            ExitReason::Killed => roux_core::SessionExitReason::Killed,
-        }
-    }
-}
-
 /// Sender half of the lifecycle bus. Clone and pass to flusher threads.
 pub type LifecycleTx = mpsc::Sender<PtyLifecycleMessage>;
 
@@ -123,7 +90,7 @@ pub type LifecycleRx = mpsc::Receiver<PtyLifecycleMessage>;
 
 /// Create a new lifecycle bus channel pair.
 pub fn channel() -> (LifecycleTx, LifecycleRx) {
-    mpsc::channel()
+    roux_runtime::pty_lifecycle::channel()
 }
 
 /// Context needed by the lifecycle handler to dispatch events.
@@ -268,22 +235,6 @@ pub(crate) fn handle_command(pty_manager: &crate::pty::PtyManager, command: PtyL
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn exit_reason_converts_to_core_type() {
-        assert_eq!(
-            roux_core::SessionExitReason::from(ExitReason::Exit),
-            roux_core::SessionExitReason::Exit
-        );
-        assert_eq!(
-            roux_core::SessionExitReason::from(ExitReason::IoError),
-            roux_core::SessionExitReason::IoError
-        );
-        assert_eq!(
-            roux_core::SessionExitReason::from(ExitReason::Killed),
-            roux_core::SessionExitReason::Killed
-        );
-    }
 
     #[test]
     fn channel_can_send_and_receive_events() {


### PR DESCRIPTION
## Summary
- move pure PTY lifecycle event/reason/channel contracts into roux-runtime
- keep Tauri lifecycle commands and handler wiring in src-tauri because they still carry PtySession and AppHandle dependencies
- re-export runtime lifecycle types from the Tauri adapter so existing call sites stay stable

## Verification
- cargo test -p roux-runtime
- CI=1 cargo clippy -p roux --all-targets -- -D warnings
- git diff --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts the pure PTY lifecycle contracts (`PtyLifecycleEvent`, `ExitReason`, and a generic `channel()`) from `src-tauri` into the `roux-runtime` crate, then re-exports them from the Tauri adapter so existing call sites remain unchanged. Tauri-specific types (`PtyLifecycleCommand`, `PtyLifecycleMessage`, concrete `LifecycleTx`/`LifecycleRx`) are intentionally left in `src-tauri`.

- `crates/roux-runtime/src/pty_lifecycle.rs` is a new file providing the platform-agnostic event/reason types, a generic `channel<Message>()` factory, and the `From<ExitReason>` conversion — accompanied by three unit tests ported from the Tauri module.
- `src-tauri/src/pty_lifecycle.rs` drops the duplicate definitions and replaces them with `pub use roux_runtime::pty_lifecycle::{ExitReason, PtyLifecycleEvent}` and a concrete `channel()` that delegates to the runtime generic.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Clean extraction refactor with no behavioral changes; the only finding is a stale attribute and misleading comment carried over from the original private definition.

The refactor correctly moves the pure data types to roux-runtime and re-exports them from the Tauri adapter. The #[allow(dead_code)] on a public library enum is harmless but carries a misleading comment claiming the variants are unimplemented when they are actively matched in the Tauri handler.

crates/roux-runtime/src/pty_lifecycle.rs — stale #[allow(dead_code)] attribute and inaccurate comment on PtyLifecycleEvent.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/roux-runtime/src/pty_lifecycle.rs | New file extracting PtyLifecycleEvent, ExitReason, and a generic channel() into roux-runtime. Logic is correct; the #[allow(dead_code)] with misleading comment was carried over unnecessarily. |
| crates/roux-runtime/src/lib.rs | Adds pub mod pty_lifecycle to expose the new module. Trivial one-line change, no issues. |
| src-tauri/src/pty_lifecycle.rs | Replaces local PtyLifecycleEvent/ExitReason definitions with pub use re-exports from roux-runtime, and delegates channel() to the runtime generic. Tauri-specific types remain local as intended. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph roux-runtime
        PLE[PtyLifecycleEvent]
        ER[ExitReason]
        CH["channel<Message>()"]
        LTX["LifecycleTx<M>"]
        LRX["LifecycleRx<M>"]
    end

    subgraph src-tauri
        PLCT[PtyLifecycleCommand]
        PLCM[PtyLifecycleMessage]
        LTXC["LifecycleTx (concrete)"]
        LRXC["LifecycleRx (concrete)"]
        CHAN["channel() delegates to runtime"]
        HE[handle_event]
        HC[handle_command]
    end

    PLE -- "pub use re-export" --> src-tauri
    ER -- "pub use re-export" --> src-tauri
    CH --> CHAN
    PLCM --> LTXC
    PLCM --> LRXC
    PLCM -- "wraps" --> PLE
    HE -- "matches" --> PLE
    HC -- "dispatches" --> PLCT
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Froux-runtime%2Fsrc%2Fpty_lifecycle.rs%3A3-6%0AThe%20%60%23%5Ballow%28dead_code%29%5D%60%20attribute%20is%20unnecessary%20for%20a%20%60pub%60%20enum%20in%20a%20library%20crate%20%E2%80%94%20Rust%20does%20not%20emit%20%60dead_code%60%20warnings%20for%20public%20API%20items.%20Additionally%2C%20the%20comment%20%22Variants%20reserved%20for%20future%20detach%20tracking%22%20is%20inaccurate%3A%20%60OutputWhileDetached%60%20and%20%60BellWhileDetached%60%20are%20actively%20matched%20in%20%60src-tauri%2Fsrc%2Fpty_lifecycle.rs%3A%3Ahandle_event%60.%20The%20stale%20comment%20was%20carried%20over%20from%20the%20original%20private%20definition%20and%20should%20be%20removed%20or%20corrected%20now%20that%20these%20variants%20are%20part%20of%20the%20published%20contract.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20Events%20that%20can%20occur%20during%20a%20PTY's%20lifecycle.%0A%23%5Bderive%28Debug%2C%20Clone%2C%20PartialEq%29%5D%0Apub%20enum%20PtyLifecycleEvent%20%7B%0A%60%60%60%0A%0A&repo=phin-tech%2Froux&pr=181&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22feature%2Fextract-pty-lifecycle-contracts%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fextract-pty-lifecycle-contracts%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Froux-runtime%2Fsrc%2Fpty_lifecycle.rs%3A3-6%0AThe%20%60%23%5Ballow%28dead_code%29%5D%60%20attribute%20is%20unnecessary%20for%20a%20%60pub%60%20enum%20in%20a%20library%20crate%20%E2%80%94%20Rust%20does%20not%20emit%20%60dead_code%60%20warnings%20for%20public%20API%20items.%20Additionally%2C%20the%20comment%20%22Variants%20reserved%20for%20future%20detach%20tracking%22%20is%20inaccurate%3A%20%60OutputWhileDetached%60%20and%20%60BellWhileDetached%60%20are%20actively%20matched%20in%20%60src-tauri%2Fsrc%2Fpty_lifecycle.rs%3A%3Ahandle_event%60.%20The%20stale%20comment%20was%20carried%20over%20from%20the%20original%20private%20definition%20and%20should%20be%20removed%20or%20corrected%20now%20that%20these%20variants%20are%20part%20of%20the%20published%20contract.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20Events%20that%20can%20occur%20during%20a%20PTY's%20lifecycle.%0A%23%5Bderive%28Debug%2C%20Clone%2C%20PartialEq%29%5D%0Apub%20enum%20PtyLifecycleEvent%20%7B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["extract pty lifecycle contracts into run..."](https://github.com/phin-tech/roux/commit/96a7baeba7ae03915d7c9fcbfdf7a62a0c767ac2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33243164)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->