### PR TITLE
[codex] extract pty output backlog

### DIFF
--- a/crates/roux-runtime/src/lib.rs
+++ b/crates/roux-runtime/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pane_service;
 pub mod process;
 pub mod project_service;
 pub mod pty_lifecycle;
+pub mod pty_output;
 pub mod pty_ready_gate;
 pub mod session_service;
 pub mod terminal_env;

--- a/crates/roux-runtime/src/pty_output.rs
+++ b/crates/roux-runtime/src/pty_output.rs
@@ -1,0 +1,89 @@
+use std::collections::VecDeque;
+
+pub const PTY_BACKLOG_LIMIT_BYTES: usize = 256 * 1024;
+
+#[derive(Debug)]
+pub struct PtyOutputBacklog {
+    chunks: VecDeque<Vec<u8>>,
+    bytes: usize,
+    limit_bytes: usize,
+}
+
+impl PtyOutputBacklog {
+    pub fn new(limit_bytes: usize) -> Self {
+        Self { chunks: VecDeque::new(), bytes: 0, limit_bytes }
+    }
+
+    pub fn buffer(&mut self, bytes: Vec<u8>) {
+        self.bytes += bytes.len();
+        self.chunks.push_back(bytes);
+        while self.bytes > self.limit_bytes {
+            let Some(removed) = self.chunks.pop_front() else {
+                self.bytes = 0;
+                break;
+            };
+            self.bytes = self.bytes.saturating_sub(removed.len());
+        }
+    }
+
+    pub fn pop_front(&mut self) -> Option<Vec<u8>> {
+        let bytes = self.chunks.pop_front()?;
+        self.bytes = self.bytes.saturating_sub(bytes.len());
+        Some(bytes)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.chunks.is_empty()
+    }
+
+    pub fn len_bytes(&self) -> usize {
+        self.bytes
+    }
+}
+
+impl Default for PtyOutputBacklog {
+    fn default() -> Self {
+        Self::new(PTY_BACKLOG_LIMIT_BYTES)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn buffers_and_drains_in_order() {
+        let mut backlog = PtyOutputBacklog::new(1024);
+        backlog.buffer(vec![1, 2, 3]);
+        backlog.buffer(vec![4, 5, 6]);
+
+        assert_eq!(backlog.len_bytes(), 6);
+        assert_eq!(backlog.pop_front(), Some(vec![1, 2, 3]));
+        assert_eq!(backlog.pop_front(), Some(vec![4, 5, 6]));
+        assert_eq!(backlog.pop_front(), None);
+        assert!(backlog.is_empty());
+    }
+
+    #[test]
+    fn trims_oldest_chunks_when_limit_is_exceeded() {
+        let mut backlog = PtyOutputBacklog::new(10);
+        backlog.buffer(vec![1; 5]);
+        backlog.buffer(vec![2; 5]);
+        backlog.buffer(vec![3; 5]);
+
+        assert_eq!(backlog.len_bytes(), 10);
+        assert_eq!(backlog.pop_front(), Some(vec![2; 5]));
+        assert_eq!(backlog.pop_front(), Some(vec![3; 5]));
+        assert_eq!(backlog.pop_front(), None);
+    }
+
+    #[test]
+    fn oversized_single_chunk_drops_backlog_to_preserve_limit() {
+        let mut backlog = PtyOutputBacklog::new(4);
+        backlog.buffer(vec![1, 2]);
+        backlog.buffer(vec![3, 4, 5, 6, 7]);
+
+        assert_eq!(backlog.len_bytes(), 0);
+        assert_eq!(backlog.pop_front(), None);
+    }
+}

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -1,5 +1,5 @@
 use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
-use std::collections::{HashMap, VecDeque};
+use std::collections::HashMap;
 use std::io::Read;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc;
@@ -17,6 +17,9 @@ use crate::pty_ready_gate::ShellReadyGate;
 
 pub use roux_core::{PtyInfo, PtyRole, PtyStatus};
 pub use roux_runtime::process::cwd_for_pid;
+use roux_runtime::pty_output::PtyOutputBacklog;
+#[cfg(test)]
+pub use roux_runtime::pty_output::PTY_BACKLOG_LIMIT_BYTES;
 pub use roux_runtime::terminal_env::{NonoConfig, NotesEnvInputs, SmolvmExec};
 use roux_runtime::terminal_env;
 
@@ -91,39 +94,28 @@ enum PtyChunk {
     Error,
 }
 
-const PTY_BACKLOG_LIMIT_BYTES: usize = 256 * 1024;
-
 struct PtyOutputState {
     channel: Option<Channel<Response>>,
-    backlog: VecDeque<Vec<u8>>,
-    backlog_bytes: usize,
+    backlog: PtyOutputBacklog,
     logger: Option<Arc<Mutex<crate::pty_logger::PtyLogger>>>,
 }
 
 impl PtyOutputState {
     #[cfg(test)]
     fn new() -> Self {
-        Self { channel: None, backlog: VecDeque::new(), backlog_bytes: 0, logger: None }
+        Self { channel: None, backlog: PtyOutputBacklog::default(), logger: None }
     }
 
     fn new_with_logger(logger: Arc<Mutex<crate::pty_logger::PtyLogger>>) -> Self {
         Self {
             channel: None,
-            backlog: VecDeque::new(),
-            backlog_bytes: 0,
+            backlog: PtyOutputBacklog::default(),
             logger: Some(logger),
         }
     }
 
     fn buffer(&mut self, bytes: Vec<u8>) {
-        self.backlog_bytes += bytes.len();
-        self.backlog.push_back(bytes);
-        while self.backlog_bytes > PTY_BACKLOG_LIMIT_BYTES {
-            let Some(removed) = self.backlog.pop_front() else {
-                break;
-            };
-            self.backlog_bytes = self.backlog_bytes.saturating_sub(removed.len());
-        }
+        self.backlog.buffer(bytes);
     }
 
     fn send_or_buffer(&mut self, bytes: Vec<u8>) {
@@ -145,7 +137,6 @@ impl PtyOutputState {
     fn attach(&mut self, channel: Channel<Response>) {
         self.channel = Some(channel);
         while let Some(bytes) = self.backlog.pop_front() {
-            self.backlog_bytes = self.backlog_bytes.saturating_sub(bytes.len());
             let Some(channel) = &self.channel else {
                 self.buffer(bytes);
                 break;


### PR DESCRIPTION
## Summary
- move PTY output backlog queue and byte-limit trimming into roux-runtime
- keep Tauri Channel<Response> delivery and PTY logging in src-tauri/src/pty.rs
- add runtime tests for backlog ordering, trimming, and oversized chunks

## Verification
- cargo test -p roux-runtime
- cargo test -p roux-runtime pty_output
- CI=1 cargo clippy -p roux --all-targets -- -D warnings
- git diff --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts the PTY output backlog (previously an inline `VecDeque` + `backlog_bytes` counter in `src-tauri/src/pty.rs`) into a dedicated `PtyOutputBacklog` type in `roux-runtime`, keeping Tauri channel delivery and PTY logging in `pty.rs`.

- `crates/roux-runtime/src/pty_output.rs` introduces `PtyOutputBacklog` with `buffer`/`pop_front`/`is_empty`/`len_bytes` methods and a `256 KB` default limit, plus three unit tests covering ordering, oldest-chunk trimming, and oversized-chunk behaviour.
- `src-tauri/src/pty.rs` replaces the two raw backlog fields with `PtyOutputBacklog`, removes the now-redundant byte-count decrement from the `attach` drain loop, and re-exports `PTY_BACKLOG_LIMIT_BYTES` under `#[cfg(test)]` for the existing integration-level test.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The refactor is a clean extraction with behaviour-preserving tests; the two observations are both edge-case issues that existed before this change.

The trimming logic and byte accounting are correct and well-tested. The two flagged points — silent data loss for chunks larger than the limit, and the re-buffer ordering on attach failure — are both pre-existing behaviours that this PR faithfully preserves rather than introduces. No new regressions are apparent in normal operation.

crates/roux-runtime/src/pty_output.rs (oversized-chunk drop, no diagnostic); src-tauri/src/pty.rs (attach re-buffer ordering)
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/roux-runtime/src/pty_output.rs | New PtyOutputBacklog type with VecDeque-based chunk queue, byte-limit trimming, and three unit tests covering order, trim, and oversized-chunk scenarios. The oversized-chunk behaviour (entire backlog dropped silently) is tested but has no diagnostic logging. |
| src-tauri/src/pty.rs | Replaces inline VecDeque + backlog_bytes fields with PtyOutputBacklog; removes redundant byte-count line from attach drain loop. Re-exports PTY_BACKLOG_LIMIT_BYTES under #[cfg(test)]. Re-buffer ordering on attach failure is a pre-existing issue preserved by the refactor. |
| crates/roux-runtime/src/lib.rs | Single-line module registration for the new pty_output module; no issues. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    PTY[PTY reader thread] -->|PtyChunk::Data| FLUSH[spawn_flusher]
    FLUSH -->|output.send| STATE[PtyOutputState]
    STATE -->|channel present| TAURI[Tauri Channel<Response>]
    STATE -->|no channel| BACKLOG[PtyOutputBacklog\ncrates/roux-runtime]
    BACKLOG -->|push_back| QUEUE[(VecDeque<Vec<u8>>)]
    BACKLOG -->|trim loop: while bytes > limit_bytes| TRIM[pop_front & discard oldest]
    ATTACH[attach call] -->|drain| BACKLOG
    ATTACH -->|send each chunk| TAURI
    ATTACH -->|send failure -> buffer back| BACKLOG
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src-tauri/src/pty.rs`, line 137-150 ([link](https://github.com/phin-tech/roux/blob/db7341c9ce2e616d2c34f232bb391e5a4e5d3e2e/src-tauri/src/pty.rs#L137-L150)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **Re-buffered chunk appended to back, breaking drain order on send failure**

   When `channel.send` fails mid-drain, `self.buffer(bytes)` calls `PtyOutputBacklog::buffer` which uses `push_back`. Any items still sitting at the front of the queue (not yet drained) will therefore be delivered before the re-buffered failed chunk on the next attach, inverting chronological order for the tail of the backlog. This behaviour pre-dated the extraction but now that `PtyOutputBacklog` is a dedicated type it would be natural to add a `push_front` / `prepend` method and use it here to preserve ordering in the error path.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src-tauri%2Fsrc%2Fpty.rs%0ALine%3A%20137-150%0A%0AComment%3A%0A**Re-buffered%20chunk%20appended%20to%20back%2C%20breaking%20drain%20order%20on%20send%20failure**%0A%0AWhen%20%60channel.send%60%20fails%20mid-drain%2C%20%60self.buffer%28bytes%29%60%20calls%20%60PtyOutputBacklog%3A%3Abuffer%60%20which%20uses%20%60push_back%60.%20Any%20items%20still%20sitting%20at%20the%20front%20of%20the%20queue%20%28not%20yet%20drained%29%20will%20therefore%20be%20delivered%20before%20the%20re-buffered%20failed%20chunk%20on%20the%20next%20attach%2C%20inverting%20chronological%20order%20for%20the%20tail%20of%20the%20backlog.%20This%20behaviour%20pre-dated%20the%20extraction%20but%20now%20that%20%60PtyOutputBacklog%60%20is%20a%20dedicated%20type%20it%20would%20be%20natural%20to%20add%20a%20%60push_front%60%20%2F%20%60prepend%60%20method%20and%20use%20it%20here%20to%20preserve%20ordering%20in%20the%20error%20path.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=phin-tech%2Froux&pr=182&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22feature%2Fextract-pty-output-backlog%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fextract-pty-output-backlog%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src-tauri%2Fsrc%2Fpty.rs%0ALine%3A%20137-150%0A%0AComment%3A%0A**Re-buffered%20chunk%20appended%20to%20back%2C%20breaking%20drain%20order%20on%20send%20failure**%0A%0AWhen%20%60channel.send%60%20fails%20mid-drain%2C%20%60self.buffer%28bytes%29%60%20calls%20%60PtyOutputBacklog%3A%3Abuffer%60%20which%20uses%20%60push_back%60.%20Any%20items%20still%20sitting%20at%20the%20front%20of%20the%20queue%20%28not%20yet%20drained%29%20will%20therefore%20be%20delivered%20before%20the%20re-buffered%20failed%20chunk%20on%20the%20next%20attach%2C%20inverting%20chronological%20order%20for%20the%20tail%20of%20the%20backlog.%20This%20behaviour%20pre-dated%20the%20extraction%20but%20now%20that%20%60PtyOutputBacklog%60%20is%20a%20dedicated%20type%20it%20would%20be%20natural%20to%20add%20a%20%60push_front%60%20%2F%20%60prepend%60%20method%20and%20use%20it%20here%20to%20preserve%20ordering%20in%20the%20error%20path.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Froux-runtime%2Fsrc%2Fpty_output.rs%3A17-27%0A**Oversized%20chunk%20is%20silently%20dropped%20with%20no%20diagnostic**%0A%0AWhen%20a%20single%20chunk%20whose%20length%20exceeds%20%60limit_bytes%60%20is%20pushed%2C%20the%20trimming%20loop%20removes%20every%20entry%20including%20the%20newly-pushed%20chunk%20itself%2C%20leaving%20%60bytes%20%3D%3D%200%60%20and%20an%20empty%20queue.%20The%20%60oversized_single_chunk_drops_backlog_to_preserve_limit%60%20test%20documents%20this%20intentionally%2C%20but%20there%20is%20no%20%60tracing%3A%3Awarn!%60%20or%20equivalent%20at%20the%20drop%20site.%20In%20production%20a%20%3E256%20KB%20batch%20%28unlikely%20but%20possible%20during%20heavy%20output%20while%20the%20frontend%20is%20detached%29%20would%20be%20silently%20lost%20with%20no%20indication%20in%20logs%20that%20trimming%20discarded%20live%20data.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc-tauri%2Fsrc%2Fpty.rs%3A137-150%0A**Re-buffered%20chunk%20appended%20to%20back%2C%20breaking%20drain%20order%20on%20send%20failure**%0A%0AWhen%20%60channel.send%60%20fails%20mid-drain%2C%20%60self.buffer%28bytes%29%60%20calls%20%60PtyOutputBacklog%3A%3Abuffer%60%20which%20uses%20%60push_back%60.%20Any%20items%20still%20sitting%20at%20the%20front%20of%20the%20queue%20%28not%20yet%20drained%29%20will%20therefore%20be%20delivered%20before%20the%20re-buffered%20failed%20chunk%20on%20the%20next%20attach%2C%20inverting%20chronological%20order%20for%20the%20tail%20of%20the%20backlog.%20This%20behaviour%20pre-dated%20the%20extraction%20but%20now%20that%20%60PtyOutputBacklog%60%20is%20a%20dedicated%20type%20it%20would%20be%20natural%20to%20add%20a%20%60push_front%60%20%2F%20%60prepend%60%20method%20and%20use%20it%20here%20to%20preserve%20ordering%20in%20the%20error%20path.%0A%0A&repo=phin-tech%2Froux&pr=182&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22feature%2Fextract-pty-output-backlog%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fextract-pty-output-backlog%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Froux-runtime%2Fsrc%2Fpty_output.rs%3A17-27%0A**Oversized%20chunk%20is%20silently%20dropped%20with%20no%20diagnostic**%0A%0AWhen%20a%20single%20chunk%20whose%20length%20exceeds%20%60limit_bytes%60%20is%20pushed%2C%20the%20trimming%20loop%20removes%20every%20entry%20including%20the%20newly-pushed%20chunk%20itself%2C%20leaving%20%60bytes%20%3D%3D%200%60%20and%20an%20empty%20queue.%20The%20%60oversized_single_chunk_drops_backlog_to_preserve_limit%60%20test%20documents%20this%20intentionally%2C%20but%20there%20is%20no%20%60tracing%3A%3Awarn!%60%20or%20equivalent%20at%20the%20drop%20site.%20In%20production%20a%20%3E256%20KB%20batch%20%28unlikely%20but%20possible%20during%20heavy%20output%20while%20the%20frontend%20is%20detached%29%20would%20be%20silently%20lost%20with%20no%20indication%20in%20logs%20that%20trimming%20discarded%20live%20data.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc-tauri%2Fsrc%2Fpty.rs%3A137-150%0A**Re-buffered%20chunk%20appended%20to%20back%2C%20breaking%20drain%20order%20on%20send%20failure**%0A%0AWhen%20%60channel.send%60%20fails%20mid-drain%2C%20%60self.buffer%28bytes%29%60%20calls%20%60PtyOutputBacklog%3A%3Abuffer%60%20which%20uses%20%60push_back%60.%20Any%20items%20still%20sitting%20at%20the%20front%20of%20the%20queue%20%28not%20yet%20drained%29%20will%20therefore%20be%20delivered%20before%20the%20re-buffered%20failed%20chunk%20on%20the%20next%20attach%2C%20inverting%20chronological%20order%20for%20the%20tail%20of%20the%20backlog.%20This%20behaviour%20pre-dated%20the%20extraction%20but%20now%20that%20%60PtyOutputBacklog%60%20is%20a%20dedicated%20type%20it%20would%20be%20natural%20to%20add%20a%20%60push_front%60%20%2F%20%60prepend%60%20method%20and%20use%20it%20here%20to%20preserve%20ordering%20in%20the%20error%20path.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["extract pty output backlog into runtime"](https://github.com/phin-tech/roux/commit/db7341c9ce2e616d2c34f232bb391e5a4e5d3e2e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33243751)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->