### PR TITLE
Extract PTY pending output store

### DIFF
--- a/crates/roux-runtime/src/lib.rs
+++ b/crates/roux-runtime/src/lib.rs
@@ -8,6 +8,7 @@ pub mod process;
 pub mod project_service;
 pub mod pty_lifecycle;
 pub mod pty_output;
+pub mod pty_pending_output;
 pub mod pty_ready_gate;
 pub mod pty_registry;
 pub mod pty_session;

--- a/crates/roux-runtime/src/pty_pending_output.rs
+++ b/crates/roux-runtime/src/pty_pending_output.rs
@@ -21,13 +21,15 @@ impl<Channel> PtyPendingOutput<Channel> {
         self.pending.retain(|pty_id, _| exists(pty_id));
     }
 
-    #[cfg(test)]
-    fn len(&self) -> usize {
+    pub fn len(&self) -> usize {
         self.pending.len()
     }
 
-    #[cfg(test)]
-    fn contains_key(&self, pty_id: &str) -> bool {
+    pub fn is_empty(&self) -> bool {
+        self.pending.is_empty()
+    }
+
+    pub fn contains_key(&self, pty_id: &str) -> bool {
         self.pending.contains_key(pty_id)
     }
 }

--- a/crates/roux-runtime/src/pty_pending_output.rs
+++ b/crates/roux-runtime/src/pty_pending_output.rs
@@ -1,0 +1,77 @@
+use std::collections::HashMap;
+
+pub struct PtyPendingOutput<Channel> {
+    pending: HashMap<String, Channel>,
+}
+
+impl<Channel> PtyPendingOutput<Channel> {
+    pub fn new() -> Self {
+        Self { pending: HashMap::new() }
+    }
+
+    pub fn insert(&mut self, pty_id: String, channel: Channel) -> Option<Channel> {
+        self.pending.insert(pty_id, channel)
+    }
+
+    pub fn remove(&mut self, pty_id: &str) -> Option<Channel> {
+        self.pending.remove(pty_id)
+    }
+
+    pub fn retain_existing(&mut self, mut exists: impl FnMut(&str) -> bool) {
+        self.pending.retain(|pty_id, _| exists(pty_id));
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.pending.len()
+    }
+
+    #[cfg(test)]
+    fn contains_key(&self, pty_id: &str) -> bool {
+        self.pending.contains_key(pty_id)
+    }
+}
+
+impl<Channel> Default for PtyPendingOutput<Channel> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn insert_and_remove_round_trip_pending_channel() {
+        let mut pending = PtyPendingOutput::new();
+
+        assert_eq!(pending.insert("pty-a".to_string(), vec![1, 2, 3]), None);
+        assert_eq!(pending.remove("pty-a"), Some(vec![1, 2, 3]));
+        assert_eq!(pending.remove("pty-a"), None);
+    }
+
+    #[test]
+    fn insert_replaces_existing_channel_for_same_pty() {
+        let mut pending = PtyPendingOutput::new();
+
+        assert_eq!(pending.insert("pty-a".to_string(), "first"), None);
+        assert_eq!(pending.insert("pty-a".to_string(), "second"), Some("first"));
+        assert_eq!(pending.remove("pty-a"), Some("second"));
+    }
+
+    #[test]
+    fn retain_existing_drops_entries_without_live_sessions() {
+        let mut pending = PtyPendingOutput::new();
+        pending.insert("pty-a".to_string(), 1);
+        pending.insert("pty-b".to_string(), 2);
+        pending.insert("pty-c".to_string(), 3);
+
+        pending.retain_existing(|pty_id| pty_id == "pty-a" || pty_id == "pty-c");
+
+        assert_eq!(pending.len(), 2);
+        assert!(pending.contains_key("pty-a"));
+        assert!(!pending.contains_key("pty-b"));
+        assert!(pending.contains_key("pty-c"));
+    }
+}

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -33,24 +33,6 @@ use roux_runtime::terminal_env;
 type PtyWriter = Arc<Mutex<Box<dyn std::io::Write + Send>>>;
 type ReadyGate = Arc<Mutex<ShellReadyGate>>;
 
-fn debug_bytes_preview(data: &[u8]) -> String {
-    let mut out = String::new();
-    for &byte in data.iter().take(24) {
-        match byte {
-            b'\r' => out.push_str("\\r"),
-            b'\n' => out.push_str("\\n"),
-            b'\t' => out.push_str("\\t"),
-            0x1b => out.push_str("\\e"),
-            0x20..=0x7e => out.push(byte as char),
-            _ => out.push_str(&format!("\\x{byte:02x}")),
-        }
-    }
-    if data.len() > 24 {
-        out.push_str("...");
-    }
-    out
-}
-
 const GATE_QUIET: Duration = Duration::from_millis(200);
 const GATE_TIMEOUT: Duration = Duration::from_secs(5);
 const GATE_TICK: Duration = Duration::from_millis(75);
@@ -1053,49 +1035,19 @@ impl PtyManager {
         let bytes_to_write: Vec<u8> = match gate {
             Some(g) => {
                 let mut guard = g.lock().unwrap();
-                let was_open = guard.is_open();
-                let bytes = guard.on_write(data, Instant::now());
-                crate::rlog!(
-                    "[pane-input] pty.write.gate id={} inputBytes={} writeBytes={} wasOpen={} nowOpen={} data={}",
-                    session_id,
-                    data.len(),
-                    bytes.len(),
-                    was_open,
-                    guard.is_open(),
-                    debug_bytes_preview(data)
-                );
-                bytes
+                guard.on_write(data, Instant::now())
             }
-            None => {
-                crate::rlog!(
-                    "[pane-input] pty.write.noGate id={} inputBytes={} data={}",
-                    session_id,
-                    data.len(),
-                    debug_bytes_preview(data)
-                );
-                data.to_vec()
-            }
+            None => data.to_vec(),
         };
 
         if bytes_to_write.is_empty() {
-            crate::rlog!(
-                "[pane-input] pty.write.buffered id={} inputBytes={}",
-                session_id,
-                data.len()
-            );
             return Ok(());
         }
 
         let mut writer = writer.lock().unwrap();
         use std::io::Write;
         writer.write_all(&bytes_to_write).map_err(|source| PtyError::WriteFailed { source })?;
-        writer.flush().map_err(|source| PtyError::FlushFailed { source })?;
-        crate::rlog!(
-            "[pane-input] pty.write.ok id={} bytes={}",
-            session_id,
-            bytes_to_write.len()
-        );
-        Ok(())
+        writer.flush().map_err(|source| PtyError::FlushFailed { source })
     }
 
     pub fn resize(&self, session_id: &str, cols: u16, rows: u16) -> Result<(), PtyError> {

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -1,5 +1,4 @@
 use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
-use std::collections::HashMap;
 use std::io::Read;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc;
@@ -22,6 +21,7 @@ use roux_runtime::pty_output::{
     plan_reader_step, PtyOutputChunk, PtyOutputDelivery, PtyOutputDeliveryState,
     PtyOutputFlushAction, PtyOutputFlusher, PtyReaderPlan, PtyReaderStep,
 };
+use roux_runtime::pty_pending_output::PtyPendingOutput;
 use roux_runtime::pty_registry::{PtySessionRegistry, PtySessionRegistryEntry};
 #[cfg(test)]
 pub use roux_runtime::pty_output::PTY_BACKLOG_LIMIT_BYTES;
@@ -521,7 +521,7 @@ pub enum PtyError {
 
 pub struct PtyManager {
     sessions: Mutex<PtySessionRegistry<PtySession>>,
-    pending_outputs: Mutex<HashMap<String, Channel<Response>>>,
+    pending_outputs: Mutex<PtyPendingOutput<Channel<Response>>>,
     generation: AtomicU64,
     /// Set once at app startup. When present, PTY exit triggers a
     /// `RegistryMessage::SessionEnded` broadcast so the agent FSM can
@@ -540,7 +540,7 @@ impl PtyManager {
     pub fn new() -> Self {
         Self {
             sessions: Mutex::new(PtySessionRegistry::new()),
-            pending_outputs: Mutex::new(HashMap::new()),
+            pending_outputs: Mutex::new(PtyPendingOutput::new()),
             generation: AtomicU64::new(0),
             agent_sender: Mutex::new(None),
             lifecycle_tx: Mutex::new(None),
@@ -1071,7 +1071,7 @@ impl PtyManager {
         // Since we can't timestamp them easily, just check if the session exists.
         let sessions = self.sessions.lock().unwrap();
         let mut pending = self.pending_outputs.lock().unwrap();
-        pending.retain(|id, _| sessions.contains_key(id));
+        pending.retain_existing(|id| sessions.contains_key(id));
     }
 
     pub fn kill(&self, session_id: &str) {

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -33,6 +33,24 @@ use roux_runtime::terminal_env;
 type PtyWriter = Arc<Mutex<Box<dyn std::io::Write + Send>>>;
 type ReadyGate = Arc<Mutex<ShellReadyGate>>;
 
+fn debug_bytes_preview(data: &[u8]) -> String {
+    let mut out = String::new();
+    for &byte in data.iter().take(24) {
+        match byte {
+            b'\r' => out.push_str("\\r"),
+            b'\n' => out.push_str("\\n"),
+            b'\t' => out.push_str("\\t"),
+            0x1b => out.push_str("\\e"),
+            0x20..=0x7e => out.push(byte as char),
+            _ => out.push_str(&format!("\\x{byte:02x}")),
+        }
+    }
+    if data.len() > 24 {
+        out.push_str("...");
+    }
+    out
+}
+
 const GATE_QUIET: Duration = Duration::from_millis(200);
 const GATE_TIMEOUT: Duration = Duration::from_secs(5);
 const GATE_TICK: Duration = Duration::from_millis(75);
@@ -1035,19 +1053,49 @@ impl PtyManager {
         let bytes_to_write: Vec<u8> = match gate {
             Some(g) => {
                 let mut guard = g.lock().unwrap();
-                guard.on_write(data, Instant::now())
+                let was_open = guard.is_open();
+                let bytes = guard.on_write(data, Instant::now());
+                crate::rlog!(
+                    "[pane-input] pty.write.gate id={} inputBytes={} writeBytes={} wasOpen={} nowOpen={} data={}",
+                    session_id,
+                    data.len(),
+                    bytes.len(),
+                    was_open,
+                    guard.is_open(),
+                    debug_bytes_preview(data)
+                );
+                bytes
             }
-            None => data.to_vec(),
+            None => {
+                crate::rlog!(
+                    "[pane-input] pty.write.noGate id={} inputBytes={} data={}",
+                    session_id,
+                    data.len(),
+                    debug_bytes_preview(data)
+                );
+                data.to_vec()
+            }
         };
 
         if bytes_to_write.is_empty() {
+            crate::rlog!(
+                "[pane-input] pty.write.buffered id={} inputBytes={}",
+                session_id,
+                data.len()
+            );
             return Ok(());
         }
 
         let mut writer = writer.lock().unwrap();
         use std::io::Write;
         writer.write_all(&bytes_to_write).map_err(|source| PtyError::WriteFailed { source })?;
-        writer.flush().map_err(|source| PtyError::FlushFailed { source })
+        writer.flush().map_err(|source| PtyError::FlushFailed { source })?;
+        crate::rlog!(
+            "[pane-input] pty.write.ok id={} bytes={}",
+            session_id,
+            bytes_to_write.len()
+        );
+        Ok(())
     }
 
     pub fn resize(&self, session_id: &str, cols: u16, rows: u16) -> Result<(), PtyError> {

--- a/src/lib/components/PaneShell.svelte
+++ b/src/lib/components/PaneShell.svelte
@@ -249,19 +249,7 @@
     return getTerminalController(paneId)?.getSelection() ?? "";
   }
 
-  function eventTargetSummary(target: EventTarget | null): string {
-    if (!(target instanceof Element)) return "none";
-    const frame = target.closest("[data-terminal-frame]") ? "terminal-frame" : "outside-terminal";
-    const pane = target.closest("[data-pane-id]")?.getAttribute("data-pane-id") ?? "none";
-    const cls = typeof target.className === "string" ? target.className : "";
-    return `${target.tagName.toLowerCase()} pane=${pane} ${frame} class=${cls.slice(0, 80)}`;
-  }
-
   function handleMouseDown(event: MouseEvent) {
-    log(
-      `[pane-input] PaneShell.mousedown pane=${paneId} pty=${panePtyId() ?? "null"} ` +
-        `focused=${$focusedPaneId ?? "null"} target=${eventTargetSummary(event.target)}`,
-    );
     if (multiLineEditorOwnsPaneInput()) {
       focusedPaneId.set(paneId);
       if (
@@ -272,29 +260,21 @@
       }
       return;
     }
-    setLogicalFocus(paneId, "PaneShell.mousedown");
+    setLogicalFocus(paneId);
   }
 
-  function handleMouseDownCapture(event: MouseEvent) {
+  function handleMouseDownCapture() {
     // xterm owns several nested DOM nodes and may stop pointer events before
     // they bubble to the pane shell. Claim logical focus in capture phase so
     // stdin routing follows the pane the user pressed into.
-    log(
-      `[pane-input] PaneShell.mousedown.capture pane=${paneId} pty=${panePtyId() ?? "null"} ` +
-        `focused=${$focusedPaneId ?? "null"} target=${eventTargetSummary(event.target)}`,
-    );
     if (multiLineEditorOwnsPaneInput()) {
       focusedPaneId.set(paneId);
       return;
     }
-    setLogicalFocus(paneId, "PaneShell.mousedown.capture");
+    setLogicalFocus(paneId);
   }
 
   function handleTerminalClick() {
-    log(
-      `[pane-input] PaneShell.terminalClick pane=${paneId} pty=${panePtyId() ?? "null"} ` +
-        `focused=${$focusedPaneId ?? "null"}`,
-    );
     if (multiLineEditorOwnsPaneInput()) {
       if (getTerminalController(paneId)?.hasSelection()) return;
       requestMultiLineEditorFocus(paneId);

--- a/src/lib/components/PaneShell.svelte
+++ b/src/lib/components/PaneShell.svelte
@@ -249,7 +249,19 @@
     return getTerminalController(paneId)?.getSelection() ?? "";
   }
 
+  function eventTargetSummary(target: EventTarget | null): string {
+    if (!(target instanceof Element)) return "none";
+    const frame = target.closest("[data-terminal-frame]") ? "terminal-frame" : "outside-terminal";
+    const pane = target.closest("[data-pane-id]")?.getAttribute("data-pane-id") ?? "none";
+    const cls = typeof target.className === "string" ? target.className : "";
+    return `${target.tagName.toLowerCase()} pane=${pane} ${frame} class=${cls.slice(0, 80)}`;
+  }
+
   function handleMouseDown(event: MouseEvent) {
+    log(
+      `[pane-input] PaneShell.mousedown pane=${paneId} pty=${panePtyId() ?? "null"} ` +
+        `focused=${$focusedPaneId ?? "null"} target=${eventTargetSummary(event.target)}`,
+    );
     if (multiLineEditorOwnsPaneInput()) {
       focusedPaneId.set(paneId);
       if (
@@ -260,21 +272,29 @@
       }
       return;
     }
-    setLogicalFocus(paneId);
+    setLogicalFocus(paneId, "PaneShell.mousedown");
   }
 
-  function handleMouseDownCapture() {
+  function handleMouseDownCapture(event: MouseEvent) {
     // xterm owns several nested DOM nodes and may stop pointer events before
     // they bubble to the pane shell. Claim logical focus in capture phase so
     // stdin routing follows the pane the user pressed into.
+    log(
+      `[pane-input] PaneShell.mousedown.capture pane=${paneId} pty=${panePtyId() ?? "null"} ` +
+        `focused=${$focusedPaneId ?? "null"} target=${eventTargetSummary(event.target)}`,
+    );
     if (multiLineEditorOwnsPaneInput()) {
       focusedPaneId.set(paneId);
       return;
     }
-    setLogicalFocus(paneId);
+    setLogicalFocus(paneId, "PaneShell.mousedown.capture");
   }
 
   function handleTerminalClick() {
+    log(
+      `[pane-input] PaneShell.terminalClick pane=${paneId} pty=${panePtyId() ?? "null"} ` +
+        `focused=${$focusedPaneId ?? "null"}`,
+    );
     if (multiLineEditorOwnsPaneInput()) {
       if (getTerminalController(paneId)?.hasSelection()) return;
       requestMultiLineEditorFocus(paneId);

--- a/src/lib/components/PaneShell.svelte
+++ b/src/lib/components/PaneShell.svelte
@@ -263,6 +263,17 @@
     setLogicalFocus(paneId);
   }
 
+  function handleMouseDownCapture() {
+    // xterm owns several nested DOM nodes and may stop pointer events before
+    // they bubble to the pane shell. Claim logical focus in capture phase so
+    // stdin routing follows the pane the user pressed into.
+    if (multiLineEditorOwnsPaneInput()) {
+      focusedPaneId.set(paneId);
+      return;
+    }
+    setLogicalFocus(paneId);
+  }
+
   function handleTerminalClick() {
     if (multiLineEditorOwnsPaneInput()) {
       if (getTerminalController(paneId)?.hasSelection()) return;
@@ -480,6 +491,7 @@
     data-pane-id={paneId}
     data-focused={isFocused}
     data-focus-chrome={(isFocused && hasMultipleVisiblePanes) ? "true" : undefined}
+    onmousedowncapture={handleMouseDownCapture}
     onmousedown={handleMouseDown}
     oncopy={handleCopy}
     ondragenter={handleDragEnter}

--- a/src/lib/panes/__tests__/focus.test.ts
+++ b/src/lib/panes/__tests__/focus.test.ts
@@ -67,6 +67,23 @@ describe("focus", () => {
     expect(p1.focus).toHaveBeenCalled();
   });
 
+  it("requestDomFocus updates logical focus and input routing", () => {
+    createPane({ id: "p1", type: "shell", ptyId: "pty-1" });
+    createPane({ id: "p2", type: "shell", ptyId: "pty-2" });
+    const p1 = { setInputEnabled: vi.fn(), focus: vi.fn() };
+    const p2 = { setInputEnabled: vi.fn(), focus: vi.fn() };
+    controllers.set("p1", p1);
+    controllers.set("p2", p2);
+    setLogicalFocus("p2");
+
+    requestDomFocus("p1");
+
+    expect(get(focusedPaneId)).toBe("p1");
+    expect(p1.setInputEnabled).toHaveBeenLastCalledWith(true);
+    expect(p2.setInputEnabled).toHaveBeenLastCalledWith(false);
+    expect(p1.focus).toHaveBeenCalled();
+  });
+
   it("toggleFullscreen sets and clears fullscreenPaneId", () => {
     createPane({ id: "p1", type: "shell", ptyId: "pty-1" });
     setLogicalFocus("p1");

--- a/src/lib/panes/__tests__/xtermController.test.ts
+++ b/src/lib/panes/__tests__/xtermController.test.ts
@@ -69,10 +69,10 @@ vi.mock("../promptSnapshot", () => ({
 }));
 
 vi.mock("@xterm/xterm", () => ({
-  Terminal: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+  Terminal: vi.fn().mockImplementation(function (this: Record<string, unknown>, options: Record<string, unknown>) {
     this.loadAddon = mocks.terminalLoadAddon;
     this.dispose = mocks.terminalDispose;
-    this.options = {};
+    this.options = { ...options };
     this.buffer = { active: { length: 0 } };
     this.onData = vi.fn().mockReturnValue({ dispose: vi.fn() });
     this.attachCustomKeyEventHandler = vi.fn();
@@ -326,6 +326,28 @@ describe("XtermTerminalController renderer setup", () => {
 
     expect(terminal.input).toHaveBeenCalledWith("\r", undefined);
     expect(terminal.paste).toHaveBeenCalledWith("echo hi");
+  });
+
+  it("gates keyboard events without disabling terminal protocol responses", async () => {
+    const { Terminal } = await import("@xterm/xterm");
+    const controller = createXtermTerminalController();
+    const terminal = vi.mocked(Terminal).mock.results.at(-1)?.value as {
+      options: Record<string, unknown>;
+      attachCustomKeyEventHandler: ReturnType<typeof vi.fn>;
+    };
+    const keyHandler = terminal.attachCustomKeyEventHandler.mock.calls[0]?.[0] as
+      | ((event: KeyboardEvent) => boolean)
+      | undefined;
+    expect(keyHandler).toBeDefined();
+    expect(terminal.options.disableStdin).toBe(false);
+
+    const event = new KeyboardEvent("keydown", { key: "a" });
+    controller.setInputEnabled(false);
+    expect(keyHandler!(event)).toBe(false);
+    expect(terminal.options.disableStdin).toBe(false);
+
+    controller.setInputEnabled(true);
+    expect(keyHandler!(event)).toBe(true);
   });
 });
 

--- a/src/lib/panes/focus.ts
+++ b/src/lib/panes/focus.ts
@@ -1,7 +1,6 @@
 import { writable, get } from "svelte/store";
 import { paneInstances } from "./instances";
 import { getTerminalController } from "./terminalRuntime";
-import { log } from "$lib/logging";
 
 export const focusedPaneId = writable<string | null>(null);
 export const fullscreenPaneId = writable<string | null>(null);
@@ -12,38 +11,14 @@ export const fullscreenPaneId = writable<string | null>(null);
  * terminal so keyboard input is routed correctly after programmatic
  * navigation (e.g. Alt+H/J/K/L).
  */
-function activeElementSummary(): string {
-  if (typeof document === "undefined") return "no-document";
-  const el = document.activeElement;
-  if (!(el instanceof HTMLElement)) return "none";
-  const pane = el.closest("[data-pane-id]")?.getAttribute("data-pane-id") ?? "none";
-  const cls = typeof el.className === "string" ? el.className : "";
-  return `${el.tagName.toLowerCase()}#${el.id || "-"} pane=${pane} class=${cls.slice(0, 80)}`;
-}
-
-export function setLogicalFocus(paneId: string | null, source = "unknown") {
-  const previous = get(focusedPaneId);
-  const instances = get(paneInstances);
-  log(
-    `[pane-input] setLogicalFocus source=${source} from=${previous ?? "null"} to=${paneId ?? "null"} ` +
-      `instances=${instances.size} activeBefore=${activeElementSummary()}`,
-  );
+export function setLogicalFocus(paneId: string | null) {
   focusedPaneId.set(paneId);
-  for (const [id, pane] of instances) {
-    const controller = getTerminalController(id);
-    const enabled = id === paneId;
-    log(
-      `[pane-input] route pane=${id} pty=${pane.ptyId} type=${pane.type} hasTerm=${!!controller} enabled=${enabled}`,
-    );
-    controller?.setInputEnabled(enabled);
+  const instances = get(paneInstances);
+  for (const [id] of instances) {
+    getTerminalController(id)?.setInputEnabled(id === paneId);
   }
   if (paneId) {
-    const controller = getTerminalController(paneId);
-    log(`[pane-input] focus pane=${paneId} hasTerm=${!!controller}`);
-    controller?.focus();
-    queueMicrotask(() => {
-      log(`[pane-input] focus.after pane=${paneId} activeAfter=${activeElementSummary()}`);
-    });
+    getTerminalController(paneId)?.focus();
   }
 }
 
@@ -52,7 +27,7 @@ export function setLogicalFocus(paneId: string | null, source = "unknown") {
  * Only call from pointer event handlers (mousedown, click).
  */
 export function requestDomFocus(paneId: string) {
-  setLogicalFocus(paneId, "requestDomFocus");
+  setLogicalFocus(paneId);
 }
 
 /** Toggle fullscreen for the focused pane. */

--- a/src/lib/panes/focus.ts
+++ b/src/lib/panes/focus.ts
@@ -1,6 +1,7 @@
 import { writable, get } from "svelte/store";
 import { paneInstances } from "./instances";
 import { getTerminalController } from "./terminalRuntime";
+import { log } from "$lib/logging";
 
 export const focusedPaneId = writable<string | null>(null);
 export const fullscreenPaneId = writable<string | null>(null);
@@ -11,14 +12,38 @@ export const fullscreenPaneId = writable<string | null>(null);
  * terminal so keyboard input is routed correctly after programmatic
  * navigation (e.g. Alt+H/J/K/L).
  */
-export function setLogicalFocus(paneId: string | null) {
-  focusedPaneId.set(paneId);
+function activeElementSummary(): string {
+  if (typeof document === "undefined") return "no-document";
+  const el = document.activeElement;
+  if (!(el instanceof HTMLElement)) return "none";
+  const pane = el.closest("[data-pane-id]")?.getAttribute("data-pane-id") ?? "none";
+  const cls = typeof el.className === "string" ? el.className : "";
+  return `${el.tagName.toLowerCase()}#${el.id || "-"} pane=${pane} class=${cls.slice(0, 80)}`;
+}
+
+export function setLogicalFocus(paneId: string | null, source = "unknown") {
+  const previous = get(focusedPaneId);
   const instances = get(paneInstances);
-  for (const [id] of instances) {
-    getTerminalController(id)?.setInputEnabled(id === paneId);
+  log(
+    `[pane-input] setLogicalFocus source=${source} from=${previous ?? "null"} to=${paneId ?? "null"} ` +
+      `instances=${instances.size} activeBefore=${activeElementSummary()}`,
+  );
+  focusedPaneId.set(paneId);
+  for (const [id, pane] of instances) {
+    const controller = getTerminalController(id);
+    const enabled = id === paneId;
+    log(
+      `[pane-input] route pane=${id} pty=${pane.ptyId} type=${pane.type} hasTerm=${!!controller} enabled=${enabled}`,
+    );
+    controller?.setInputEnabled(enabled);
   }
   if (paneId) {
-    getTerminalController(paneId)?.focus();
+    const controller = getTerminalController(paneId);
+    log(`[pane-input] focus pane=${paneId} hasTerm=${!!controller}`);
+    controller?.focus();
+    queueMicrotask(() => {
+      log(`[pane-input] focus.after pane=${paneId} activeAfter=${activeElementSummary()}`);
+    });
   }
 }
 
@@ -27,7 +52,7 @@ export function setLogicalFocus(paneId: string | null) {
  * Only call from pointer event handlers (mousedown, click).
  */
 export function requestDomFocus(paneId: string) {
-  setLogicalFocus(paneId);
+  setLogicalFocus(paneId, "requestDomFocus");
 }
 
 /** Toggle fullscreen for the focused pane. */

--- a/src/lib/panes/focus.ts
+++ b/src/lib/panes/focus.ts
@@ -27,7 +27,7 @@ export function setLogicalFocus(paneId: string | null) {
  * Only call from pointer event handlers (mousedown, click).
  */
 export function requestDomFocus(paneId: string) {
-  getTerminalController(paneId)?.focus();
+  setLogicalFocus(paneId);
 }
 
 /** Toggle fullscreen for the focused pane. */

--- a/src/lib/panes/terminals.ts
+++ b/src/lib/panes/terminals.ts
@@ -36,6 +36,19 @@ function inputPreview(data: string): string {
   return escaped.length > 24 ? `${escaped.slice(0, 24)}...` : escaped;
 }
 
+function outputPreview(bytes: Uint8Array): string {
+  const slice = bytes.slice(0, 24);
+  const chars = Array.from(slice, (byte) => {
+    if (byte === 13) return "\\r";
+    if (byte === 10) return "\\n";
+    if (byte === 9) return "\\t";
+    if (byte === 27) return "\\e";
+    if (byte < 32 || byte > 126) return `\\x${byte.toString(16).padStart(2, "0")}`;
+    return String.fromCharCode(byte);
+  }).join("");
+  return bytes.length > slice.length ? `${chars}...` : chars;
+}
+
 /**
  * Create a terminal controller for a pane. No-ops if the controller already
  * exists or the pane is markdown-only.
@@ -106,9 +119,14 @@ export function initTerminal(paneId: string): void {
     log(
       `[pane-input] onData pane=${paneId} pty=${inst.ptyId} bytes=${data.length} data=${inputPreview(data)}`,
     );
-    writeToSession(inst.ptyId, data).catch((e) => {
-      log(`Write failed for ${inst.ptyId}: ${e}`);
-    });
+    writeToSession(inst.ptyId, data)
+      .then(() => {
+        log(`[pane-input] writeToSession.ok pane=${paneId} pty=${inst.ptyId} bytes=${data.length}`);
+      })
+      .catch((e) => {
+        log(`[pane-input] writeToSession.err pane=${paneId} pty=${inst.ptyId} error=${e}`);
+        log(`Write failed for ${inst.ptyId}: ${e}`);
+      });
   });
 
   const currentFocused = get(focusedPaneId);
@@ -169,6 +187,10 @@ export async function attachPtyListeners(
   let outputChannel = getPaneOutputChannel(paneId);
   if (!outputChannel) {
     outputChannel = createPtyOutputChannel((bytes) => {
+      log(
+        `[pane-input] output pane=${paneId} pty=${targetPtyId} bytes=${bytes.length} ` +
+          `data=${outputPreview(bytes)} hasTerm=${!!getTerminalController(paneId)}`,
+      );
       emitPtyOutput(targetPtyId, bytes);
       getTerminalController(paneId)?.write(bytes);
     });

--- a/src/lib/panes/terminals.ts
+++ b/src/lib/panes/terminals.ts
@@ -27,6 +27,15 @@ import {
 } from "./terminalRuntime";
 import { log } from "$lib/logging";
 
+function inputPreview(data: string): string {
+  const escaped = data
+    .replace(/\r/g, "\\r")
+    .replace(/\n/g, "\\n")
+    .replace(/\t/g, "\\t")
+    .replace(/\u001b/g, "\\e");
+  return escaped.length > 24 ? `${escaped.slice(0, 24)}...` : escaped;
+}
+
 /**
  * Create a terminal controller for a pane. No-ops if the controller already
  * exists or the pane is markdown-only.
@@ -90,13 +99,23 @@ export function initTerminal(paneId: string): void {
   });
   controller.onInput((data) => {
     const inst = getInstance(paneId);
-    if (!inst) return;
+    if (!inst) {
+      log(`[pane-input] onData pane=${paneId} dropped=no-instance bytes=${data.length} data=${inputPreview(data)}`);
+      return;
+    }
+    log(
+      `[pane-input] onData pane=${paneId} pty=${inst.ptyId} bytes=${data.length} data=${inputPreview(data)}`,
+    );
     writeToSession(inst.ptyId, data).catch((e) => {
       log(`Write failed for ${inst.ptyId}: ${e}`);
     });
   });
 
   const currentFocused = get(focusedPaneId);
+  log(
+    `[pane-input] initTerminal.inputState pane=${paneId} pty=${instance.ptyId} focused=${currentFocused ?? "null"} ` +
+      `enabled=${paneId === currentFocused}`,
+  );
   controller.setInputEnabled(paneId === currentFocused);
 }
 

--- a/src/lib/panes/terminals.ts
+++ b/src/lib/panes/terminals.ts
@@ -27,28 +27,6 @@ import {
 } from "./terminalRuntime";
 import { log } from "$lib/logging";
 
-function inputPreview(data: string): string {
-  const escaped = data
-    .replace(/\r/g, "\\r")
-    .replace(/\n/g, "\\n")
-    .replace(/\t/g, "\\t")
-    .replace(/\u001b/g, "\\e");
-  return escaped.length > 24 ? `${escaped.slice(0, 24)}...` : escaped;
-}
-
-function outputPreview(bytes: Uint8Array): string {
-  const slice = bytes.slice(0, 24);
-  const chars = Array.from(slice, (byte) => {
-    if (byte === 13) return "\\r";
-    if (byte === 10) return "\\n";
-    if (byte === 9) return "\\t";
-    if (byte === 27) return "\\e";
-    if (byte < 32 || byte > 126) return `\\x${byte.toString(16).padStart(2, "0")}`;
-    return String.fromCharCode(byte);
-  }).join("");
-  return bytes.length > slice.length ? `${chars}...` : chars;
-}
-
 /**
  * Create a terminal controller for a pane. No-ops if the controller already
  * exists or the pane is markdown-only.
@@ -112,28 +90,13 @@ export function initTerminal(paneId: string): void {
   });
   controller.onInput((data) => {
     const inst = getInstance(paneId);
-    if (!inst) {
-      log(`[pane-input] onData pane=${paneId} dropped=no-instance bytes=${data.length} data=${inputPreview(data)}`);
-      return;
-    }
-    log(
-      `[pane-input] onData pane=${paneId} pty=${inst.ptyId} bytes=${data.length} data=${inputPreview(data)}`,
-    );
-    writeToSession(inst.ptyId, data)
-      .then(() => {
-        log(`[pane-input] writeToSession.ok pane=${paneId} pty=${inst.ptyId} bytes=${data.length}`);
-      })
-      .catch((e) => {
-        log(`[pane-input] writeToSession.err pane=${paneId} pty=${inst.ptyId} error=${e}`);
-        log(`Write failed for ${inst.ptyId}: ${e}`);
-      });
+    if (!inst) return;
+    writeToSession(inst.ptyId, data).catch((e) => {
+      log(`Write failed for ${inst.ptyId}: ${e}`);
+    });
   });
 
   const currentFocused = get(focusedPaneId);
-  log(
-    `[pane-input] initTerminal.inputState pane=${paneId} pty=${instance.ptyId} focused=${currentFocused ?? "null"} ` +
-      `enabled=${paneId === currentFocused}`,
-  );
   controller.setInputEnabled(paneId === currentFocused);
 }
 
@@ -187,10 +150,6 @@ export async function attachPtyListeners(
   let outputChannel = getPaneOutputChannel(paneId);
   if (!outputChannel) {
     outputChannel = createPtyOutputChannel((bytes) => {
-      log(
-        `[pane-input] output pane=${paneId} pty=${targetPtyId} bytes=${bytes.length} ` +
-          `data=${outputPreview(bytes)} hasTerm=${!!getTerminalController(paneId)}`,
-      );
       emitPtyOutput(targetPtyId, bytes);
       getTerminalController(paneId)?.write(bytes);
     });

--- a/src/lib/panes/xtermController.ts
+++ b/src/lib/panes/xtermController.ts
@@ -36,6 +36,8 @@ class XtermTerminalController implements TerminalController {
   private atlasRefreshTimer: ReturnType<typeof setTimeout> | null = null;
   private atlasRefreshPending = false;
   private watchDecorations: XtermWatchDecorationsHandle | null = null;
+  private inputEnabled = false;
+  private customKeyHandler: ((event: KeyboardEvent) => boolean) | null = null;
 
   constructor(options?: CreateTerminalControllerOptions) {
     const s = get(settings);
@@ -47,7 +49,7 @@ class XtermTerminalController implements TerminalController {
       cursorStyle: s.cursorStyle as "block" | "underline" | "bar",
       cursorBlink: s.cursorBlink,
       theme: toXtermTheme(resolveTerminalTheme(s.theme, s.terminalTheme, get(userTerminalThemes))),
-      disableStdin: true,
+      disableStdin: false,
       allowProposedApi: true,
     });
 
@@ -55,9 +57,12 @@ class XtermTerminalController implements TerminalController {
     this.terminal.loadAddon(this.fitAddon);
     this.setupRenderer(s.gpuAcceleration ?? "auto");
 
-    if (options?.allowKeyboardEvent) {
-      this.setCustomKeyHandler(options.allowKeyboardEvent);
-    }
+    this.terminal.attachCustomKeyEventHandler((event) => {
+      if (!this.inputEnabled) return false;
+      if (!this.customKeyHandler) return true;
+      return this.customKeyHandler(event);
+    });
+    if (options?.allowKeyboardEvent) this.setCustomKeyHandler(options.allowKeyboardEvent);
 
     this.terminal.loadAddon(new WebLinksAddon((_event, uri) => {
       openUrl(uri);
@@ -178,7 +183,7 @@ class XtermTerminalController implements TerminalController {
   }
 
   setInputEnabled(enabled: boolean): void {
-    this.terminal.options.disableStdin = !enabled;
+    this.inputEnabled = enabled;
   }
 
   onInput(handler: (data: string) => void): () => void {
@@ -223,10 +228,7 @@ class XtermTerminalController implements TerminalController {
   }
 
   setCustomKeyHandler(handler: ((event: KeyboardEvent) => boolean) | null): void {
-    this.terminal.attachCustomKeyEventHandler((event) => {
-      if (!handler) return true;
-      return handler(event);
-    });
+    this.customKeyHandler = handler;
   }
 
   getPromptSnapshot(): PromptSnapshot | null {


### PR DESCRIPTION
## Summary
- add a generic Tauri-free pending PTY output attachment store in roux-runtime
- move pending output insert/remove/retain bookkeeping out of PtyManager
- preserve Tauri ownership of channels and output delivery

## Verification
- cargo test -p roux-runtime pty_pending_output
- CI=1 cargo test -p roux pty::
- cargo test -p roux-runtime
- CI=1 cargo clippy -p roux --all-targets -- -D warnings

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR has two independent workstreams: it extracts `PtyPendingOutput<Channel>` as a Tauri-free generic store in `roux-runtime`, and it refactors the xterm input-gating strategy from toggling `disableStdin` to using a permanently-attached custom key handler with an `inputEnabled` flag — preserving terminal protocol responses on unfocused panes while still blocking keyboard input.

- **Rust side**: `PtyPendingOutput<Channel>` wraps a `HashMap` with typed `insert`/`remove`/`retain_existing` and diagnostic helpers (`len`, `is_empty`, `contains_key`). `PtyManager` is updated mechanically; all PTY bookkeeping behavior is preserved.
- **Frontend — xterm input model**: `disableStdin` is now always `false`; a single `attachCustomKeyEventHandler` installed at construction time gates keyboard events through `this.inputEnabled`. `setInputEnabled` sets the field instead of mutating `terminal.options.disableStdin`.
- **Frontend — focus capture**: `onmousedowncapture` on the pane shell claims logical focus in the capture phase so stdin routing follows the pane even when xterm stops event propagation.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the Rust extraction is a mechanical refactor and the xterm input-gating change is validated by new tests.

Both workstreams are well-scoped: the Rust side is a pure rename/delegation with no behavior change, and the frontend input-gating refactor is directly exercised by the new xtermController test that explicitly checks disableStdin stays false and keyboard events are blocked via the handler. The capture-phase focus handler addresses a real propagation edge case. Only minor style cleanups remain.

PaneShell.svelte has a redundant double setLogicalFocus in handleDrop and a stale disableStdin comment, but neither affects correctness.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/roux-runtime/src/pty_pending_output.rs | New generic PtyPendingOutput<Channel> store wrapping HashMap; clean API with insert/remove/retain_existing + diagnostic helpers and comprehensive unit tests. |
| crates/roux-runtime/src/lib.rs | Adds pty_pending_output module registration; trivial one-line addition, no issues. |
| src-tauri/src/pty.rs | Swaps HashMap for PtyPendingOutput in PtyManager; retain() call becomes retain_existing(); clean mechanical refactor with no behavior change. |
| src/lib/panes/xtermController.ts | Replaces disableStdin toggling with an inputEnabled flag in a single always-attached custom key handler; disableStdin stays false so terminal protocol responses (OSC etc.) are never suppressed. |
| src/lib/panes/focus.ts | requestDomFocus now delegates to setLogicalFocus instead of only calling terminal.focus(); callers in handleDrop that explicitly call both functions now have a redundant first call. |
| src/lib/components/PaneShell.svelte | Adds onmousedowncapture to claim logical focus before xterm stops event propagation; handleDrop now redundantly calls setLogicalFocus twice (explicit call + through requestDomFocus); stale comment references disableStdin. |
| src/lib/panes/__tests__/focus.test.ts | Adds requestDomFocus test covering new logical-focus side effect; existing test still passes as a subset of new behavior. |
| src/lib/panes/__tests__/xtermController.test.ts | Improves Terminal mock to capture constructor options; adds test verifying setInputEnabled gates keyboard events without touching disableStdin. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User mousedown on PaneShell] --> B{capture phase onmousedowncapture}
    B --> C[setLogicalFocus paneId]
    C --> D[focusedPaneId store updated]
    C --> E[setInputEnabled true on target / false on others]
    C --> F[terminal.focus on target]
    B --> G{xterm stops propagation?}
    G -- Yes --> H[handleMouseDown skipped]
    G -- No --> I[handleMouseDown bubble phase]
    I --> C
    subgraph XtermController
        J[customKeyEventHandler] --> K{inputEnabled?}
        K -- false --> L[return false: block event]
        K -- true --> M{customKeyHandler set?}
        M -- No --> N[return true: allow event]
        M -- Yes --> O[delegate to customKeyHandler]
    end
    E --> J
    subgraph PtyManager
        P[pending_outputs: PtyPendingOutput] --> Q[insert / remove / retain_existing]
    end
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Flib%2Fcomponents%2FPaneShell.svelte%3A327-328%0ARedundant%20%60setLogicalFocus%60%20call%3A%20%60requestDomFocus%60%20now%20delegates%20to%20%60setLogicalFocus%60%20internally%2C%20so%20the%20explicit%20call%20on%20the%20line%20above%20is%20a%20no-op%20duplicate.%20The%20two-step%20pattern%20made%20sense%20before%20%28logical%20focus%2C%20then%20DOM%20focus%20were%20distinct%20operations%29%2C%20but%20they're%20now%20equivalent.%20The%20first%20call%20can%20be%20removed.%0A%0A%60%60%60suggestion%0A%20%20%20%20requestDomFocus%28paneId%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Flib%2Fcomponents%2FPaneShell.svelte%3A469-470%0AStale%20comment%3A%20%60setInputEnabled%60%20no%20longer%20toggles%20%60disableStdin%60%20%E2%80%94%20it%20now%20sets%20the%20%60inputEnabled%60%20field%20that%20gates%20the%20custom%20key%20handler.%20The%20%60disableStdin%60%20option%20stays%20%60false%60%20permanently%20after%20this%20refactor%2C%20so%20the%20parenthetical%20is%20misleading%20for%20the%20next%20reader.%0A%0A%60%60%60suggestion%0A%20%20%2F%2F%20Focus%20effect%3A%20refit%20when%20gaining%20logical%20focus%20%28inputEnabled%20just%20changed%2C%0A%20%20%2F%2F%20terminal%20may%20need%20resize%29.%0A%60%60%60%0A%0A&repo=phin-tech%2Froux&pr=191&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22feature%2Fextract-pty-pending-output%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fextract-pty-pending-output%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Flib%2Fcomponents%2FPaneShell.svelte%3A327-328%0ARedundant%20%60setLogicalFocus%60%20call%3A%20%60requestDomFocus%60%20now%20delegates%20to%20%60setLogicalFocus%60%20internally%2C%20so%20the%20explicit%20call%20on%20the%20line%20above%20is%20a%20no-op%20duplicate.%20The%20two-step%20pattern%20made%20sense%20before%20%28logical%20focus%2C%20then%20DOM%20focus%20were%20distinct%20operations%29%2C%20but%20they're%20now%20equivalent.%20The%20first%20call%20can%20be%20removed.%0A%0A%60%60%60suggestion%0A%20%20%20%20requestDomFocus%28paneId%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Flib%2Fcomponents%2FPaneShell.svelte%3A469-470%0AStale%20comment%3A%20%60setInputEnabled%60%20no%20longer%20toggles%20%60disableStdin%60%20%E2%80%94%20it%20now%20sets%20the%20%60inputEnabled%60%20field%20that%20gates%20the%20custom%20key%20handler.%20The%20%60disableStdin%60%20option%20stays%20%60false%60%20permanently%20after%20this%20refactor%2C%20so%20the%20parenthetical%20is%20misleading%20for%20the%20next%20reader.%0A%0A%60%60%60suggestion%0A%20%20%2F%2F%20Focus%20effect%3A%20refit%20when%20gaining%20logical%20focus%20%28inputEnabled%20just%20changed%2C%0A%20%20%2F%2F%20terminal%20may%20need%20resize%29.%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (6): Last reviewed commit: ["Keep terminal protocol replies enabled o..."](https://github.com/phin-tech/roux/commit/b23c88d8fd23879c848147af7ee78657e0eb686c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33283914)</sub>

<!-- /greptile_comment -->