### PR TITLE
Extract PTY output flusher planning

### DIFF
--- a/crates/roux-runtime/src/pty_output.rs
+++ b/crates/roux-runtime/src/pty_output.rs
@@ -1,6 +1,10 @@
 use std::collections::VecDeque;
 
+use crate::pty_lifecycle::ExitReason;
+
 pub const PTY_BACKLOG_LIMIT_BYTES: usize = 256 * 1024;
+pub const PTY_FLUSH_INTERVAL_MS: u64 = 16;
+pub const PTY_FLUSH_BATCH_LIMIT_BYTES: usize = 32 * 1024;
 
 #[derive(Debug)]
 pub struct PtyOutputBacklog {
@@ -47,6 +51,108 @@ impl Default for PtyOutputBacklog {
     }
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub enum PtyOutputChunk {
+    Data(Vec<u8>),
+    Eof,
+    Error,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum PtyOutputFlushAction {
+    Output(Vec<u8>),
+    Exit(ExitReason),
+}
+
+#[derive(Debug, Clone)]
+pub struct PtyOutputFlusher {
+    batch: Vec<u8>,
+    last_flush_ms: u64,
+    flush_interval_ms: u64,
+    batch_limit_bytes: usize,
+    finished: bool,
+}
+
+impl PtyOutputFlusher {
+    pub fn new(start_ms: u64) -> Self {
+        Self::with_limits(start_ms, PTY_FLUSH_INTERVAL_MS, PTY_FLUSH_BATCH_LIMIT_BYTES)
+    }
+
+    pub fn with_limits(
+        start_ms: u64,
+        flush_interval_ms: u64,
+        batch_limit_bytes: usize,
+    ) -> Self {
+        Self {
+            batch: Vec::with_capacity(8192),
+            last_flush_ms: start_ms,
+            flush_interval_ms,
+            batch_limit_bytes,
+            finished: false,
+        }
+    }
+
+    pub fn is_finished(&self) -> bool {
+        self.finished
+    }
+
+    pub fn recv_timeout_ms(&self, now_ms: u64) -> Option<u64> {
+        if self.batch.is_empty() || self.finished {
+            return None;
+        }
+        let elapsed_ms = now_ms.saturating_sub(self.last_flush_ms);
+        Some(self.flush_interval_ms.saturating_sub(elapsed_ms))
+    }
+
+    pub fn on_timeout(&mut self, now_ms: u64) -> Vec<PtyOutputFlushAction> {
+        self.flush_batch(now_ms)
+            .map(PtyOutputFlushAction::Output)
+            .into_iter()
+            .collect()
+    }
+
+    pub fn on_chunk(
+        &mut self,
+        chunk: PtyOutputChunk,
+        now_ms: u64,
+    ) -> Vec<PtyOutputFlushAction> {
+        if self.finished {
+            return Vec::new();
+        }
+
+        match chunk {
+            PtyOutputChunk::Data(data) => {
+                self.batch.extend_from_slice(&data);
+                let elapsed_ms = now_ms.saturating_sub(self.last_flush_ms);
+                if elapsed_ms >= self.flush_interval_ms
+                    || self.batch.len() >= self.batch_limit_bytes
+                {
+                    self.on_timeout(now_ms)
+                } else {
+                    Vec::new()
+                }
+            }
+            PtyOutputChunk::Eof => self.finish(ExitReason::Exit, now_ms),
+            PtyOutputChunk::Error => self.finish(ExitReason::IoError, now_ms),
+        }
+    }
+
+    fn finish(&mut self, reason: ExitReason, now_ms: u64) -> Vec<PtyOutputFlushAction> {
+        self.finished = true;
+        let mut actions = self.on_timeout(now_ms);
+        actions.push(PtyOutputFlushAction::Exit(reason));
+        actions
+    }
+
+    fn flush_batch(&mut self, now_ms: u64) -> Option<Vec<u8>> {
+        if self.batch.is_empty() {
+            return None;
+        }
+        self.last_flush_ms = now_ms;
+        Some(std::mem::take(&mut self.batch))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -85,5 +191,71 @@ mod tests {
 
         assert_eq!(backlog.len_bytes(), 0);
         assert_eq!(backlog.pop_front(), None);
+    }
+
+    #[test]
+    fn flusher_buffers_data_until_interval_or_size_threshold() {
+        let mut flusher = PtyOutputFlusher::with_limits(0, 16, 8);
+
+        assert_eq!(
+            flusher.on_chunk(PtyOutputChunk::Data(vec![1, 2, 3]), 1),
+            Vec::<PtyOutputFlushAction>::new()
+        );
+        assert_eq!(flusher.recv_timeout_ms(1), Some(15));
+
+        assert_eq!(
+            flusher.on_chunk(PtyOutputChunk::Data(vec![4, 5, 6]), 10),
+            Vec::<PtyOutputFlushAction>::new()
+        );
+        assert_eq!(flusher.recv_timeout_ms(10), Some(6));
+
+        assert_eq!(
+            flusher.on_chunk(PtyOutputChunk::Data(vec![7, 8]), 11),
+            vec![PtyOutputFlushAction::Output(vec![1, 2, 3, 4, 5, 6, 7, 8])]
+        );
+        assert_eq!(flusher.recv_timeout_ms(11), None);
+    }
+
+    #[test]
+    fn flusher_flushes_batch_on_timeout() {
+        let mut flusher = PtyOutputFlusher::with_limits(0, 16, 32);
+        assert!(flusher
+            .on_chunk(PtyOutputChunk::Data(vec![1, 2, 3]), 1)
+            .is_empty());
+
+        assert_eq!(
+            flusher.on_timeout(17),
+            vec![PtyOutputFlushAction::Output(vec![1, 2, 3])]
+        );
+        assert_eq!(flusher.recv_timeout_ms(17), None);
+        assert_eq!(flusher.on_timeout(18), Vec::<PtyOutputFlushAction>::new());
+    }
+
+    #[test]
+    fn flusher_finishes_after_flushing_pending_output() {
+        let mut flusher = PtyOutputFlusher::with_limits(0, 16, 32);
+        assert!(flusher
+            .on_chunk(PtyOutputChunk::Data(vec![1, 2, 3]), 1)
+            .is_empty());
+
+        assert_eq!(
+            flusher.on_chunk(PtyOutputChunk::Eof, 2),
+            vec![
+                PtyOutputFlushAction::Output(vec![1, 2, 3]),
+                PtyOutputFlushAction::Exit(ExitReason::Exit),
+            ]
+        );
+        assert!(flusher.is_finished());
+    }
+
+    #[test]
+    fn flusher_maps_error_to_io_error_exit() {
+        let mut flusher = PtyOutputFlusher::with_limits(0, 16, 32);
+
+        assert_eq!(
+            flusher.on_chunk(PtyOutputChunk::Error, 1),
+            vec![PtyOutputFlushAction::Exit(ExitReason::IoError)]
+        );
+        assert!(flusher.is_finished());
     }
 }

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -18,7 +18,9 @@ use crate::pty_ready_gate::ShellReadyGate;
 pub use roux_core::{PtyInfo, PtyRole, PtyStatus};
 pub use roux_runtime::process::cwd_for_pid;
 use roux_runtime::pty_lifecycle::{self, PtyMetadataCommand, PtyMetadataCommandResult};
-use roux_runtime::pty_output::PtyOutputBacklog;
+use roux_runtime::pty_output::{
+    PtyOutputBacklog, PtyOutputChunk, PtyOutputFlushAction, PtyOutputFlusher,
+};
 #[cfg(test)]
 pub use roux_runtime::pty_output::PTY_BACKLOG_LIMIT_BYTES;
 use roux_runtime::pty_session::{PtySessionMetadata, PtySessionMetadataInputs};
@@ -98,12 +100,6 @@ fn spawn_gate_ticker(gate: ReadyGate, writer: PtyWriter, session_id: String) {
             return;
         }
     });
-}
-
-enum PtyChunk {
-    Data(Vec<u8>),
-    Eof,
-    Error,
 }
 
 struct PtyOutputState {
@@ -192,96 +188,94 @@ impl PtyOutput {
 /// plumbing, bundled alongside the Tauri event emission at EOF.
 type ExitRegistryHook = (mpsc::Sender<crate::agent_registry::RegistryMessage>, String);
 
+fn elapsed_ms_since(started_at: Instant) -> u64 {
+    started_at.elapsed().as_millis() as u64
+}
+
+fn apply_direct_flusher_action(
+    output: &PtyOutput,
+    action: PtyOutputFlushAction,
+    exit_event: &Option<(String, u64)>,
+    app: &tauri::AppHandle,
+    exit_registry_hook: &Option<ExitRegistryHook>,
+) -> bool {
+    match action {
+        PtyOutputFlushAction::Output(bytes) => {
+            output.send(bytes);
+            false
+        }
+        PtyOutputFlushAction::Exit(reason) => {
+            if let Some((evt, gen)) = exit_event {
+                let _ = app.emit(
+                    evt,
+                    &roux_core::SessionExitPayload {
+                        code: None,
+                        generation: *gen,
+                        reason: reason.into(),
+                    },
+                );
+            }
+            if let Some((tx, sid)) = exit_registry_hook {
+                let _ = tx.send(crate::agent_registry::RegistryMessage::SessionEnded {
+                    session_id: sid.clone(),
+                });
+            }
+            true
+        }
+    }
+}
+
 fn spawn_flusher(
     output: PtyOutput,
     exit_event: Option<(String, u64)>, // (event_name, generation)
     app: tauri::AppHandle,
     exit_registry_hook: Option<ExitRegistryHook>,
-) -> mpsc::Sender<PtyChunk> {
-    let (tx, rx) = mpsc::channel::<PtyChunk>();
+) -> mpsc::Sender<PtyOutputChunk> {
+    let (tx, rx) = mpsc::channel::<PtyOutputChunk>();
 
     thread::spawn(move || {
-        let flush_interval = Duration::from_millis(16);
-        let mut batch = Vec::with_capacity(8192);
-        let mut last_flush = Instant::now();
+        let started_at = Instant::now();
+        let mut flusher = PtyOutputFlusher::new(0);
 
         loop {
-            // If batch is empty, block until data arrives
-            // If batch has data, use timeout to ensure timely flush
-            let chunk = if batch.is_empty() {
-                match rx.recv() {
+            let chunk = match flusher.recv_timeout_ms(elapsed_ms_since(started_at)) {
+                None => match rx.recv() {
                     Ok(c) => c,
                     Err(_) => break,
-                }
-            } else {
-                let remaining = flush_interval.saturating_sub(last_flush.elapsed());
-                match rx.recv_timeout(remaining) {
-                    Ok(c) => c,
-                    Err(mpsc::RecvTimeoutError::Timeout) => {
-                        // Flush what we have
-                        output.send(std::mem::take(&mut batch));
-                        batch.clear();
-                        last_flush = Instant::now();
-                        continue;
+                },
+                Some(timeout_ms) => {
+                    match rx.recv_timeout(Duration::from_millis(timeout_ms)) {
+                        Ok(c) => c,
+                        Err(mpsc::RecvTimeoutError::Timeout) => {
+                            for action in flusher.on_timeout(elapsed_ms_since(started_at)) {
+                                apply_direct_flusher_action(
+                                    &output,
+                                    action,
+                                    &exit_event,
+                                    &app,
+                                    &exit_registry_hook,
+                                );
+                            }
+                            continue;
+                        }
+                        Err(mpsc::RecvTimeoutError::Disconnected) => break,
                     }
-                    Err(mpsc::RecvTimeoutError::Disconnected) => break,
                 }
             };
 
-            match chunk {
-                PtyChunk::Data(data) => {
-                    batch.extend_from_slice(&data);
-                    if last_flush.elapsed() >= flush_interval || batch.len() >= 32768 {
-                        output.send(std::mem::take(&mut batch));
-                        last_flush = Instant::now();
-                    }
-                }
-                PtyChunk::Eof => {
-                    if !batch.is_empty() {
-                        output.send(std::mem::take(&mut batch));
-                    }
-                    if let Some((evt, gen)) = &exit_event {
-                        let _ = app.emit(
-                            evt,
-                            &roux_core::SessionExitPayload {
-                                code: None,
-                                generation: *gen,
-                                reason: roux_core::SessionExitReason::Exit,
-                            },
-                        );
-                    }
-                    if let Some((tx, sid)) = &exit_registry_hook {
-                        let _ = tx.send(
-                            crate::agent_registry::RegistryMessage::SessionEnded {
-                                session_id: sid.clone(),
-                            },
-                        );
-                    }
+            for action in flusher.on_chunk(chunk, elapsed_ms_since(started_at)) {
+                if apply_direct_flusher_action(
+                    &output,
+                    action,
+                    &exit_event,
+                    &app,
+                    &exit_registry_hook,
+                ) {
                     break;
                 }
-                PtyChunk::Error => {
-                    if !batch.is_empty() {
-                        output.send(std::mem::take(&mut batch));
-                    }
-                    if let Some((evt, gen)) = &exit_event {
-                        let _ = app.emit(
-                            evt,
-                            &roux_core::SessionExitPayload {
-                                code: None,
-                                generation: *gen,
-                                reason: roux_core::SessionExitReason::IoError,
-                            },
-                        );
-                    }
-                    if let Some((tx, sid)) = &exit_registry_hook {
-                        let _ = tx.send(
-                            crate::agent_registry::RegistryMessage::SessionEnded {
-                                session_id: sid.clone(),
-                            },
-                        );
-                    }
-                    break;
-                }
+            }
+            if flusher.is_finished() {
+                break;
             }
         }
     });
@@ -298,76 +292,57 @@ fn spawn_flusher_with_lifecycle(
     generation: u64,
     lifecycle_tx: crate::pty_lifecycle::LifecycleTx,
     emit_exit_event: bool,
-) -> mpsc::Sender<PtyChunk> {
-    let (tx, rx) = mpsc::channel::<PtyChunk>();
+) -> mpsc::Sender<PtyOutputChunk> {
+    let (tx, rx) = mpsc::channel::<PtyOutputChunk>();
 
     thread::spawn(move || {
-        let flush_interval = Duration::from_millis(16);
-        let mut batch = Vec::with_capacity(8192);
-        let mut last_flush = Instant::now();
+        let started_at = Instant::now();
+        let mut flusher = PtyOutputFlusher::new(0);
 
         loop {
-            let chunk = if batch.is_empty() {
-                match rx.recv() {
+            let chunk = match flusher.recv_timeout_ms(elapsed_ms_since(started_at)) {
+                None => match rx.recv() {
                     Ok(c) => c,
                     Err(_) => break,
-                }
-            } else {
-                let remaining = flush_interval.saturating_sub(last_flush.elapsed());
-                match rx.recv_timeout(remaining) {
-                    Ok(c) => c,
-                    Err(mpsc::RecvTimeoutError::Timeout) => {
-                        output.send(std::mem::take(&mut batch));
-                        batch.clear();
-                        last_flush = Instant::now();
-                        continue;
+                },
+                Some(timeout_ms) => {
+                    match rx.recv_timeout(Duration::from_millis(timeout_ms)) {
+                        Ok(c) => c,
+                        Err(mpsc::RecvTimeoutError::Timeout) => {
+                            for action in flusher.on_timeout(elapsed_ms_since(started_at)) {
+                                if let PtyOutputFlushAction::Output(bytes) = action {
+                                    output.send(bytes);
+                                }
+                            }
+                            continue;
+                        }
+                        Err(mpsc::RecvTimeoutError::Disconnected) => break,
                     }
-                    Err(mpsc::RecvTimeoutError::Disconnected) => break,
                 }
             };
 
-            match chunk {
-                PtyChunk::Data(data) => {
-                    batch.extend_from_slice(&data);
-                    if last_flush.elapsed() >= flush_interval || batch.len() >= 32768 {
-                        output.send(std::mem::take(&mut batch));
-                        last_flush = Instant::now();
+            for action in flusher.on_chunk(chunk, elapsed_ms_since(started_at)) {
+                match action {
+                    PtyOutputFlushAction::Output(bytes) => output.send(bytes),
+                    PtyOutputFlushAction::Exit(reason) => {
+                        if emit_exit_event {
+                            let _ = lifecycle_tx.send(
+                                crate::pty_lifecycle::PtyLifecycleMessage::Event(
+                                    crate::pty_lifecycle::PtyLifecycleEvent::Exited {
+                                        pty_id: pty_id.clone(),
+                                        session_id: session_id.clone(),
+                                        code: None,
+                                        reason,
+                                        generation,
+                                    },
+                                ),
+                            );
+                        }
                     }
                 }
-                PtyChunk::Eof => {
-                    if !batch.is_empty() {
-                        output.send(std::mem::take(&mut batch));
-                    }
-                    if emit_exit_event {
-                        let _ = lifecycle_tx.send(crate::pty_lifecycle::PtyLifecycleMessage::Event(
-                            crate::pty_lifecycle::PtyLifecycleEvent::Exited {
-                                pty_id: pty_id.clone(),
-                                session_id: session_id.clone(),
-                                code: None,
-                                reason: crate::pty_lifecycle::ExitReason::Exit,
-                                generation,
-                            },
-                        ));
-                    }
-                    break;
-                }
-                PtyChunk::Error => {
-                    if !batch.is_empty() {
-                        output.send(std::mem::take(&mut batch));
-                    }
-                    if emit_exit_event {
-                        let _ = lifecycle_tx.send(crate::pty_lifecycle::PtyLifecycleMessage::Event(
-                            crate::pty_lifecycle::PtyLifecycleEvent::Exited {
-                                pty_id: pty_id.clone(),
-                                session_id: session_id.clone(),
-                                code: None,
-                                reason: crate::pty_lifecycle::ExitReason::IoError,
-                                generation,
-                            },
-                        ));
-                    }
-                    break;
-                }
+            }
+            if flusher.is_finished() {
+                break;
             }
         }
     });
@@ -380,7 +355,7 @@ fn spawn_flusher_with_lifecycle(
 /// before being forwarded (non-consuming — bytes pass through unchanged).
 fn spawn_reader(
     mut reader: Box<dyn Read + Send>,
-    tx: mpsc::Sender<PtyChunk>,
+    tx: mpsc::Sender<PtyOutputChunk>,
     mut sniffer: Option<crate::notifications::OscSniffer>,
     gate: Option<(ReadyGate, PtyWriter, String)>,
 ) {
@@ -389,7 +364,7 @@ fn spawn_reader(
         loop {
             match reader.read(&mut buf) {
                 Ok(0) => {
-                    let _ = tx.send(PtyChunk::Eof);
+                    let _ = tx.send(PtyOutputChunk::Eof);
                     break;
                 }
                 Ok(n) => {
@@ -414,12 +389,12 @@ fn spawn_reader(
                             );
                         }
                     }
-                    if tx.send(PtyChunk::Data(buf[..n].to_vec())).is_err() {
+                    if tx.send(PtyOutputChunk::Data(buf[..n].to_vec())).is_err() {
                         break;
                     }
                 }
                 Err(_) => {
-                    let _ = tx.send(PtyChunk::Error);
+                    let _ = tx.send(PtyOutputChunk::Error);
                     break;
                 }
             }
@@ -1646,7 +1621,7 @@ mod flusher_lifecycle_tests {
         );
 
         // Send EOF to trigger exit
-        tx.send(PtyChunk::Eof).unwrap();
+        tx.send(PtyOutputChunk::Eof).unwrap();
 
         // Verify lifecycle event was sent
         let event = lifecycle_rx.recv_timeout(Duration::from_secs(1)).unwrap();
@@ -1679,7 +1654,7 @@ mod flusher_lifecycle_tests {
         );
 
         // Send Error to trigger exit
-        tx.send(PtyChunk::Error).unwrap();
+        tx.send(PtyOutputChunk::Error).unwrap();
 
         // Verify lifecycle event was sent with IoError reason
         let event = lifecycle_rx.recv_timeout(Duration::from_secs(1)).unwrap();
@@ -1716,8 +1691,8 @@ mod flusher_lifecycle_tests {
         );
 
         // Send data then EOF
-        tx.send(PtyChunk::Data(vec![1, 2, 3])).unwrap();
-        tx.send(PtyChunk::Eof).unwrap();
+        tx.send(PtyOutputChunk::Data(vec![1, 2, 3])).unwrap();
+        tx.send(PtyOutputChunk::Eof).unwrap();
 
         // Wait for exit event
         let event = lifecycle_rx.recv_timeout(Duration::from_secs(1)).unwrap();
@@ -1743,7 +1718,7 @@ mod flusher_lifecycle_tests {
             false,
         );
 
-        tx.send(PtyChunk::Eof).unwrap();
+        tx.send(PtyOutputChunk::Eof).unwrap();
 
         assert!(matches!(
             lifecycle_rx.recv_timeout(Duration::from_millis(100)),


### PR DESCRIPTION
## Summary
- add a Tauri-free PTY output flusher state machine in roux-runtime
- move chunk batching, timeout flushes, and EOF/error exit actions into runtime tests
- keep Tauri-side flusher threads responsible only for delivery and event emission

## Verification
- cargo test -p roux-runtime pty_output
- cargo test -p roux-runtime
- CI=1 cargo test -p roux flusher_lifecycle_tests
- CI=1 cargo test -p roux pty::
- CI=1 cargo clippy -p roux --all-targets -- -D warnings

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts the PTY output batching and flush-timeout logic from the Tauri-side flusher threads into a new `PtyOutputFlusher` state machine in `roux-runtime`, making the core behavior testable without Tauri. The Tauri threads now only handle delivery (calling `output.send`) and exit-event emission.

- `PtyOutputFlusher` encapsulates batch accumulation, interval-based flush (`PTY_FLUSH_INTERVAL_MS = 16ms`), size-based flush (`PTY_FLUSH_BATCH_LIMIT_BYTES = 32KB`), and EOF/Error termination; callers drive it with `on_chunk` / `on_timeout` and act on the returned `Vec<PtyOutputFlushAction>`.
- `spawn_flusher` and `spawn_flusher_with_lifecycle` are re-implemented to delegate all state to the flusher; the local `PtyChunk` enum is replaced by the now-public `PtyOutputChunk` from `roux-runtime`.
- Four new unit tests in `roux-runtime` cover buffering, timeout flush, EOF flush+exit, and error-to-IoError mapping.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the refactor is behaviorally equivalent to the old inline code, all exit paths are exercised, and the tests cover the key state transitions.

The flusher state machine is correct and the tests validate the core transitions. Two small issues are worth cleaning up: the Timeout branch in spawn_flusher drops the apply_direct_flusher_action return value and skips the is_finished guard via continue, which is safe today but creates a latent hang if on_timeout ever yields an Exit action; and recv_timeout_ms silently returns None when finished=true, which could mislead a future caller into blocking indefinitely.

src-tauri/src/pty.rs — specifically the Timeout arm of spawn_flusher (lines 249-259) where the exit-signal return value is ignored and no is_finished check follows.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/roux-runtime/src/pty_output.rs | Adds PtyOutputFlusher state machine with PtyOutputChunk/PtyOutputFlushAction enums and four unit tests; logic is sound but recv_timeout_ms returning None when finished=true creates a latent hang path |
| src-tauri/src/pty.rs | Replaces inline batch/flush logic in spawn_flusher and spawn_flusher_with_lifecycle with PtyOutputFlusher; the two implementations have asymmetric loop-exit patterns and spawn_flusher silently ignores apply_direct_flusher_action's return value in the Timeout branch |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([Thread starts\nPtyOutputFlusher::new 0]) --> B{recv_timeout_ms}
    B -- None\nbatch empty or finished --> C[rx.recv blocking]
    B -- Some timeout_ms --> D[rx.recv_timeout timeout_ms]
    C -- Ok chunk --> F
    C -- Err Disconnected --> Z([Thread exits])
    D -- Ok chunk --> F[on_chunk chunk now_ms]
    D -- Timeout --> G[on_timeout now_ms\nflush_batch]
    D -- Disconnected --> Z
    G -- dispatch Output actions --> B
    F -- Data: append + check interval/size --> H{elapsed >= interval\nor batch >= limit}
    H -- No --> B
    H -- Yes --> I[flush_batch Output]
    I --> B
    F -- Eof --> J
    F -- Error --> J
    J[finish: set finished=true\nflush pending Output\npush Exit action] --> K[dispatch Output then Exit actions]
    K --> L{is_finished?}
    L -- Yes --> Z
    L -- No --> B
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc-tauri%2Fsrc%2Fpty.rs%3A250-258%0A**Ignored%20exit%20signal%20in%20timeout%20path**%0A%0A%60apply_direct_flusher_action%60%20returns%20%60bool%60%20%28true%20%3D%20Exit%20was%20processed%29%20but%20the%20return%20value%20is%20silently%20dropped%20here%2C%20and%20the%20%60continue%60%20bypasses%20the%20%60if%20flusher.is_finished%28%29%20%7B%20break%3B%20%7D%60%20guard%20that%20follows%20the%20on_chunk%20path.%20Today%20%60on_timeout%60%20can%20only%20emit%20%60Output%60%20actions%20so%20this%20is%20safe%2C%20but%20the%20inconsistency%20with%20the%20on_chunk%20path%20%28lines%20266-275%29%20means%20a%20future%20change%20to%20%60on_timeout%60%20that%20yields%20an%20%60Exit%60%20action%20would%20leave%20the%20thread%20spinning%20rather%20than%20terminating%20%E2%80%94%20the%20missing%20%60is_finished%28%29%60%20check%20after%20%60continue%60%20would%20keep%20calling%20%60recv_timeout_ms%60%20with%20%60finished%3Dtrue%60%2C%20which%20returns%20%60None%60%2C%20funnelling%20into%20the%20blocking%20%60rx.recv%28%29%60%20call%20indefinitely.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Froux-runtime%2Fsrc%2Fpty_output.rs%3A99-105%0A**%60recv_timeout_ms%60%20returns%20%60None%60%20when%20%60finished%3Dtrue%60%2C%20masking%20the%20finished%20state%20to%20callers**%0A%0AWhen%20%60self.finished%60%20is%20%60true%60%20the%20method%20returns%20%60None%60%2C%20which%20the%20flusher%20loop%20interprets%20as%20%22no%20pending%20batch%2C%20block%20on%20%60rx.recv%28%29%60%22.%20In%20the%20current%20loop%20design%20this%20state%20is%20unreachable%20because%20the%20outer%20loop%20always%20%60break%60s%20via%20%60if%20flusher.is_finished%28%29%20%7B%20break%3B%20%7D%60%20before%20the%20next%20iteration.%20However%2C%20if%20a%20caller%20ever%20invokes%20%60recv_timeout_ms%60%20after%20the%20flusher%20has%20finished%20%28e.g.%2C%20a%20second%20consumer%20or%20a%20future%20test%29%2C%20they%20will%20block%20indefinitely%20waiting%20for%20a%20message%20that%20will%20never%20arrive.%20Returning%20a%20distinct%20sentinel%20%E2%80%94%20or%20documenting%20that%20the%20caller%20must%20check%20%60is_finished%28%29%60%20before%20calling%20%E2%80%94%20would%20make%20this%20contract%20explicit.%0A%0A&repo=phin-tech%2Froux&pr=187&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22feature%2Fextract-pty-output-events%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fextract-pty-output-events%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc-tauri%2Fsrc%2Fpty.rs%3A250-258%0A**Ignored%20exit%20signal%20in%20timeout%20path**%0A%0A%60apply_direct_flusher_action%60%20returns%20%60bool%60%20%28true%20%3D%20Exit%20was%20processed%29%20but%20the%20return%20value%20is%20silently%20dropped%20here%2C%20and%20the%20%60continue%60%20bypasses%20the%20%60if%20flusher.is_finished%28%29%20%7B%20break%3B%20%7D%60%20guard%20that%20follows%20the%20on_chunk%20path.%20Today%20%60on_timeout%60%20can%20only%20emit%20%60Output%60%20actions%20so%20this%20is%20safe%2C%20but%20the%20inconsistency%20with%20the%20on_chunk%20path%20%28lines%20266-275%29%20means%20a%20future%20change%20to%20%60on_timeout%60%20that%20yields%20an%20%60Exit%60%20action%20would%20leave%20the%20thread%20spinning%20rather%20than%20terminating%20%E2%80%94%20the%20missing%20%60is_finished%28%29%60%20check%20after%20%60continue%60%20would%20keep%20calling%20%60recv_timeout_ms%60%20with%20%60finished%3Dtrue%60%2C%20which%20returns%20%60None%60%2C%20funnelling%20into%20the%20blocking%20%60rx.recv%28%29%60%20call%20indefinitely.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Froux-runtime%2Fsrc%2Fpty_output.rs%3A99-105%0A**%60recv_timeout_ms%60%20returns%20%60None%60%20when%20%60finished%3Dtrue%60%2C%20masking%20the%20finished%20state%20to%20callers**%0A%0AWhen%20%60self.finished%60%20is%20%60true%60%20the%20method%20returns%20%60None%60%2C%20which%20the%20flusher%20loop%20interprets%20as%20%22no%20pending%20batch%2C%20block%20on%20%60rx.recv%28%29%60%22.%20In%20the%20current%20loop%20design%20this%20state%20is%20unreachable%20because%20the%20outer%20loop%20always%20%60break%60s%20via%20%60if%20flusher.is_finished%28%29%20%7B%20break%3B%20%7D%60%20before%20the%20next%20iteration.%20However%2C%20if%20a%20caller%20ever%20invokes%20%60recv_timeout_ms%60%20after%20the%20flusher%20has%20finished%20%28e.g.%2C%20a%20second%20consumer%20or%20a%20future%20test%29%2C%20they%20will%20block%20indefinitely%20waiting%20for%20a%20message%20that%20will%20never%20arrive.%20Returning%20a%20distinct%20sentinel%20%E2%80%94%20or%20documenting%20that%20the%20caller%20must%20check%20%60is_finished%28%29%60%20before%20calling%20%E2%80%94%20would%20make%20this%20contract%20explicit.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["extract pty output flusher planning"](https://github.com/phin-tech/roux/commit/44d6f21e4f856c30c2746f0248260caed02a004d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33272883)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->