### PR TITLE
Extract PTY session registry

### DIFF
--- a/crates/roux-runtime/src/lib.rs
+++ b/crates/roux-runtime/src/lib.rs
@@ -9,6 +9,7 @@ pub mod project_service;
 pub mod pty_lifecycle;
 pub mod pty_output;
 pub mod pty_ready_gate;
+pub mod pty_registry;
 pub mod pty_session;
 pub mod pty_spawn;
 pub mod session_service;

--- a/crates/roux-runtime/src/pty_registry.rs
+++ b/crates/roux-runtime/src/pty_registry.rs
@@ -1,0 +1,235 @@
+use std::collections::HashMap;
+
+use roux_core::PtyInfo;
+
+use crate::pty_lifecycle::{
+    apply_metadata_command, PtyMetadataCommand, PtyMetadataCommandResult,
+};
+use crate::pty_session::PtySessionMetadata;
+
+pub trait PtySessionRegistryEntry {
+    fn metadata(&self) -> &PtySessionMetadata;
+    fn metadata_mut(&mut self) -> &mut PtySessionMetadata;
+    fn generation(&self) -> u64;
+
+    fn touch_last_activity(&mut self) {}
+}
+
+pub struct PtySessionRegistry<Entry> {
+    sessions: HashMap<String, Entry>,
+}
+
+impl<Entry> PtySessionRegistry<Entry> {
+    pub fn new() -> Self {
+        Self { sessions: HashMap::new() }
+    }
+
+    pub fn insert(&mut self, pty_id: String, entry: Entry) -> Option<Entry> {
+        self.sessions.insert(pty_id, entry)
+    }
+
+    pub fn remove(&mut self, pty_id: &str) -> Option<Entry> {
+        self.sessions.remove(pty_id)
+    }
+
+    pub fn get(&self, pty_id: &str) -> Option<&Entry> {
+        self.sessions.get(pty_id)
+    }
+
+    pub fn get_mut(&mut self, pty_id: &str) -> Option<&mut Entry> {
+        self.sessions.get_mut(pty_id)
+    }
+
+    pub fn contains_key(&self, pty_id: &str) -> bool {
+        self.sessions.contains_key(pty_id)
+    }
+
+    pub fn keys(&self) -> impl Iterator<Item = &String> {
+        self.sessions.keys()
+    }
+}
+
+impl<Entry> Default for PtySessionRegistry<Entry> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<Entry: PtySessionRegistryEntry> PtySessionRegistry<Entry> {
+    pub fn apply_metadata_command(
+        &mut self,
+        command: &PtyMetadataCommand,
+    ) -> PtyMetadataCommandResult {
+        let Some(entry) = self.sessions.get_mut(command.pty_id()) else {
+            return PtyMetadataCommandResult::Missing;
+        };
+
+        let generation = entry.generation();
+        let result = apply_metadata_command(entry.metadata_mut(), generation, command);
+        if matches!(result, PtyMetadataCommandResult::Applied)
+            && matches!(command, PtyMetadataCommand::AttachToPane { .. })
+        {
+            entry.touch_last_activity();
+        }
+        result
+    }
+
+    pub fn generation(&self, pty_id: &str) -> Option<u64> {
+        self.sessions.get(pty_id).map(PtySessionRegistryEntry::generation)
+    }
+
+    pub fn get_info(&self, pty_id: &str) -> Option<PtyInfo> {
+        self.sessions.get(pty_id).map(|entry| entry.metadata().to_info(pty_id))
+    }
+
+    pub fn ids_for_session(&self, session_id: &str) -> Vec<String> {
+        self.sessions
+            .iter()
+            .filter(|(_, entry)| entry.metadata().belongs_to_session(session_id))
+            .map(|(id, _)| id.clone())
+            .collect()
+    }
+
+    pub fn list_for_session(&self, session_id: &str) -> Vec<PtyInfo> {
+        self.sessions
+            .iter()
+            .filter(|(_, entry)| entry.metadata().belongs_to_session(session_id))
+            .map(|(id, entry)| entry.metadata().to_info(id))
+            .collect()
+    }
+
+    pub fn list_all(&self) -> Vec<PtyInfo> {
+        self.sessions
+            .iter()
+            .map(|(id, entry)| entry.metadata().to_info(id))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use roux_core::{PtyRole, PtyStatus};
+
+    #[derive(Debug)]
+    struct TestEntry {
+        metadata: PtySessionMetadata,
+        generation: u64,
+        touch_count: usize,
+    }
+
+    impl TestEntry {
+        fn new(session_id: Option<&str>, generation: u64) -> Self {
+            Self {
+                metadata: PtySessionMetadata::new(crate::pty_session::PtySessionMetadataInputs {
+                    role: PtyRole::Secondary,
+                    pane_id: None,
+                    detached_since_ms: 1,
+                    session_id,
+                    working_dir: Some("/repo"),
+                    profile: Some("plain-shell"),
+                    last_size: (80, 24),
+                }),
+                generation,
+                touch_count: 0,
+            }
+        }
+    }
+
+    impl PtySessionRegistryEntry for TestEntry {
+        fn metadata(&self) -> &PtySessionMetadata {
+            &self.metadata
+        }
+
+        fn metadata_mut(&mut self) -> &mut PtySessionMetadata {
+            &mut self.metadata
+        }
+
+        fn generation(&self) -> u64 {
+            self.generation
+        }
+
+        fn touch_last_activity(&mut self) {
+            self.touch_count += 1;
+        }
+    }
+
+    #[test]
+    fn registry_lists_and_filters_by_session() {
+        let mut registry = PtySessionRegistry::new();
+        registry.insert("pty-a".to_string(), TestEntry::new(Some("session-a"), 1));
+        registry.insert("pty-b".to_string(), TestEntry::new(Some("session-b"), 1));
+        registry.insert("detached".to_string(), TestEntry::new(None, 1));
+
+        let infos = registry.list_for_session("session-a");
+        assert_eq!(infos.len(), 1);
+        assert_eq!(infos[0].id, "pty-a");
+        assert_eq!(registry.ids_for_session("session-b"), vec!["pty-b".to_string()]);
+        assert_eq!(registry.list_all().len(), 3);
+    }
+
+    #[test]
+    fn registry_applies_metadata_commands_and_touches_on_attach() {
+        let mut registry = PtySessionRegistry::new();
+        registry.insert("pty-a".to_string(), TestEntry::new(Some("session-a"), 7));
+
+        assert_eq!(
+            registry.apply_metadata_command(&PtyMetadataCommand::SetUnreadOutput {
+                pty_id: "pty-a".to_string(),
+                value: true,
+            }),
+            PtyMetadataCommandResult::Applied
+        );
+        assert!(registry.get("pty-a").unwrap().metadata.unread_output);
+        assert_eq!(registry.get("pty-a").unwrap().touch_count, 0);
+
+        assert_eq!(
+            registry.apply_metadata_command(&PtyMetadataCommand::AttachToPane {
+                pty_id: "pty-a".to_string(),
+                pane_id: "pane-a".to_string(),
+            }),
+            PtyMetadataCommandResult::Applied
+        );
+        let entry = registry.get("pty-a").unwrap();
+        assert!(matches!(
+            entry.metadata.status,
+            PtyStatus::RunningAttached { ref pane_id } if pane_id == "pane-a"
+        ));
+        assert!(!entry.metadata.unread_output);
+        assert_eq!(entry.touch_count, 1);
+    }
+
+    #[test]
+    fn registry_rejects_stale_exit_generation() {
+        let mut registry = PtySessionRegistry::new();
+        registry.insert("pty-a".to_string(), TestEntry::new(Some("session-a"), 7));
+
+        assert_eq!(
+            registry.apply_metadata_command(
+                &PtyMetadataCommand::MarkExitedIfGenerationMatches {
+                    pty_id: "pty-a".to_string(),
+                    generation: 6,
+                    code: Some(1),
+                    at_ms: 99,
+                },
+            ),
+            PtyMetadataCommandResult::StaleGeneration
+        );
+        assert!(matches!(
+            registry.get("pty-a").unwrap().metadata.status,
+            PtyStatus::RunningDetached { .. }
+        ));
+    }
+
+    #[test]
+    fn registry_reports_missing_metadata_targets() {
+        let mut registry: PtySessionRegistry<TestEntry> = PtySessionRegistry::new();
+
+        assert_eq!(
+            registry.apply_metadata_command(&PtyMetadataCommand::MarkRead {
+                pty_id: "missing".to_string(),
+            }),
+            PtyMetadataCommandResult::Missing
+        );
+    }
+}

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -17,11 +17,12 @@ use crate::pty_ready_gate::ShellReadyGate;
 
 pub use roux_core::{PtyInfo, PtyRole, PtyStatus};
 pub use roux_runtime::process::cwd_for_pid;
-use roux_runtime::pty_lifecycle::{self, PtyMetadataCommand, PtyMetadataCommandResult};
+use roux_runtime::pty_lifecycle::{PtyMetadataCommand, PtyMetadataCommandResult};
 use roux_runtime::pty_output::{
     plan_reader_step, PtyOutputChunk, PtyOutputDelivery, PtyOutputDeliveryState,
     PtyOutputFlushAction, PtyOutputFlusher, PtyReaderPlan, PtyReaderStep,
 };
+use roux_runtime::pty_registry::{PtySessionRegistry, PtySessionRegistryEntry};
 #[cfg(test)]
 pub use roux_runtime::pty_output::PTY_BACKLOG_LIMIT_BYTES;
 use roux_runtime::pty_session::{PtySessionMetadata, PtySessionMetadataInputs};
@@ -454,6 +455,24 @@ pub(crate) struct PtySession {
     pub logger: Option<Arc<Mutex<crate::pty_logger::PtyLogger>>>,
 }
 
+impl PtySessionRegistryEntry for PtySession {
+    fn metadata(&self) -> &PtySessionMetadata {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut PtySessionMetadata {
+        &mut self.metadata
+    }
+
+    fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    fn touch_last_activity(&mut self) {
+        self.last_activity = std::time::Instant::now();
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum PtyError {
     #[error("Failed to open PTY: {source}")]
@@ -501,7 +520,7 @@ pub enum PtyError {
 }
 
 pub struct PtyManager {
-    sessions: Mutex<HashMap<String, PtySession>>,
+    sessions: Mutex<PtySessionRegistry<PtySession>>,
     pending_outputs: Mutex<HashMap<String, Channel<Response>>>,
     generation: AtomicU64,
     /// Set once at app startup. When present, PTY exit triggers a
@@ -520,7 +539,7 @@ pub struct PtyManager {
 impl PtyManager {
     pub fn new() -> Self {
         Self {
-            sessions: Mutex::new(HashMap::new()),
+            sessions: Mutex::new(PtySessionRegistry::new()),
             pending_outputs: Mutex::new(HashMap::new()),
             generation: AtomicU64::new(0),
             agent_sender: Mutex::new(None),
@@ -586,15 +605,10 @@ impl PtyManager {
         command: &PtyMetadataCommand,
     ) -> PtyMetadataCommandResult {
         let mut sessions = self.sessions.lock().unwrap();
-        let Some(session) = sessions.get_mut(command.pty_id()) else {
-            return PtyMetadataCommandResult::Missing;
-        };
-        let result =
-            pty_lifecycle::apply_metadata_command(&mut session.metadata, session.generation, command);
+        let result = sessions.apply_metadata_command(command);
         if matches!(result, PtyMetadataCommandResult::Applied) {
             match command {
                 PtyMetadataCommand::AttachToPane { pty_id, pane_id } => {
-                    session.last_activity = std::time::Instant::now();
                     rlog!("PtyManager: attached PTY '{}' to pane '{}'", pty_id, pane_id);
                 }
                 PtyMetadataCommand::Detach { pty_id } => {
@@ -634,14 +648,7 @@ impl PtyManager {
     }
 
     pub(crate) fn kill_session_ptys_direct(&self, session_id: &str) {
-        let ids: Vec<String> = {
-            let sessions = self.sessions.lock().unwrap();
-            sessions
-                .iter()
-                .filter(|(_, s)| s.metadata.belongs_to_session(session_id))
-                .map(|(id, _)| id.clone())
-                .collect()
-        };
+        let ids = self.sessions.lock().unwrap().ids_for_session(session_id);
         for id in ids {
             self.kill_direct(&id);
         }
@@ -1076,31 +1083,21 @@ impl PtyManager {
     }
 
     pub fn get_generation(&self, session_id: &str) -> Option<u64> {
-        self.sessions.lock().unwrap().get(session_id).map(|s| s.generation)
+        self.sessions.lock().unwrap().generation(session_id)
     }
 
     pub(crate) fn get_info_direct(&self, pty_id: &str) -> Option<PtyInfo> {
-        let sessions = self.sessions.lock().unwrap();
-        sessions.get(pty_id).map(|s| s.metadata.to_info(pty_id))
+        self.sessions.lock().unwrap().get_info(pty_id)
     }
 
     /// List PTY info snapshots for a given session (for picker UI).
     pub fn list_for_session(&self, session_id: &str) -> Vec<PtyInfo> {
-        let sessions = self.sessions.lock().unwrap();
-        sessions
-            .iter()
-            .filter(|(_, s)| s.metadata.belongs_to_session(session_id))
-            .map(|(id, s)| s.metadata.to_info(id))
-            .collect()
+        self.sessions.lock().unwrap().list_for_session(session_id)
     }
 
     /// List all PTY info snapshots in one pass.
     pub fn list_all(&self) -> Vec<PtyInfo> {
-        let sessions = self.sessions.lock().unwrap();
-        sessions
-            .iter()
-            .map(|(id, s)| s.metadata.to_info(id))
-            .collect()
+        self.sessions.lock().unwrap().list_all()
     }
 
     /// Detach a PTY from its pane (PTY keeps running).


### PR DESCRIPTION
## Summary
- add a Tauri-free generic PTY session registry in roux-runtime
- route PtyManager metadata/listing/generation lookups through the runtime registry
- keep Tauri-owned process, channel, logger, and kill effects in src-tauri

## Verification
- cargo test -p roux-runtime pty_registry
- CI=1 cargo test -p roux pty::
- cargo test -p roux-runtime
- CI=1 cargo clippy -p roux --all-targets -- -D warnings

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts a generic `PtySessionRegistry<Entry>` struct and `PtySessionRegistryEntry` trait into `roux-runtime`, replacing the raw `HashMap<String, PtySession>` inside `PtyManager` and routing metadata lookups, session listing, and generation queries through the new registry. All Tauri-specific concerns (process handles, channels, logger, kill) remain in `src-tauri`.

- `crates/roux-runtime/src/pty_registry.rs` introduces the Tauri-free `PtySessionRegistry<Entry>` generic with `apply_metadata_command`, `ids_for_session`, `list_for_session`, `list_all`, and `generation` helpers, backed by four focused unit tests.
- `src-tauri/src/pty.rs` implements `PtySessionRegistryEntry` for `PtySession` (delegating `touch_last_activity` to update `last_activity`), swaps the `HashMap` field for `PtySessionRegistry<PtySession>`, and trims ~30 lines of inline iteration/filtering in favor of registry method calls.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — purely structural refactoring with no behavioral changes to PTY lifecycle, metadata mutation, or Tauri event emission.

The extraction faithfully replicates the original logic: touch_last_activity is called only on a successful AttachToPane command, lock acquisition and release patterns are unchanged, and all existing integration tests continue to cover the affected paths. No data is dropped, no contracts change, and the new unit tests in pty_registry.rs directly exercise the registry filtering, metadata mutation, and generation-guard paths.

No files require special attention. All three changed files are consistent with each other.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/roux-runtime/src/lib.rs | Single line addition exposing `pty_registry` as a public module — no issues. |
| crates/roux-runtime/src/pty_registry.rs | New generic `PtySessionRegistry<Entry>` + `PtySessionRegistryEntry` trait; logic faithfully extracted from `pty.rs`, touch_last_activity wired only for AttachToPane (matching prior behaviour), four unit tests covering the main paths. |
| src-tauri/src/pty.rs | Implements `PtySessionRegistryEntry` for `PtySession`, replaces raw `HashMap` field with `PtySessionRegistry`, and delegates metadata/listing/generation queries to the registry; behavior is preserved and all existing tests continue to exercise the affected paths. |

</details>

</details>

<h3>Class Diagram</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
classDiagram
    class PtySessionRegistryEntry {
        <<trait>>
        +metadata() PtySessionMetadata
        +metadata_mut() PtySessionMetadata
        +generation() u64
        +touch_last_activity()
    }

    class PtySessionRegistry {
        -sessions HashMap
        +new() Self
        +insert(pty_id, entry)
        +remove(pty_id)
        +get(pty_id)
        +get_mut(pty_id)
        +contains_key(pty_id) bool
        +keys() Iterator
        +apply_metadata_command(cmd) PtyMetadataCommandResult
        +generation(pty_id) u64
        +get_info(pty_id) PtyInfo
        +ids_for_session(session_id) Vec
        +list_for_session(session_id) Vec
        +list_all() Vec
    }

    class PtySession {
        +metadata PtySessionMetadata
        +last_activity Instant
        +generation u64
    }

    class PtyManager {
        -sessions Mutex
        +apply_metadata_command_direct(cmd)
        +get_generation(session_id)
        +get_info_direct(pty_id)
        +list_for_session(session_id)
        +list_all()
        +kill_session_ptys_direct(session_id)
    }

    PtySession ..|> PtySessionRegistryEntry : implements
    PtyManager *-- PtySessionRegistry : owns via Mutex
    PtySessionRegistry --> PtySessionRegistryEntry : Entry bound
```

<sub>Reviews (1): Last reviewed commit: ["extract pty session registry"](https://github.com/phin-tech/roux/commit/f195d0e47654787a772671f4f498c349ebc95298) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33278040)</sub>

<!-- /greptile_comment -->