### PR TITLE
[codex] Document daemon architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,13 +2,14 @@
 
 ## Project Overview
 
-Roux is a Tauri 2 + Svelte 5 desktop app for managing multiple Claude Code terminal sessions in one native window.
+Roux is a Tauri 2 + Svelte 5 desktop app, plus a Rust headless runtime daemon, for managing multiple Claude Code terminal sessions in one native window or from CLI/socket clients.
 
 The app combines:
 - split panes and stacked tabs
 - persistent Claude and shell terminals
 - git worktree support
-- a Unix socket / CLI bridge
+- a daemon-owned Unix/TCP socket / CLI bridge
+- daemon-owned runtime services for sessions, projects, PTYs, processes, watches, aliases, mailbox/bus state, notes, and automation hooks
 - project notes, docs, tasks, and watches
 
 This codebase has real filesystem, process, and terminal side effects. Defensive reasoning is the correct default.
@@ -26,16 +27,22 @@ npm run check        # Svelte type check
 ## Architecture
 
 - **Frontend**: Svelte 5 with runes (`$state`, `$derived`, `$effect`, `$props`), Tailwind CSS 4, xterm.js
-- **Backend**: Rust with Tauri 2, portable-pty for PTY management
+- **Desktop shell**: Tauri 2 command adapters, native windowing, tray/menu integration, notifications, pane layout, and xterm.js rendering
+- **Runtime daemon**: `roux daemon` in `crates/roux-cli` starts the shared `roux-runtime` service host and owns durable runtime state plus PTY/process lifetimes
+- **Shared runtime**: `crates/roux-runtime` contains the session/project/pane/process/PTY/watch services used by the daemon and by the explicit desktop fallback
+- **Daemon client**: `src-tauri/src/daemon_client.rs` connects to an existing daemon or autostarts one; Tauri commands route through it when the daemon advertises the needed capability
 - **State**: Svelte writable stores in `src/lib/stores/`
 - **Pane tree**: `SplitNode` recursive union in `src/lib/stores/panes.ts`
 - **Terminal registry**: `src/lib/panes/terminalRegistry.ts` keeps xterm instances alive across re-mounts
 - **Commands**: frontend command registration in `src/lib/commands/index.ts`
 - **Backend commands**: Tauri commands are registered from `src-tauri/src/main.rs`
-- **Persistence**: layouts in localStorage, sessions/settings/projects handled in Rust
+- **Socket protocol**: when a daemon is connected, it owns the Roux command endpoint; the desktop socket server starts only for local fallback
+- **Persistence**: layouts in localStorage; sessions/projects/watches/aliases/mailbox/bus state and other runtime data are daemon-owned when connected; settings remain desktop-readable Rust state
 
 ## Key Files
 
+- `docs/v2/daemon-protocol.md` - implemented daemon socket command surface
+- `docs/v2/session-daemon.md` - daemon architecture and migration note
 - `src/lib/stores/panes.ts` - pane tree data model, splits, stacking, persistence
 - `src/lib/stores/sessions.ts` - session management on the frontend
 - `src/lib/components/SplitPane.svelte` - recursive pane renderer
@@ -43,11 +50,20 @@ npm run check        # Svelte type check
 - `src/lib/components/ShellTerminal.svelte` - shell terminal pane
 - `src/lib/commands/index.ts` - command palette and keybindings
 - `src-tauri/src/main.rs` - Tauri bootstrap and command registration
+- `src-tauri/src/daemon_client.rs` - desktop connection/autostart client for daemon-owned runtime services
+- `src-tauri/src/commands/daemon.rs` - Tauri commands for daemon status, daemon processes, and daemon PTYs
 - `src-tauri/src/pty.rs` - PTY spawning and lifecycle
 - `src-tauri/src/session.rs` - session persistence
 - `src-tauri/src/watches.rs` - watch execution and state
 - `src-tauri/src/worktree.rs` - git worktree operations
-- `src-tauri/src/socket.rs` - local socket protocol / CLI bridge
+- `src-tauri/src/socket.rs` - desktop-owned local socket protocol / CLI bridge used only when the daemon is not connected
+- `crates/roux-cli/src/daemon.rs` - daemon entrypoint, socket server, and daemon command routing
+- `crates/roux-cli/src/attach.rs` - CLI attach client for daemon-owned PTYs
+- `crates/roux-cli/src/cli_socket.rs` - CLI socket client request/response helpers
+- `crates/roux-runtime/src/host.rs` - shared runtime service host construction
+- `crates/roux-runtime/src/pty_service.rs` - daemon/runtime PTY registry and output handling
+- `crates/roux-runtime/src/process_service.rs` - daemon/runtime process registry
+- `crates/roux-runtime/src/session_service.rs` - daemon/runtime session store and persistence
 
 ## Frontend Conventions
 
@@ -62,7 +78,12 @@ npm run check        # Svelte type check
 
 - Prefer typed internal errors over `Result<_, String>`
 - Keep Tauri command handlers thin; push logic into normal Rust functions/modules
-- Be careful with PTY, socket, process, and filesystem lifecycles
+- Prefer daemon-first routing for durable/runtime behavior: check `state.daemon_client` and daemon capabilities before falling back to desktop-local services
+- Use daemon capabilities from `daemon-status` instead of hardcoding protocol assumptions while the protocol is experimental
+- Keep GUI-only concerns in the desktop process: pane layout, xterm.js rendering, native menus/tray, and notification presentation
+- Keep daemon-owned concerns in the daemon when connected: session/project/watch metadata, PTY/process lifetimes, worktree filesystem operations, aliases, mailbox/bus state, notes vault operations, and automation hook execution
+- Do not create split-brain ownership where both daemon and desktop persist or mutate the same runtime state
+- Be careful with PTY, socket, process, daemon, and filesystem lifecycles
 - Avoid broad process-kill commands; Claude Code is a Node app, so never blindly kill `node` / `node.exe`
 - Do not use `git add .`; stage files explicitly
 
@@ -74,6 +95,8 @@ For this repo, the failure modes are:
 - breaking pane-tree invariants
 - corrupting persisted session/project/settings state
 - leaking PTYs, watchers, or background tasks
+- creating split-brain daemon/desktop ownership of sessions, projects, PTYs, watches, aliases, mailbox/bus state, notes, or automation hooks
+- changing daemon socket payloads or capabilities without updating all desktop, CLI, MCP, and docs callers
 - making a wrong filesystem assumption and deleting or moving the wrong thing
 - changing Tauri/Rust contracts without updating the frontend
 
@@ -196,7 +219,10 @@ If the correct verification path is ambiguous, ask the human which test or verif
 
 - Keep command handlers as adapters, not as the main home for business logic
 - Be explicit about Rust/TypeScript contract changes
-- Treat `AppState`, PTY/session lifecycle, socket handling, and watchers as long-lived system components
+- Treat `AppState`, `DaemonClient`, PTY/session lifecycle, socket handling, and watchers as long-lived system components
+- Before adding or changing durable/runtime behavior, decide whether the daemon owns it. The default answer should be "daemon owns it when connected; desktop adapts or renders it."
+- When changing the daemon protocol, update `docs/v2/daemon-protocol.md`, the CLI socket callers, the Tauri `DaemonClient`, capability checks, and any MCP/frontend callers together
+- If daemon autostart or detection changes, verify the three startup modes: existing daemon connected, daemon autostarted, and explicit local fallback with `ROUX_DAEMON_AUTOSTART=0`
 - Verify startup/shutdown behavior when changing background services
 - Be conservative around filesystem and worktree operations
 - Do not guess Tauri behavior when the official docs are available
@@ -207,6 +233,7 @@ Before changing a Tauri command or backend payload, identify:
 - which frontend caller depends on it
 - which persisted data shape might change
 - whether the CLI/socket protocol also depends on it
+- whether the daemon protocol/capability list also depends on it
 
 ## Root Cause Discipline
 
@@ -228,6 +255,7 @@ Especially in this repo, be careful with:
 - xterm lifecycle code
 - terminal registry behavior
 - PTY buffering / attach behavior
+- daemon/client fallback boundaries
 - socket protocol compatibility
 - settings migration / persistence behavior
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,13 +2,14 @@
 
 ## Project Overview
 
-Roux is a Tauri 2 + Svelte 5 desktop app for managing multiple Claude Code terminal sessions in one native window.
+Roux is a Tauri 2 + Svelte 5 desktop app, plus a Rust headless runtime daemon, for managing multiple Claude Code terminal sessions in one native window or from CLI/socket clients.
 
 The app combines:
 - split panes and stacked tabs
 - persistent Claude and shell terminals
 - git worktree support
-- a Unix socket / CLI bridge
+- a daemon-owned Unix/TCP socket / CLI bridge
+- daemon-owned runtime services for sessions, projects, PTYs, processes, watches, aliases, mailbox/bus state, notes, and automation hooks
 - project notes, docs, tasks, and watches
 
 This codebase has real filesystem, process, and terminal side effects. Defensive reasoning is the correct default.
@@ -26,16 +27,22 @@ npm run check        # Svelte type check
 ## Architecture
 
 - **Frontend**: Svelte 5 with runes (`$state`, `$derived`, `$effect`, `$props`), Tailwind CSS 4, xterm.js
-- **Backend**: Rust with Tauri 2, portable-pty for PTY management
+- **Desktop shell**: Tauri 2 command adapters, native windowing, tray/menu integration, notifications, pane layout, and xterm.js rendering
+- **Runtime daemon**: `roux daemon` in `crates/roux-cli` starts the shared `roux-runtime` service host and owns durable runtime state plus PTY/process lifetimes
+- **Shared runtime**: `crates/roux-runtime` contains the session/project/pane/process/PTY/watch services used by the daemon and by the explicit desktop fallback
+- **Daemon client**: `src-tauri/src/daemon_client.rs` connects to an existing daemon or autostarts one; Tauri commands route through it when the daemon advertises the needed capability
 - **State**: Svelte writable stores in `src/lib/stores/`
 - **Pane tree**: `SplitNode` recursive union in `src/lib/stores/panes.ts`
 - **Terminal registry**: `src/lib/panes/terminalRegistry.ts` keeps xterm instances alive across re-mounts
 - **Commands**: frontend command registration in `src/lib/commands/index.ts`
 - **Backend commands**: Tauri commands are registered from `src-tauri/src/main.rs`
-- **Persistence**: layouts in localStorage, sessions/settings/projects handled in Rust
+- **Socket protocol**: when a daemon is connected, it owns the Roux command endpoint; the desktop socket server starts only for local fallback
+- **Persistence**: layouts in localStorage; sessions/projects/watches/aliases/mailbox/bus state and other runtime data are daemon-owned when connected; settings remain desktop-readable Rust state
 
 ## Key Files
 
+- `docs/v2/daemon-protocol.md` - implemented daemon socket command surface
+- `docs/v2/session-daemon.md` - daemon architecture and migration note
 - `src/lib/stores/panes.ts` - pane tree data model, splits, stacking, persistence
 - `src/lib/stores/sessions.ts` - session management on the frontend
 - `src/lib/components/SplitPane.svelte` - recursive pane renderer
@@ -43,11 +50,20 @@ npm run check        # Svelte type check
 - `src/lib/components/ShellTerminal.svelte` - shell terminal pane
 - `src/lib/commands/index.ts` - command palette and keybindings
 - `src-tauri/src/main.rs` - Tauri bootstrap and command registration
+- `src-tauri/src/daemon_client.rs` - desktop connection/autostart client for daemon-owned runtime services
+- `src-tauri/src/commands/daemon.rs` - Tauri commands for daemon status, daemon processes, and daemon PTYs
 - `src-tauri/src/pty.rs` - PTY spawning and lifecycle
 - `src-tauri/src/session.rs` - session persistence
 - `src-tauri/src/watches.rs` - watch execution and state
 - `src-tauri/src/worktree.rs` - git worktree operations
-- `src-tauri/src/socket.rs` - local socket protocol / CLI bridge
+- `src-tauri/src/socket.rs` - desktop-owned local socket protocol / CLI bridge used only when the daemon is not connected
+- `crates/roux-cli/src/daemon.rs` - daemon entrypoint, socket server, and daemon command routing
+- `crates/roux-cli/src/attach.rs` - CLI attach client for daemon-owned PTYs
+- `crates/roux-cli/src/cli_socket.rs` - CLI socket client request/response helpers
+- `crates/roux-runtime/src/host.rs` - shared runtime service host construction
+- `crates/roux-runtime/src/pty_service.rs` - daemon/runtime PTY registry and output handling
+- `crates/roux-runtime/src/process_service.rs` - daemon/runtime process registry
+- `crates/roux-runtime/src/session_service.rs` - daemon/runtime session store and persistence
 
 ## Frontend Conventions
 
@@ -62,7 +78,12 @@ npm run check        # Svelte type check
 
 - Prefer typed internal errors over `Result<_, String>`
 - Keep Tauri command handlers thin; push logic into normal Rust functions/modules
-- Be careful with PTY, socket, process, and filesystem lifecycles
+- Prefer daemon-first routing for durable/runtime behavior: check `state.daemon_client` and daemon capabilities before falling back to desktop-local services
+- Use daemon capabilities from `daemon-status` instead of hardcoding protocol assumptions while the protocol is experimental
+- Keep GUI-only concerns in the desktop process: pane layout, xterm.js rendering, native menus/tray, and notification presentation
+- Keep daemon-owned concerns in the daemon when connected: session/project/watch metadata, PTY/process lifetimes, worktree filesystem operations, aliases, mailbox/bus state, notes vault operations, and automation hook execution
+- Do not create split-brain ownership where both daemon and desktop persist or mutate the same runtime state
+- Be careful with PTY, socket, process, daemon, and filesystem lifecycles
 - Avoid broad process-kill commands; Claude Code is a Node app, so never blindly kill `node` / `node.exe`
 - Do not use `git add .`; stage files explicitly
 
@@ -74,6 +95,8 @@ For this repo, the failure modes are:
 - breaking pane-tree invariants
 - corrupting persisted session/project/settings state
 - leaking PTYs, watchers, or background tasks
+- creating split-brain daemon/desktop ownership of sessions, projects, PTYs, watches, aliases, mailbox/bus state, notes, or automation hooks
+- changing daemon socket payloads or capabilities without updating all desktop, CLI, MCP, and docs callers
 - making a wrong filesystem assumption and deleting or moving the wrong thing
 - changing Tauri/Rust contracts without updating the frontend
 
@@ -197,7 +220,10 @@ If the correct verification path is ambiguous, ask the human which test or verif
 
 - Keep command handlers as adapters, not as the main home for business logic
 - Be explicit about Rust/TypeScript contract changes
-- Treat `AppState`, PTY/session lifecycle, socket handling, and watchers as long-lived system components
+- Treat `AppState`, `DaemonClient`, PTY/session lifecycle, socket handling, and watchers as long-lived system components
+- Before adding or changing durable/runtime behavior, decide whether the daemon owns it. The default answer should be "daemon owns it when connected; desktop adapts or renders it."
+- When changing the daemon protocol, update `docs/v2/daemon-protocol.md`, the CLI socket callers, the Tauri `DaemonClient`, capability checks, and any MCP/frontend callers together
+- If daemon autostart or detection changes, verify the three startup modes: existing daemon connected, daemon autostarted, and explicit local fallback with `ROUX_DAEMON_AUTOSTART=0`
 - Verify startup/shutdown behavior when changing background services
 - Be conservative around filesystem and worktree operations
 - Do not guess Tauri behavior when the official docs are available
@@ -208,6 +234,7 @@ Before changing a Tauri command or backend payload, identify:
 - which frontend caller depends on it
 - which persisted data shape might change
 - whether the CLI/socket protocol also depends on it
+- whether the daemon protocol/capability list also depends on it
 
 ## Root Cause Discipline
 
@@ -229,6 +256,7 @@ Especially in this repo, be careful with:
 - xterm lifecycle code
 - terminal registry behavior
 - PTY buffering / attach behavior
+- daemon/client fallback boundaries
 - socket protocol compatibility
 - settings migration / persistence behavior
 


### PR DESCRIPTION
## Summary

- Update AGENTS.md and CLAUDE.md to describe the daemon-first runtime architecture.
- Add the key daemon/runtime files and protocol docs agents should inspect.
- Clarify ownership boundaries, daemon capability checks, fallback behavior, and split-brain risks.

## Validation

- `git diff --cached --check` before commit
- Documentation-only change; no test suite run

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a documentation-only PR that updates `AGENTS.md` and `CLAUDE.md` to reflect the project's daemon-first runtime architecture, providing agents with accurate ownership boundaries, key file paths, and guidance on split-brain avoidance. All referenced source and doc files (`daemon_client.rs`, `daemon-protocol.md`, `session-daemon.md`, and the `crates/roux-runtime` service modules) exist in the repository.

- Both files receive identical additions describing the desktop/daemon split, daemon capability routing, three startup modes, and the `ROUX_DAEMON_AUTOSTART=0` fallback path.
- New failure modes and checklist items are added for protocol/capability changes, split-brain state, and daemon autostart verification.
- A minor redundancy exists in the feature list: "notes" and "watches" appear in both the new daemon-services bullet and the retained `project notes, docs, tasks, and watches` bullet.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; documentation-only change with no runtime behaviour affected.

All referenced files exist, the ownership model described is internally consistent, and both AGENTS.md and CLAUDE.md are kept in sync. The only rough edge is a minor list redundancy where notes and watches are named twice in the feature list.

No files require special attention beyond the minor feature-list redundancy in both AGENTS.md and CLAUDE.md.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| AGENTS.md | Documentation updated to reflect daemon-first architecture; one minor redundancy in the feature list between the new daemon-services bullet and the retained "project notes, docs, tasks, and watches" bullet. |
| CLAUDE.md | Mirrors the AGENTS.md changes exactly; all referenced key files exist; same minor redundancy in the feature list present here as well. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Startup["Startup Modes"]
        A[Roux.app launches] --> B{Detect existing daemon?}
        B -- Yes --> C[Connect to running daemon]
        B -- No --> D{ROUX_DAEMON_AUTOSTART?}
        D -- Enabled --> E[Autostart daemon subprocess]
        D -- Disabled / 0 --> F[Explicit local fallback\ncrates/roux-runtime embedded]
        E --> C
    end

    subgraph DaemonOwned["Daemon-Owned (roux-runtime)"]
        G[Sessions / Projects]
        H[PTYs / Processes]
        I[Watches / Aliases]
        J[Mailbox / Bus State]
        K[Notes Vault]
        L[Automation Hooks]
    end

    subgraph DesktopShell["Desktop Shell (Tauri)"]
        M[Pane Layout]
        N[xterm.js rendering]
        O[Native menus / Tray]
        P[Notifications]
        Q[daemon_client.rs\nCapability routing]
    end

    C --> Q
    Q -- capability check: daemon owns --> DaemonOwned
    Q -- GUI-only: desktop handles --> DesktopShell

    subgraph CLI["CLI Clients"]
        R[roux attach\nroux daemon run/output/kill]
    end
    R --> C
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0AAGENTS.md%3A12-13%0AAfter%20the%20new%20bullet%20is%20added%2C%20%22notes%22%20and%20%22watches%22%20now%20appear%20in%20both%20the%20daemon-owned%20services%20bullet%20and%20the%20retained%20%60project%20notes%2C%20docs%2C%20tasks%2C%20and%20watches%60%20bullet%2C%20creating%20overlap.%20The%20old%20bullet%20could%20be%20trimmed%20to%20only%20the%20items%20not%20covered%20by%20the%20new%20one%20%28%60docs%60%20and%20%60tasks%60%29%2C%20or%20dropped%20entirely%20if%20those%20items%20are%20considered%20subsumed.%0A%0A%60%60%60suggestion%0A-%20daemon-owned%20runtime%20services%20for%20sessions%2C%20projects%2C%20PTYs%2C%20processes%2C%20watches%2C%20aliases%2C%20mailbox%2Fbus%20state%2C%20notes%2C%20and%20automation%20hooks%0A-%20project%20docs%20and%20tasks%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACLAUDE.md%3A12-13%0ASame%20redundancy%20as%20in%20%60AGENTS.md%60%3A%20%22notes%22%20and%20%22watches%22%20are%20listed%20in%20both%20the%20new%20daemon-services%20bullet%20and%20the%20old%20%60project%20notes%2C%20docs%2C%20tasks%2C%20and%20watches%60%20bullet.%20Trimming%20the%20old%20bullet%20to%20just%20the%20items%20not%20yet%20mentioned%20%28%60docs%60%20and%20%60tasks%60%29%20would%20keep%20the%20list%20clean.%0A%0A%60%60%60suggestion%0A-%20daemon-owned%20runtime%20services%20for%20sessions%2C%20projects%2C%20PTYs%2C%20processes%2C%20watches%2C%20aliases%2C%20mailbox%2Fbus%20state%2C%20notes%2C%20and%20automation%20hooks%0A-%20project%20docs%20and%20tasks%0A%60%60%60%0A%0A&repo=phin-tech%2Froux&pr=196&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22feature%2Ftui%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Ftui%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0AAGENTS.md%3A12-13%0AAfter%20the%20new%20bullet%20is%20added%2C%20%22notes%22%20and%20%22watches%22%20now%20appear%20in%20both%20the%20daemon-owned%20services%20bullet%20and%20the%20retained%20%60project%20notes%2C%20docs%2C%20tasks%2C%20and%20watches%60%20bullet%2C%20creating%20overlap.%20The%20old%20bullet%20could%20be%20trimmed%20to%20only%20the%20items%20not%20covered%20by%20the%20new%20one%20%28%60docs%60%20and%20%60tasks%60%29%2C%20or%20dropped%20entirely%20if%20those%20items%20are%20considered%20subsumed.%0A%0A%60%60%60suggestion%0A-%20daemon-owned%20runtime%20services%20for%20sessions%2C%20projects%2C%20PTYs%2C%20processes%2C%20watches%2C%20aliases%2C%20mailbox%2Fbus%20state%2C%20notes%2C%20and%20automation%20hooks%0A-%20project%20docs%20and%20tasks%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACLAUDE.md%3A12-13%0ASame%20redundancy%20as%20in%20%60AGENTS.md%60%3A%20%22notes%22%20and%20%22watches%22%20are%20listed%20in%20both%20the%20new%20daemon-services%20bullet%20and%20the%20old%20%60project%20notes%2C%20docs%2C%20tasks%2C%20and%20watches%60%20bullet.%20Trimming%20the%20old%20bullet%20to%20just%20the%20items%20not%20yet%20mentioned%20%28%60docs%60%20and%20%60tasks%60%29%20would%20keep%20the%20list%20clean.%0A%0A%60%60%60suggestion%0A-%20daemon-owned%20runtime%20services%20for%20sessions%2C%20projects%2C%20PTYs%2C%20processes%2C%20watches%2C%20aliases%2C%20mailbox%2Fbus%20state%2C%20notes%2C%20and%20automation%20hooks%0A-%20project%20docs%20and%20tasks%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into feature/tui"](https://github.com/phin-tech/roux/commit/fa9f261478a587c6c55a8d9a165ca683a97a4929) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33593995)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=1a7e8e25-9dde-4d49-9e7f-60e7033075a1))
- Context used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=9d02afcc-6277-4c1c-8d4f-6d512b83417e))

<!-- /greptile_comment -->