### PR TITLE
[codex] extract pty lifecycle metadata commands

### DIFF
--- a/crates/roux-runtime/src/pty_lifecycle.rs
+++ b/crates/roux-runtime/src/pty_lifecycle.rs
@@ -29,7 +29,7 @@ pub enum ExitReason {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PtyMetadataCommand {
-    Detach { pty_id: String, since_ms: u64 },
+    Detach { pty_id: String },
     AttachToPane { pty_id: String, pane_id: String },
     MarkRead { pty_id: String },
     SetUnreadOutput { pty_id: String, value: bool },
@@ -69,9 +69,18 @@ pub fn apply_metadata_command(
     session_generation: u64,
     command: &PtyMetadataCommand,
 ) -> PtyMetadataCommandResult {
+    apply_metadata_command_at(metadata, session_generation, command, unix_now_ms())
+}
+
+pub fn apply_metadata_command_at(
+    metadata: &mut PtySessionMetadata,
+    session_generation: u64,
+    command: &PtyMetadataCommand,
+    now_ms: u64,
+) -> PtyMetadataCommandResult {
     match command {
-        PtyMetadataCommand::Detach { since_ms, .. } => {
-            metadata.detach(*since_ms);
+        PtyMetadataCommand::Detach { .. } => {
+            metadata.detach(now_ms);
             PtyMetadataCommandResult::Applied
         }
         PtyMetadataCommand::AttachToPane { pane_id, .. } => {
@@ -107,6 +116,13 @@ pub fn apply_metadata_command(
             PtyMetadataCommandResult::Applied
         }
     }
+}
+
+fn unix_now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64
 }
 
 impl From<ExitReason> for roux_core::SessionExitReason {
@@ -229,35 +245,38 @@ mod tests {
         let mut metadata = metadata();
 
         assert_eq!(
-            apply_metadata_command(
+            apply_metadata_command_at(
                 &mut metadata,
                 7,
                 &PtyMetadataCommand::SetUnreadOutput {
                     pty_id: "pty-a".to_string(),
                     value: true,
                 },
+                44,
             ),
             PtyMetadataCommandResult::Applied
         );
         assert!(metadata.unread_output);
 
-        apply_metadata_command(
+        apply_metadata_command_at(
             &mut metadata,
             7,
             &PtyMetadataCommand::SetBellPending {
                 pty_id: "pty-a".to_string(),
                 value: true,
             },
+            44,
         );
         assert!(metadata.bell_pending);
 
-        apply_metadata_command(
+        apply_metadata_command_at(
             &mut metadata,
             7,
             &PtyMetadataCommand::AttachToPane {
                 pty_id: "pty-a".to_string(),
                 pane_id: "pane-b".to_string(),
             },
+            44,
         );
         assert!(matches!(
             metadata.status,
@@ -266,19 +285,21 @@ mod tests {
         assert!(!metadata.unread_output);
         assert!(!metadata.bell_pending);
 
-        apply_metadata_command(
+        apply_metadata_command_at(
             &mut metadata,
             7,
-            &PtyMetadataCommand::Detach { pty_id: "pty-a".to_string(), since_ms: 44 },
+            &PtyMetadataCommand::Detach { pty_id: "pty-a".to_string() },
+            44,
         );
         assert!(matches!(metadata.status, PtyStatus::RunningDetached { since_ms: 44 }));
 
         metadata.set_unread_output(true);
         metadata.set_bell_pending(true);
-        apply_metadata_command(
+        apply_metadata_command_at(
             &mut metadata,
             7,
             &PtyMetadataCommand::MarkRead { pty_id: "pty-a".to_string() },
+            44,
         );
         assert!(!metadata.unread_output);
         assert!(!metadata.bell_pending);
@@ -288,20 +309,22 @@ mod tests {
     fn apply_metadata_command_sets_name() {
         let mut metadata = metadata();
 
-        apply_metadata_command(
+        apply_metadata_command_at(
             &mut metadata,
             7,
             &PtyMetadataCommand::SetName {
                 pty_id: "pty-a".to_string(),
                 name: Some("build".to_string()),
             },
+            44,
         );
         assert_eq!(metadata.name.as_deref(), Some("build"));
 
-        apply_metadata_command(
+        apply_metadata_command_at(
             &mut metadata,
             7,
             &PtyMetadataCommand::SetName { pty_id: "pty-a".to_string(), name: None },
+            44,
         );
         assert_eq!(metadata.name, None);
     }
@@ -310,7 +333,7 @@ mod tests {
     fn apply_metadata_command_marks_matching_generation_exited() {
         let mut metadata = metadata();
 
-        let result = apply_metadata_command(
+        let result = apply_metadata_command_at(
             &mut metadata,
             7,
             &PtyMetadataCommand::MarkExitedIfGenerationMatches {
@@ -319,6 +342,7 @@ mod tests {
                 code: Some(2),
                 at_ms: 99,
             },
+            44,
         );
 
         assert_eq!(result, PtyMetadataCommandResult::Applied);
@@ -336,7 +360,7 @@ mod tests {
     fn apply_metadata_command_rejects_stale_exit_generation() {
         let mut metadata = metadata();
 
-        let result = apply_metadata_command(
+        let result = apply_metadata_command_at(
             &mut metadata,
             7,
             &PtyMetadataCommand::MarkExitedIfGenerationMatches {
@@ -345,6 +369,7 @@ mod tests {
                 code: Some(1),
                 at_ms: 99,
             },
+            44,
         );
 
         assert_eq!(result, PtyMetadataCommandResult::StaleGeneration);

--- a/crates/roux-runtime/src/pty_lifecycle.rs
+++ b/crates/roux-runtime/src/pty_lifecycle.rs
@@ -1,5 +1,7 @@
 use std::sync::mpsc;
 
+use crate::pty_session::PtySessionMetadata;
+
 /// Events that can occur during a PTY's lifecycle.
 #[derive(Debug, Clone, PartialEq)]
 #[allow(dead_code)] // Variants reserved for future detach tracking
@@ -23,6 +25,88 @@ pub enum ExitReason {
     Exit,
     IoError,
     Killed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PtyMetadataCommand {
+    Detach { pty_id: String, since_ms: u64 },
+    AttachToPane { pty_id: String, pane_id: String },
+    MarkRead { pty_id: String },
+    SetUnreadOutput { pty_id: String, value: bool },
+    SetBellPending { pty_id: String, value: bool },
+    SetName { pty_id: String, name: Option<String> },
+    MarkExitedIfGenerationMatches {
+        pty_id: String,
+        generation: u64,
+        code: Option<i32>,
+        at_ms: u64,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PtyMetadataCommandResult {
+    Applied,
+    Missing,
+    StaleGeneration,
+}
+
+impl PtyMetadataCommand {
+    pub fn pty_id(&self) -> &str {
+        match self {
+            Self::Detach { pty_id, .. }
+            | Self::AttachToPane { pty_id, .. }
+            | Self::MarkRead { pty_id }
+            | Self::SetUnreadOutput { pty_id, .. }
+            | Self::SetBellPending { pty_id, .. }
+            | Self::SetName { pty_id, .. }
+            | Self::MarkExitedIfGenerationMatches { pty_id, .. } => pty_id,
+        }
+    }
+}
+
+pub fn apply_metadata_command(
+    metadata: &mut PtySessionMetadata,
+    session_generation: u64,
+    command: &PtyMetadataCommand,
+) -> PtyMetadataCommandResult {
+    match command {
+        PtyMetadataCommand::Detach { since_ms, .. } => {
+            metadata.detach(*since_ms);
+            PtyMetadataCommandResult::Applied
+        }
+        PtyMetadataCommand::AttachToPane { pane_id, .. } => {
+            metadata.attach_to_pane(pane_id);
+            PtyMetadataCommandResult::Applied
+        }
+        PtyMetadataCommand::MarkRead { .. } => {
+            metadata.mark_read();
+            PtyMetadataCommandResult::Applied
+        }
+        PtyMetadataCommand::SetUnreadOutput { value, .. } => {
+            metadata.set_unread_output(*value);
+            PtyMetadataCommandResult::Applied
+        }
+        PtyMetadataCommand::SetBellPending { value, .. } => {
+            metadata.set_bell_pending(*value);
+            PtyMetadataCommandResult::Applied
+        }
+        PtyMetadataCommand::SetName { name, .. } => {
+            metadata.set_name(name.as_deref());
+            PtyMetadataCommandResult::Applied
+        }
+        PtyMetadataCommand::MarkExitedIfGenerationMatches {
+            generation,
+            code,
+            at_ms,
+            ..
+        } => {
+            if *generation != session_generation {
+                return PtyMetadataCommandResult::StaleGeneration;
+            }
+            metadata.mark_exited(*code, *at_ms);
+            PtyMetadataCommandResult::Applied
+        }
+    }
 }
 
 impl From<ExitReason> for roux_core::SessionExitReason {
@@ -49,6 +133,8 @@ pub fn channel<Message>() -> (LifecycleTx<Message>, LifecycleRx<Message>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::pty_session::{PtyExitInfo, PtySessionMetadata, PtySessionMetadataInputs};
+    use roux_core::{PtyRole, PtyStatus};
 
     #[test]
     fn exit_reason_converts_to_core_type() {
@@ -114,5 +200,155 @@ mod tests {
         assert_eq!(ids.len(), 2);
         assert!(ids.contains(&"pty-1".to_string()));
         assert!(ids.contains(&"pty-2".to_string()));
+    }
+
+    fn metadata() -> PtySessionMetadata {
+        PtySessionMetadata::new(PtySessionMetadataInputs {
+            role: PtyRole::Secondary,
+            pane_id: Some("pane-a"),
+            detached_since_ms: 1,
+            session_id: Some("session-a"),
+            working_dir: Some("/repo"),
+            profile: Some("plain-shell"),
+            last_size: (80, 24),
+        })
+    }
+
+    #[test]
+    fn metadata_command_exposes_target_pty_id() {
+        let command = PtyMetadataCommand::AttachToPane {
+            pty_id: "pty-a".to_string(),
+            pane_id: "pane-b".to_string(),
+        };
+
+        assert_eq!(command.pty_id(), "pty-a");
+    }
+
+    #[test]
+    fn apply_metadata_command_handles_attach_detach_and_flags() {
+        let mut metadata = metadata();
+
+        assert_eq!(
+            apply_metadata_command(
+                &mut metadata,
+                7,
+                &PtyMetadataCommand::SetUnreadOutput {
+                    pty_id: "pty-a".to_string(),
+                    value: true,
+                },
+            ),
+            PtyMetadataCommandResult::Applied
+        );
+        assert!(metadata.unread_output);
+
+        apply_metadata_command(
+            &mut metadata,
+            7,
+            &PtyMetadataCommand::SetBellPending {
+                pty_id: "pty-a".to_string(),
+                value: true,
+            },
+        );
+        assert!(metadata.bell_pending);
+
+        apply_metadata_command(
+            &mut metadata,
+            7,
+            &PtyMetadataCommand::AttachToPane {
+                pty_id: "pty-a".to_string(),
+                pane_id: "pane-b".to_string(),
+            },
+        );
+        assert!(matches!(
+            metadata.status,
+            PtyStatus::RunningAttached { ref pane_id } if pane_id == "pane-b"
+        ));
+        assert!(!metadata.unread_output);
+        assert!(!metadata.bell_pending);
+
+        apply_metadata_command(
+            &mut metadata,
+            7,
+            &PtyMetadataCommand::Detach { pty_id: "pty-a".to_string(), since_ms: 44 },
+        );
+        assert!(matches!(metadata.status, PtyStatus::RunningDetached { since_ms: 44 }));
+
+        metadata.set_unread_output(true);
+        metadata.set_bell_pending(true);
+        apply_metadata_command(
+            &mut metadata,
+            7,
+            &PtyMetadataCommand::MarkRead { pty_id: "pty-a".to_string() },
+        );
+        assert!(!metadata.unread_output);
+        assert!(!metadata.bell_pending);
+    }
+
+    #[test]
+    fn apply_metadata_command_sets_name() {
+        let mut metadata = metadata();
+
+        apply_metadata_command(
+            &mut metadata,
+            7,
+            &PtyMetadataCommand::SetName {
+                pty_id: "pty-a".to_string(),
+                name: Some("build".to_string()),
+            },
+        );
+        assert_eq!(metadata.name.as_deref(), Some("build"));
+
+        apply_metadata_command(
+            &mut metadata,
+            7,
+            &PtyMetadataCommand::SetName { pty_id: "pty-a".to_string(), name: None },
+        );
+        assert_eq!(metadata.name, None);
+    }
+
+    #[test]
+    fn apply_metadata_command_marks_matching_generation_exited() {
+        let mut metadata = metadata();
+
+        let result = apply_metadata_command(
+            &mut metadata,
+            7,
+            &PtyMetadataCommand::MarkExitedIfGenerationMatches {
+                pty_id: "pty-a".to_string(),
+                generation: 7,
+                code: Some(2),
+                at_ms: 99,
+            },
+        );
+
+        assert_eq!(result, PtyMetadataCommandResult::Applied);
+        assert!(matches!(
+            metadata.status,
+            PtyStatus::Exited { code: Some(2), at_ms: 99 }
+        ));
+        assert_eq!(
+            metadata.exit_info,
+            Some(PtyExitInfo { code: Some(2), at_ms: 99, was_attached: true })
+        );
+    }
+
+    #[test]
+    fn apply_metadata_command_rejects_stale_exit_generation() {
+        let mut metadata = metadata();
+
+        let result = apply_metadata_command(
+            &mut metadata,
+            7,
+            &PtyMetadataCommand::MarkExitedIfGenerationMatches {
+                pty_id: "pty-a".to_string(),
+                generation: 6,
+                code: Some(1),
+                at_ms: 99,
+            },
+        );
+
+        assert_eq!(result, PtyMetadataCommandResult::StaleGeneration);
+        assert!(matches!(metadata.status, PtyStatus::RunningAttached { .. }));
+        assert_eq!(metadata.exit_info, None);
     }
 }

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -612,10 +612,17 @@ impl PtyManager {
         };
         let result =
             pty_lifecycle::apply_metadata_command(&mut session.metadata, session.generation, command);
-        if matches!(result, PtyMetadataCommandResult::Applied)
-            && matches!(command, PtyMetadataCommand::AttachToPane { .. })
-        {
-            session.last_activity = std::time::Instant::now();
+        if matches!(result, PtyMetadataCommandResult::Applied) {
+            match command {
+                PtyMetadataCommand::AttachToPane { pty_id, pane_id } => {
+                    session.last_activity = std::time::Instant::now();
+                    rlog!("PtyManager: attached PTY '{}' to pane '{}'", pty_id, pane_id);
+                }
+                PtyMetadataCommand::Detach { pty_id } => {
+                    rlog!("PtyManager: detached PTY '{}'", pty_id);
+                }
+                _ => {}
+            }
         }
         result
     }
@@ -1151,7 +1158,6 @@ impl PtyManager {
     pub fn detach(&self, pty_id: &str) {
         let command = PtyMetadataCommand::Detach {
             pty_id: pty_id.to_string(),
-            since_ms: unix_now_ms(),
         };
         if !self.send_lifecycle_command(crate::pty_lifecycle::PtyLifecycleCommand::Metadata(
             command.clone(),

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -17,6 +17,7 @@ use crate::pty_ready_gate::ShellReadyGate;
 
 pub use roux_core::{PtyInfo, PtyRole, PtyStatus};
 pub use roux_runtime::process::cwd_for_pid;
+use roux_runtime::pty_lifecycle::{self, PtyMetadataCommand, PtyMetadataCommandResult};
 use roux_runtime::pty_output::PtyOutputBacklog;
 #[cfg(test)]
 pub use roux_runtime::pty_output::PTY_BACKLOG_LIMIT_BYTES;
@@ -601,6 +602,24 @@ impl PtyManager {
         self.sessions.lock().unwrap().insert(pty_id, session);
     }
 
+    pub(crate) fn apply_metadata_command_direct(
+        &self,
+        command: &PtyMetadataCommand,
+    ) -> PtyMetadataCommandResult {
+        let mut sessions = self.sessions.lock().unwrap();
+        let Some(session) = sessions.get_mut(command.pty_id()) else {
+            return PtyMetadataCommandResult::Missing;
+        };
+        let result =
+            pty_lifecycle::apply_metadata_command(&mut session.metadata, session.generation, command);
+        if matches!(result, PtyMetadataCommandResult::Applied)
+            && matches!(command, PtyMetadataCommand::AttachToPane { .. })
+        {
+            session.last_activity = std::time::Instant::now();
+        }
+        result
+    }
+
     pub(crate) fn kill_direct(&self, session_id: &str) {
         let session = self.sessions.lock().unwrap().remove(session_id);
         self.pending_outputs.lock().unwrap().remove(session_id);
@@ -628,67 +647,34 @@ impl PtyManager {
         }
     }
 
-    pub(crate) fn detach_direct(&self, pty_id: &str) {
-        let mut sessions = self.sessions.lock().unwrap();
-        if let Some(session) = sessions.get_mut(pty_id) {
-            session.metadata.detach(unix_now_ms());
-            rlog!("PtyManager: detached PTY '{}'", pty_id);
-        }
-    }
-
-    pub(crate) fn attach_to_pane_direct(&self, pty_id: &str, pane_id: &str) {
-        let mut sessions = self.sessions.lock().unwrap();
-        if let Some(session) = sessions.get_mut(pty_id) {
-            session.metadata.attach_to_pane(pane_id);
-            session.last_activity = std::time::Instant::now();
-            rlog!("PtyManager: attached PTY '{}' to pane '{}'", pty_id, pane_id);
-        }
-    }
-
     pub(crate) fn mark_exited_if_generation_matches_direct(
         &self,
         pty_id: &str,
         generation: u64,
         code: Option<i32>,
     ) -> bool {
-        let mut sessions = self.sessions.lock().unwrap();
-        let Some(session) = sessions.get_mut(pty_id) else {
-            return false;
+        let command = PtyMetadataCommand::MarkExitedIfGenerationMatches {
+            pty_id: pty_id.to_string(),
+            generation,
+            code,
+            at_ms: unix_now_ms(),
         };
-        if session.generation != generation {
-            return false;
-        }
-
-        session.metadata.mark_exited(code, unix_now_ms());
-        true
-    }
-
-    pub(crate) fn mark_read_direct(&self, pty_id: &str) {
-        let mut sessions = self.sessions.lock().unwrap();
-        if let Some(session) = sessions.get_mut(pty_id) {
-            session.metadata.mark_read();
-        }
+        matches!(
+            self.apply_metadata_command_direct(&command),
+            PtyMetadataCommandResult::Applied
+        )
     }
 
     pub(crate) fn set_unread_output_direct(&self, pty_id: &str, value: bool) {
-        let mut sessions = self.sessions.lock().unwrap();
-        if let Some(session) = sessions.get_mut(pty_id) {
-            session.metadata.set_unread_output(value);
-        }
+        let command =
+            PtyMetadataCommand::SetUnreadOutput { pty_id: pty_id.to_string(), value };
+        self.apply_metadata_command_direct(&command);
     }
 
     pub(crate) fn set_bell_pending_direct(&self, pty_id: &str, value: bool) {
-        let mut sessions = self.sessions.lock().unwrap();
-        if let Some(session) = sessions.get_mut(pty_id) {
-            session.metadata.set_bell_pending(value);
-        }
-    }
-
-    pub(crate) fn set_name_direct(&self, pty_id: &str, name: Option<&str>) {
-        let mut sessions = self.sessions.lock().unwrap();
-        if let Some(session) = sessions.get_mut(pty_id) {
-            session.metadata.set_name(name);
-        }
+        let command =
+            PtyMetadataCommand::SetBellPending { pty_id: pty_id.to_string(), value };
+        self.apply_metadata_command_direct(&command);
     }
 
     pub(crate) fn kill_session_ptys_direct(&self, session_id: &str) {
@@ -1163,29 +1149,39 @@ impl PtyManager {
 
     /// Detach a PTY from its pane (PTY keeps running).
     pub fn detach(&self, pty_id: &str) {
-        if !self.send_lifecycle_command(crate::pty_lifecycle::PtyLifecycleCommand::Detach {
+        let command = PtyMetadataCommand::Detach {
             pty_id: pty_id.to_string(),
-        }) {
-            self.detach_direct(pty_id);
+            since_ms: unix_now_ms(),
+        };
+        if !self.send_lifecycle_command(crate::pty_lifecycle::PtyLifecycleCommand::Metadata(
+            command.clone(),
+        )) {
+            self.apply_metadata_command_direct(&command);
         }
     }
 
     /// Mark a PTY as attached to a pane.
     pub fn attach_to_pane(&self, pty_id: &str, pane_id: &str) {
-        if !self.send_lifecycle_command(crate::pty_lifecycle::PtyLifecycleCommand::AttachToPane {
+        let command = PtyMetadataCommand::AttachToPane {
             pty_id: pty_id.to_string(),
             pane_id: pane_id.to_string(),
-        }) {
-            self.attach_to_pane_direct(pty_id, pane_id);
+        };
+        if !self.send_lifecycle_command(crate::pty_lifecycle::PtyLifecycleCommand::Metadata(
+            command.clone(),
+        )) {
+            self.apply_metadata_command_direct(&command);
         }
     }
 
     /// Clear unread output and bell flags for a PTY.
     pub fn mark_read(&self, pty_id: &str) {
-        if !self.send_lifecycle_command(crate::pty_lifecycle::PtyLifecycleCommand::MarkRead {
+        let command = PtyMetadataCommand::MarkRead {
             pty_id: pty_id.to_string(),
-        }) {
-            self.mark_read_direct(pty_id);
+        };
+        if !self.send_lifecycle_command(crate::pty_lifecycle::PtyLifecycleCommand::Metadata(
+            command.clone(),
+        )) {
+            self.apply_metadata_command_direct(&command);
         }
     }
 
@@ -1201,11 +1197,14 @@ impl PtyManager {
 
     /// Set the display name for a PTY.
     pub fn set_name(&self, pty_id: &str, name: Option<&str>) {
-        if !self.send_lifecycle_command(crate::pty_lifecycle::PtyLifecycleCommand::SetName {
+        let command = PtyMetadataCommand::SetName {
             pty_id: pty_id.to_string(),
-            name: name.map(|s| s.to_string()),
-        }) {
-            self.set_name_direct(pty_id, name);
+            name: name.map(str::to_string),
+        };
+        if !self.send_lifecycle_command(crate::pty_lifecycle::PtyLifecycleCommand::Metadata(
+            command.clone(),
+        )) {
+            self.apply_metadata_command_direct(&command);
         }
     }
 

--- a/src-tauri/src/pty_lifecycle.rs
+++ b/src-tauri/src/pty_lifecycle.rs
@@ -10,7 +10,7 @@
 use std::sync::{mpsc, Arc};
 use std::thread;
 
-pub use roux_runtime::pty_lifecycle::{ExitReason, PtyLifecycleEvent};
+pub use roux_runtime::pty_lifecycle::{ExitReason, PtyLifecycleEvent, PtyMetadataCommand};
 
 pub enum PtyLifecycleCommand {
     Register {
@@ -23,20 +23,7 @@ pub enum PtyLifecycleCommand {
     KillSessionPtys {
         session_id: String,
     },
-    Detach {
-        pty_id: String,
-    },
-    AttachToPane {
-        pty_id: String,
-        pane_id: String,
-    },
-    MarkRead {
-        pty_id: String,
-    },
-    SetName {
-        pty_id: String,
-        name: Option<String>,
-    },
+    Metadata(PtyMetadataCommand),
 }
 
 pub enum PtyLifecycleMessage {
@@ -55,20 +42,7 @@ impl std::fmt::Debug for PtyLifecycleCommand {
                 .debug_struct("KillSessionPtys")
                 .field("session_id", session_id)
                 .finish(),
-            Self::Detach { pty_id } => f.debug_struct("Detach").field("pty_id", pty_id).finish(),
-            Self::AttachToPane { pty_id, pane_id } => f
-                .debug_struct("AttachToPane")
-                .field("pty_id", pty_id)
-                .field("pane_id", pane_id)
-                .finish(),
-            Self::MarkRead { pty_id } => {
-                f.debug_struct("MarkRead").field("pty_id", pty_id).finish()
-            }
-            Self::SetName { pty_id, name } => f
-                .debug_struct("SetName")
-                .field("pty_id", pty_id)
-                .field("name", name)
-                .finish(),
+            Self::Metadata(command) => f.debug_tuple("Metadata").field(command).finish(),
         }
     }
 }
@@ -217,17 +191,8 @@ pub(crate) fn handle_command(pty_manager: &crate::pty::PtyManager, command: PtyL
         PtyLifecycleCommand::KillSessionPtys { session_id } => {
             pty_manager.kill_session_ptys_direct(&session_id);
         }
-        PtyLifecycleCommand::Detach { pty_id } => {
-            pty_manager.detach_direct(&pty_id);
-        }
-        PtyLifecycleCommand::AttachToPane { pty_id, pane_id } => {
-            pty_manager.attach_to_pane_direct(&pty_id, &pane_id);
-        }
-        PtyLifecycleCommand::MarkRead { pty_id } => {
-            pty_manager.mark_read_direct(&pty_id);
-        }
-        PtyLifecycleCommand::SetName { pty_id, name } => {
-            pty_manager.set_name_direct(&pty_id, name.as_deref());
+        PtyLifecycleCommand::Metadata(command) => {
+            pty_manager.apply_metadata_command_direct(&command);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add runtime PTY metadata lifecycle commands and command results for attach, detach, mark-read, unread/bell flags, display names, and generation-checked exits
- route Tauri PTY metadata mutations through the runtime command application API
- keep Tauri-specific register, kill, kill-session, PTY child handles, and event emission in the Tauri lifecycle layer

## Verification
- cargo test -p roux-runtime
- CI=1 cargo clippy -p roux --all-targets -- -D warnings
- CI=1 cargo test -p roux lifecycle_command_tests
- git diff --check
- git diff --cached --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts PTY lifecycle metadata commands (`Detach`, `AttachToPane`, `MarkRead`, `SetUnreadOutput`, `SetBellPending`, `SetName`, `MarkExitedIfGenerationMatches`) from the Tauri layer into the `roux-runtime` crate as a `PtyMetadataCommand` enum, with corresponding `apply_metadata_command` / `apply_metadata_command_at` helpers. Tauri-specific operations (register, kill, PTY child handles, event emission) remain in the Tauri lifecycle layer.

- **`crates/roux-runtime/src/pty_lifecycle.rs`**: Adds `PtyMetadataCommand`, `PtyMetadataCommandResult`, `apply_metadata_command`, `apply_metadata_command_at`, and a private `unix_now_ms` helper; covers all new variants with tests.
- **`src-tauri/src/pty.rs`**: Replaces four separate `_direct` methods (`detach_direct`, `attach_to_pane_direct`, `mark_read_direct`, `set_name_direct`) with a single `apply_metadata_command_direct`; `detach()`, `attach_to_pane()`, `mark_read()`, and `set_name()` all now fan out to `Metadata(command)` on the lifecycle channel with a direct fallback.
- **`src-tauri/src/pty_lifecycle.rs`**: Collapses the four separate `PtyLifecycleCommand` variants into `Metadata(PtyMetadataCommand)` and removes their individual `handle_command` arms.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The refactoring is safe to merge — no behavioural regressions were identified across the direct, lifecycle-channel, and fallback code paths.

All four previously separate _direct methods are correctly replaced by the unified apply_metadata_command_direct. The rlog! calls for Attach and Detach are preserved in the new consolidated path. The at_ms timestamp for MarkExitedIfGenerationMatches is captured at call time and applied immediately (no channel queuing for that variant), so the clock semantics are unchanged. Generation-guard, Missing, and StaleGeneration results map correctly to the callers' boolean expectations. New unit tests in roux-runtime cover the full command matrix.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/roux-runtime/src/pty_lifecycle.rs | Adds PtyMetadataCommand enum, apply_metadata_command/apply_metadata_command_at helpers, and a private unix_now_ms; all new code paths are covered by unit tests including generation-guard, detach/attach, and flag mutations. |
| src-tauri/src/pty.rs | Removes four individual _direct methods in favour of apply_metadata_command_direct; rlog! calls for Detach and AttachToPane are preserved in the new consolidated path; mark_exited_if_generation_matches_direct correctly captures at_ms at application time via unix_now_ms(). |
| src-tauri/src/pty_lifecycle.rs | Collapses four PtyLifecycleCommand variants into Metadata(PtyMetadataCommand) and removes their individual handle_command arms; no behavioural changes in event handling or channel plumbing. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant PtyManager
    participant LifecycleChannel
    participant LifecycleThread
    participant apply_metadata_command

    Caller->>PtyManager: detach(pty_id) / attach_to_pane() / mark_read() / set_name()
    PtyManager->>PtyManager: build PtyMetadataCommand
    PtyManager->>LifecycleChannel: send Metadata(command)
    alt channel available
        LifecycleChannel->>LifecycleThread: Metadata(command)
        LifecycleThread->>PtyManager: "apply_metadata_command_direct(&command)"
        PtyManager->>apply_metadata_command: "(&mut metadata, generation, command)"
        apply_metadata_command-->>PtyManager: PtyMetadataCommandResult
        PtyManager-->>LifecycleThread: result
    else channel full / not running
        PtyManager->>PtyManager: "apply_metadata_command_direct(&command) [direct fallback]"
    end

    Note over PtyManager: Tauri-only: last_activity update + rlog! for Attach/Detach

    Caller->>PtyManager: mark_exited_if_generation_matches_direct(pty_id, gen, code)
    PtyManager->>PtyManager: "build MarkExitedIfGenerationMatches{at_ms: unix_now_ms()}"
    PtyManager->>PtyManager: apply_metadata_command_direct (direct, no channel)
    PtyManager->>apply_metadata_command: check generation, mark_exited(code, at_ms)
    apply_metadata_command-->>PtyManager: "Applied | StaleGeneration | Missing"
```

<sub>Reviews (2): Last reviewed commit: ["address pty lifecycle metadata review"](https://github.com/phin-tech/roux/commit/6d8509fb00e677b4bf50b32e48cead0cba736a98) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33267126)</sub>

<!-- /greptile_comment -->