### PR TITLE
Extract PTY reader planning

### DIFF
--- a/crates/roux-runtime/src/pty_output.rs
+++ b/crates/roux-runtime/src/pty_output.rs
@@ -72,16 +72,16 @@ pub enum PtyReaderStep<'a> {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct PtyReaderPlan {
-    pub observer_bytes: Option<Vec<u8>>,
+pub struct PtyReaderPlan<'a> {
+    pub observer_bytes: Option<&'a [u8]>,
     pub output_chunk: PtyOutputChunk,
     pub stop: bool,
 }
 
-pub fn plan_reader_step(step: PtyReaderStep<'_>) -> PtyReaderPlan {
+pub fn plan_reader_step<'a>(step: PtyReaderStep<'a>) -> PtyReaderPlan<'a> {
     match step {
         PtyReaderStep::Data(bytes) => PtyReaderPlan {
-            observer_bytes: Some(bytes.to_vec()),
+            observer_bytes: Some(bytes),
             output_chunk: PtyOutputChunk::Data(bytes.to_vec()),
             stop: false,
         },
@@ -300,7 +300,7 @@ mod tests {
         assert_eq!(
             plan,
             PtyReaderPlan {
-                observer_bytes: Some(b"abc".to_vec()),
+                observer_bytes: Some(&b"abc"[..]),
                 output_chunk: PtyOutputChunk::Data(b"abc".to_vec()),
                 stop: false,
             }

--- a/crates/roux-runtime/src/pty_output.rs
+++ b/crates/roux-runtime/src/pty_output.rs
@@ -64,6 +64,40 @@ pub enum PtyOutputFlushAction {
     Exit(ExitReason),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PtyReaderStep<'a> {
+    Data(&'a [u8]),
+    Eof,
+    Error,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PtyReaderPlan {
+    pub observer_bytes: Option<Vec<u8>>,
+    pub output_chunk: PtyOutputChunk,
+    pub stop: bool,
+}
+
+pub fn plan_reader_step(step: PtyReaderStep<'_>) -> PtyReaderPlan {
+    match step {
+        PtyReaderStep::Data(bytes) => PtyReaderPlan {
+            observer_bytes: Some(bytes.to_vec()),
+            output_chunk: PtyOutputChunk::Data(bytes.to_vec()),
+            stop: false,
+        },
+        PtyReaderStep::Eof => PtyReaderPlan {
+            observer_bytes: None,
+            output_chunk: PtyOutputChunk::Eof,
+            stop: true,
+        },
+        PtyReaderStep::Error => PtyReaderPlan {
+            observer_bytes: None,
+            output_chunk: PtyOutputChunk::Error,
+            stop: true,
+        },
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct PtyOutputFlusher {
     batch: Vec<u8>,
@@ -257,5 +291,47 @@ mod tests {
             vec![PtyOutputFlushAction::Exit(ExitReason::IoError)]
         );
         assert!(flusher.is_finished());
+    }
+
+    #[test]
+    fn reader_plan_for_data_feeds_observers_and_output() {
+        let plan = plan_reader_step(PtyReaderStep::Data(b"abc"));
+
+        assert_eq!(
+            plan,
+            PtyReaderPlan {
+                observer_bytes: Some(b"abc".to_vec()),
+                output_chunk: PtyOutputChunk::Data(b"abc".to_vec()),
+                stop: false,
+            }
+        );
+    }
+
+    #[test]
+    fn reader_plan_for_eof_stops_after_eof_chunk() {
+        let plan = plan_reader_step(PtyReaderStep::Eof);
+
+        assert_eq!(
+            plan,
+            PtyReaderPlan {
+                observer_bytes: None,
+                output_chunk: PtyOutputChunk::Eof,
+                stop: true,
+            }
+        );
+    }
+
+    #[test]
+    fn reader_plan_for_error_stops_after_error_chunk() {
+        let plan = plan_reader_step(PtyReaderStep::Error);
+
+        assert_eq!(
+            plan,
+            PtyReaderPlan {
+                observer_bytes: None,
+                output_chunk: PtyOutputChunk::Error,
+                stop: true,
+            }
+        );
     }
 }

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -357,7 +357,7 @@ fn apply_reader_plan(
     sniffer: &mut Option<crate::notifications::OscSniffer>,
     gate: &Option<(ReadyGate, PtyWriter, String)>,
 ) -> bool {
-    if let Some(bytes) = plan.observer_bytes.as_deref() {
+    if let Some(bytes) = plan.observer_bytes {
         if let Some(s) = sniffer {
             s.feed(bytes);
         }

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -19,7 +19,8 @@ pub use roux_core::{PtyInfo, PtyRole, PtyStatus};
 pub use roux_runtime::process::cwd_for_pid;
 use roux_runtime::pty_lifecycle::{self, PtyMetadataCommand, PtyMetadataCommandResult};
 use roux_runtime::pty_output::{
-    PtyOutputBacklog, PtyOutputChunk, PtyOutputFlushAction, PtyOutputFlusher,
+    plan_reader_step, PtyOutputBacklog, PtyOutputChunk, PtyOutputFlushAction, PtyOutputFlusher,
+    PtyReaderPlan, PtyReaderStep,
 };
 #[cfg(test)]
 pub use roux_runtime::pty_output::PTY_BACKLOG_LIMIT_BYTES;
@@ -350,6 +351,37 @@ fn spawn_flusher_with_lifecycle(
     tx
 }
 
+fn apply_reader_plan(
+    plan: PtyReaderPlan,
+    tx: &mpsc::Sender<PtyOutputChunk>,
+    sniffer: &mut Option<crate::notifications::OscSniffer>,
+    gate: &Option<(ReadyGate, PtyWriter, String)>,
+) -> bool {
+    if let Some(bytes) = plan.observer_bytes.as_deref() {
+        if let Some(s) = sniffer {
+            s.feed(bytes);
+        }
+        // Feed the readiness gate. If this output opens the gate and had
+        // writes buffered, flush them back into the PTY so the user's typed
+        // command actually runs. Must not short-circuit the output send below:
+        // a poisoned gate mutex would otherwise silently stop output forwarding.
+        if let Some((g, w, id)) = gate {
+            if let Ok(mut guard) = g.lock() {
+                let flush = guard.on_output(bytes, Instant::now());
+                drop(guard);
+                flush_to_writer(w, &flush, &format!("reader({})", id));
+            } else {
+                rlog!(
+                    "pty_ready_gate: reader saw poisoned gate mutex, skipping feed for {}",
+                    id,
+                );
+            }
+        }
+    }
+
+    tx.send(plan.output_chunk).is_err() || plan.stop
+}
+
 /// Spawn a reader thread that blocks on PTY reads and sends chunks to the flusher.
 /// If `sniffer` is provided, every chunk is also fed through the OSC parser
 /// before being forwarded (non-consuming — bytes pass through unchanged).
@@ -362,41 +394,13 @@ fn spawn_reader(
     thread::spawn(move || {
         let mut buf = [0u8; 4096];
         loop {
-            match reader.read(&mut buf) {
-                Ok(0) => {
-                    let _ = tx.send(PtyOutputChunk::Eof);
-                    break;
-                }
-                Ok(n) => {
-                    if let Some(ref mut s) = sniffer {
-                        s.feed(&buf[..n]);
-                    }
-                    // Feed the readiness gate. If this output opens the
-                    // gate and had writes buffered, flush them back into
-                    // the PTY so the user's typed command actually runs.
-                    // Must not short-circuit the tx.send below — a
-                    // poisoned gate mutex would otherwise silently stop
-                    // output forwarding for the session.
-                    if let Some((ref g, ref w, ref id)) = gate {
-                        if let Ok(mut guard) = g.lock() {
-                            let flush = guard.on_output(&buf[..n], Instant::now());
-                            drop(guard);
-                            flush_to_writer(w, &flush, &format!("reader({})", id));
-                        } else {
-                            rlog!(
-                                "pty_ready_gate: reader saw poisoned gate mutex, skipping feed for {}",
-                                id,
-                            );
-                        }
-                    }
-                    if tx.send(PtyOutputChunk::Data(buf[..n].to_vec())).is_err() {
-                        break;
-                    }
-                }
-                Err(_) => {
-                    let _ = tx.send(PtyOutputChunk::Error);
-                    break;
-                }
+            let plan = match reader.read(&mut buf) {
+                Ok(0) => plan_reader_step(PtyReaderStep::Eof),
+                Ok(n) => plan_reader_step(PtyReaderStep::Data(&buf[..n])),
+                Err(_) => plan_reader_step(PtyReaderStep::Error),
+            };
+            if apply_reader_plan(plan, &tx, &mut sniffer, &gate) {
+                break;
             }
         }
     });


### PR DESCRIPTION
## Summary
- add runtime reader-step planning for PTY data/eof/error reads
- keep OSC sniffer, ready-gate mutation, writer flushes, and channel sends in Tauri
- refactor the Tauri reader loop to apply runtime reader plans

## Verification
- cargo test -p roux-runtime pty_output
- cargo test -p roux-runtime
- CI=1 cargo test -p roux pty::
- CI=1 cargo clippy -p roux --all-targets -- -D warnings

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts PTY reader decision logic into a small `plan_reader_step` function and a `PtyReaderPlan` struct in `roux-runtime`, then refactors the Tauri reader loop to use them via a new `apply_reader_plan` helper. The behavioural contract of the original loop — feed sniffer/gate first, send to channel, break on error or stop signals — is preserved exactly.

- **`crates/roux-runtime/src/pty_output.rs`**: adds `PtyReaderStep<'a>`, `PtyReaderPlan<'a>`, `plan_reader_step`, and three unit tests covering all three step variants.
- **`src-tauri/src/pty.rs`**: introduces `apply_reader_plan` (sniffer feed → gate feed → channel send → stop decision) and collapses the 30-line `match` in `spawn_reader` to four lines, with no change to execution order or error-handling semantics.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a pure mechanical refactor that correctly preserves all of the original reader loop's behaviour.

The extraction introduces no new logic: sniffer and gate are still fed from a borrowed slice before the channel send, EOF and error still break unconditionally after attempting the send, and data still breaks only on a send failure. The observer_bytes field is a slice reference (not a .to_vec()), so allocation pressure is identical to the original. Unit tests cover all three step variants and CI verification commands are listed in the PR description.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/roux-runtime/src/pty_output.rs | Adds PtyReaderStep, PtyReaderPlan, and plan_reader_step with full unit test coverage; observer_bytes is a borrowed slice (no extra allocation vs the original), output_chunk is one owned Vec — correct and clean. |
| src-tauri/src/pty.rs | apply_reader_plan correctly preserves ordering (sniffer/gate before channel send) and all three break conditions from the original loop; spawn_reader is a straightforward mechanical simplification. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Reader as PTY Reader Thread
    participant Planner as plan_reader_step()
    participant Applier as apply_reader_plan()
    participant Sniffer as OscSniffer
    participant Gate as ReadyGate
    participant TX as mpsc::Sender

    loop read loop
        Reader->>Reader: "reader.read(&mut buf)"
        alt "Ok(n > 0)"
            Reader->>Planner: "PtyReaderStep::Data(&buf[..n])"
            Planner-->>Reader: "PtyReaderPlan { observer_bytes: Some, output_chunk: Data(vec), stop: false }"
        else Ok(0) EOF
            Reader->>Planner: PtyReaderStep::Eof
            Planner-->>Reader: "PtyReaderPlan { observer_bytes: None, output_chunk: Eof, stop: true }"
        else Err(_)
            Reader->>Planner: PtyReaderStep::Error
            Planner-->>Reader: "PtyReaderPlan { observer_bytes: None, output_chunk: Error, stop: true }"
        end
        Reader->>Applier: apply_reader_plan(plan, tx, sniffer, gate)
        opt observer_bytes is Some
            Applier->>Sniffer: s.feed(bytes)
            Applier->>Gate: guard.on_output(bytes, now)
            Gate-->>Applier: flush bytes
            Applier->>Gate: flush_to_writer(...)
        end
        Applier->>TX: tx.send(plan.output_chunk)
        Applier-->>Reader: is_err() OR plan.stop
        alt should_stop
            Reader->>Reader: break
        end
    end
```

<sub>Reviews (2): Last reviewed commit: ["address pty reader allocation review"](https://github.com/phin-tech/roux/commit/c3cd454b047def0fe18278b056984b2f1ebe722d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33274402)</sub>

<!-- /greptile_comment -->