### PR TITLE
Extract PTY lifecycle event planning

### DIFF
--- a/crates/roux-runtime/src/pty_lifecycle.rs
+++ b/crates/roux-runtime/src/pty_lifecycle.rs
@@ -1,6 +1,7 @@
 use std::sync::mpsc;
 
 use crate::pty_session::PtySessionMetadata;
+use roux_core::PtyInfo;
 
 /// Events that can occur during a PTY's lifecycle.
 #[derive(Debug, Clone, PartialEq)]
@@ -125,6 +126,133 @@ fn unix_now_ms() -> u64 {
         .as_millis() as u64
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct PtyExitEmit {
+    pub pty_id: String,
+    pub code: Option<u32>,
+    pub generation: u64,
+    pub reason: ExitReason,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PtyTaskHookKind {
+    PostTaskSuccess,
+    PostTaskFailure,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PtyTaskHookIntent {
+    pub kind: PtyTaskHookKind,
+    pub task_id: String,
+    pub session_id: Option<String>,
+    pub repo_path: Option<String>,
+    pub worktree_path: Option<String>,
+    pub scope: Option<String>,
+    pub cwd: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PtyExitLog {
+    pub pty_id: String,
+    pub code: Option<u32>,
+    pub reason: ExitReason,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PtyStaleExitLog {
+    pub pty_id: String,
+    pub generation: u64,
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct PtyLifecycleEffects {
+    pub emit_exit: Option<PtyExitEmit>,
+    pub registry_session_ended: Option<String>,
+    pub task_hook: Option<PtyTaskHookIntent>,
+    pub exit_log: Option<PtyExitLog>,
+    pub stale_exit_log: Option<PtyStaleExitLog>,
+}
+
+pub fn plan_lifecycle_metadata_command(
+    event: &PtyLifecycleEvent,
+    now_ms: u64,
+) -> PtyMetadataCommand {
+    match event {
+        PtyLifecycleEvent::Exited { pty_id, generation, code, .. } => {
+            PtyMetadataCommand::MarkExitedIfGenerationMatches {
+                pty_id: pty_id.clone(),
+                generation: *generation,
+                code: code.map(|c| c as i32),
+                at_ms: now_ms,
+            }
+        }
+        PtyLifecycleEvent::OutputWhileDetached { pty_id } => PtyMetadataCommand::SetUnreadOutput {
+            pty_id: pty_id.clone(),
+            value: true,
+        },
+        PtyLifecycleEvent::BellWhileDetached { pty_id } => PtyMetadataCommand::SetBellPending {
+            pty_id: pty_id.clone(),
+            value: true,
+        },
+    }
+}
+
+pub fn plan_lifecycle_effects(
+    event: &PtyLifecycleEvent,
+    metadata_result: PtyMetadataCommandResult,
+    pty_info: Option<&PtyInfo>,
+) -> PtyLifecycleEffects {
+    let PtyLifecycleEvent::Exited {
+        pty_id,
+        session_id,
+        code,
+        reason,
+        generation,
+    } = event
+    else {
+        return PtyLifecycleEffects::default();
+    };
+
+    if !matches!(metadata_result, PtyMetadataCommandResult::Applied) {
+        return PtyLifecycleEffects {
+            stale_exit_log: Some(PtyStaleExitLog {
+                pty_id: pty_id.clone(),
+                generation: *generation,
+            }),
+            ..PtyLifecycleEffects::default()
+        };
+    }
+
+    let task_hook = pty_info.and_then(|info| {
+        (info.profile.as_deref() == Some("task")).then(|| PtyTaskHookIntent {
+            kind: if *code == Some(0) {
+                PtyTaskHookKind::PostTaskSuccess
+            } else {
+                PtyTaskHookKind::PostTaskFailure
+            },
+            task_id: pty_id.clone(),
+            session_id: info.session_id.clone(),
+            repo_path: info.working_dir.clone(),
+            worktree_path: info.working_dir.clone(),
+            scope: info.session_id.as_ref().map(|_| "session".to_string()),
+            cwd: info.working_dir.clone(),
+        })
+    });
+
+    PtyLifecycleEffects {
+        emit_exit: Some(PtyExitEmit {
+            pty_id: pty_id.clone(),
+            code: *code,
+            generation: *generation,
+            reason: *reason,
+        }),
+        registry_session_ended: session_id.clone(),
+        task_hook,
+        exit_log: Some(PtyExitLog { pty_id: pty_id.clone(), code: *code, reason: *reason }),
+        stale_exit_log: None,
+    }
+}
+
 impl From<ExitReason> for roux_core::SessionExitReason {
     fn from(r: ExitReason) -> Self {
         match r {
@@ -228,6 +356,20 @@ mod tests {
             profile: Some("plain-shell"),
             last_size: (80, 24),
         })
+    }
+
+    fn task_info(profile: Option<&str>) -> PtyInfo {
+        PtyInfo {
+            id: "pty-task".to_string(),
+            session_id: Some("session-a".to_string()),
+            role: PtyRole::Secondary,
+            status: PtyStatus::RunningDetached { since_ms: 1 },
+            name: None,
+            working_dir: Some("/repo".to_string()),
+            profile: profile.map(str::to_string),
+            unread_output: false,
+            bell_pending: false,
+        }
     }
 
     #[test]
@@ -375,5 +517,169 @@ mod tests {
         assert_eq!(result, PtyMetadataCommandResult::StaleGeneration);
         assert!(matches!(metadata.status, PtyStatus::RunningAttached { .. }));
         assert_eq!(metadata.exit_info, None);
+    }
+
+    #[test]
+    fn plan_metadata_command_for_lifecycle_events() {
+        let exit = PtyLifecycleEvent::Exited {
+            pty_id: "pty-a".to_string(),
+            session_id: Some("session-a".to_string()),
+            code: Some(0),
+            reason: ExitReason::Exit,
+            generation: 7,
+        };
+
+        assert_eq!(
+            plan_lifecycle_metadata_command(&exit, 123),
+            PtyMetadataCommand::MarkExitedIfGenerationMatches {
+                pty_id: "pty-a".to_string(),
+                generation: 7,
+                code: Some(0),
+                at_ms: 123,
+            }
+        );
+
+        assert_eq!(
+            plan_lifecycle_metadata_command(
+                &PtyLifecycleEvent::OutputWhileDetached { pty_id: "pty-b".to_string() },
+                123,
+            ),
+            PtyMetadataCommand::SetUnreadOutput {
+                pty_id: "pty-b".to_string(),
+                value: true,
+            }
+        );
+
+        assert_eq!(
+            plan_lifecycle_metadata_command(
+                &PtyLifecycleEvent::BellWhileDetached { pty_id: "pty-c".to_string() },
+                123,
+            ),
+            PtyMetadataCommand::SetBellPending {
+                pty_id: "pty-c".to_string(),
+                value: true,
+            }
+        );
+    }
+
+    #[test]
+    fn plan_exit_effects_after_successful_metadata_application() {
+        let event = PtyLifecycleEvent::Exited {
+            pty_id: "pty-task".to_string(),
+            session_id: Some("session-a".to_string()),
+            code: Some(0),
+            reason: ExitReason::Exit,
+            generation: 9,
+        };
+        let info = task_info(Some("task"));
+
+        let effects =
+            plan_lifecycle_effects(&event, PtyMetadataCommandResult::Applied, Some(&info));
+
+        assert_eq!(
+            effects.emit_exit,
+            Some(PtyExitEmit {
+                pty_id: "pty-task".to_string(),
+                code: Some(0),
+                generation: 9,
+                reason: ExitReason::Exit,
+            })
+        );
+        assert_eq!(effects.registry_session_ended.as_deref(), Some("session-a"));
+        assert_eq!(
+            effects.task_hook,
+            Some(PtyTaskHookIntent {
+                kind: PtyTaskHookKind::PostTaskSuccess,
+                task_id: "pty-task".to_string(),
+                session_id: Some("session-a".to_string()),
+                repo_path: Some("/repo".to_string()),
+                worktree_path: Some("/repo".to_string()),
+                scope: Some("session".to_string()),
+                cwd: Some("/repo".to_string()),
+            })
+        );
+        assert_eq!(
+            effects.exit_log,
+            Some(PtyExitLog {
+                pty_id: "pty-task".to_string(),
+                code: Some(0),
+                reason: ExitReason::Exit,
+            })
+        );
+        assert_eq!(effects.stale_exit_log, None);
+    }
+
+    #[test]
+    fn plan_exit_effects_marks_nonzero_or_missing_codes_as_task_failure() {
+        let event = PtyLifecycleEvent::Exited {
+            pty_id: "pty-task".to_string(),
+            session_id: None,
+            code: None,
+            reason: ExitReason::IoError,
+            generation: 9,
+        };
+        let info = task_info(Some("task"));
+
+        let effects =
+            plan_lifecycle_effects(&event, PtyMetadataCommandResult::Applied, Some(&info));
+
+        assert_eq!(
+            effects.task_hook.as_ref().map(|intent| intent.kind),
+            Some(PtyTaskHookKind::PostTaskFailure)
+        );
+        assert_eq!(effects.registry_session_ended, None);
+    }
+
+    #[test]
+    fn plan_exit_effects_skips_task_hook_for_non_task_profile() {
+        let event = PtyLifecycleEvent::Exited {
+            pty_id: "pty-shell".to_string(),
+            session_id: Some("session-a".to_string()),
+            code: Some(0),
+            reason: ExitReason::Exit,
+            generation: 9,
+        };
+        let info = task_info(Some("plain-shell"));
+
+        let effects =
+            plan_lifecycle_effects(&event, PtyMetadataCommandResult::Applied, Some(&info));
+
+        assert_eq!(effects.task_hook, None);
+        assert!(effects.emit_exit.is_some());
+        assert_eq!(effects.registry_session_ended.as_deref(), Some("session-a"));
+    }
+
+    #[test]
+    fn plan_exit_effects_drops_stale_or_missing_exits() {
+        let event = PtyLifecycleEvent::Exited {
+            pty_id: "pty-task".to_string(),
+            session_id: Some("session-a".to_string()),
+            code: Some(0),
+            reason: ExitReason::Exit,
+            generation: 9,
+        };
+
+        let effects =
+            plan_lifecycle_effects(&event, PtyMetadataCommandResult::StaleGeneration, None);
+
+        assert_eq!(
+            effects.stale_exit_log,
+            Some(PtyStaleExitLog { pty_id: "pty-task".to_string(), generation: 9 })
+        );
+        assert_eq!(effects.emit_exit, None);
+        assert_eq!(effects.registry_session_ended, None);
+        assert_eq!(effects.task_hook, None);
+        assert_eq!(effects.exit_log, None);
+    }
+
+    #[test]
+    fn plan_non_exit_effects_are_empty() {
+        let effects = plan_lifecycle_effects(
+            &PtyLifecycleEvent::OutputWhileDetached { pty_id: "pty-a".to_string() },
+            PtyMetadataCommandResult::Applied,
+            None,
+        );
+
+        assert_eq!(effects, PtyLifecycleEffects::default());
     }
 }

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -654,36 +654,6 @@ impl PtyManager {
         }
     }
 
-    pub(crate) fn mark_exited_if_generation_matches_direct(
-        &self,
-        pty_id: &str,
-        generation: u64,
-        code: Option<i32>,
-    ) -> bool {
-        let command = PtyMetadataCommand::MarkExitedIfGenerationMatches {
-            pty_id: pty_id.to_string(),
-            generation,
-            code,
-            at_ms: unix_now_ms(),
-        };
-        matches!(
-            self.apply_metadata_command_direct(&command),
-            PtyMetadataCommandResult::Applied
-        )
-    }
-
-    pub(crate) fn set_unread_output_direct(&self, pty_id: &str, value: bool) {
-        let command =
-            PtyMetadataCommand::SetUnreadOutput { pty_id: pty_id.to_string(), value };
-        self.apply_metadata_command_direct(&command);
-    }
-
-    pub(crate) fn set_bell_pending_direct(&self, pty_id: &str, value: bool) {
-        let command =
-            PtyMetadataCommand::SetBellPending { pty_id: pty_id.to_string(), value };
-        self.apply_metadata_command_direct(&command);
-    }
-
     pub(crate) fn kill_session_ptys_direct(&self, session_id: &str) {
         let ids: Vec<String> = {
             let sessions = self.sessions.lock().unwrap();
@@ -1189,16 +1159,6 @@ impl PtyManager {
         )) {
             self.apply_metadata_command_direct(&command);
         }
-    }
-
-    /// Set the unread output flag for a PTY.
-    pub fn set_unread_output(&self, pty_id: &str, value: bool) {
-        self.set_unread_output_direct(pty_id, value);
-    }
-
-    /// Set the bell pending flag for a PTY.
-    pub fn set_bell_pending(&self, pty_id: &str, value: bool) {
-        self.set_bell_pending_direct(pty_id, value);
     }
 
     /// Set the display name for a PTY.
@@ -1963,8 +1923,20 @@ mod lifecycle_command_tests {
         );
         register_via_bus(&lifecycle_tx, "pty-a", session);
 
-        manager.set_unread_output_direct("pty-a", true);
-        manager.set_bell_pending_direct("pty-a", true);
+        assert_eq!(
+            manager.apply_metadata_command_direct(&PtyMetadataCommand::SetUnreadOutput {
+                pty_id: "pty-a".to_string(),
+                value: true,
+            }),
+            PtyMetadataCommandResult::Applied
+        );
+        assert_eq!(
+            manager.apply_metadata_command_direct(&PtyMetadataCommand::SetBellPending {
+                pty_id: "pty-a".to_string(),
+                value: true,
+            }),
+            PtyMetadataCommandResult::Applied
+        );
         manager.detach("pty-a");
         manager.attach_to_pane("pty-a", "pane-b");
         manager.set_name("pty-a", Some("Renamed"));
@@ -2063,7 +2035,17 @@ mod lifecycle_command_tests {
         );
         register_via_bus(&lifecycle_tx, "pty-a", session);
 
-        assert!(!manager.mark_exited_if_generation_matches_direct("pty-a", 1, Some(1)));
+        assert_eq!(
+            manager.apply_metadata_command_direct(
+                &PtyMetadataCommand::MarkExitedIfGenerationMatches {
+                    pty_id: "pty-a".to_string(),
+                    generation: 1,
+                    code: Some(1),
+                    at_ms: 123,
+                }
+            ),
+            PtyMetadataCommandResult::StaleGeneration
+        );
 
         let snapshot = manager.list_for_session("session-a");
         assert_eq!(snapshot.len(), 1);
@@ -2086,7 +2068,17 @@ mod lifecycle_command_tests {
         );
         register_via_bus(&lifecycle_tx, "pty-a", session);
 
-        assert!(manager.mark_exited_if_generation_matches_direct("pty-a", 2, Some(0)));
+        assert_eq!(
+            manager.apply_metadata_command_direct(
+                &PtyMetadataCommand::MarkExitedIfGenerationMatches {
+                    pty_id: "pty-a".to_string(),
+                    generation: 2,
+                    code: Some(0),
+                    at_ms: 123,
+                }
+            ),
+            PtyMetadataCommandResult::Applied
+        );
 
         let snapshot = manager.list_for_session("session-a");
         assert_eq!(snapshot.len(), 1);

--- a/src-tauri/src/pty_lifecycle.rs
+++ b/src-tauri/src/pty_lifecycle.rs
@@ -11,6 +11,10 @@ use std::sync::{mpsc, Arc};
 use std::thread;
 
 pub use roux_runtime::pty_lifecycle::{ExitReason, PtyLifecycleEvent, PtyMetadataCommand};
+use roux_runtime::pty_lifecycle as runtime_lifecycle;
+use roux_runtime::pty_lifecycle::{
+    PtyLifecycleEffects, PtyMetadataCommandResult, PtyTaskHookKind,
+};
 
 pub enum PtyLifecycleCommand {
     Register {
@@ -98,86 +102,82 @@ pub fn spawn_handler(ctx: LifecycleHandlerContext) -> LifecycleTx {
 }
 
 fn handle_event(ctx: &LifecycleHandlerContext, event: PtyLifecycleEvent) {
-    match event {
-        PtyLifecycleEvent::Exited {
-            pty_id,
-            session_id,
-            code,
-            reason,
-            generation,
-        } => {
-            // Drop stale exit events from a previous PTY generation before they
-            // mutate state or notify the frontend for a reused PTY id.
-            if !ctx
-                .pty_manager
-                .mark_exited_if_generation_matches_direct(&pty_id, generation, code.map(|c| c as i32))
-            {
-                rlog!(
-                    "PTY lifecycle: dropping stale exit for {} generation {}",
-                    pty_id,
-                    generation
-                );
-                return;
-            }
-            let pty_info = ctx.pty_manager.get_info_direct(&pty_id);
+    let metadata_command =
+        runtime_lifecycle::plan_lifecycle_metadata_command(&event, unix_now_ms());
+    let metadata_result = ctx.pty_manager.apply_metadata_command_direct(&metadata_command);
+    let pty_info = if matches!(metadata_result, PtyMetadataCommandResult::Applied)
+        && matches!(event, PtyLifecycleEvent::Exited { .. })
+    {
+        ctx.pty_manager.get_info_direct(metadata_command.pty_id())
+    } else {
+        None
+    };
+    let effects =
+        runtime_lifecycle::plan_lifecycle_effects(&event, metadata_result, pty_info.as_ref());
+    execute_effects(ctx, effects);
+}
 
-            // 2. Emit frontend event
-            use tauri::Emitter;
-            let event_name = format!("session-exit:{}", pty_id);
-            let _ = ctx.app.emit(
-                &event_name,
-                &roux_core::SessionExitPayload {
-                    code,
-                    generation,
-                    reason: reason.into(),
-                },
-            );
-
-            // 3. Notify agent registry if session_id present
-            if let Some(sid) = session_id {
-                let _ = ctx.agent_registry_tx.send(
-                    crate::agent_registry::RegistryMessage::SessionEnded {
-                        session_id: sid,
-                    },
-                );
-            }
-
-            if let Some(info) = pty_info {
-                if info.profile.as_deref() == Some("task") {
-                    let event = if code == Some(0) {
-                        crate::automation_hooks::HookEvent::PostTaskSuccess
-                    } else {
-                        crate::automation_hooks::HookEvent::PostTaskFailure
-                    };
-                    let context = crate::automation_hooks::HookContext {
-                        repo_path: info.working_dir.clone(),
-                        worktree_path: info.working_dir.clone(),
-                        task_id: Some(pty_id.clone()),
-                        session_id: info.session_id.clone(),
-                        scope: info.session_id.as_ref().map(|_| "session".to_string()),
-                        cwd: info.working_dir,
-                        ..crate::automation_hooks::HookContext::new(event)
-                    };
-                    ctx.automation_hooks.spawn_background(event, context);
-                }
-            }
-
-            rlog!(
-                "PTY lifecycle: {} exited (code={:?}, reason={:?})",
-                pty_id,
-                code,
-                reason
-            );
-        }
-
-        PtyLifecycleEvent::OutputWhileDetached { pty_id } => {
-            ctx.pty_manager.set_unread_output(&pty_id, true);
-        }
-
-        PtyLifecycleEvent::BellWhileDetached { pty_id } => {
-            ctx.pty_manager.set_bell_pending(&pty_id, true);
-        }
+fn execute_effects(ctx: &LifecycleHandlerContext, effects: PtyLifecycleEffects) {
+    if let Some(stale) = effects.stale_exit_log {
+        rlog!(
+            "PTY lifecycle: dropping stale exit for {} generation {}",
+            stale.pty_id,
+            stale.generation
+        );
+        return;
     }
+
+    if let Some(exit) = effects.emit_exit {
+        use tauri::Emitter;
+        let event_name = format!("session-exit:{}", exit.pty_id);
+        let _ = ctx.app.emit(
+            &event_name,
+            &roux_core::SessionExitPayload {
+                code: exit.code,
+                generation: exit.generation,
+                reason: exit.reason.into(),
+            },
+        );
+    }
+
+    if let Some(session_id) = effects.registry_session_ended {
+        let _ = ctx
+            .agent_registry_tx
+            .send(crate::agent_registry::RegistryMessage::SessionEnded { session_id });
+    }
+
+    if let Some(intent) = effects.task_hook {
+        let event = match intent.kind {
+            PtyTaskHookKind::PostTaskSuccess => crate::automation_hooks::HookEvent::PostTaskSuccess,
+            PtyTaskHookKind::PostTaskFailure => crate::automation_hooks::HookEvent::PostTaskFailure,
+        };
+        let context = crate::automation_hooks::HookContext {
+            repo_path: intent.repo_path,
+            worktree_path: intent.worktree_path,
+            task_id: Some(intent.task_id),
+            session_id: intent.session_id,
+            scope: intent.scope,
+            cwd: intent.cwd,
+            ..crate::automation_hooks::HookContext::new(event)
+        };
+        ctx.automation_hooks.spawn_background(event, context);
+    }
+
+    if let Some(exit) = effects.exit_log {
+        rlog!(
+            "PTY lifecycle: {} exited (code={:?}, reason={:?})",
+            exit.pty_id,
+            exit.code,
+            exit.reason
+        );
+    }
+}
+
+fn unix_now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64
 }
 
 pub(crate) fn handle_command(pty_manager: &crate::pty::PtyManager, command: PtyLifecycleCommand) {


### PR DESCRIPTION
## Summary
- add runtime planners for lifecycle metadata commands and exit side effects
- make the Tauri lifecycle handler execute planned effects instead of owning planning logic
- update PTY lifecycle command tests to exercise metadata commands directly

## Verification
- cargo test -p roux-runtime pty_lifecycle
- cargo test -p roux-runtime
- CI=1 cargo clippy -p roux --all-targets -- -D warnings
- CI=1 cargo test -p roux lifecycle_command_tests

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts the PTY lifecycle planning logic out of the Tauri-specific handler into two pure functions in `roux-runtime` (`plan_lifecycle_metadata_command` and `plan_lifecycle_effects`), consistent with the project's guideline to keep Tauri command handlers thin.

- **`crates/roux-runtime/src/pty_lifecycle.rs`**: Adds `PtyLifecycleEffects` and related types plus the two planner functions, tested by five new unit tests that cover exit, stale-generation, task-hook, and non-exit paths.
- **`src-tauri/src/pty_lifecycle.rs`**: `handle_event` now calls the runtime planners and delegates side effects to a new `execute_effects` function; behavioral parity with the removed monolithic handler is maintained.
- **`src-tauri/src/pty.rs`**: Removes five thin wrapper methods (`mark_exited_if_generation_matches_direct`, `set_unread_output_direct`, `set_bell_pending_direct`, and their public variants) now superseded by `apply_metadata_command_direct` being called directly.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — behavioral parity with the original handler is preserved across all three event variants; the extraction correctly handles the stale-generation early return, frontend emit ordering, agent registry notification, and task hook dispatch.

The refactoring faithfully mirrors the original dispatch logic and is well-tested. Two minor observations — a test that advertises Missing coverage but only exercises StaleGeneration, and a third independent copy of unix_now_ms — have no runtime impact but are worth a quick follow-up.

No files require special attention, though the test at line 652 of crates/roux-runtime/src/pty_lifecycle.rs would benefit from an added Missing case, and the new unix_now_ms in src-tauri/src/pty_lifecycle.rs is a third independent copy of the same utility.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/roux-runtime/src/pty_lifecycle.rs | Adds plan_lifecycle_metadata_command and plan_lifecycle_effects planners plus supporting types; new unit tests cover all happy-path and stale-generation cases cleanly. |
| src-tauri/src/pty_lifecycle.rs | handle_event now delegates to runtime planners and calls execute_effects; a local unix_now_ms is added (third copy across crates); behavioral parity with the old monolithic handler is preserved. |
| src-tauri/src/pty.rs | Removes thin wrapper methods; tests updated to call apply_metadata_command_direct directly — straightforward cleanup with no behavioral change. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Flusher
    participant LifecycleBus as Lifecycle Bus Thread
    participant Planner as roux-runtime planners
    participant PtyManager
    participant Frontend
    participant AgentRegistry
    participant AutomationHooks

    Flusher->>LifecycleBus: PtyLifecycleMessage::Event(event)
    LifecycleBus->>Planner: plan_lifecycle_metadata_command(event, now_ms)
    Planner-->>LifecycleBus: PtyMetadataCommand
    LifecycleBus->>PtyManager: apply_metadata_command_direct(cmd)
    PtyManager-->>LifecycleBus: PtyMetadataCommandResult
    alt Exited and Applied
        LifecycleBus->>PtyManager: get_info_direct(pty_id)
        PtyManager-->>LifecycleBus: Option PtyInfo
    end
    LifecycleBus->>Planner: plan_lifecycle_effects(event, result, pty_info)
    Planner-->>LifecycleBus: PtyLifecycleEffects
    alt stale_exit_log set
        LifecycleBus->>LifecycleBus: rlog stale exit, return
    else applied exit
        LifecycleBus->>Frontend: emit session-exit
        LifecycleBus->>AgentRegistry: SessionEnded
        LifecycleBus->>AutomationHooks: spawn_background PostTask
        LifecycleBus->>LifecycleBus: rlog exit
    end
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Froux-runtime%2Fsrc%2Fpty_lifecycle.rs%3A652-684%0A**Test%20name%20implies%20%60Missing%60%20coverage%2C%20but%20only%20%60StaleGeneration%60%20is%20exercised**%0A%0A%60plan_lifecycle_effects%60%20routes%20any%20%60metadata_result%60%20that%20is%20not%20%60Applied%60%20%E2%80%94%20including%20%60PtyMetadataCommandResult%3A%3AMissing%60%20%28PTY%20absent%20from%20the%20registry%29%20%E2%80%94%20through%20the%20same%20%60stale_exit_log%60%20branch.%20The%20test%20name%20%60plan_exit_effects_drops_stale_or_missing_exits%60%20signals%20intent%20to%20cover%20both%20cases%2C%20but%20the%20body%20only%20passes%20%60StaleGeneration%60.%20A%20call%20with%20%60Missing%60%20reaching%20a%20different%20outcome%20%28e.g.%2C%20if%20the%20branch%20condition%20were%20ever%20tightened%29%20would%20go%20undetected.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc-tauri%2Fsrc%2Fpty_lifecycle.rs%3A176-181%0A**Third%20copy%20of%20%60unix_now_ms%60**%0A%0AAn%20identical%20%60unix_now_ms%60%20already%20lives%20in%20%60crates%2Froux-runtime%2Fsrc%2Fpty_lifecycle.rs%60%20%28private%29%20and%20in%20%60src-tauri%2Fsrc%2Fpty.rs%60.%20This%20PR%20adds%20a%20third%20independent%20copy%20rather%20than%20making%20the%20runtime%20version%20%60pub%60%20and%20re-exporting%20it.%20Keeping%20three%20independent%20copies%20risks%20subtle%20drift%20if%20the%20implementation%20needs%20to%20change%20%28e.g.%2C%20clock%20source%2C%20overflow%20handling%29.%0A%0A&repo=phin-tech%2Froux&pr=186&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22feature%2Fextract-pty-lifecycle-event-plan%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fextract-pty-lifecycle-event-plan%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Froux-runtime%2Fsrc%2Fpty_lifecycle.rs%3A652-684%0A**Test%20name%20implies%20%60Missing%60%20coverage%2C%20but%20only%20%60StaleGeneration%60%20is%20exercised**%0A%0A%60plan_lifecycle_effects%60%20routes%20any%20%60metadata_result%60%20that%20is%20not%20%60Applied%60%20%E2%80%94%20including%20%60PtyMetadataCommandResult%3A%3AMissing%60%20%28PTY%20absent%20from%20the%20registry%29%20%E2%80%94%20through%20the%20same%20%60stale_exit_log%60%20branch.%20The%20test%20name%20%60plan_exit_effects_drops_stale_or_missing_exits%60%20signals%20intent%20to%20cover%20both%20cases%2C%20but%20the%20body%20only%20passes%20%60StaleGeneration%60.%20A%20call%20with%20%60Missing%60%20reaching%20a%20different%20outcome%20%28e.g.%2C%20if%20the%20branch%20condition%20were%20ever%20tightened%29%20would%20go%20undetected.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc-tauri%2Fsrc%2Fpty_lifecycle.rs%3A176-181%0A**Third%20copy%20of%20%60unix_now_ms%60**%0A%0AAn%20identical%20%60unix_now_ms%60%20already%20lives%20in%20%60crates%2Froux-runtime%2Fsrc%2Fpty_lifecycle.rs%60%20%28private%29%20and%20in%20%60src-tauri%2Fsrc%2Fpty.rs%60.%20This%20PR%20adds%20a%20third%20independent%20copy%20rather%20than%20making%20the%20runtime%20version%20%60pub%60%20and%20re-exporting%20it.%20Keeping%20three%20independent%20copies%20risks%20subtle%20drift%20if%20the%20implementation%20needs%20to%20change%20%28e.g.%2C%20clock%20source%2C%20overflow%20handling%29.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["extract pty lifecycle event planning"](https://github.com/phin-tech/roux/commit/af5a706089d8188b59af5bce58ec39576d1a7854) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33271605)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->