### PR TITLE
Extract PTY output delivery state

### DIFF
--- a/crates/roux-runtime/src/pty_output.rs
+++ b/crates/roux-runtime/src/pty_output.rs
@@ -51,6 +51,73 @@ impl Default for PtyOutputBacklog {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PtyOutputDeliveryKind {
+    Live,
+    Backlog,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PtyOutputDelivery {
+    pub kind: PtyOutputDeliveryKind,
+    pub bytes: Vec<u8>,
+}
+
+#[derive(Debug)]
+pub struct PtyOutputDeliveryState {
+    attached: bool,
+    backlog: PtyOutputBacklog,
+}
+
+impl PtyOutputDeliveryState {
+    pub fn new() -> Self {
+        Self { attached: false, backlog: PtyOutputBacklog::default() }
+    }
+
+    pub fn send(&mut self, bytes: Vec<u8>) -> Option<PtyOutputDelivery> {
+        if self.attached {
+            Some(PtyOutputDelivery { kind: PtyOutputDeliveryKind::Live, bytes })
+        } else {
+            self.backlog.buffer(bytes);
+            None
+        }
+    }
+
+    pub fn attach(&mut self) -> Option<PtyOutputDelivery> {
+        self.attached = true;
+        self.next_backlog_delivery()
+    }
+
+    pub fn delivery_succeeded(
+        &mut self,
+        kind: PtyOutputDeliveryKind,
+    ) -> Option<PtyOutputDelivery> {
+        if matches!(kind, PtyOutputDeliveryKind::Backlog) {
+            self.next_backlog_delivery()
+        } else {
+            None
+        }
+    }
+
+    pub fn delivery_failed(&mut self, delivery: PtyOutputDelivery) {
+        self.attached = false;
+        self.backlog.buffer(delivery.bytes);
+    }
+
+    fn next_backlog_delivery(&mut self) -> Option<PtyOutputDelivery> {
+        self.backlog.pop_front().map(|bytes| PtyOutputDelivery {
+            kind: PtyOutputDeliveryKind::Backlog,
+            bytes,
+        })
+    }
+}
+
+impl Default for PtyOutputDeliveryState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum PtyOutputChunk {
     Data(Vec<u8>),
@@ -225,6 +292,90 @@ mod tests {
 
         assert_eq!(backlog.len_bytes(), 0);
         assert_eq!(backlog.pop_front(), None);
+    }
+
+    #[test]
+    fn delivery_state_buffers_until_attach_then_drains_backlog() {
+        let mut state = PtyOutputDeliveryState::default();
+
+        assert_eq!(state.send(vec![1, 2, 3]), None);
+        assert_eq!(state.send(vec![4, 5, 6]), None);
+
+        let first = state.attach().expect("first backlog delivery");
+        assert_eq!(
+            first,
+            PtyOutputDelivery {
+                kind: PtyOutputDeliveryKind::Backlog,
+                bytes: vec![1, 2, 3],
+            }
+        );
+
+        let second = state.delivery_succeeded(first.kind).expect("second backlog delivery");
+        assert_eq!(
+            second,
+            PtyOutputDelivery {
+                kind: PtyOutputDeliveryKind::Backlog,
+                bytes: vec![4, 5, 6],
+            }
+        );
+        assert_eq!(state.delivery_succeeded(second.kind), None);
+    }
+
+    #[test]
+    fn delivery_state_sends_live_output_when_attached() {
+        let mut state = PtyOutputDeliveryState::default();
+        assert_eq!(state.attach(), None);
+
+        let delivery = state.send(vec![9, 8, 7]).expect("live delivery");
+        assert_eq!(
+            delivery,
+            PtyOutputDelivery {
+                kind: PtyOutputDeliveryKind::Live,
+                bytes: vec![9, 8, 7],
+            }
+        );
+        assert_eq!(state.delivery_succeeded(delivery.kind), None);
+    }
+
+    #[test]
+    fn delivery_state_rebuffers_failed_live_delivery() {
+        let mut state = PtyOutputDeliveryState::default();
+        assert_eq!(state.attach(), None);
+
+        let delivery = state.send(vec![1, 2, 3]).expect("live delivery");
+        state.delivery_failed(delivery);
+
+        let retry = state.attach().expect("retry delivery");
+        assert_eq!(
+            retry,
+            PtyOutputDelivery {
+                kind: PtyOutputDeliveryKind::Backlog,
+                bytes: vec![1, 2, 3],
+            }
+        );
+    }
+
+    #[test]
+    fn delivery_state_rebuffers_failed_backlog_delivery_after_remaining_backlog() {
+        let mut state = PtyOutputDeliveryState::default();
+        assert_eq!(state.send(vec![1]), None);
+        assert_eq!(state.send(vec![2]), None);
+        assert_eq!(state.send(vec![3]), None);
+
+        let first = state.attach().expect("first backlog delivery");
+        assert_eq!(first.bytes, vec![1]);
+        assert_eq!(first.kind, PtyOutputDeliveryKind::Backlog);
+        assert_eq!(state.delivery_succeeded(first.kind).map(|d| d.bytes), Some(vec![2]));
+
+        state.delivery_failed(PtyOutputDelivery {
+            kind: PtyOutputDeliveryKind::Backlog,
+            bytes: vec![2],
+        });
+
+        let next = state.attach().expect("remaining backlog delivery");
+        assert_eq!(next.bytes, vec![3]);
+        let retry = state.delivery_succeeded(next.kind).expect("failed chunk retry");
+        assert_eq!(retry.bytes, vec![2]);
     }
 
     #[test]

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -19,8 +19,8 @@ pub use roux_core::{PtyInfo, PtyRole, PtyStatus};
 pub use roux_runtime::process::cwd_for_pid;
 use roux_runtime::pty_lifecycle::{self, PtyMetadataCommand, PtyMetadataCommandResult};
 use roux_runtime::pty_output::{
-    plan_reader_step, PtyOutputBacklog, PtyOutputChunk, PtyOutputFlushAction, PtyOutputFlusher,
-    PtyReaderPlan, PtyReaderStep,
+    plan_reader_step, PtyOutputChunk, PtyOutputDelivery, PtyOutputDeliveryState,
+    PtyOutputFlushAction, PtyOutputFlusher, PtyReaderPlan, PtyReaderStep,
 };
 #[cfg(test)]
 pub use roux_runtime::pty_output::PTY_BACKLOG_LIMIT_BYTES;
@@ -105,26 +105,22 @@ fn spawn_gate_ticker(gate: ReadyGate, writer: PtyWriter, session_id: String) {
 
 struct PtyOutputState {
     channel: Option<Channel<Response>>,
-    backlog: PtyOutputBacklog,
+    delivery: PtyOutputDeliveryState,
     logger: Option<Arc<Mutex<crate::pty_logger::PtyLogger>>>,
 }
 
 impl PtyOutputState {
     #[cfg(test)]
     fn new() -> Self {
-        Self { channel: None, backlog: PtyOutputBacklog::default(), logger: None }
+        Self { channel: None, delivery: PtyOutputDeliveryState::default(), logger: None }
     }
 
     fn new_with_logger(logger: Arc<Mutex<crate::pty_logger::PtyLogger>>) -> Self {
         Self {
             channel: None,
-            backlog: PtyOutputBacklog::default(),
+            delivery: PtyOutputDeliveryState::default(),
             logger: Some(logger),
         }
-    }
-
-    fn buffer(&mut self, bytes: Vec<u8>) {
-        self.backlog.buffer(bytes);
     }
 
     fn send_or_buffer(&mut self, bytes: Vec<u8>) {
@@ -134,27 +130,31 @@ impl PtyOutputState {
                 l.write(&bytes);
             }
         }
-        if let Some(channel) = &self.channel {
-            if channel.send(Response::new(bytes.clone())).is_ok() {
-                return;
-            }
-            self.channel = None;
+        if let Some(delivery) = self.delivery.send(bytes) {
+            self.deliver(delivery);
         }
-        self.buffer(bytes);
     }
 
     fn attach(&mut self, channel: Channel<Response>) {
         self.channel = Some(channel);
-        while let Some(bytes) = self.backlog.pop_front() {
-            let Some(channel) = &self.channel else {
-                self.buffer(bytes);
-                break;
-            };
-            if channel.send(Response::new(bytes.clone())).is_err() {
-                self.channel = None;
-                self.buffer(bytes);
-                break;
-            }
+        let mut next = self.delivery.attach();
+        while let Some(delivery) = next {
+            next = self.deliver(delivery);
+        }
+    }
+
+    fn deliver(&mut self, delivery: PtyOutputDelivery) -> Option<PtyOutputDelivery> {
+        let Some(channel) = &self.channel else {
+            self.delivery.delivery_failed(delivery);
+            return None;
+        };
+        let kind = delivery.kind;
+        if channel.send(Response::new(delivery.bytes.clone())).is_ok() {
+            self.delivery.delivery_succeeded(kind)
+        } else {
+            self.channel = None;
+            self.delivery.delivery_failed(delivery);
+            None
         }
     }
 }


### PR DESCRIPTION
## Summary
- add runtime-owned PTY output delivery/backlog state
- preserve live delivery, backlog drain, and failed-delivery rebuffering semantics in runtime tests
- keep Tauri Channel and logger side effects in the app adapter

## Verification
- cargo test -p roux-runtime pty_output::tests::delivery_state
- cargo test -p roux-runtime
- CI=1 cargo test -p roux pty::
- CI=1 cargo clippy -p roux --all-targets -- -D warnings

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts PTY output delivery/backlog state into a new `PtyOutputDeliveryState` type in `roux-runtime`, replacing the direct `PtyOutputBacklog` field and manual channel checks in the Tauri adapter (`PtyOutputState`). The runtime now owns the `attached` flag and backlog, while Tauri-specific concerns (channel dispatch, logger side effects) stay in `src-tauri/src/pty.rs`.

- `PtyOutputDeliveryState` codifies three transitions: buffer-while-detached, drain-on-attach, and rebuffer-on-failure; all backed by four new unit tests in `roux-runtime`.
- `PtyOutputState::deliver()` is a new thin helper that calls into the state machine and returns the next queued delivery, keeping the backlog-drain loop in `attach()` clean.
- Failure semantics are preserved: a failed delivery (live or backlog) re-buffers the bytes at the **end** of the remaining backlog, consistent with the previous implementation.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The changes are a bounded refactor of internal delivery/backlog state with no public API or Tauri contract changes.

The state machine is correct and all three observable behaviors — buffering before attach, live delivery after attach, and rebuffering on failure — are verified by dedicated unit tests. The Tauri adapter's deliver() method is a straightforward delegation; the defensive channel.is_none() guard handles the unreachable-in-practice path without masking state. Failure ordering (failed chunk appended after remaining backlog) is identical to the previous implementation and is explicitly exercised by the new test.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/roux-runtime/src/pty_output.rs | Adds PtyOutputDeliveryKind, PtyOutputDelivery, and PtyOutputDeliveryState types with four well-scoped unit tests covering the key state transitions: buffer-until-attach, live delivery, and failed-delivery rebuffering. |
| src-tauri/src/pty.rs | PtyOutputState.backlog replaced with PtyOutputDeliveryState; buffer() removed; new deliver() helper delegates channel dispatch and state transitions to the runtime type; attach/send_or_buffer updated accordingly. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([attached=false\nbacklog may have items]) -->|send bytes| B[buffer into backlog\nreturn None]
    A -->|attach called| C[attached=true\npop first backlog item]
    C -->|backlog empty| D([attached=true\nbacklog empty\nlive mode])
    C -->|backlog item available| E[deliver Backlog chunk\nvia channel]
    E -->|send ok| F[delivery_succeeded Backlog\npop next item]
    F -->|more items| E
    F -->|backlog empty| D
    E -->|send err| G[delivery_failed\nattached=false\nrebuffer chunk at END\nof remaining backlog]
    G --> A
    D -->|send bytes| H[return Some Live delivery\ndeliver via channel]
    H -->|send ok| I[delivery_succeeded Live\nreturns None]
    I --> D
    H -->|send err| J[delivery_failed\nattached=false\nrebuffer bytes]
    J --> A
```

<sub>Reviews (1): Last reviewed commit: ["extract pty output delivery state"](https://github.com/phin-tech/roux/commit/179b415a3d799ebe5468ceee09397fa4283b3941) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33276425)</sub>

<!-- /greptile_comment -->