### PR TITLE
[codex] extract pty spawn planning

### DIFF
--- a/crates/roux-runtime/src/lib.rs
+++ b/crates/roux-runtime/src/lib.rs
@@ -9,5 +9,6 @@ pub mod project_service;
 pub mod pty_lifecycle;
 pub mod pty_output;
 pub mod pty_ready_gate;
+pub mod pty_spawn;
 pub mod session_service;
 pub mod terminal_env;

--- a/crates/roux-runtime/src/pty_spawn.rs
+++ b/crates/roux-runtime/src/pty_spawn.rs
@@ -1,0 +1,374 @@
+use std::path::PathBuf;
+
+use crate::terminal_env::{self, NonoConfig, SmolvmExec};
+
+pub const DEFAULT_PTY_COLS: u16 = 80;
+pub const DEFAULT_PTY_ROWS: u16 = 24;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PtyDimensions {
+    pub cols: u16,
+    pub rows: u16,
+}
+
+impl PtyDimensions {
+    pub fn as_tuple(self) -> (u16, u16) {
+        (self.cols, self.rows)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PtyCommandPlan {
+    pub program: PathBuf,
+    pub args: Vec<String>,
+    pub env: Vec<(String, String)>,
+    pub cwd: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PtySpawnPlan {
+    pub size: PtyDimensions,
+    pub command: PtyCommandPlan,
+}
+
+pub struct ShellSpawnPlanInputs<'a> {
+    pub working_dir: &'a str,
+    pub shell: &'a str,
+    pub roux_env: &'a [(String, String)],
+    pub worktree_path: Option<&'a str>,
+    pub nono: Option<&'a NonoConfig>,
+    pub smolvm: Option<&'a SmolvmExec>,
+    pub initial_size: Option<(u16, u16)>,
+}
+
+pub struct TaskSpawnPlanInputs<'a> {
+    pub command: &'a str,
+    pub working_dir: &'a str,
+    pub shell: &'a str,
+    pub roux_env: &'a [(String, String)],
+    pub worktree_path: Option<&'a str>,
+    pub smolvm: Option<&'a SmolvmExec>,
+    pub initial_size: Option<(u16, u16)>,
+}
+
+pub fn pty_dimensions(initial: Option<(u16, u16)>) -> PtyDimensions {
+    let (cols, rows) = initial.unwrap_or((DEFAULT_PTY_COLS, DEFAULT_PTY_ROWS));
+    PtyDimensions { cols: cols.max(1), rows: rows.max(1) }
+}
+
+pub fn shell_spawn_plan(inputs: ShellSpawnPlanInputs<'_>) -> PtySpawnPlan {
+    let mut command = if let Some(smolvm) = inputs.smolvm {
+        let mut args = smolvm_exec_args(smolvm, inputs.worktree_path, inputs.roux_env);
+        args.push(smolvm.guest_shell.clone());
+        PtyCommandPlan {
+            program: smolvm.binary.clone(),
+            args,
+            env: inputs.roux_env.to_vec(),
+            cwd: inputs.working_dir.to_string(),
+        }
+    } else if let Some(nono) = inputs.nono {
+        let mut args = vec![
+            "run".to_string(),
+            "--profile".to_string(),
+            nono.profile.clone(),
+            "--allow-cwd".to_string(),
+        ];
+        for dir in nono.resolved_allow_dirs(inputs.working_dir) {
+            args.push("--allow-dir".to_string());
+            args.push(dir);
+        }
+        args.push("--".to_string());
+        args.push(inputs.shell.to_string());
+        PtyCommandPlan {
+            program: PathBuf::from("nono"),
+            args,
+            env: inputs.roux_env.to_vec(),
+            cwd: inputs.working_dir.to_string(),
+        }
+    } else {
+        PtyCommandPlan {
+            program: PathBuf::from(inputs.shell),
+            args: Vec::new(),
+            env: inputs.roux_env.to_vec(),
+            cwd: inputs.working_dir.to_string(),
+        }
+    };
+
+    append_shell_command_flags(&mut command.args, inputs.shell);
+
+    PtySpawnPlan { size: pty_dimensions(inputs.initial_size), command }
+}
+
+pub fn task_spawn_plan(inputs: TaskSpawnPlanInputs<'_>) -> PtySpawnPlan {
+    let command = if let Some(smolvm) = inputs.smolvm {
+        let mut args = smolvm_exec_args(smolvm, inputs.worktree_path, inputs.roux_env);
+        args.push(smolvm.guest_shell.clone());
+        args.push("-c".to_string());
+        args.push(inputs.command.to_string());
+        PtyCommandPlan {
+            program: smolvm.binary.clone(),
+            args,
+            env: inputs.roux_env.to_vec(),
+            cwd: inputs.working_dir.to_string(),
+        }
+    } else {
+        PtyCommandPlan {
+            program: PathBuf::from(inputs.shell),
+            args: task_command_args(inputs.shell, inputs.command),
+            env: inputs.roux_env.to_vec(),
+            cwd: inputs.working_dir.to_string(),
+        }
+    };
+
+    PtySpawnPlan { size: pty_dimensions(inputs.initial_size), command }
+}
+
+fn smolvm_exec_args(
+    smolvm: &SmolvmExec,
+    worktree_path: Option<&str>,
+    roux_env: &[(String, String)],
+) -> Vec<String> {
+    let mut args = vec![
+        "machine".to_string(),
+        "exec".to_string(),
+        "--name".to_string(),
+        smolvm.machine_name.clone(),
+        "-i".to_string(),
+        "-t".to_string(),
+    ];
+    if let Some(wt) = worktree_path.filter(|path| !path.is_empty()) {
+        args.push("--workdir".to_string());
+        args.push(wt.to_string());
+    }
+    for (key, value) in roux_env {
+        if terminal_env::is_guest_safe_env_key(key) {
+            args.push("-e".to_string());
+            args.push(format!("{key}={value}"));
+        }
+    }
+    args.push("--".to_string());
+    args
+}
+
+fn append_shell_command_flags(args: &mut Vec<String>, shell: &str) {
+    #[cfg(windows)]
+    {
+        let shell_lower = shell.to_ascii_lowercase();
+        if shell_lower.contains("pwsh") || shell_lower.contains("powershell") {
+            args.push("-NoLogo".to_string());
+        }
+    }
+
+    #[cfg(not(windows))]
+    {
+        let _ = (args, shell);
+    }
+}
+
+fn task_command_args(shell: &str, command: &str) -> Vec<String> {
+    #[cfg(windows)]
+    {
+        let shell_lower = shell.to_ascii_lowercase();
+        if shell_lower.contains("pwsh") {
+            return vec![
+                "-NoLogo".to_string(),
+                "-NoProfile".to_string(),
+                "-Command".to_string(),
+                command.to_string(),
+            ];
+        }
+        if shell_lower.contains("powershell") {
+            return vec![
+                "-NoLogo".to_string(),
+                "-NoProfile".to_string(),
+                "-ExecutionPolicy".to_string(),
+                "Bypass".to_string(),
+                "-Command".to_string(),
+                command.to_string(),
+            ];
+        }
+        vec!["/C".to_string(), command.to_string()]
+    }
+
+    #[cfg(not(windows))]
+    {
+        let _ = shell;
+        vec!["-c".to_string(), command.to_string()]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn roux_env() -> Vec<(String, String)> {
+        vec![
+            ("PATH".to_string(), "/usr/bin".to_string()),
+            ("TERM".to_string(), "xterm-256color".to_string()),
+            ("ROUX_SOCKET".to_string(), "/tmp/roux.sock".to_string()),
+            ("ROUX_CLI".to_string(), "/roux/bin/roux-cli".to_string()),
+            ("ROUX_SESSION_ID".to_string(), "session-a".to_string()),
+            ("ROUX_AGENT_ALIAS".to_string(), "builder".to_string()),
+        ]
+    }
+
+    #[test]
+    fn pty_dimensions_default_and_zero_safe() {
+        assert_eq!(
+            pty_dimensions(None),
+            PtyDimensions { cols: DEFAULT_PTY_COLS, rows: DEFAULT_PTY_ROWS }
+        );
+        assert_eq!(pty_dimensions(Some((0, 0))), PtyDimensions { cols: 1, rows: 1 });
+    }
+
+    #[test]
+    fn shell_plan_wraps_nono_with_resolved_allow_dirs() {
+        let env = roux_env();
+        let nono = NonoConfig {
+            profile: "sandbox".to_string(),
+            allow_dirs: vec!["relative".to_string(), "/absolute".to_string()],
+        };
+
+        let plan = shell_spawn_plan(ShellSpawnPlanInputs {
+            working_dir: "/work/project",
+            shell: "/bin/zsh",
+            roux_env: &env,
+            worktree_path: None,
+            nono: Some(&nono),
+            smolvm: None,
+            initial_size: Some((132, 37)),
+        });
+
+        assert_eq!(plan.size, PtyDimensions { cols: 132, rows: 37 });
+        assert_eq!(plan.command.program, PathBuf::from("nono"));
+        assert_eq!(
+            plan.command.args,
+            vec![
+                "run",
+                "--profile",
+                "sandbox",
+                "--allow-cwd",
+                "--allow-dir",
+                "/work/project/relative",
+                "--allow-dir",
+                "/absolute",
+                "--",
+                "/bin/zsh",
+            ]
+        );
+        assert_eq!(plan.command.env, env);
+        assert_eq!(plan.command.cwd, "/work/project");
+    }
+
+    #[test]
+    fn shell_plan_prefers_smolvm_and_filters_guest_env() {
+        let env = roux_env();
+        let nono = NonoConfig { profile: "ignored".to_string(), allow_dirs: vec![] };
+        let smolvm = SmolvmExec {
+            binary: PathBuf::from("/opt/smolvm"),
+            machine_name: "dev".to_string(),
+            guest_shell: "/bin/bash".to_string(),
+        };
+
+        let plan = shell_spawn_plan(ShellSpawnPlanInputs {
+            working_dir: "/host/project",
+            shell: "/bin/zsh",
+            roux_env: &env,
+            worktree_path: Some("/guest/project"),
+            nono: Some(&nono),
+            smolvm: Some(&smolvm),
+            initial_size: None,
+        });
+
+        assert_eq!(plan.command.program, PathBuf::from("/opt/smolvm"));
+        assert_eq!(
+            plan.command.args,
+            vec![
+                "machine",
+                "exec",
+                "--name",
+                "dev",
+                "-i",
+                "-t",
+                "--workdir",
+                "/guest/project",
+                "-e",
+                "TERM=xterm-256color",
+                "-e",
+                "ROUX_SESSION_ID=session-a",
+                "-e",
+                "ROUX_AGENT_ALIAS=builder",
+                "--",
+                "/bin/bash",
+            ]
+        );
+        assert_eq!(plan.command.env, env);
+        assert_eq!(plan.command.cwd, "/host/project");
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn task_plan_uses_shell_command_on_unix() {
+        let env = roux_env();
+
+        let plan = task_spawn_plan(TaskSpawnPlanInputs {
+            command: "cargo test",
+            working_dir: "/work/project",
+            shell: "/bin/zsh",
+            roux_env: &env,
+            worktree_path: None,
+            smolvm: None,
+            initial_size: Some((90, 20)),
+        });
+
+        assert_eq!(plan.size, PtyDimensions { cols: 90, rows: 20 });
+        assert_eq!(plan.command.program, PathBuf::from("/bin/zsh"));
+        assert_eq!(plan.command.args, vec!["-c", "cargo test"]);
+        assert_eq!(plan.command.env, env);
+    }
+
+    #[test]
+    fn task_plan_smolvm_execs_guest_shell_command() {
+        let env = roux_env();
+        let smolvm = SmolvmExec {
+            binary: PathBuf::from("/opt/smolvm"),
+            machine_name: "dev".to_string(),
+            guest_shell: "/bin/bash".to_string(),
+        };
+
+        let plan = task_spawn_plan(TaskSpawnPlanInputs {
+            command: "npm test",
+            working_dir: "/host/project",
+            shell: "/bin/zsh",
+            roux_env: &env,
+            worktree_path: Some("/guest/project"),
+            smolvm: Some(&smolvm),
+            initial_size: None,
+        });
+
+        assert_eq!(plan.command.program, PathBuf::from("/opt/smolvm"));
+        assert_eq!(
+            plan.command.args,
+            vec![
+                "machine",
+                "exec",
+                "--name",
+                "dev",
+                "-i",
+                "-t",
+                "--workdir",
+                "/guest/project",
+                "-e",
+                "TERM=xterm-256color",
+                "-e",
+                "ROUX_SESSION_ID=session-a",
+                "-e",
+                "ROUX_AGENT_ALIAS=builder",
+                "--",
+                "/bin/bash",
+                "-c",
+                "npm test",
+            ]
+        );
+    }
+}

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -20,6 +20,7 @@ pub use roux_runtime::process::cwd_for_pid;
 use roux_runtime::pty_output::PtyOutputBacklog;
 #[cfg(test)]
 pub use roux_runtime::pty_output::PTY_BACKLOG_LIMIT_BYTES;
+use roux_runtime::pty_spawn::{self, ShellSpawnPlanInputs, TaskSpawnPlanInputs};
 pub use roux_runtime::terminal_env::{NonoConfig, NotesEnvInputs, SmolvmExec};
 use roux_runtime::terminal_env;
 
@@ -30,18 +31,20 @@ const GATE_QUIET: Duration = Duration::from_millis(200);
 const GATE_TIMEOUT: Duration = Duration::from_secs(5);
 const GATE_TICK: Duration = Duration::from_millis(75);
 
-/// Fallback PTY size for spawn paths that don't have a measured pane size.
-/// Callers should pass the pane's actual `(cols, rows)` whenever possible
-/// — starting at the real size avoids a post-spawn SIGWINCH, which
-/// otherwise triggers `zle reset-prompt` in zsh and causes async prompt
-/// frameworks (oh-my-zsh git, p10k without instant-prompt, etc.) to
-/// redraw on top of any keystrokes the user has already typed.
-const DEFAULT_PTY_COLS: u16 = 80;
-const DEFAULT_PTY_ROWS: u16 = 24;
+fn pty_size_from_dimensions(size: pty_spawn::PtyDimensions) -> PtySize {
+    PtySize { rows: size.rows, cols: size.cols, pixel_width: 0, pixel_height: 0 }
+}
 
-fn pty_size_from(initial: Option<(u16, u16)>) -> PtySize {
-    let (cols, rows) = initial.unwrap_or((DEFAULT_PTY_COLS, DEFAULT_PTY_ROWS));
-    PtySize { rows: rows.max(1), cols: cols.max(1), pixel_width: 0, pixel_height: 0 }
+fn command_builder_from_plan(plan: &pty_spawn::PtyCommandPlan) -> CommandBuilder {
+    let mut cmd = CommandBuilder::new(plan.program.as_os_str());
+    for arg in &plan.args {
+        cmd.arg(arg);
+    }
+    for (key, value) in &plan.env {
+        cmd.env(key, value);
+    }
+    cmd.cwd(&plan.cwd);
+    cmd
 }
 
 /// Best-effort flush of bytes the gate released. Errors are logged but
@@ -757,14 +760,26 @@ impl PtyManager {
                 })?;
         }
 
+        let shell = resolve_default_shell();
+        let user_path = get_user_path();
+        let roux_env =
+            roux_env_pairs(&user_path, session_id, pane_id, project_id, worktree_path, notes);
+        let spawn_plan = pty_spawn::shell_spawn_plan(ShellSpawnPlanInputs {
+            working_dir,
+            shell: &shell,
+            roux_env: &roux_env,
+            worktree_path,
+            nono,
+            smolvm,
+            initial_size,
+        });
+
         let pty_system = native_pty_system();
 
         let pair = pty_system
-            .openpty(pty_size_from(initial_size))
+            .openpty(pty_size_from_dimensions(spawn_plan.size))
             .map_err(|source| PtyError::OpenPty { source })?;
 
-        let shell = resolve_default_shell();
-        let user_path = get_user_path();
         let nono_label = nono.map(|n| format!(" (nono profile={})", n.profile)).unwrap_or_default();
         let smol_label = smolvm.map(|s| format!(" (smol machine={})", s.machine_name)).unwrap_or_default();
         let pane_label = pane_id.map(|p| format!(", pane '{}'", p)).unwrap_or_default();
@@ -780,77 +795,7 @@ impl PtyManager {
             smol_label
         );
 
-        // Wrap precedence: smolvm wins over nono. nono is host-side and
-        // doesn't exist inside a guest VM unless the image installs it.
-        // Treat them as mutually exclusive in v1 and silently skip nono
-        // in the smolvm branch (the caller has already logged a warning
-        // if both were configured).
-        let mut cmd = if let Some(smol) = smolvm {
-            let mut c = CommandBuilder::new(smol.binary.as_os_str());
-            c.arg("machine");
-            c.arg("exec");
-            c.arg("--name");
-            c.arg(&smol.machine_name);
-            c.arg("-i");
-            c.arg("-t");
-            // Phase 2.9: when the session has a worktree path, ask
-            // smolvm to start the guest shell there. The path must be
-            // covered by a [dev].volumes mount in the Smolfile;
-            // otherwise smolvm exits with "workdir not found". The
-            // panel's auto-mount UX (bind-time prompt) prevents that
-            // case for new bindings; pre-existing bindings on
-            // un-mounted machines will surface the smolvm error in the
-            // dead-pane view.
-            if let Some(wt) = worktree_path.filter(|p| !p.is_empty()) {
-                c.arg("--workdir");
-                c.arg(wt);
-            }
-            // Forward the subset of ROUX_* env that's meaningful in the
-            // guest. Host paths (PATH, ROUX_SOCKET, ROUX_CLI, notes paths)
-            // are filtered out — see `is_guest_safe_env_key`.
-            for (k, v) in roux_env_pairs(
-                &user_path,
-                session_id,
-                pane_id,
-                project_id,
-                worktree_path,
-                notes,
-            ) {
-                if is_guest_safe_env_key(&k) {
-                    c.arg("-e");
-                    c.arg(format!("{}={}", k, v));
-                }
-            }
-            c.arg("--");
-            c.arg(&smol.guest_shell);
-            c
-        } else if let Some(nono) = nono {
-            let mut c = CommandBuilder::new("nono");
-            c.arg("run");
-            c.arg("--profile");
-            c.arg(&nono.profile);
-            c.arg("--allow-cwd");
-            for dir in &nono.resolved_allow_dirs(working_dir) {
-                c.arg("--allow-dir");
-                c.arg(dir);
-            }
-            c.arg("--");
-            c.arg(&shell);
-            c
-        } else {
-            CommandBuilder::new(&shell)
-        };
-        // apply_shell_command_flags is a no-op outside Windows. On
-        // Windows + smolvm doesn't combine (smolvm is Linux/macOS-only),
-        // so we keep this unconditional — it's a safe no-op for the
-        // smolvm branch on the platforms smolvm runs on.
-        apply_shell_command_flags(&mut cmd, &shell);
-        // apply_roux_env populates the *outer* CommandBuilder's env.
-        // For the smolvm branch this decorates the host-side smolvm CLI
-        // process (useful for its own logging) but doesn't reach the
-        // guest — the `-e` flags above handle that.
-        apply_roux_env(&mut cmd, &user_path, session_id, pane_id, project_id, worktree_path, notes);
-        cmd.cwd(working_dir);
+        let cmd = command_builder_from_plan(&spawn_plan.command);
 
         let child = pair.slave.spawn_command(cmd).map_err(|source| {
             rlog!("Failed to spawn shell: {}", source);
@@ -885,7 +830,7 @@ impl PtyManager {
                 PtyStatus::RunningDetached { since_ms }
             }
         };
-        let size = initial_size.unwrap_or((DEFAULT_PTY_COLS, DEFAULT_PTY_ROWS));
+        let size = spawn_plan.size.as_tuple();
         let session = PtySession {
             master: pair.master,
             child,
@@ -1006,58 +951,27 @@ impl PtyManager {
             })?;
         }
 
+        let shell = resolve_default_shell();
+        let user_path = get_user_path();
+        let roux_env =
+            roux_env_pairs(&user_path, session_id, pane_id, project_id, worktree_path, notes);
+        let spawn_plan = pty_spawn::task_spawn_plan(TaskSpawnPlanInputs {
+            command,
+            working_dir,
+            shell: &shell,
+            roux_env: &roux_env,
+            worktree_path,
+            smolvm,
+            initial_size,
+        });
+
         let pty_system = native_pty_system();
 
         let pair = pty_system
-            .openpty(pty_size_from(initial_size))
+            .openpty(pty_size_from_dimensions(spawn_plan.size))
             .map_err(|source| PtyError::OpenPty { source })?;
 
-        let shell = resolve_default_shell();
-        let user_path = get_user_path();
-
-        // When the session is bound to a smol machine, run the command
-        // inside the guest via `smolvm machine exec --name <m> -- /bin/sh
-        // -c <cmd>`. Mirrors the spawn_shell smolvm wrap (env subset
-        // forwarded via `-e KEY=VAL`, optional `--workdir` from the
-        // session's worktree) so `roux run` behaves identically to a
-        // shell pane on a bound session.
-        let mut cmd = if let Some(smol) = smolvm {
-            let mut c = CommandBuilder::new(smol.binary.as_os_str());
-            c.arg("machine");
-            c.arg("exec");
-            c.arg("--name");
-            c.arg(&smol.machine_name);
-            c.arg("-i");
-            c.arg("-t");
-            if let Some(wt) = worktree_path.filter(|p| !p.is_empty()) {
-                c.arg("--workdir");
-                c.arg(wt);
-            }
-            for (k, v) in roux_env_pairs(
-                &user_path,
-                session_id,
-                pane_id,
-                project_id,
-                worktree_path,
-                notes,
-            ) {
-                if is_guest_safe_env_key(&k) {
-                    c.arg("-e");
-                    c.arg(format!("{}={}", k, v));
-                }
-            }
-            c.arg("--");
-            c.arg(&smol.guest_shell);
-            c.arg("-c");
-            c.arg(command);
-            c
-        } else {
-            let mut c = CommandBuilder::new(&shell);
-            apply_task_command_args(&mut c, &shell, command);
-            c
-        };
-        apply_roux_env(&mut cmd, &user_path, session_id, pane_id, project_id, worktree_path, notes);
-        cmd.cwd(working_dir);
+        let cmd = command_builder_from_plan(&spawn_plan.command);
 
         let mut child =
             pair.slave.spawn_command(cmd).map_err(|source| PtyError::SpawnTask { source })?;
@@ -1087,7 +1001,7 @@ impl PtyManager {
                 PtyStatus::RunningDetached { since_ms }
             }
         };
-        let size_task = initial_size.unwrap_or((DEFAULT_PTY_COLS, DEFAULT_PTY_ROWS));
+        let size_task = spawn_plan.size.as_tuple();
         let session = PtySession {
             master: pair.master,
             child: Box::new(WaitedChild),
@@ -1510,34 +1424,9 @@ fn roux_cli_shim() -> Option<(String, String)> {
         .clone()
 }
 
-/// Apply the common Roux env vars to a `CommandBuilder`: PATH with shim dir
-/// prepended, `ROUX_CLI` pointing at the absolute roux-cli path, and the
-/// standard `ROUX_*` markers. Called by every `spawn_*` method so the three
-/// paths stay in sync.
-///
-/// `session_id` and `pane_id` are threaded through so every shell/task/agent
-/// PTY hosts `ROUX_SESSION_ID` and `ROUX_PANE_ID` in its env unconditionally.
-/// Hooks and `roux notify` read them to route events back to the correct
-/// pane without cwd heuristics.
-fn apply_roux_env(
-    cmd: &mut CommandBuilder,
-    user_path: &str,
-    session_id: Option<&str>,
-    pane_id: Option<&str>,
-    project_id: Option<&str>,
-    worktree_path: Option<&str>,
-    notes: Option<&NotesEnvInputs>,
-) {
-    for (k, v) in
-        roux_env_pairs(user_path, session_id, pane_id, project_id, worktree_path, notes)
-    {
-        cmd.env(k, v);
-    }
-}
-
-/// Pure pair-emitting variant of [`apply_roux_env`]. Used by both the
-/// host-side `CommandBuilder` path and the smolvm-wrap branch (which
-/// folds a filtered subset into `-e KEY=VAL` flags).
+/// Build common Roux env vars with the Tauri-owned socket, CLI shim, and
+/// persisted alias lookup. The runtime planner decides whether each pair
+/// becomes process env or a guest-safe smolvm `-e KEY=VAL` flag.
 fn roux_env_pairs(
     user_path: &str,
     session_id: Option<&str>,
@@ -1576,15 +1465,6 @@ fn roux_env_pairs(
         );
     }
     output.pairs
-}
-
-/// True for env keys that are meaningful inside a smolvm guest. Host
-/// paths (PATH, ROUX_SOCKET, ROUX_CLI, ROUX_NOTES_*) are excluded — the
-/// guest has its own filesystem and they'd point at non-existent
-/// locations. Forwarding them would mislead shell-rc scripts that test
-/// for them.
-fn is_guest_safe_env_key(key: &str) -> bool {
-    terminal_env::is_guest_safe_env_key(key)
 }
 
 /// Best-effort lookup: which alias is bound to `pane_id` right now?
@@ -1715,44 +1595,6 @@ fn shell_binary_path_override() -> Option<String> {
 fn shell_binary_path_cache() -> &'static Mutex<Option<Option<String>>> {
     static CACHE: std::sync::OnceLock<Mutex<Option<Option<String>>>> = std::sync::OnceLock::new();
     CACHE.get_or_init(|| Mutex::new(None))
-}
-
-fn apply_shell_command_flags(cmd: &mut CommandBuilder, shell: &str) {
-    #[cfg(windows)]
-    {
-        let shell_lower = shell.to_ascii_lowercase();
-        if shell_lower.contains("pwsh") || shell_lower.contains("powershell") {
-            cmd.arg("-NoLogo");
-        }
-    }
-
-    #[cfg(not(windows))]
-    {
-        let _ = (cmd, shell);
-    }
-}
-
-fn apply_task_command_args(cmd: &mut CommandBuilder, shell: &str, command: &str) {
-    #[cfg(windows)]
-    {
-        let shell_lower = shell.to_ascii_lowercase();
-        if shell_lower.contains("pwsh") {
-            cmd.args(["-NoLogo", "-NoProfile", "-Command", command]);
-            return;
-        }
-        if shell_lower.contains("powershell") {
-            cmd.args(["-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", command]);
-            return;
-        }
-        cmd.args(["/C", command]);
-        return;
-    }
-
-    #[cfg(not(windows))]
-    {
-        cmd.args(["-c", command]);
-        let _ = shell;
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- add a Tauri-free runtime PTY spawn planner for dimensions, command argv, cwd, env, nono, and smolvm wrapping
- refactor Tauri PTY spawn paths to translate runtime plans into portable-pty CommandBuilder instances
- keep actual PTY opening, child lifecycle, logging, readiness gates, and app event wiring in Tauri

## Verification
- cargo test -p roux-runtime
- CI=1 cargo clippy -p roux --all-targets -- -D warnings
- git diff --check
- git diff --cached --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts PTY spawn planning from the Tauri layer into a new `roux-runtime` module (`pty_spawn.rs`), introducing `PtySpawnPlan`, `PtyCommandPlan`, and `PtyDimensions` data structures, plus two pure-Rust planner functions (`shell_spawn_plan`, `task_spawn_plan`). The Tauri `pty.rs` is refactored to call these planners and then translate the resulting plans into portable-pty `CommandBuilder` instances via a new `command_builder_from_plan` adapter.

- **New `crates/roux-runtime/src/pty_spawn.rs`**: Tauri-free planners for smolvm, nono, and plain-shell spawns, including Windows shell flag handling and guest-safe env filtering; ships with four focused unit tests.
- **`src-tauri/src/pty.rs`**: Removes ~130 lines of inline command-building across `spawn_shell` and `spawn_task`, replacing them with plan construction + a single `command_builder_from_plan` call; ordering of `shell`/`user_path`/env computation is now before `openpty` rather than after.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; all spawn paths produce equivalent PTY commands to the old inline code with no functional regression.

The refactoring correctly preserves every old behavior: env computation is now done once before openpty (eliminating a potential double-read of aliases.json in the smolvm path), all arg-building logic is faithfully reproduced in pty_spawn.rs, and command_builder_from_plan correctly translates plans back into CommandBuilder instances. The two findings are documentation gaps only.

crates/roux-runtime/src/pty_spawn.rs around append_shell_command_flags (smolvm-branch platform assumption) and src-tauri/src/pty.rs around pty_size_from_dimensions (missing SIGWINCH context).
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/roux-runtime/src/pty_spawn.rs | New module; logic faithfully mirrors what was in pty.rs. append_shell_command_flags is applied unconditionally to all plan branches (including smolvm), which is a pre-existing no-op on non-Windows but loses the old comment justifying it. |
| src-tauri/src/pty.rs | Refactored correctly; env computation moved before openpty, duplicate roux_env_pairs calls eliminated. The detailed SIGWINCH/zle context comment on DEFAULT_PTY_COLS/ROWS was removed without a replacement in this file. |
| crates/roux-runtime/src/lib.rs | Single pub mod declaration added; no issues. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller as Tauri spawn_shell / spawn_task
    participant Plan as pty_spawn (roux-runtime)
    participant Builder as command_builder_from_plan
    participant PTY as portable-pty

    Caller->>Caller: resolve_default_shell()
    Caller->>Caller: get_user_path()
    Caller->>Caller: roux_env_pairs(...)
    Caller->>Plan: shell_spawn_plan(ShellSpawnPlanInputs)
    alt smolvm present
        Plan->>Plan: smolvm_exec_args() guest-safe -e flags in args
        Plan->>Plan: append_shell_command_flags (no-op on non-Windows)
        Plan-->>Caller: "PtySpawnPlan size command program=smolvm_binary"
    else nono present
        Plan->>Plan: build nono run --profile ... -- shell args
        Plan->>Plan: append_shell_command_flags
        Plan-->>Caller: "PtySpawnPlan size command program=nono"
    else plain shell
        Plan->>Plan: append_shell_command_flags
        Plan-->>Caller: "PtySpawnPlan size command program=shell"
    end
    Caller->>PTY: openpty(pty_size_from_dimensions(spawn_plan.size))
    Caller->>Builder: command_builder_from_plan(spawn_plan.command)
    Builder->>Builder: CommandBuilder::new(program)
    Builder->>Builder: cmd.arg(each arg)
    Builder->>Builder: cmd.env(key, value) for each env pair
    Builder->>Builder: cmd.cwd(plan.cwd)
    Builder-->>Caller: CommandBuilder
    Caller->>PTY: slave.spawn_command(cmd)
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Froux-runtime%2Fsrc%2Fpty_spawn.rs%3A153-166%0A**%60append_shell_command_flags%60%20mutates%20smolvm%20plan%20args%20on%20Windows**%0A%0A%60append_shell_command_flags%60%20is%20called%20after%20the%20smolvm%20branch%20builds%20its%20arg%20list%2C%20which%20already%20ends%20with%20%60%5B%22--%22%2C%20guest_shell%5D%60.%20On%20Windows%2C%20if%20%60inputs.shell%60%20matches%20%60pwsh%60%20or%20%60powershell%60%2C%20%60-NoLogo%60%20is%20appended%20%E2%80%94%20making%20the%20final%20argv%20%60%5B...%2C%20%22--%22%2C%20%22%2Fbin%2Fbash%22%2C%20%22-NoLogo%22%5D%60.%20That%20passes%20%60-NoLogo%60%20as%20an%20argument%20to%20the%20guest%20shell%2C%20not%20to%20smolvm.%20The%20old%20code%20had%20the%20same%20behaviour%20and%20carried%20an%20explicit%20comment%3A%20*%22smolvm%20is%20Linux%2FmacOS-only%2C%20so%20we%20keep%20this%20unconditional%20%E2%80%94%20it's%20a%20safe%20no-op%20for%20the%20smolvm%20branch%20on%20the%20platforms%20smolvm%20runs%20on.%22*%20That%20justification%20was%20deleted%20in%20this%20refactor%2C%20leaving%20the%20silent%20assumption%20undocumented%20for%20future%20contributors.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc-tauri%2Fsrc%2Fpty.rs%3A34-36%0A**SIGWINCH%2Fzle%20context%20comment%20removed%20without%20replacement**%0A%0AThe%20old%20%60pty.rs%60%20carried%20a%20block%20comment%20on%20%60DEFAULT_PTY_COLS%60%2F%60DEFAULT_PTY_ROWS%60%20explaining%20that%20callers%20*must*%20pass%20the%20real%20pane%20size%20to%20avoid%20a%20post-spawn%20%60SIGWINCH%60%20that%20triggers%20%60zle%20reset-prompt%60%20in%20zsh%20and%20races%20with%20async%20prompt%20frameworks%20%28p10k%2C%20oh-my-zsh%20git%2C%20etc.%29.%20Those%20constants%20now%20live%20in%20%60pty_spawn.rs%60%20as%20bare%20%60pub%20const%60%20declarations%20without%20that%20explanation%2C%20and%20the%20Tauri-layer%20site%20that%20opens%20the%20PTY%20has%20no%20reminder%20at%20all.%20If%20a%20future%20caller%20adds%20a%20new%20spawn%20path%20and%20omits%20%60initial_size%60%2C%20they'll%20hit%20the%20redraw%20race%20with%20no%20contextual%20hint%20as%20to%20why%20it%20matters.%0A%0A&repo=phin-tech%2Froux&pr=183&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22feature%2Fextract-pty-spawn-plan%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fextract-pty-spawn-plan%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Froux-runtime%2Fsrc%2Fpty_spawn.rs%3A153-166%0A**%60append_shell_command_flags%60%20mutates%20smolvm%20plan%20args%20on%20Windows**%0A%0A%60append_shell_command_flags%60%20is%20called%20after%20the%20smolvm%20branch%20builds%20its%20arg%20list%2C%20which%20already%20ends%20with%20%60%5B%22--%22%2C%20guest_shell%5D%60.%20On%20Windows%2C%20if%20%60inputs.shell%60%20matches%20%60pwsh%60%20or%20%60powershell%60%2C%20%60-NoLogo%60%20is%20appended%20%E2%80%94%20making%20the%20final%20argv%20%60%5B...%2C%20%22--%22%2C%20%22%2Fbin%2Fbash%22%2C%20%22-NoLogo%22%5D%60.%20That%20passes%20%60-NoLogo%60%20as%20an%20argument%20to%20the%20guest%20shell%2C%20not%20to%20smolvm.%20The%20old%20code%20had%20the%20same%20behaviour%20and%20carried%20an%20explicit%20comment%3A%20*%22smolvm%20is%20Linux%2FmacOS-only%2C%20so%20we%20keep%20this%20unconditional%20%E2%80%94%20it's%20a%20safe%20no-op%20for%20the%20smolvm%20branch%20on%20the%20platforms%20smolvm%20runs%20on.%22*%20That%20justification%20was%20deleted%20in%20this%20refactor%2C%20leaving%20the%20silent%20assumption%20undocumented%20for%20future%20contributors.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc-tauri%2Fsrc%2Fpty.rs%3A34-36%0A**SIGWINCH%2Fzle%20context%20comment%20removed%20without%20replacement**%0A%0AThe%20old%20%60pty.rs%60%20carried%20a%20block%20comment%20on%20%60DEFAULT_PTY_COLS%60%2F%60DEFAULT_PTY_ROWS%60%20explaining%20that%20callers%20*must*%20pass%20the%20real%20pane%20size%20to%20avoid%20a%20post-spawn%20%60SIGWINCH%60%20that%20triggers%20%60zle%20reset-prompt%60%20in%20zsh%20and%20races%20with%20async%20prompt%20frameworks%20%28p10k%2C%20oh-my-zsh%20git%2C%20etc.%29.%20Those%20constants%20now%20live%20in%20%60pty_spawn.rs%60%20as%20bare%20%60pub%20const%60%20declarations%20without%20that%20explanation%2C%20and%20the%20Tauri-layer%20site%20that%20opens%20the%20PTY%20has%20no%20reminder%20at%20all.%20If%20a%20future%20caller%20adds%20a%20new%20spawn%20path%20and%20omits%20%60initial_size%60%2C%20they'll%20hit%20the%20redraw%20race%20with%20no%20contextual%20hint%20as%20to%20why%20it%20matters.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["extract pty spawn planning into runtime"](https://github.com/phin-tech/roux/commit/481eab5c53c566c270214cdc96b5481a5afc205a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33252122)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->