### PR TITLE
[codex] extract pty session metadata

### DIFF
--- a/crates/roux-runtime/src/lib.rs
+++ b/crates/roux-runtime/src/lib.rs
@@ -9,6 +9,7 @@ pub mod project_service;
 pub mod pty_lifecycle;
 pub mod pty_output;
 pub mod pty_ready_gate;
+pub mod pty_session;
 pub mod pty_spawn;
 pub mod session_service;
 pub mod terminal_env;

--- a/crates/roux-runtime/src/pty_session.rs
+++ b/crates/roux-runtime/src/pty_session.rs
@@ -1,0 +1,224 @@
+use roux_core::{PtyInfo, PtyRole, PtyStatus};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PtyExitInfo {
+    pub code: Option<i32>,
+    pub at_ms: u64,
+    pub was_attached: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct PtySessionMetadata {
+    pub role: PtyRole,
+    pub status: PtyStatus,
+    pub exit_info: Option<PtyExitInfo>,
+    pub session_id: Option<String>,
+    pub name: Option<String>,
+    pub working_dir: Option<String>,
+    pub profile: Option<String>,
+    pub last_size: (u16, u16),
+    pub unread_output: bool,
+    pub bell_pending: bool,
+}
+
+pub struct PtySessionMetadataInputs<'a> {
+    pub role: PtyRole,
+    pub pane_id: Option<&'a str>,
+    pub detached_since_ms: u64,
+    pub session_id: Option<&'a str>,
+    pub working_dir: Option<&'a str>,
+    pub profile: Option<&'a str>,
+    pub last_size: (u16, u16),
+}
+
+impl PtySessionMetadata {
+    pub fn new(inputs: PtySessionMetadataInputs<'_>) -> Self {
+        let status = match inputs.pane_id {
+            Some(pane_id) => PtyStatus::RunningAttached { pane_id: pane_id.to_string() },
+            None => PtyStatus::RunningDetached { since_ms: inputs.detached_since_ms },
+        };
+
+        Self {
+            role: inputs.role,
+            status,
+            exit_info: None,
+            session_id: inputs.session_id.map(str::to_string),
+            name: None,
+            working_dir: inputs.working_dir.map(str::to_string),
+            profile: inputs.profile.map(str::to_string),
+            last_size: inputs.last_size,
+            unread_output: false,
+            bell_pending: false,
+        }
+    }
+
+    pub fn attach_to_pane(&mut self, pane_id: &str) {
+        self.status = PtyStatus::RunningAttached { pane_id: pane_id.to_string() };
+        self.unread_output = false;
+        self.bell_pending = false;
+    }
+
+    pub fn detach(&mut self, since_ms: u64) {
+        self.status = PtyStatus::RunningDetached { since_ms };
+    }
+
+    pub fn mark_exited(&mut self, code: Option<i32>, at_ms: u64) {
+        let was_attached = matches!(self.status, PtyStatus::RunningAttached { .. });
+        self.status = PtyStatus::Exited { code, at_ms };
+        self.exit_info = Some(PtyExitInfo { code, at_ms, was_attached });
+    }
+
+    pub fn mark_read(&mut self) {
+        self.unread_output = false;
+        self.bell_pending = false;
+    }
+
+    pub fn set_unread_output(&mut self, value: bool) {
+        self.unread_output = value;
+    }
+
+    pub fn set_bell_pending(&mut self, value: bool) {
+        self.bell_pending = value;
+    }
+
+    pub fn set_name(&mut self, name: Option<&str>) {
+        self.name = name.map(str::to_string);
+    }
+
+    pub fn belongs_to_session(&self, session_id: &str) -> bool {
+        self.session_id.as_deref() == Some(session_id)
+    }
+
+    pub fn to_info(&self, id: &str) -> PtyInfo {
+        PtyInfo {
+            id: id.to_string(),
+            session_id: self.session_id.clone(),
+            role: self.role.clone(),
+            status: self.status.clone(),
+            name: self.name.clone(),
+            working_dir: self.working_dir.clone(),
+            profile: self.profile.clone(),
+            unread_output: self.unread_output,
+            bell_pending: self.bell_pending,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn metadata(pane_id: Option<&str>) -> PtySessionMetadata {
+        PtySessionMetadata::new(PtySessionMetadataInputs {
+            role: PtyRole::Secondary,
+            pane_id,
+            detached_since_ms: 1234,
+            session_id: Some("session-a"),
+            working_dir: Some("/repo"),
+            profile: Some("plain-shell"),
+            last_size: (120, 40),
+        })
+    }
+
+    #[test]
+    fn new_metadata_is_attached_when_pane_id_is_present() {
+        let metadata = metadata(Some("pane-a"));
+
+        assert!(matches!(
+            metadata.status,
+            PtyStatus::RunningAttached { ref pane_id } if pane_id == "pane-a"
+        ));
+        assert_eq!(metadata.session_id.as_deref(), Some("session-a"));
+        assert_eq!(metadata.working_dir.as_deref(), Some("/repo"));
+        assert_eq!(metadata.profile.as_deref(), Some("plain-shell"));
+        assert_eq!(metadata.last_size, (120, 40));
+        assert!(!metadata.unread_output);
+        assert!(!metadata.bell_pending);
+    }
+
+    #[test]
+    fn new_metadata_is_detached_when_pane_id_is_absent() {
+        let metadata = metadata(None);
+
+        assert!(matches!(
+            metadata.status,
+            PtyStatus::RunningDetached { since_ms } if since_ms == 1234
+        ));
+    }
+
+    #[test]
+    fn attach_detach_and_mark_read_update_flags() {
+        let mut metadata = metadata(None);
+        metadata.set_unread_output(true);
+        metadata.set_bell_pending(true);
+
+        metadata.attach_to_pane("pane-b");
+        assert!(matches!(
+            metadata.status,
+            PtyStatus::RunningAttached { ref pane_id } if pane_id == "pane-b"
+        ));
+        assert!(!metadata.unread_output);
+        assert!(!metadata.bell_pending);
+
+        metadata.set_unread_output(true);
+        metadata.set_bell_pending(true);
+        metadata.detach(99);
+        assert!(matches!(metadata.status, PtyStatus::RunningDetached { since_ms: 99 }));
+
+        metadata.mark_read();
+        assert!(!metadata.unread_output);
+        assert!(!metadata.bell_pending);
+    }
+
+    #[test]
+    fn mark_exited_records_status_and_attachment_state() {
+        let mut metadata = metadata(Some("pane-a"));
+
+        metadata.mark_exited(Some(7), 222);
+
+        assert!(matches!(
+            metadata.status,
+            PtyStatus::Exited { code: Some(7), at_ms: 222 }
+        ));
+        assert_eq!(
+            metadata.exit_info,
+            Some(PtyExitInfo { code: Some(7), at_ms: 222, was_attached: true })
+        );
+    }
+
+    #[test]
+    fn to_info_projects_metadata_for_frontend() {
+        let mut metadata = metadata(Some("pane-a"));
+        metadata.set_name(Some("build shell"));
+        metadata.set_unread_output(true);
+
+        let info = metadata.to_info("pty-a");
+
+        assert_eq!(info.id, "pty-a");
+        assert_eq!(info.session_id.as_deref(), Some("session-a"));
+        assert!(matches!(info.role, PtyRole::Secondary));
+        assert_eq!(info.name.as_deref(), Some("build shell"));
+        assert_eq!(info.working_dir.as_deref(), Some("/repo"));
+        assert_eq!(info.profile.as_deref(), Some("plain-shell"));
+        assert!(info.unread_output);
+        assert!(!info.bell_pending);
+    }
+
+    #[test]
+    fn belongs_to_session_checks_optional_session_id() {
+        let metadata = metadata(Some("pane-a"));
+        let detached = PtySessionMetadata::new(PtySessionMetadataInputs {
+            role: PtyRole::Secondary,
+            pane_id: None,
+            detached_since_ms: 1,
+            session_id: None,
+            working_dir: None,
+            profile: None,
+            last_size: (80, 24),
+        });
+
+        assert!(metadata.belongs_to_session("session-a"));
+        assert!(!metadata.belongs_to_session("session-b"));
+        assert!(!detached.belongs_to_session("session-a"));
+    }
+}

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -20,6 +20,7 @@ pub use roux_runtime::process::cwd_for_pid;
 use roux_runtime::pty_output::PtyOutputBacklog;
 #[cfg(test)]
 pub use roux_runtime::pty_output::PTY_BACKLOG_LIMIT_BYTES;
+use roux_runtime::pty_session::{PtySessionMetadata, PtySessionMetadataInputs};
 use roux_runtime::pty_spawn::{self, ShellSpawnPlanInputs, TaskSpawnPlanInputs};
 pub use roux_runtime::terminal_env::{NonoConfig, NotesEnvInputs, SmolvmExec};
 use roux_runtime::terminal_env;
@@ -45,6 +46,13 @@ fn command_builder_from_plan(plan: &pty_spawn::PtyCommandPlan) -> CommandBuilder
     }
     cmd.cwd(&plan.cwd);
     cmd
+}
+
+fn unix_now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64
 }
 
 /// Best-effort flush of bytes the gate released. Errors are logged but
@@ -448,14 +456,6 @@ impl portable_pty::Child for WaitedChild {
     }
 }
 
-/// Information captured when a PTY exits.
-#[derive(Clone, Debug, serde::Serialize, specta::Type)]
-pub struct ExitInfo {
-    pub code: Option<i32>,
-    pub at_ms: u64,
-    pub was_attached: bool,
-}
-
 pub(crate) struct PtySession {
     master: Box<dyn MasterPty + Send>,
     #[allow(dead_code)]
@@ -469,19 +469,8 @@ pub(crate) struct PtySession {
     /// `None` means writes pass through unchecked.
     ready_gate: Option<ReadyGate>,
 
-    // --- attach/detach metadata ---
-    pub role: PtyRole,
-    pub status: PtyStatus,
-    pub exit_info: Option<ExitInfo>,
-    pub session_id: Option<String>,
-    pub name: Option<String>,
-    pub working_dir: Option<String>,
-    pub profile: Option<String>,
-    #[allow(dead_code)] // Reserved for future PTY size tracking
-    pub last_size: (u16, u16),
+    pub metadata: PtySessionMetadata,
     pub last_activity: std::time::Instant,
-    pub unread_output: bool,
-    pub bell_pending: bool,
     pub logger: Option<Arc<Mutex<crate::pty_logger::PtyLogger>>>,
 }
 
@@ -642,11 +631,7 @@ impl PtyManager {
     pub(crate) fn detach_direct(&self, pty_id: &str) {
         let mut sessions = self.sessions.lock().unwrap();
         if let Some(session) = sessions.get_mut(pty_id) {
-            let now_ms = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_millis() as u64;
-            session.status = PtyStatus::RunningDetached { since_ms: now_ms };
+            session.metadata.detach(unix_now_ms());
             rlog!("PtyManager: detached PTY '{}'", pty_id);
         }
     }
@@ -654,9 +639,7 @@ impl PtyManager {
     pub(crate) fn attach_to_pane_direct(&self, pty_id: &str, pane_id: &str) {
         let mut sessions = self.sessions.lock().unwrap();
         if let Some(session) = sessions.get_mut(pty_id) {
-            session.status = PtyStatus::RunningAttached { pane_id: pane_id.to_string() };
-            session.unread_output = false;
-            session.bell_pending = false;
+            session.metadata.attach_to_pane(pane_id);
             session.last_activity = std::time::Instant::now();
             rlog!("PtyManager: attached PTY '{}' to pane '{}'", pty_id, pane_id);
         }
@@ -676,42 +659,35 @@ impl PtyManager {
             return false;
         }
 
-        let now_ms = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_millis() as u64;
-        let was_attached = matches!(session.status, PtyStatus::RunningAttached { .. });
-        session.status = PtyStatus::Exited { code, at_ms: now_ms };
-        session.exit_info = Some(ExitInfo { code, at_ms: now_ms, was_attached });
+        session.metadata.mark_exited(code, unix_now_ms());
         true
     }
 
     pub(crate) fn mark_read_direct(&self, pty_id: &str) {
         let mut sessions = self.sessions.lock().unwrap();
         if let Some(session) = sessions.get_mut(pty_id) {
-            session.unread_output = false;
-            session.bell_pending = false;
+            session.metadata.mark_read();
         }
     }
 
     pub(crate) fn set_unread_output_direct(&self, pty_id: &str, value: bool) {
         let mut sessions = self.sessions.lock().unwrap();
         if let Some(session) = sessions.get_mut(pty_id) {
-            session.unread_output = value;
+            session.metadata.set_unread_output(value);
         }
     }
 
     pub(crate) fn set_bell_pending_direct(&self, pty_id: &str, value: bool) {
         let mut sessions = self.sessions.lock().unwrap();
         if let Some(session) = sessions.get_mut(pty_id) {
-            session.bell_pending = value;
+            session.metadata.set_bell_pending(value);
         }
     }
 
     pub(crate) fn set_name_direct(&self, pty_id: &str, name: Option<&str>) {
         let mut sessions = self.sessions.lock().unwrap();
         if let Some(session) = sessions.get_mut(pty_id) {
-            session.name = name.map(|s| s.to_string());
+            session.metadata.set_name(name);
         }
     }
 
@@ -720,7 +696,7 @@ impl PtyManager {
             let sessions = self.sessions.lock().unwrap();
             sessions
                 .iter()
-                .filter(|(_, s)| s.session_id.as_deref() == Some(session_id))
+                .filter(|(_, s)| s.metadata.belongs_to_session(session_id))
                 .map(|(id, _)| id.clone())
                 .collect()
         };
@@ -819,17 +795,6 @@ impl PtyManager {
         let gate =
             Arc::new(Mutex::new(ShellReadyGate::new(Instant::now(), GATE_QUIET, GATE_TIMEOUT)));
 
-        let initial_pane = pane_id.map(|p| p.to_string());
-        let initial_status = match initial_pane {
-            Some(ref p) => PtyStatus::RunningAttached { pane_id: p.clone() },
-            None => {
-                let since_ms = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap()
-                    .as_millis() as u64;
-                PtyStatus::RunningDetached { since_ms }
-            }
-        };
         let size = spawn_plan.size.as_tuple();
         let session = PtySession {
             master: pair.master,
@@ -838,17 +803,16 @@ impl PtyManager {
             output: output.clone(),
             generation: gen,
             ready_gate: Some(Arc::clone(&gate)),
-            role,
-            status: initial_status,
-            exit_info: None,
-            session_id: session_id.map(|s| s.to_string()),
-            name: None,
-            working_dir: Some(working_dir.to_string()),
-            profile: profile.map(|p| p.to_string()),
-            last_size: size,
+            metadata: PtySessionMetadata::new(PtySessionMetadataInputs {
+                role,
+                pane_id,
+                detached_since_ms: unix_now_ms(),
+                session_id,
+                working_dir: Some(working_dir),
+                profile,
+                last_size: size,
+            }),
             last_activity: std::time::Instant::now(),
-            unread_output: false,
-            bell_pending: false,
             logger: Some(logger),
         };
         let lifecycle_tx = self.lifecycle_tx.lock().unwrap().clone();
@@ -990,17 +954,6 @@ impl PtyManager {
         let output = PtyOutput::new_with_logger(Arc::clone(&logger_task));
 
         // Insert session before attaching pending output and starting threads
-        let initial_pane_task = pane_id.map(|p| p.to_string());
-        let initial_status_task = match initial_pane_task {
-            Some(ref p) => PtyStatus::RunningAttached { pane_id: p.clone() },
-            None => {
-                let since_ms = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap()
-                    .as_millis() as u64;
-                PtyStatus::RunningDetached { since_ms }
-            }
-        };
         let size_task = spawn_plan.size.as_tuple();
         let session = PtySession {
             master: pair.master,
@@ -1011,17 +964,16 @@ impl PtyManager {
             // One-shot tasks run the command as argv to the shell
             // (non-interactive), so there is no ZLE/readline init to race.
             ready_gate: None,
-            role,
-            status: initial_status_task,
-            exit_info: None,
-            session_id: session_id.map(|s| s.to_string()),
-            name: None,
-            working_dir: Some(working_dir.to_string()),
-            profile: profile.map(|p| p.to_string()),
-            last_size: size_task,
+            metadata: PtySessionMetadata::new(PtySessionMetadataInputs {
+                role,
+                pane_id,
+                detached_since_ms: unix_now_ms(),
+                session_id,
+                working_dir: Some(working_dir),
+                profile,
+                last_size: size_task,
+            }),
             last_activity: std::time::Instant::now(),
-            unread_output: false,
-            bell_pending: false,
             logger: Some(logger_task),
         };
         let lifecycle_tx = self.lifecycle_tx.lock().unwrap().clone();
@@ -1187,17 +1139,7 @@ impl PtyManager {
 
     pub(crate) fn get_info_direct(&self, pty_id: &str) -> Option<PtyInfo> {
         let sessions = self.sessions.lock().unwrap();
-        sessions.get(pty_id).map(|s| PtyInfo {
-            id: pty_id.to_string(),
-            session_id: s.session_id.clone(),
-            role: s.role.clone(),
-            status: s.status.clone(),
-            name: s.name.clone(),
-            working_dir: s.working_dir.clone(),
-            profile: s.profile.clone(),
-            unread_output: s.unread_output,
-            bell_pending: s.bell_pending,
-        })
+        sessions.get(pty_id).map(|s| s.metadata.to_info(pty_id))
     }
 
     /// List PTY info snapshots for a given session (for picker UI).
@@ -1205,18 +1147,8 @@ impl PtyManager {
         let sessions = self.sessions.lock().unwrap();
         sessions
             .iter()
-            .filter(|(_, s)| s.session_id.as_deref() == Some(session_id))
-            .map(|(id, s)| PtyInfo {
-                id: id.clone(),
-                session_id: s.session_id.clone(),
-                role: s.role.clone(),
-                status: s.status.clone(),
-                name: s.name.clone(),
-                working_dir: s.working_dir.clone(),
-                profile: s.profile.clone(),
-                unread_output: s.unread_output,
-                bell_pending: s.bell_pending,
-            })
+            .filter(|(_, s)| s.metadata.belongs_to_session(session_id))
+            .map(|(id, s)| s.metadata.to_info(id))
             .collect()
     }
 
@@ -1225,17 +1157,7 @@ impl PtyManager {
         let sessions = self.sessions.lock().unwrap();
         sessions
             .iter()
-            .map(|(id, s)| PtyInfo {
-                id: id.clone(),
-                session_id: s.session_id.clone(),
-                role: s.role.clone(),
-                status: s.status.clone(),
-                name: s.name.clone(),
-                working_dir: s.working_dir.clone(),
-                profile: s.profile.clone(),
-                unread_output: s.unread_output,
-                bell_pending: s.bell_pending,
-            })
+            .map(|(id, s)| s.metadata.to_info(id))
             .collect()
     }
 
@@ -1968,6 +1890,17 @@ mod lifecycle_command_tests {
         let child: Box<dyn portable_pty::Child + Send> =
             Box::new(FakeChild { kill_count: Arc::clone(&kill_count) });
 
+        let mut metadata = PtySessionMetadata::new(PtySessionMetadataInputs {
+            role: PtyRole::Secondary,
+            pane_id: None,
+            detached_since_ms: 1,
+            session_id,
+            working_dir: Some("/tmp"),
+            profile: Some("plain-shell"),
+            last_size: (80, 24),
+        });
+        metadata.status = status;
+
         let session = PtySession {
             master: pair.master,
             child,
@@ -1975,17 +1908,8 @@ mod lifecycle_command_tests {
             output: PtyOutput::new(),
             generation,
             ready_gate: None,
-            role: PtyRole::Secondary,
-            status,
-            exit_info: None,
-            session_id: session_id.map(ToString::to_string),
-            name: None,
-            working_dir: Some("/tmp".to_string()),
-            profile: Some("plain-shell".to_string()),
-            last_size: (80, 24),
+            metadata,
             last_activity: Instant::now(),
-            unread_output: false,
-            bell_pending: false,
             logger: None,
         };
 
@@ -2111,7 +2035,7 @@ mod lifecycle_command_tests {
             Some("session-a"),
             PtyStatus::RunningAttached { pane_id: "session-a-main".to_string() },
         );
-        restored_primary.role = PtyRole::SessionPrimary;
+        restored_primary.metadata.role = PtyRole::SessionPrimary;
         register_via_bus(&lifecycle_tx, "session-a", restored_primary);
 
         let snapshot = manager.list_for_session("session-a");


### PR DESCRIPTION
## Summary
- add runtime-owned PTY session metadata for initial attached/detached status, exit info, unread/bell/name state, and frontend PtyInfo projection
- embed the metadata object in Tauri PtySession while keeping PTY handles, child process, writer, logger, readiness gate, and app channels in Tauri
- route attach/detach/mark-read/exit/listing helpers through the runtime metadata API

## Verification
- cargo test -p roux-runtime
- CI=1 cargo clippy -p roux --all-targets -- -D warnings
- CI=1 cargo test -p roux lifecycle_command_tests
- git diff --check
- git diff --cached --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts PTY session metadata (role, status, exit info, name, working dir, profile, unread/bell flags) from the Tauri-side `PtySession` into a new `PtySessionMetadata` type in `roux-runtime`, and routes all attach/detach/exit/listing helpers through its methods.

- **Extraction**: `PtySession` in `src-tauri/src/pty.rs` now holds a single `pub metadata: PtySessionMetadata` field instead of ~10 individual fields; all duplicate `PtyInfo` projection inline code is replaced by `metadata.to_info(id)`.
- **New module**: `crates/roux-runtime/src/pty_session.rs` defines `PtySessionMetadata`, `PtyExitInfo`, and `PtySessionMetadataInputs`, with focused methods (`attach_to_pane`, `detach`, `mark_exited`, `mark_read`, `set_name`, `belongs_to_session`, `to_info`) and a comprehensive unit-test suite covering each transition.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The refactoring is mechanically correct and the production call paths are equivalent to the original code.

All state-mutation sites in pty.rs now delegate to PtySessionMetadata methods instead of duplicating inline logic, and the new module ships with solid unit tests. The main concern is that all fields on PtySessionMetadata are pub, which allows callers to set status = Exited without populating exit_info — the test helper already does this at line 1902. For now every test uses RunningAttached or RunningDetached, so no test is broken, but the pattern is fragile and will silently produce an inconsistent exit_info if a test or future caller passes Exited directly.

crates/roux-runtime/src/pty_session.rs — field visibility design; src-tauri/src/pty.rs — test helper direct status mutation.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/roux-runtime/src/pty_session.rs | New module introducing PtySessionMetadata and PtyExitInfo; logic is correct and well-tested, but all fields are pub which allows bypassing invariant-maintaining methods (notably status/exit_info pairing). |
| src-tauri/src/pty.rs | Clean mechanical refactoring: PtySession now embeds PtySessionMetadata, all state-mutation call sites delegate to metadata methods, and duplicated PtyInfo projection is replaced by to_info(). Test helper directly mutates metadata.status and metadata.role, which is acceptable today but creates an invariant risk if Exited status is ever injected. |
| crates/roux-runtime/src/lib.rs | Adds the new pty_session module to the public module list; no other changes. |

</details>

</details>

<h3>Class Diagram</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
classDiagram
    class PtySession {
        +master: Box~MasterPty~
        +child: Box~Child~
        +writer: PtyWriter
        +output: PtyOutput
        +generation: u64
        +ready_gate: Option~ReadyGate~
        +metadata: PtySessionMetadata
        +last_activity: Instant
        +logger: Option~PtyLogger~
    }

    class PtySessionMetadata {
        +pub role: PtyRole
        +pub status: PtyStatus
        +pub exit_info: Option~PtyExitInfo~
        +pub session_id: Option~String~
        +pub name: Option~String~
        +pub working_dir: Option~String~
        +pub profile: Option~String~
        +pub last_size: (u16, u16)
        +pub unread_output: bool
        +pub bell_pending: bool
        +new(inputs) PtySessionMetadata
        +attach_to_pane(pane_id)
        +detach(since_ms)
        +mark_exited(code, at_ms)
        +mark_read()
        +set_unread_output(value)
        +set_bell_pending(value)
        +set_name(name)
        +belongs_to_session(session_id) bool
        +to_info(id) PtyInfo
    }

    class PtyExitInfo {
        +pub code: Option~i32~
        +pub at_ms: u64
        +pub was_attached: bool
    }

    class PtyInfo {
        +id: String
        +session_id: Option~String~
        +role: PtyRole
        +status: PtyStatus
        +name: Option~String~
        +working_dir: Option~String~
        +profile: Option~String~
        +unread_output: bool
        +bell_pending: bool
    }

    PtySession *-- PtySessionMetadata : embeds
    PtySessionMetadata *-- PtyExitInfo : optional
    PtySessionMetadata ..> PtyInfo : to_info()
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Froux-runtime%2Fsrc%2Fpty_session.rs%3A10-22%0A**Public%20fields%20undermine%20method-level%20invariants**%0A%0AAll%20fields%20on%20%60PtySessionMetadata%60%20are%20%60pub%60%2C%20so%20callers%20can%20bypass%20the%20methods%20that%20maintain%20invariants.%20The%20most%20fragile%20is%20the%20%60status%60%2F%60exit_info%60%20pairing%3A%20%60mark_exited%60%20sets%20both%20together%2C%20but%20direct%20assignment%20to%20%60status%60%20%28e.g.%2C%20%60metadata.status%20%3D%20PtyStatus%3A%3AExited%20%7B%20..%20%7D%60%29%20leaves%20%60exit_info%60%20as%20%60None%60.%20The%20test%20helper%20at%20line%201902%20of%20%60pty.rs%60%20already%20does%20exactly%20this%20%28%60metadata.status%20%3D%20status%60%29.%20If%20a%20test%20ever%20passes%20%60PtyStatus%3A%3AExited%60%20there%2C%20the%20invariant%20is%20silently%20broken.%20Similarly%2C%20calling%20%60detach%60%20or%20%60attach_to_pane%60%20on%20an%20already-exited%20session%20would%20flip%20%60status%60%20back%20to%20running%20while%20%60exit_info%60%20retains%20stale%20data.%20Making%20%60status%60%20and%20%60exit_info%60%20private%20%28with%20method-only%20mutation%29%20would%20prevent%20both%20classes%20of%20misuse.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc-tauri%2Fsrc%2Fpty.rs%3A1893-1902%0A**Direct%20status%20mutation%20bypasses%20invariant-maintaining%20methods**%0A%0A%60metadata.status%20%3D%20status%60%20injects%20any%20%60PtyStatus%60%20variant%20without%20going%20through%20%60attach_to_pane%60%2C%20%60detach%60%2C%20or%20%60mark_exited%60.%20For%20%60RunningAttached%60%20and%20%60RunningDetached%60%20this%20is%20harmless%20today%20because%20%60unread_output%60%2F%60bell_pending%60%20default%20to%20%60false%60.%20However%2C%20if%20any%20future%20test%20passes%20%60PtyStatus%3A%3AExited%20%7B%20..%20%7D%60%2C%20the%20session%20will%20have%20%60status%20%3D%3D%20Exited%60%20but%20%60exit_info%20%3D%3D%20None%60%2C%20making%20any%20assertion%20on%20%60exit_info%60%20a%20false%20positive.%20A%20dedicated%20%60with_status%60%20or%20%60override_status_for_test%60%20helper%20on%20%60PtySessionMetadata%60%20%28or%20in%20the%20test%20module%29%20that%20also%20sets%20%60exit_info%60%20for%20the%20%60Exited%60%20variant%20would%20close%20this%20gap.%0A%0A&repo=phin-tech%2Froux&pr=184&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22feature%2Fextract-pty-session-metadata%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fextract-pty-session-metadata%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Froux-runtime%2Fsrc%2Fpty_session.rs%3A10-22%0A**Public%20fields%20undermine%20method-level%20invariants**%0A%0AAll%20fields%20on%20%60PtySessionMetadata%60%20are%20%60pub%60%2C%20so%20callers%20can%20bypass%20the%20methods%20that%20maintain%20invariants.%20The%20most%20fragile%20is%20the%20%60status%60%2F%60exit_info%60%20pairing%3A%20%60mark_exited%60%20sets%20both%20together%2C%20but%20direct%20assignment%20to%20%60status%60%20%28e.g.%2C%20%60metadata.status%20%3D%20PtyStatus%3A%3AExited%20%7B%20..%20%7D%60%29%20leaves%20%60exit_info%60%20as%20%60None%60.%20The%20test%20helper%20at%20line%201902%20of%20%60pty.rs%60%20already%20does%20exactly%20this%20%28%60metadata.status%20%3D%20status%60%29.%20If%20a%20test%20ever%20passes%20%60PtyStatus%3A%3AExited%60%20there%2C%20the%20invariant%20is%20silently%20broken.%20Similarly%2C%20calling%20%60detach%60%20or%20%60attach_to_pane%60%20on%20an%20already-exited%20session%20would%20flip%20%60status%60%20back%20to%20running%20while%20%60exit_info%60%20retains%20stale%20data.%20Making%20%60status%60%20and%20%60exit_info%60%20private%20%28with%20method-only%20mutation%29%20would%20prevent%20both%20classes%20of%20misuse.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc-tauri%2Fsrc%2Fpty.rs%3A1893-1902%0A**Direct%20status%20mutation%20bypasses%20invariant-maintaining%20methods**%0A%0A%60metadata.status%20%3D%20status%60%20injects%20any%20%60PtyStatus%60%20variant%20without%20going%20through%20%60attach_to_pane%60%2C%20%60detach%60%2C%20or%20%60mark_exited%60.%20For%20%60RunningAttached%60%20and%20%60RunningDetached%60%20this%20is%20harmless%20today%20because%20%60unread_output%60%2F%60bell_pending%60%20default%20to%20%60false%60.%20However%2C%20if%20any%20future%20test%20passes%20%60PtyStatus%3A%3AExited%20%7B%20..%20%7D%60%2C%20the%20session%20will%20have%20%60status%20%3D%3D%20Exited%60%20but%20%60exit_info%20%3D%3D%20None%60%2C%20making%20any%20assertion%20on%20%60exit_info%60%20a%20false%20positive.%20A%20dedicated%20%60with_status%60%20or%20%60override_status_for_test%60%20helper%20on%20%60PtySessionMetadata%60%20%28or%20in%20the%20test%20module%29%20that%20also%20sets%20%60exit_info%60%20for%20the%20%60Exited%60%20variant%20would%20close%20this%20gap.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["extract pty session metadata into runtim..."](https://github.com/phin-tech/roux/commit/45ae2a0fccaac8f6f8b7a81981bc70787265970b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33262709)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->