### PR TITLE
[codex] Require daemon for desktop sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4054,6 +4054,7 @@ dependencies = [
  "roux-gh",
  "roux-git",
  "roux-runtime",
+ "roux-sdk",
  "roux-smolvm",
  "roux-worktrunk",
  "schemars 1.2.1",

--- a/crates/roux-cli/src/daemon.rs
+++ b/crates/roux-cli/src/daemon.rs
@@ -2473,7 +2473,13 @@ async fn handle_session_refresh_branch(req: Request, host: &RuntimeHost) -> Resp
         Ok(None) => return Response::err("session not found"),
         Err(err) => return Response::err(err.to_string()),
     };
-    if !session.is_git_repo {
+    let is_git_repo = is_git_repo(&session.worktree_path);
+    if is_git_repo != session.is_git_repo {
+        if let Err(err) = host.session_handle.set_git_repo(session_id, is_git_repo).await {
+            return Response::err(err.to_string());
+        }
+    }
+    if !is_git_repo {
         return Response::success(serde_json::json!({ "branch": session.branch }));
     }
     let branch = get_current_branch(&session.worktree_path)
@@ -6359,6 +6365,61 @@ post-worktree-create = "{post_create}"
         .await;
         assert!(delete.ok, "delete failed: {:?}", delete.error);
         assert!(host.session_handle.get("session-life").await.unwrap().is_none());
+
+        host.process_handle.shutdown().await;
+        host.pty_handle.shutdown().await;
+        host.watch_handle.shutdown().await;
+        host.session_handle.shutdown().await;
+        host.project_handle.shutdown().await;
+        drop(host);
+        for join in joins {
+            join.await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn daemon_session_refresh_branch_updates_git_status_when_repo_is_initialized() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut session = make_session("s1");
+        session.repo_root = dir.path().to_string_lossy().into_owned();
+        session.worktree_path = session.repo_root.clone();
+        session.is_git_repo = false;
+
+        let services = RuntimeHostConfig {
+            initial_sessions: vec![session],
+            session_persist_path: dir.path().join("sessions.json"),
+            initial_projects: Vec::new(),
+            project_persist_path: dir.path().join("projects.json"),
+            initial_watches: Vec::new(),
+            watch_persist_path: Some(dir.path().join("watches.json")),
+        }
+        .build();
+        let (host, joins) = services.spawn_with(tokio::spawn);
+        let identity = DaemonIdentity::new_for_test("/tmp/roux.sock");
+
+        let init = Command::new("git").arg("init").current_dir(dir.path()).output().unwrap();
+        assert!(
+            init.status.success(),
+            "git init failed: {}",
+            String::from_utf8_lossy(&init.stderr)
+        );
+
+        let refresh = handle_request(
+            Request {
+                command: "session-refresh-branch".to_string(),
+                session_id: Some("s1".to_string()),
+                pane_id: None,
+                auth_token: None,
+                args: serde_json::json!({}),
+            },
+            &host,
+            &identity,
+        )
+        .await;
+        assert!(refresh.ok, "refresh failed: {:?}", refresh.error);
+
+        let refreshed = host.session_handle.get("s1").await.unwrap().unwrap();
+        assert!(refreshed.is_git_repo);
 
         host.process_handle.shutdown().await;
         host.pty_handle.shutdown().await;

--- a/crates/roux-sdk/src/lib.rs
+++ b/crates/roux-sdk/src/lib.rs
@@ -62,7 +62,48 @@ pub struct SpawnShell {
     session_id: Option<String>,
     pane_id: Option<String>,
     profile: Option<String>,
+    nono_profile: Option<String>,
+    nono_allow_dirs: Vec<String>,
     initial_size: Option<(u16, u16)>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct NotesEnv {
+    pub vault_root: String,
+    pub session_slug: String,
+    pub repo_slug: String,
+    pub project_slug: Option<String>,
+    pub context_paths: Vec<String>,
+    pub project_prompt: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct CreateSessionShell {
+    pub id: String,
+    pub repo_path: String,
+    pub name: String,
+    pub worktree_path: Option<String>,
+    pub branch: Option<String>,
+    pub base: Option<String>,
+    pub fetch_first: bool,
+    pub profile: Option<String>,
+    pub nono_profile: Option<String>,
+    pub nono_allow_dirs: Vec<String>,
+    pub initial_size: Option<(u16, u16)>,
+    pub project_id: Option<String>,
+    pub blueprint_id: Option<String>,
+    pub smol_machine_name: Option<String>,
+    pub notes: Option<NotesEnv>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ReconnectSessionShell {
+    pub id: String,
+    pub profile: Option<String>,
+    pub nono_profile: Option<String>,
+    pub nono_allow_dirs: Vec<String>,
+    pub initial_size: Option<(u16, u16)>,
+    pub notes: Option<NotesEnv>,
 }
 
 impl Roux {
@@ -94,6 +135,26 @@ impl Roux {
         self.command(CommandRequest::new("watch-list")).await
     }
 
+    pub async fn create_session_shell(
+        &self,
+        request: CreateSessionShell,
+    ) -> RouxResult<roux_core::Session> {
+        self.command(CommandRequest::new("session-create-shell").args(request.into_args())).await
+    }
+
+    pub async fn reconnect_session_shell(
+        &self,
+        request: ReconnectSessionShell,
+    ) -> RouxResult<roux_core::Session> {
+        let session_id = request.id.clone();
+        self.command(
+            CommandRequest::new("session-reconnect-shell")
+                .session_id(session_id)
+                .args(request.into_args()),
+        )
+        .await
+    }
+
     pub fn session(&self, session: roux_core::Session) -> Session {
         Session { client: self.clone(), session }
     }
@@ -123,6 +184,8 @@ impl Roux {
             session_id: None,
             pane_id: None,
             profile: None,
+            nono_profile: None,
+            nono_allow_dirs: Vec::new(),
             initial_size: None,
         }
     }
@@ -178,6 +241,81 @@ impl RouxBuilder {
             self.endpoint.or_else(resolve_socket_endpoint).ok_or(RouxError::NotRunning)?;
         let auth_token = self.auth_token.or_else(endpoint::load_socket_auth_token);
         Ok(Roux { endpoint, auth_token, timeout: self.timeout })
+    }
+}
+
+impl CreateSessionShell {
+    fn into_args(self) -> Value {
+        let mut args = serde_json::Map::new();
+        args.insert("id".into(), Value::String(self.id));
+        args.insert("repoPath".into(), Value::String(self.repo_path));
+        args.insert("name".into(), Value::String(self.name));
+        insert_optional_string(&mut args, "worktreePath", self.worktree_path);
+        insert_optional_string(&mut args, "branch", self.branch);
+        insert_optional_string(&mut args, "base", self.base);
+        if self.fetch_first {
+            args.insert("fetchFirst".into(), Value::Bool(true));
+        }
+        insert_optional_string(&mut args, "profile", self.profile);
+        insert_optional_string(&mut args, "nonoProfile", self.nono_profile);
+        if !self.nono_allow_dirs.is_empty() {
+            args.insert("nonoAllowDirs".into(), serde_json::json!(self.nono_allow_dirs));
+        }
+        insert_initial_size(&mut args, self.initial_size);
+        insert_optional_string(&mut args, "projectId", self.project_id);
+        insert_optional_string(&mut args, "blueprintId", self.blueprint_id);
+        insert_optional_string(&mut args, "smolMachineName", self.smol_machine_name);
+        insert_notes_env(&mut args, self.notes);
+        Value::Object(args)
+    }
+}
+
+impl ReconnectSessionShell {
+    fn into_args(self) -> Value {
+        let mut args = serde_json::Map::new();
+        insert_optional_string(&mut args, "profile", self.profile);
+        insert_optional_string(&mut args, "nonoProfile", self.nono_profile);
+        if !self.nono_allow_dirs.is_empty() {
+            args.insert("nonoAllowDirs".into(), serde_json::json!(self.nono_allow_dirs));
+        }
+        insert_initial_size(&mut args, self.initial_size);
+        insert_notes_env(&mut args, self.notes);
+        Value::Object(args)
+    }
+}
+
+fn insert_optional_string(
+    args: &mut serde_json::Map<String, Value>,
+    key: &'static str,
+    value: Option<String>,
+) {
+    if let Some(value) = value {
+        args.insert(key.into(), Value::String(value));
+    }
+}
+
+fn insert_initial_size(
+    args: &mut serde_json::Map<String, Value>,
+    initial_size: Option<(u16, u16)>,
+) {
+    if let Some((cols, rows)) = initial_size {
+        args.insert("initialSize".into(), serde_json::json!([cols, rows]));
+    }
+}
+
+fn insert_notes_env(args: &mut serde_json::Map<String, Value>, notes: Option<NotesEnv>) {
+    if let Some(notes) = notes {
+        args.insert(
+            "notesEnv".into(),
+            serde_json::json!({
+                "vaultRoot": notes.vault_root,
+                "sessionSlug": notes.session_slug,
+                "repoSlug": notes.repo_slug,
+                "projectSlug": notes.project_slug,
+                "contextPaths": notes.context_paths,
+                "projectPrompt": notes.project_prompt,
+            }),
+        );
     }
 }
 
@@ -380,6 +518,12 @@ impl SpawnTask {
     }
 
     pub async fn spawn(self) -> RouxResult<Pty> {
+        let client = self.client.clone();
+        let record = self.spawn_record().await?;
+        Ok(client.pty(record.id))
+    }
+
+    pub async fn spawn_record(self) -> RouxResult<PtyRecord> {
         let mut args = serde_json::Map::new();
         args.insert("command".into(), Value::String(self.command));
         if let Some(id) = self.id {
@@ -400,11 +544,9 @@ impl SpawnTask {
         if let Some((cols, rows)) = self.initial_size {
             args.insert("initialSize".into(), serde_json::json!([cols, rows]));
         }
-        let record: PtyRecord = self
-            .client
+        self.client
             .command(CommandRequest::new("daemon-pty-spawn-task").args(Value::Object(args)))
-            .await?;
-        Ok(self.client.pty(record.id))
+            .await
     }
 }
 
@@ -434,12 +576,28 @@ impl SpawnShell {
         self
     }
 
+    pub fn nono_profile(mut self, profile: impl Into<String>) -> Self {
+        self.nono_profile = Some(profile.into());
+        self
+    }
+
+    pub fn nono_allow_dirs(mut self, allow_dirs: Vec<String>) -> Self {
+        self.nono_allow_dirs = allow_dirs;
+        self
+    }
+
     pub fn initial_size(mut self, cols: u16, rows: u16) -> Self {
         self.initial_size = Some((cols, rows));
         self
     }
 
     pub async fn spawn(self) -> RouxResult<Pty> {
+        let client = self.client.clone();
+        let record = self.spawn_record().await?;
+        Ok(client.pty(record.id))
+    }
+
+    pub async fn spawn_record(self) -> RouxResult<PtyRecord> {
         let mut args = serde_json::Map::new();
         if let Some(id) = self.id {
             args.insert("id".into(), Value::String(id));
@@ -456,14 +614,18 @@ impl SpawnShell {
         if let Some(profile) = self.profile {
             args.insert("profile".into(), Value::String(profile));
         }
+        if let Some(nono_profile) = self.nono_profile {
+            args.insert("nonoProfile".into(), Value::String(nono_profile));
+        }
+        if !self.nono_allow_dirs.is_empty() {
+            args.insert("nonoAllowDirs".into(), serde_json::json!(self.nono_allow_dirs));
+        }
         if let Some((cols, rows)) = self.initial_size {
             args.insert("initialSize".into(), serde_json::json!([cols, rows]));
         }
-        let record: PtyRecord = self
-            .client
+        self.client
             .command(CommandRequest::new("daemon-pty-spawn-shell").args(Value::Object(args)))
-            .await?;
-        Ok(self.client.pty(record.id))
+            .await
     }
 }
 
@@ -674,6 +836,131 @@ mod tests {
     }
 
     #[test]
+    fn typed_create_session_shell_uses_daemon_command_shape() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut line = String::new();
+            BufReader::new(stream.try_clone().unwrap()).read_line(&mut line).unwrap();
+            let request: Value = serde_json::from_str(line.trim()).unwrap();
+            stream
+                .write_all(
+                    format!(r#"{{"ok":true,"data":{}}}"#, sample_session_json("session-a", false))
+                        .as_bytes(),
+                )
+                .unwrap();
+            stream.write_all(b"\n").unwrap();
+            request
+        });
+
+        let client = Roux::builder()
+            .endpoint(SocketEndpoint::Tcp(addr))
+            .auth_token("secret")
+            .connect()
+            .unwrap();
+        let rt = tokio::runtime::Builder::new_current_thread().build().unwrap();
+        let session = rt
+            .block_on(client.create_session_shell(CreateSessionShell {
+                id: "session-a".to_string(),
+                repo_path: "/repo".to_string(),
+                name: "Daemon Session".to_string(),
+                worktree_path: None,
+                branch: Some("feature/demo".to_string()),
+                base: Some("origin/main".to_string()),
+                fetch_first: true,
+                profile: Some("plain-shell".to_string()),
+                nono_profile: Some("strict".to_string()),
+                nono_allow_dirs: vec!["/tmp".to_string()],
+                initial_size: Some((100, 30)),
+                project_id: Some("project-a".to_string()),
+                blueprint_id: Some("blueprint-a".to_string()),
+                smol_machine_name: Some("vm-a".to_string()),
+                notes: Some(NotesEnv {
+                    vault_root: "/vault".to_string(),
+                    session_slug: "feature-demo--sessio".to_string(),
+                    repo_slug: "repo-a".to_string(),
+                    project_slug: Some("project-a".to_string()),
+                    context_paths: vec!["/repo/docs".to_string()],
+                    project_prompt: "Use project notes".to_string(),
+                }),
+            }))
+            .unwrap();
+        let request = handle.join().unwrap();
+
+        assert_eq!(session.id, "session-a");
+        assert_eq!(request["command"], "session-create-shell");
+        assert_eq!(request["args"]["id"], "session-a");
+        assert_eq!(request["args"]["repoPath"], "/repo");
+        assert_eq!(request["args"]["branch"], "feature/demo");
+        assert_eq!(request["args"]["base"], "origin/main");
+        assert_eq!(request["args"]["fetchFirst"], true);
+        assert_eq!(request["args"]["profile"], "plain-shell");
+        assert_eq!(request["args"]["nonoProfile"], "strict");
+        assert_eq!(request["args"]["nonoAllowDirs"][0], "/tmp");
+        assert_eq!(request["args"]["initialSize"], serde_json::json!([100, 30]));
+        assert_eq!(request["args"]["projectId"], "project-a");
+        assert_eq!(request["args"]["blueprintId"], "blueprint-a");
+        assert_eq!(request["args"]["smolMachineName"], "vm-a");
+        assert_eq!(request["args"]["notesEnv"]["vaultRoot"], "/vault");
+        assert_eq!(request["args"]["notesEnv"]["contextPaths"][0], "/repo/docs");
+    }
+
+    #[test]
+    fn typed_reconnect_session_shell_uses_daemon_command_shape() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut line = String::new();
+            BufReader::new(stream.try_clone().unwrap()).read_line(&mut line).unwrap();
+            let request: Value = serde_json::from_str(line.trim()).unwrap();
+            stream
+                .write_all(
+                    format!(r#"{{"ok":true,"data":{}}}"#, sample_session_json("session-a", false))
+                        .as_bytes(),
+                )
+                .unwrap();
+            stream.write_all(b"\n").unwrap();
+            request
+        });
+
+        let client = Roux::builder()
+            .endpoint(SocketEndpoint::Tcp(addr))
+            .auth_token("secret")
+            .connect()
+            .unwrap();
+        let rt = tokio::runtime::Builder::new_current_thread().build().unwrap();
+        let session = rt
+            .block_on(client.reconnect_session_shell(ReconnectSessionShell {
+                id: "session-a".to_string(),
+                profile: Some("plain-shell".to_string()),
+                nono_profile: Some("strict".to_string()),
+                nono_allow_dirs: vec!["/tmp".to_string()],
+                initial_size: Some((120, 40)),
+                notes: Some(NotesEnv {
+                    vault_root: "/vault".to_string(),
+                    session_slug: "feature-demo--sessio".to_string(),
+                    repo_slug: "repo-a".to_string(),
+                    project_slug: None,
+                    context_paths: vec![],
+                    project_prompt: "".to_string(),
+                }),
+            }))
+            .unwrap();
+        let request = handle.join().unwrap();
+
+        assert_eq!(session.id, "session-a");
+        assert_eq!(request["command"], "session-reconnect-shell");
+        assert_eq!(request["session_id"], "session-a");
+        assert_eq!(request["args"]["profile"], "plain-shell");
+        assert_eq!(request["args"]["nonoProfile"], "strict");
+        assert_eq!(request["args"]["nonoAllowDirs"][0], "/tmp");
+        assert_eq!(request["args"]["initialSize"], serde_json::json!([120, 40]));
+        assert_eq!(request["args"]["notesEnv"]["vaultRoot"], "/vault");
+    }
+
+    #[test]
     fn typed_pty_attach_decodes_ndjson_frames() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap().to_string();
@@ -721,6 +1008,31 @@ mod tests {
         assert_eq!(request["command"], "daemon-pty-attach");
         assert_eq!(request["args"]["id"], "pty-1");
         assert_eq!(*frames.lock().unwrap(), vec!["ready", "exit"]);
+    }
+
+    fn sample_session_json(id: &str, archived: bool) -> String {
+        serde_json::json!({
+            "id": id,
+            "name": "Daemon Session",
+            "repoRoot": "/repo",
+            "worktreePath": "/repo",
+            "branch": "feature/demo",
+            "isWorktree": false,
+            "model": null,
+            "cost": null,
+            "createdAt": 1,
+            "status": "idle",
+            "isGitRepo": true,
+            "nameOverride": null,
+            "primaryPtyId": "pty-primary",
+            "archived": archived,
+            "endedAt": null,
+            "projectId": "project-a",
+            "blueprintId": "blueprint-a",
+            "pinnedPrUrl": null,
+            "smolMachineName": "vm-a"
+        })
+        .to_string()
     }
 
     fn sample_pty_record_json(id: &str) -> String {

--- a/crates/roux-sdk/src/lib.rs
+++ b/crates/roux-sdk/src/lib.rs
@@ -476,7 +476,7 @@ impl Pty {
                     }
                 },
             );
-            result.and_then(|_| match parse_error {
+            result.and(match parse_error {
                 Some(err) => Err(err),
                 None => Ok(()),
             })

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -52,6 +52,7 @@ roux-core = { path = "../crates/roux-core" }
 roux-git = { path = "../crates/roux-git" }
 roux-gh = { path = "../crates/roux-gh" }
 roux-runtime = { path = "../crates/roux-runtime" }
+roux-sdk = { path = "../crates/roux-sdk" }
 roux-smolvm = { path = "../crates/roux-smolvm" }
 roux-worktrunk = { path = "../crates/roux-worktrunk" }
 schemars = "1"

--- a/src-tauri/src/commands/daemon.rs
+++ b/src-tauri/src/commands/daemon.rs
@@ -3,14 +3,13 @@ use std::path::PathBuf;
 use crate::daemon_client::DaemonStatus;
 use crate::state::AppState;
 use roux_runtime::process_service::{ProcessRecord, ProcessSnapshot};
-use roux_runtime::pty_service::{PtyRecord, PtySnapshot, PtySpawnRequest};
+use roux_sdk::{PtyRecord, PtySnapshot};
 use serde::Serialize;
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub(crate) enum RuntimeMode {
     Daemon,
-    LocalFallback,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -44,37 +43,19 @@ pub(crate) fn get_daemon_status(state: tauri::State<'_, AppState>) -> Option<Dae
 pub(crate) async fn get_runtime_status(
     state: tauri::State<'_, AppState>,
 ) -> Result<RuntimeStatus, String> {
-    let daemon_client = state.daemon_client.clone();
-    let daemon_startup_error = state.daemon_startup_error.clone();
-    let runtime_started_at_ms = state.runtime_started_at_ms;
-    let runtime = state.runtime.clone();
-
-    if let Some(client) = daemon_client {
-        let (daemon, status_error) = match client.refresh_status().await {
-            Ok(status) => (status, None),
-            Err(err) => (client.status().clone(), Some(err)),
-        };
-        return Ok(RuntimeStatus {
-            mode: RuntimeMode::Daemon,
-            desktop_pid: std::process::id(),
-            started_at_ms: daemon.started_at_ms,
-            uptime_ms: daemon.uptime_ms,
-            daemon: Some(daemon),
-            local: None,
-            status_error,
-        });
-    }
-
-    let counts = local_runtime_counts(runtime).await;
-    let now = unix_now_ms();
+    let client = required_daemon_client_ref(&state)?;
+    let (daemon, status_error) = match client.refresh_status().await {
+        Ok(status) => (status, None),
+        Err(err) => (client.status().clone(), Some(err)),
+    };
     Ok(RuntimeStatus {
-        mode: RuntimeMode::LocalFallback,
+        mode: RuntimeMode::Daemon,
         desktop_pid: std::process::id(),
-        started_at_ms: runtime_started_at_ms,
-        uptime_ms: now.saturating_sub(runtime_started_at_ms),
-        daemon: None,
-        local: Some(counts),
-        status_error: daemon_startup_error,
+        started_at_ms: daemon.started_at_ms,
+        uptime_ms: daemon.uptime_ms,
+        daemon: Some(daemon),
+        local: None,
+        status_error,
     })
 }
 
@@ -94,16 +75,6 @@ pub(crate) async fn daemon_process_start(
         .start(command, working_dir.map(PathBuf::from))
         .await
         .map_err(|err| err.to_string())
-}
-
-async fn local_runtime_counts(runtime: roux_runtime::host::RuntimeHost) -> RuntimeCounts {
-    RuntimeCounts {
-        session_count: runtime.session_handle.list().await.map(|items| items.len()).unwrap_or(0),
-        project_count: runtime.project_handle.list().await.map(|items| items.len()).unwrap_or(0),
-        watch_count: runtime.watch_handle.list().await.map(|items| items.len()).unwrap_or(0),
-        process_count: runtime.process_handle.list().await.map(|items| items.len()).unwrap_or(0),
-        pty_count: runtime.pty_handle.list().await.map(|items| items.len()).unwrap_or(0),
-    }
 }
 
 fn unix_now_ms() -> u64 {
@@ -174,27 +145,19 @@ pub(crate) async fn daemon_pty_spawn_shell(
     initial_size: Option<(u16, u16)>,
     state: tauri::State<'_, AppState>,
 ) -> Result<PtyRecord, String> {
-    if let Some(client) = &state.daemon_client {
-        return client
-            .spawn_daemon_pty_shell(
-                id,
-                working_dir,
-                session_id,
-                pane_id,
-                profile,
-                None,
-                Vec::new(),
-                initial_size,
-            )
-            .await;
-    }
-
-    state
-        .runtime
-        .pty_handle
-        .spawn_shell(pty_spawn_request(id, working_dir, session_id, pane_id, profile, initial_size))
+    let client = required_daemon_client_ref(&state)?;
+    client
+        .spawn_daemon_pty_shell(
+            id,
+            working_dir,
+            session_id,
+            pane_id,
+            profile,
+            None,
+            Vec::new(),
+            initial_size,
+        )
         .await
-        .map_err(|err| err.to_string())
 }
 
 #[tauri::command]
@@ -208,29 +171,10 @@ pub(crate) async fn daemon_pty_spawn_task(
     initial_size: Option<(u16, u16)>,
     state: tauri::State<'_, AppState>,
 ) -> Result<PtyRecord, String> {
-    if let Some(client) = &state.daemon_client {
-        return client
-            .spawn_daemon_pty_task(
-                command,
-                id,
-                working_dir,
-                session_id,
-                pane_id,
-                profile,
-                initial_size,
-            )
-            .await;
-    }
-
-    state
-        .runtime
-        .pty_handle
-        .spawn_task(
-            command,
-            pty_spawn_request(id, working_dir, session_id, pane_id, profile, initial_size),
-        )
+    let client = required_daemon_client_ref(&state)?;
+    client
+        .spawn_daemon_pty_task(command, id, working_dir, session_id, pane_id, profile, initial_size)
         .await
-        .map_err(|err| err.to_string())
 }
 
 #[tauri::command]
@@ -239,31 +183,16 @@ pub(crate) async fn daemon_pty_output(
     max_bytes: Option<usize>,
     state: tauri::State<'_, AppState>,
 ) -> Result<PtySnapshot, String> {
-    if let Some(client) = &state.daemon_client {
-        return client.daemon_pty_output(id, max_bytes).await;
-    }
-
-    state
-        .runtime
-        .pty_handle
-        .snapshot(
-            &id,
-            max_bytes.unwrap_or(roux_runtime::pty_service::PTY_OUTPUT_DEFAULT_POLL_BYTES),
-        )
-        .await
-        .map_err(|err| err.to_string())?
-        .ok_or_else(|| "daemon pty not found".to_string())
+    let client = required_daemon_client_ref(&state)?;
+    client.daemon_pty_output(id, max_bytes).await
 }
 
 #[tauri::command]
 pub(crate) async fn daemon_pty_list(
     state: tauri::State<'_, AppState>,
 ) -> Result<Vec<PtyRecord>, String> {
-    if let Some(client) = &state.daemon_client {
-        return client.list_daemon_ptys().await;
-    }
-
-    state.runtime.pty_handle.list().await.map_err(|err| err.to_string())
+    let client = required_daemon_client_ref(&state)?;
+    client.list_daemon_ptys().await
 }
 
 #[tauri::command]
@@ -272,11 +201,8 @@ pub(crate) async fn daemon_pty_write(
     data: String,
     state: tauri::State<'_, AppState>,
 ) -> Result<(), String> {
-    if let Some(client) = &state.daemon_client {
-        return client.write_daemon_pty(id, data).await;
-    }
-
-    state.runtime.pty_handle.write(&id, data.into_bytes()).await.map_err(|err| err.to_string())
+    let client = required_daemon_client_ref(&state)?;
+    client.write_daemon_pty(id, data).await
 }
 
 #[tauri::command]
@@ -286,17 +212,8 @@ pub(crate) async fn daemon_pty_resize(
     rows: u16,
     state: tauri::State<'_, AppState>,
 ) -> Result<PtyRecord, String> {
-    if let Some(client) = &state.daemon_client {
-        return client.resize_daemon_pty(id, cols, rows).await;
-    }
-
-    state
-        .runtime
-        .pty_handle
-        .resize(&id, cols, rows)
-        .await
-        .map_err(|err| err.to_string())?
-        .ok_or_else(|| "daemon pty not found".to_string())
+    let client = required_daemon_client_ref(&state)?;
+    client.resize_daemon_pty(id, cols, rows).await
 }
 
 #[tauri::command]
@@ -304,34 +221,15 @@ pub(crate) async fn daemon_pty_kill(
     id: String,
     state: tauri::State<'_, AppState>,
 ) -> Result<PtyRecord, String> {
-    if let Some(client) = &state.daemon_client {
-        return client.kill_daemon_pty(id).await;
-    }
-
-    state
-        .runtime
-        .pty_handle
-        .kill(&id)
-        .await
-        .map_err(|err| err.to_string())?
-        .ok_or_else(|| "daemon pty not found".to_string())
+    let client = required_daemon_client_ref(&state)?;
+    client.kill_daemon_pty(id).await
 }
 
-fn pty_spawn_request(
-    id: Option<String>,
-    working_dir: Option<String>,
-    session_id: Option<String>,
-    pane_id: Option<String>,
-    profile: Option<String>,
-    initial_size: Option<(u16, u16)>,
-) -> PtySpawnRequest {
-    PtySpawnRequest {
-        id,
-        working_dir: working_dir.map(PathBuf::from),
-        session_id,
-        pane_id,
-        profile,
-        initial_size,
-        ..PtySpawnRequest::default()
-    }
+fn required_daemon_client_ref(
+    state: &AppState,
+) -> Result<&crate::daemon_client::DaemonClient, String> {
+    state
+        .daemon_client
+        .as_ref()
+        .ok_or_else(|| "Roux daemon is required but not connected".to_string())
 }

--- a/src-tauri/src/commands/daemon.rs
+++ b/src-tauri/src/commands/daemon.rs
@@ -77,13 +77,6 @@ pub(crate) async fn daemon_process_start(
         .map_err(|err| err.to_string())
 }
 
-fn unix_now_ms() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis() as u64
-}
-
 #[tauri::command]
 pub(crate) async fn daemon_process_output(
     id: String,

--- a/src-tauri/src/commands/daemon.rs
+++ b/src-tauri/src/commands/daemon.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use crate::daemon_client::DaemonStatus;
-use crate::state::AppState;
+use crate::state::{required_daemon_client_ref, AppState};
 use roux_runtime::process_service::{ProcessRecord, ProcessSnapshot};
 use roux_sdk::{PtyRecord, PtySnapshot};
 use serde::Serialize;
@@ -216,13 +216,4 @@ pub(crate) async fn daemon_pty_kill(
 ) -> Result<PtyRecord, String> {
     let client = required_daemon_client_ref(&state)?;
     client.kill_daemon_pty(id).await
-}
-
-fn required_daemon_client_ref(
-    state: &AppState,
-) -> Result<&crate::daemon_client::DaemonClient, String> {
-    state
-        .daemon_client
-        .as_ref()
-        .ok_or_else(|| "Roux daemon is required but not connected".to_string())
 }

--- a/src-tauri/src/commands/pty.rs
+++ b/src-tauri/src/commands/pty.rs
@@ -1,5 +1,5 @@
 use crate::pty::PtyInfo;
-use crate::state::AppState;
+use crate::state::{required_daemon_client, AppState};
 
 #[tauri::command]
 #[specta::specta]
@@ -81,11 +81,4 @@ pub(crate) async fn set_pty_name(
     let client = required_daemon_client(&state)?;
     let _ = client.set_daemon_pty_name(pty_id, name).await?;
     Ok(())
-}
-
-fn required_daemon_client(state: &AppState) -> Result<crate::daemon_client::DaemonClient, String> {
-    state
-        .daemon_client
-        .clone()
-        .ok_or_else(|| "Roux daemon is required but not connected".to_string())
 }

--- a/src-tauri/src/commands/pty.rs
+++ b/src-tauri/src/commands/pty.rs
@@ -7,19 +7,14 @@ pub(crate) async fn list_session_ptys(
     session_id: String,
     state: tauri::State<'_, AppState>,
 ) -> Result<Vec<PtyInfo>, String> {
-    let mut ptys = Vec::new();
-    if let Some(client) = state.daemon_client.clone() {
-        ptys.extend(
-            client
-                .list_daemon_ptys()
-                .await?
-                .into_iter()
-                .map(|record| record.info)
-                .filter(|info| info.session_id.as_deref() == Some(session_id.as_str())),
-        );
-    }
-    ptys.extend(state.pty_manager.list_for_session(&session_id));
-    Ok(ptys)
+    let client = required_daemon_client(&state)?;
+    Ok(client
+        .list_daemon_ptys()
+        .await?
+        .into_iter()
+        .map(|record| record.info)
+        .filter(|info| info.session_id.as_deref() == Some(session_id.as_str()))
+        .collect())
 }
 
 #[tauri::command]
@@ -27,12 +22,8 @@ pub(crate) async fn list_session_ptys(
 pub(crate) async fn list_all_ptys(
     state: tauri::State<'_, AppState>,
 ) -> Result<Vec<PtyInfo>, String> {
-    let mut ptys = Vec::new();
-    if let Some(client) = state.daemon_client.clone() {
-        ptys.extend(client.list_daemon_ptys().await?.into_iter().map(|record| record.info));
-    }
-    ptys.extend(state.pty_manager.list_all());
-    Ok(ptys)
+    let client = required_daemon_client(&state)?;
+    Ok(client.list_daemon_ptys().await?.into_iter().map(|record| record.info).collect())
 }
 
 #[tauri::command]
@@ -41,17 +32,9 @@ pub(crate) async fn detach_pty(
     pty_id: String,
     state: tauri::State<'_, AppState>,
 ) -> Result<(), String> {
-    if let Some(client) = state.daemon_client.clone() {
-        match client.detach_daemon_pty(pty_id.clone()).await {
-            Ok(_) => {
-                super::sessions::abort_daemon_attach_task(&state, &pty_id)?;
-                return Ok(());
-            }
-            Err(err) if is_daemon_pty_not_found(&err) => {}
-            Err(err) => return Err(err),
-        }
-    }
-    state.pty_manager.detach(&pty_id);
+    let client = required_daemon_client(&state)?;
+    client.detach_daemon_pty(pty_id.clone()).await?;
+    super::sessions::abort_daemon_attach_task(&state, &pty_id)?;
     Ok(())
 }
 
@@ -69,21 +52,11 @@ pub(crate) async fn attach_pty_to_pane(
     rows: u16,
     state: tauri::State<'_, AppState>,
 ) -> Result<AttachResult, String> {
-    if let Some(client) = state.daemon_client.clone() {
-        match client.daemon_pty_output(pty_id.clone(), Some(256 * 1024)).await {
-            Ok(snapshot) => {
-                let _ = client.attach_daemon_pty_to_pane(pty_id.clone(), pane_id).await?;
-                let _ = client.resize_daemon_pty(pty_id, cols, rows).await?;
-                return Ok(AttachResult { replay_bytes: snapshot.output_bytes });
-            }
-            Err(err) if is_daemon_pty_not_found(&err) => {}
-            Err(err) => return Err(err),
-        }
-    }
-
-    let replay_bytes = state.pty_manager.get_replay(&pty_id, 256 * 1024);
-    state.pty_manager.attach_to_pane(&pty_id, &pane_id);
-    let _ = state.pty_manager.resize(&pty_id, cols, rows);
+    let client = required_daemon_client(&state)?;
+    let snapshot = client.daemon_pty_output(pty_id.clone(), Some(256 * 1024)).await?;
+    let _ = client.attach_daemon_pty_to_pane(pty_id.clone(), pane_id).await?;
+    let _ = client.resize_daemon_pty(pty_id, cols, rows).await?;
+    let replay_bytes = snapshot.output_bytes;
     Ok(AttachResult { replay_bytes })
 }
 
@@ -93,14 +66,8 @@ pub(crate) async fn mark_pty_read(
     pty_id: String,
     state: tauri::State<'_, AppState>,
 ) -> Result<(), String> {
-    if let Some(client) = state.daemon_client.clone() {
-        match client.mark_daemon_pty_read(pty_id.clone()).await {
-            Ok(_) => return Ok(()),
-            Err(err) if is_daemon_pty_not_found(&err) => {}
-            Err(err) => return Err(err),
-        }
-    }
-    state.pty_manager.mark_read(&pty_id);
+    let client = required_daemon_client(&state)?;
+    let _ = client.mark_daemon_pty_read(pty_id).await?;
     Ok(())
 }
 
@@ -111,17 +78,14 @@ pub(crate) async fn set_pty_name(
     name: Option<String>,
     state: tauri::State<'_, AppState>,
 ) -> Result<(), String> {
-    if let Some(client) = state.daemon_client.clone() {
-        match client.set_daemon_pty_name(pty_id.clone(), name.clone()).await {
-            Ok(_) => return Ok(()),
-            Err(err) if is_daemon_pty_not_found(&err) => {}
-            Err(err) => return Err(err),
-        }
-    }
-    state.pty_manager.set_name(&pty_id, name.as_deref());
+    let client = required_daemon_client(&state)?;
+    let _ = client.set_daemon_pty_name(pty_id, name).await?;
     Ok(())
 }
 
-fn is_daemon_pty_not_found(err: &str) -> bool {
-    err.contains("daemon pty not found")
+fn required_daemon_client(state: &AppState) -> Result<crate::daemon_client::DaemonClient, String> {
+    state
+        .daemon_client
+        .clone()
+        .ok_or_else(|| "Roux daemon is required but not connected".to_string())
 }

--- a/src-tauri/src/commands/sessions.rs
+++ b/src-tauri/src/commands/sessions.rs
@@ -1,6 +1,8 @@
 use crate::services::sessions as svc;
 use crate::session::Session;
-use crate::state::{AppState, DaemonPtyAttachTask};
+use crate::state::{
+    required_daemon_client, required_daemon_client_ref, AppState, DaemonPtyAttachTask,
+};
 use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicU64, Ordering};
 use tauri::Manager;
@@ -635,8 +637,9 @@ pub(crate) async fn refresh_session_git_status(
     state: tauri::State<'_, AppState>,
 ) -> Result<bool, String> {
     let client = required_daemon_client_ref(&state)?;
+    let _ = client.refresh_session_branch(id.clone()).await?;
     let session = client.get_session(id).await?;
-    Ok(svc::is_git_repo(&session.worktree_path))
+    Ok(session.is_git_repo)
 }
 
 #[tauri::command]
@@ -667,20 +670,4 @@ pub(crate) fn list_claude_sessions(cwd: String) -> Result<Vec<svc::ClaudeSession
 pub(crate) fn get_builtin_profiles(state: tauri::State<AppState>) -> Vec<roux_core::SpawnProfile> {
     let settings = state.settings.lock().unwrap().clone();
     crate::providers::builtin_profiles(&settings)
-}
-
-fn required_daemon_client(state: &AppState) -> Result<crate::daemon_client::DaemonClient, String> {
-    state
-        .daemon_client
-        .clone()
-        .ok_or_else(|| "Roux daemon is required but not connected".to_string())
-}
-
-fn required_daemon_client_ref(
-    state: &AppState,
-) -> Result<&crate::daemon_client::DaemonClient, String> {
-    state
-        .daemon_client
-        .as_ref()
-        .ok_or_else(|| "Roux daemon is required but not connected".to_string())
 }

--- a/src-tauri/src/commands/sessions.rs
+++ b/src-tauri/src/commands/sessions.rs
@@ -49,10 +49,6 @@ pub(crate) struct CreateShellOpts {
     pub smol_machine_name: Option<String>,
 }
 
-fn is_daemon_pty_not_found(err: &str) -> bool {
-    err.contains("daemon pty not found")
-}
-
 pub(crate) fn abort_daemon_attach_task(state: &AppState, id: &str) -> Result<(), String> {
     let previous = state.daemon_pty_attach_tasks.lock().map_err(|err| err.to_string())?.remove(id);
     if let Some(previous) = previous {
@@ -68,14 +64,8 @@ pub(crate) async fn write_to_session(
     data: String,
     state: tauri::State<'_, AppState>,
 ) -> Result<(), String> {
-    if let Some(client) = state.daemon_client.clone() {
-        match client.write_daemon_pty(id.clone(), data.clone()).await {
-            Ok(()) => return Ok(()),
-            Err(err) if is_daemon_pty_not_found(&err) => {}
-            Err(err) => return Err(err),
-        }
-    }
-    state.pty_manager.write(&id, data.as_bytes()).map_err(|e| e.to_string())
+    let client = required_daemon_client(&state)?;
+    client.write_daemon_pty(id, data).await
 }
 
 /// Frontend reply for a socket-initiated round-trip (e.g. panes list / create).
@@ -110,14 +100,9 @@ pub(crate) async fn resize_session(
     rows: u16,
     state: tauri::State<'_, AppState>,
 ) -> Result<(), String> {
-    if let Some(client) = state.daemon_client.clone() {
-        match client.resize_daemon_pty(id.clone(), cols, rows).await {
-            Ok(_) => return Ok(()),
-            Err(err) if is_daemon_pty_not_found(&err) => {}
-            Err(err) => return Err(err),
-        }
-    }
-    state.pty_manager.resize(&id, cols, rows).map_err(|e| e.to_string())
+    let client = required_daemon_client(&state)?;
+    let _ = client.resize_daemon_pty(id, cols, rows).await?;
+    Ok(())
 }
 
 // No #[specta::specta] — Channel<Response> doesn't implement specta::Type
@@ -128,44 +113,32 @@ pub(crate) async fn attach_pty_output(
     state: tauri::State<'_, AppState>,
     app: tauri::AppHandle,
 ) -> Result<(), String> {
-    if let Some(client) = state.daemon_client.clone() {
-        match client.daemon_pty_output(id.clone(), Some(0)).await {
-            Ok(_) => {
-                let token = NEXT_DAEMON_ATTACH_TASK_TOKEN.fetch_add(1, Ordering::Relaxed);
-                let bridge =
-                    client.spawn_daemon_pty_output_bridge(id.clone(), on_event, app.clone());
-                let cleanup_id = id.clone();
-                let cleanup_app = app.clone();
-                let handle = tauri::async_runtime::spawn(async move {
-                    let _ = bridge.await;
-                    if let Some(state) = cleanup_app.try_state::<AppState>() {
-                        if let Ok(mut tasks) = state.daemon_pty_attach_tasks.lock() {
-                            let should_remove = tasks
-                                .get(&cleanup_id)
-                                .map(|task| task.token == token)
-                                .unwrap_or(false);
-                            if should_remove {
-                                tasks.remove(&cleanup_id);
-                            }
-                        }
-                    }
-                });
-                let previous = state
-                    .daemon_pty_attach_tasks
-                    .lock()
-                    .map_err(|err| err.to_string())?
-                    .insert(id, DaemonPtyAttachTask { token, handle });
-                if let Some(previous) = previous {
-                    previous.handle.abort();
+    let client = required_daemon_client(&state)?;
+    let _ = client.daemon_pty_output(id.clone(), Some(0)).await?;
+    let token = NEXT_DAEMON_ATTACH_TASK_TOKEN.fetch_add(1, Ordering::Relaxed);
+    let bridge = client.spawn_daemon_pty_output_bridge(id.clone(), on_event, app.clone());
+    let cleanup_id = id.clone();
+    let cleanup_app = app.clone();
+    let handle = tauri::async_runtime::spawn(async move {
+        let _ = bridge.await;
+        if let Some(state) = cleanup_app.try_state::<AppState>() {
+            if let Ok(mut tasks) = state.daemon_pty_attach_tasks.lock() {
+                let should_remove =
+                    tasks.get(&cleanup_id).map(|task| task.token == token).unwrap_or(false);
+                if should_remove {
+                    tasks.remove(&cleanup_id);
                 }
-                return Ok(());
             }
-            Err(err) if is_daemon_pty_not_found(&err) => {}
-            Err(err) => return Err(err),
         }
+    });
+    let previous = state
+        .daemon_pty_attach_tasks
+        .lock()
+        .map_err(|err| err.to_string())?
+        .insert(id, DaemonPtyAttachTask { token, handle });
+    if let Some(previous) = previous {
+        previous.handle.abort();
     }
-
-    state.pty_manager.attach_output_channel(&id, on_event);
     Ok(())
 }
 
@@ -181,82 +154,25 @@ pub(crate) async fn spawn_shell(
     profile: Option<String>,
     initial_size: Option<(u16, u16)>,
     state: tauri::State<'_, AppState>,
-    app: tauri::AppHandle,
+    _app: tauri::AppHandle,
 ) -> Result<(), String> {
-    use crate::pty::{NonoConfig, SmolvmExec};
     let daemon_nono_profile = nono_profile.clone();
     let daemon_nono_allow_dirs = nono_allow_dirs.clone().unwrap_or_default();
-    let nono = nono_profile
-        .map(|profile| NonoConfig { profile, allow_dirs: nono_allow_dirs.unwrap_or_default() });
 
-    if let Some(client) = state.daemon_client.clone() {
-        client
-            .spawn_daemon_pty_shell(
-                Some(id.clone()),
-                Some(working_dir.clone()),
-                session_id.clone(),
-                pane_id.clone(),
-                profile.clone(),
-                daemon_nono_profile,
-                daemon_nono_allow_dirs,
-                initial_size,
-            )
-            .await?;
-        return Ok(());
-    }
-
-    // Look up the session record so secondary panes inherit its
-    // smol-machine binding. Promoted to async (was sync) so the lookup
-    // can happen here rather than forcing the frontend to thread
-    // smol_machine_name through every spawn call site. Lookup failures
-    // (DB read error, IO error) propagate so we never silently bypass
-    // VM isolation by treating an error as "no binding". `Ok(None)` —
-    // the session genuinely doesn't exist yet, e.g. CLI bridge spawning
-    // ahead of session creation — falls through with no binding.
-    let session_record = match session_id.as_deref() {
-        Some(sid) => state.runtime.session_handle.get(sid).await.map_err(|e| e.to_string())?,
-        None => None,
-    };
-    let smol_name = session_record.as_ref().and_then(|s| s.smol_machine_name.clone());
-    let smolvm = match smol_name {
-        Some(name) if !name.trim().is_empty() => {
-            let install = crate::services::smolvm::resolve_smolvm_binary().ok_or_else(|| {
-                format!(
-                    "session is bound to smol machine '{name}', but smolvm is not installed; \
-                         unbind via the panel or install smolvm to continue"
-                )
-            })?;
-            Some(SmolvmExec {
-                binary: install.path,
-                machine_name: name.trim().to_string(),
-                guest_shell: "/bin/sh".to_string(),
-            })
-        }
-        _ => None,
-    };
-
-    // Secondary pane spawn path. Primary session shells already carry
-    // ROUX_PROJECT_ID / ROUX_WORKTREE_PATH via services::sessions. Secondary
-    // panes could resolve the same from `session_record` above; left as
-    // None until callers actually need them downstream.
-    state
-        .pty_manager
-        .spawn_shell(
-            &id,
-            &working_dir,
-            session_id.as_deref(),
-            pane_id.as_deref(),
-            None,
-            None,
-            None, // notes env snapshot — session-creation path only
-            nono.as_ref(),
-            smolvm.as_ref(),
+    let client = required_daemon_client(&state)?;
+    client
+        .spawn_daemon_pty_shell(
+            Some(id),
+            Some(working_dir),
+            session_id,
+            pane_id,
+            profile,
+            daemon_nono_profile,
+            daemon_nono_allow_dirs,
             initial_size,
-            crate::pty::PtyRole::Secondary,
-            profile.as_deref(),
-            app.clone(),
         )
-        .map_err(|e| e.to_string())
+        .await?;
+    Ok(())
 }
 
 #[tauri::command]
@@ -270,10 +186,8 @@ pub(crate) async fn spawn_task(
     profile: Option<String>,
     initial_size: Option<(u16, u16)>,
     state: tauri::State<'_, AppState>,
-    app: tauri::AppHandle,
+    _app: tauri::AppHandle,
 ) -> Result<(), String> {
-    use crate::pty::SmolvmExec;
-
     // See spawn_shell above: project/worktree env is deferred for the
     // secondary-pane path until this command goes async.
     let context = crate::automation_hooks::HookContext {
@@ -291,81 +205,18 @@ pub(crate) async fn spawn_task(
         .await
         .map_err(|e| e.to_string())?;
 
-    if let Some(client) = state.daemon_client.clone() {
-        client
-            .spawn_daemon_pty_task(
-                command.clone(),
-                Some(id.clone()),
-                Some(working_dir.clone()),
-                session_id.clone(),
-                pane_id.clone(),
-                profile.clone(),
-                initial_size,
-            )
-            .await?;
-        let scope = session_id.as_ref().map(|_| "session".to_string());
-        let context = crate::automation_hooks::HookContext {
-            repo_path: Some(working_dir.clone()),
-            worktree_path: Some(working_dir.clone()),
-            task_id: Some(id),
-            session_id,
-            scope,
-            cwd: Some(working_dir),
-            ..crate::automation_hooks::HookContext::new(
-                crate::automation_hooks::HookEvent::PostTaskRun,
-            )
-        };
-        state
-            .automation_hooks
-            .spawn_background(crate::automation_hooks::HookEvent::PostTaskRun, context);
-        return Ok(());
-    }
-
-    // Inherit the session's smol-machine binding so a `roux run`-style
-    // task lands inside the same VM as the rest of the session. Mirrors
-    // the spawn_shell flow above (via build_smolvm_exec_for_session
-    // in services::sessions). See `commands/sessions.rs::spawn_shell`
-    // and `socket.rs::handle_run` for the matching wraps.
-    let session_record = match session_id.as_deref() {
-        Some(sid) => state.runtime.session_handle.get(sid).await.map_err(|e| e.to_string())?,
-        None => None,
-    };
-    let smol_name = session_record.as_ref().and_then(|s| s.smol_machine_name.clone());
-    let smolvm = match smol_name {
-        Some(name) if !name.trim().is_empty() => {
-            let install = crate::services::smolvm::resolve_smolvm_binary().ok_or_else(|| {
-                format!(
-                    "session is bound to smol machine '{name}', but smolvm is not installed; \
-                         unbind via the panel or install smolvm to continue"
-                )
-            })?;
-            Some(SmolvmExec {
-                binary: install.path,
-                machine_name: name.trim().to_string(),
-                guest_shell: "/bin/sh".to_string(),
-            })
-        }
-        _ => None,
-    };
-
-    state
-        .pty_manager
-        .spawn_task(
-            &id,
-            &command,
-            &working_dir,
-            session_id.as_deref(),
-            pane_id.as_deref(),
-            None,
-            None,
-            None, // notes env snapshot — session-creation path only
-            smolvm.as_ref(),
+    let client = required_daemon_client(&state)?;
+    client
+        .spawn_daemon_pty_task(
+            command.clone(),
+            Some(id.clone()),
+            Some(working_dir.clone()),
+            session_id.clone(),
+            pane_id,
+            profile,
             initial_size,
-            crate::pty::PtyRole::Secondary,
-            profile.as_deref(),
-            app.clone(),
         )
-        .map_err(|e| e.to_string())?;
+        .await?;
     let scope = session_id.as_ref().map(|_| "session".to_string());
     let context = crate::automation_hooks::HookContext {
         repo_path: Some(working_dir.clone()),
@@ -402,51 +253,26 @@ pub(crate) fn get_pty_cwd(id: String, state: tauri::State<AppState>) -> Option<S
 /// watch-cleanup work. Shared by the Tauri command and the CLI/socket
 /// handler so both code paths get identical lifecycle behavior.
 pub(crate) async fn archive_session_with_hooks(state: &AppState, id: &str) -> Result<(), String> {
-    let session = if let Some(client) = &state.daemon_client {
-        match client.get_session(id.to_string()).await {
-            Ok(session) => Some(session),
-            Err(err) if err.contains("session not found") => {
-                state.runtime.session_handle.get(id).await.map_err(|e| e.to_string())?
-            }
-            Err(err) => return Err(err),
-        }
-    } else {
-        state.runtime.session_handle.get(id).await.map_err(|e| e.to_string())?
+    let client = required_daemon_client_ref(state)?;
+    let session = client.get_session(id.to_string()).await?;
+    let context = crate::automation_hooks::HookContext {
+        repo_path: Some(session.repo_root.clone()),
+        worktree_path: Some(session.worktree_path.clone()),
+        branch: Some(session.branch.clone()),
+        session_id: Some(session.id.clone()),
+        project_id: session.project_id.clone(),
+        scope: Some("session".into()),
+        cwd: Some(session.worktree_path.clone()),
+        ..crate::automation_hooks::HookContext::new(
+            crate::automation_hooks::HookEvent::PreSessionClose,
+        )
     };
-    if let Some(session) = session.as_ref() {
-        let context = crate::automation_hooks::HookContext {
-            repo_path: Some(session.repo_root.clone()),
-            worktree_path: Some(session.worktree_path.clone()),
-            branch: Some(session.branch.clone()),
-            session_id: Some(session.id.clone()),
-            project_id: session.project_id.clone(),
-            scope: Some("session".into()),
-            cwd: Some(session.worktree_path.clone()),
-            ..crate::automation_hooks::HookContext::new(
-                crate::automation_hooks::HookEvent::PreSessionClose,
-            )
-        };
-        state
-            .automation_hooks
-            .run_blocking(crate::automation_hooks::HookEvent::PreSessionClose, context)
-            .await
-            .map_err(|e| e.to_string())?;
-    }
-    if let Some(client) = &state.daemon_client {
-        match client.archive_session(id.to_string()).await {
-            Ok(_) => {}
-            Err(err) if err.contains("session not found") => {
-                svc::kill_session(&state.pty_manager, &state.runtime.session_handle, id)
-                    .await
-                    .map_err(|e| e.to_string())?;
-            }
-            Err(err) => return Err(err),
-        }
-    } else {
-        svc::kill_session(&state.pty_manager, &state.runtime.session_handle, id)
-            .await
-            .map_err(|e| e.to_string())?;
-    }
+    state
+        .automation_hooks
+        .run_blocking(crate::automation_hooks::HookEvent::PreSessionClose, context)
+        .await
+        .map_err(|e| e.to_string())?;
+    let _ = client.archive_session(id.to_string()).await?;
     // Stop session-scoped recurring watches (e.g. PR pollers) so they
     // don't outlive the archived session and keep firing forever.
     if let Some(client) =
@@ -457,23 +283,21 @@ pub(crate) async fn archive_session_with_hooks(state: &AppState, id: &str) -> Re
         }
     }
     state.watch_manager.remove_watches_for_session(id).await;
-    if let Some(session) = session {
-        let context = crate::automation_hooks::HookContext {
-            repo_path: Some(session.repo_root.clone()),
-            worktree_path: Some(session.worktree_path.clone()),
-            branch: Some(session.branch.clone()),
-            session_id: Some(session.id.clone()),
-            project_id: session.project_id.clone(),
-            scope: Some("session".into()),
-            cwd: Some(session.worktree_path.clone()),
-            ..crate::automation_hooks::HookContext::new(
-                crate::automation_hooks::HookEvent::PostSessionClose,
-            )
-        };
-        state
-            .automation_hooks
-            .spawn_background(crate::automation_hooks::HookEvent::PostSessionClose, context);
-    }
+    let context = crate::automation_hooks::HookContext {
+        repo_path: Some(session.repo_root.clone()),
+        worktree_path: Some(session.worktree_path.clone()),
+        branch: Some(session.branch.clone()),
+        session_id: Some(session.id.clone()),
+        project_id: session.project_id.clone(),
+        scope: Some("session".into()),
+        cwd: Some(session.worktree_path.clone()),
+        ..crate::automation_hooks::HookContext::new(
+            crate::automation_hooks::HookEvent::PostSessionClose,
+        )
+    };
+    state
+        .automation_hooks
+        .spawn_background(crate::automation_hooks::HookEvent::PostSessionClose, context);
     Ok(())
 }
 
@@ -496,14 +320,9 @@ pub(crate) async fn restore_session(
     id: String,
     state: tauri::State<'_, AppState>,
 ) -> Result<(), String> {
-    if let Some(client) = &state.daemon_client {
-        match client.restore_session(id.clone()).await {
-            Ok(_) => return Ok(()),
-            Err(err) if err.contains("session not found") => {}
-            Err(err) => return Err(err),
-        }
-    }
-    svc::restore_session(&state.runtime.session_handle, &id).await.map_err(|e| e.to_string())
+    let client = required_daemon_client_ref(&state)?;
+    let _ = client.restore_session(id).await?;
+    Ok(())
 }
 
 /// Permanently delete a session record. Irreversible. Does not touch the
@@ -515,28 +334,10 @@ pub(crate) async fn delete_session_permanently(
     id: String,
     state: tauri::State<'_, AppState>,
 ) -> Result<(), String> {
-    if let Some(client) = &state.daemon_client {
-        match client.delete_session(id.clone()).await {
-            Ok(()) => {
-                if let Err(e) = crate::pane_state::delete_pane_state(&id) {
-                    rlog!("delete_session_permanently: failed to delete pane state for {id}: {e}");
-                }
-            }
-            Err(err) if err.contains("session not found") => {
-                svc::delete_session_permanently(
-                    &state.pty_manager,
-                    &state.runtime.session_handle,
-                    &id,
-                )
-                .await
-                .map_err(|e| e.to_string())?;
-            }
-            Err(err) => return Err(err),
-        }
-    } else {
-        svc::delete_session_permanently(&state.pty_manager, &state.runtime.session_handle, &id)
-            .await
-            .map_err(|e| e.to_string())?;
+    let client = required_daemon_client_ref(&state)?;
+    client.delete_session(id.clone()).await?;
+    if let Err(e) = crate::pane_state::delete_pane_state(&id) {
+        rlog!("delete_session_permanently: failed to delete pane state for {id}: {e}");
     }
     // Tear down any session-scoped watches that may still be polling
     // (no-op if the session was already archived and watches were
@@ -561,15 +362,8 @@ pub(crate) async fn session_worktree_exists(
     id: String,
     state: tauri::State<'_, AppState>,
 ) -> Result<bool, String> {
-    if let Some(client) = &state.daemon_client {
-        match client.session_worktree_exists(id.clone()).await {
-            Ok(exists) => return Ok(exists),
-            Err(err) if err.contains("session not found") => {}
-            Err(err) => return Err(err),
-        }
-    }
-    let session = state.runtime.session_handle.get(&id).await.map_err(|e| e.to_string())?;
-    Ok(session.map(|s| std::path::Path::new(&s.worktree_path).exists()).unwrap_or(false))
+    let client = required_daemon_client_ref(&state)?;
+    client.session_worktree_exists(id).await
 }
 
 /// Kill only the PTY for `id`, leaving session state, pane-state files, and
@@ -586,18 +380,9 @@ pub(crate) async fn session_worktree_exists(
 #[tauri::command]
 #[specta::specta]
 pub(crate) async fn kill_pty(id: String, state: tauri::State<'_, AppState>) -> Result<(), String> {
-    if let Some(client) = state.daemon_client.clone() {
-        match client.kill_daemon_pty(id.clone()).await {
-            Ok(_) => {
-                abort_daemon_attach_task(&state, &id)?;
-                return Ok(());
-            }
-            Err(err) if is_daemon_pty_not_found(&err) => {}
-            Err(err) => return Err(err),
-        }
-    }
+    let client = required_daemon_client(&state)?;
+    let _ = client.kill_daemon_pty(id.clone()).await?;
     abort_daemon_attach_task(&state, &id)?;
-    state.pty_manager.kill(&id);
     Ok(())
 }
 
@@ -608,15 +393,8 @@ pub(crate) async fn set_session_name_override(
     name_override: Option<String>,
     state: tauri::State<'_, AppState>,
 ) -> Result<(), String> {
-    if let Some(client) = &state.daemon_client {
-        return client.set_session_name_override(session_id, name_override).await;
-    }
-    state
-        .runtime
-        .session_handle
-        .set_name_override(&session_id, name_override)
-        .await
-        .map_err(|e| e.to_string())
+    let client = required_daemon_client_ref(&state)?;
+    client.set_session_name_override(session_id, name_override).await
 }
 
 /// Pin (or clear) a PR for a session. The status bar uses this when set
@@ -637,15 +415,8 @@ pub(crate) async fn set_session_pinned_pr_url(
             Some(t.to_string())
         }
     });
-    if let Some(client) = &state.daemon_client {
-        return client.set_session_pinned_pr_url(session_id, normalized).await;
-    }
-    state
-        .runtime
-        .session_handle
-        .set_pinned_pr_url(&session_id, normalized)
-        .await
-        .map_err(|e| e.to_string())
+    let client = required_daemon_client_ref(&state)?;
+    client.set_session_pinned_pr_url(session_id, normalized).await
 }
 
 /// Bind (or clear) a smol machine for a session. When set, every PTY
@@ -661,15 +432,8 @@ pub(crate) async fn set_session_smol_machine(
     machine_name: Option<String>,
     state: tauri::State<'_, AppState>,
 ) -> Result<(), String> {
-    if let Some(client) = &state.daemon_client {
-        return client.set_session_smol_machine(session_id, machine_name).await;
-    }
-    state
-        .runtime
-        .session_handle
-        .set_smol_machine_name(&session_id, machine_name)
-        .await
-        .map_err(|e| e.to_string())
+    let client = required_daemon_client_ref(&state)?;
+    client.set_session_smol_machine(session_id, machine_name).await
 }
 
 /// Re-read the session's worktree branch via `git rev-parse` and update the
@@ -682,34 +446,8 @@ pub(crate) async fn refresh_session_branch(
     session_id: String,
     state: tauri::State<'_, AppState>,
 ) -> Result<Option<String>, String> {
-    if let Some(client) = &state.daemon_client {
-        match client.refresh_session_branch(session_id.clone()).await {
-            Ok(branch) => return Ok(branch),
-            Err(err) if err.contains("session not found") => {}
-            Err(err) => return Err(err),
-        }
-    }
-    let session = state.runtime.session_handle.get(&session_id).await.map_err(|e| e.to_string())?;
-    let Some(session) = session else { return Ok(None) };
-    if !session.is_git_repo {
-        return Ok(Some(session.branch));
-    }
-    // `git branch --show-current` returns empty on detached HEAD; in that
-    // case keep whatever the session already has rather than overwriting
-    // with "" — the chip would otherwise vanish during a transient rebase.
-    let Some(current) = svc::get_current_branch(&session.worktree_path) else {
-        return Ok(Some(session.branch));
-    };
-    if current.is_empty() {
-        return Ok(Some(session.branch));
-    }
-    let _ = state
-        .runtime
-        .session_handle
-        .set_branch(&session_id, current.clone())
-        .await
-        .map_err(|e| e.to_string())?;
-    Ok(Some(current))
+    let client = required_daemon_client_ref(&state)?;
+    client.refresh_session_branch(session_id).await
 }
 
 /// Spawns a plain shell in the session's
@@ -726,7 +464,7 @@ pub(crate) async fn create_session_shell(
     branch: Option<String>,
     opts: Option<CreateShellOpts>,
     state: tauri::State<'_, AppState>,
-    app: tauri::AppHandle,
+    _app: tauri::AppHandle,
 ) -> Result<Session, String> {
     use crate::pty::NonoConfig;
     let opts = opts.unwrap_or_default();
@@ -753,86 +491,65 @@ pub(crate) async fn create_session_shell(
     let smol_machine_name =
         opts.smol_machine_name.map(|n| n.trim().to_string()).filter(|n| !n.is_empty());
 
-    if let Some(client) = state.daemon_client.clone() {
-        let session_id = uuid::Uuid::new_v4().to_string();
-        let branch_for_notes = match &target {
-            svc::SessionTarget::Repo => {
-                svc::get_current_branch(&repo_path).unwrap_or_else(|| "main".to_string())
-            }
-            svc::SessionTarget::ExistingWorktree { path } => {
-                svc::get_current_branch(path).unwrap_or_else(|| "main".to_string())
-            }
-            svc::SessionTarget::NewWorktree { branch, .. } => branch.to_string(),
-        };
-        let project_record = match opts.project_id.as_deref() {
-            Some(pid) => client
-                .list_projects()
-                .await
-                .ok()
-                .and_then(|projects| projects.into_iter().find(|project| project.id == pid)),
-            None => None,
-        };
-        let notes = svc::build_notes_env_for_new_session(
-            &settings,
-            &session_id,
-            &branch_for_notes,
-            &repo_path,
-            project_record.as_ref(),
-        );
-        let (daemon_worktree_path, daemon_branch, daemon_base, daemon_fetch_first) = match &target {
-            svc::SessionTarget::Repo => (None, None, None, false),
-            svc::SessionTarget::ExistingWorktree { path } => {
-                (Some(path.to_string()), None, None, false)
-            }
-            svc::SessionTarget::NewWorktree { branch, start_point, fetch_first } => {
-                (None, Some(branch.to_string()), start_point.map(str::to_string), *fetch_first)
-            }
-        };
-
-        return client
-            .create_session_shell(crate::daemon_client::DaemonCreateSessionShellRequest {
-                id: session_id,
-                repo_path,
-                name,
-                worktree_path: daemon_worktree_path,
-                branch: daemon_branch,
-                base: daemon_base,
-                fetch_first: daemon_fetch_first,
-                profile: opts.profile,
-                nono_profile: nono.as_ref().map(|config| config.profile.clone()),
-                nono_allow_dirs: nono
-                    .as_ref()
-                    .map(|config| config.allow_dirs.clone())
-                    .unwrap_or_default(),
-                initial_size,
-                project_id: opts.project_id,
-                blueprint_id: opts.blueprint_id,
-                smol_machine_name,
-                notes: Some(notes),
-            })
+    let client = required_daemon_client(&state)?;
+    let session_id = uuid::Uuid::new_v4().to_string();
+    let branch_for_notes = match &target {
+        svc::SessionTarget::Repo => {
+            svc::get_current_branch(&repo_path).unwrap_or_else(|| "main".to_string())
+        }
+        svc::SessionTarget::ExistingWorktree { path } => {
+            svc::get_current_branch(path).unwrap_or_else(|| "main".to_string())
+        }
+        svc::SessionTarget::NewWorktree { branch, .. } => branch.to_string(),
+    };
+    let project_record = match opts.project_id.as_deref() {
+        Some(pid) => client
+            .list_projects()
             .await
-            .map_err(|e| e.to_string());
-    }
-
-    svc::create_session_shell(
-        &state.pty_manager,
-        &state.runtime.session_handle,
-        &state.runtime.project_handle,
+            .ok()
+            .and_then(|projects| projects.into_iter().find(|project| project.id == pid)),
+        None => None,
+    };
+    let notes = svc::build_notes_env_for_new_session(
         &settings,
+        &session_id,
+        &branch_for_notes,
         &repo_path,
-        &name,
-        target,
-        nono.as_ref(),
-        opts.profile.as_deref(),
-        initial_size,
-        opts.project_id.as_deref(),
-        opts.blueprint_id.as_deref(),
-        smol_machine_name.as_deref(),
-        Some(&state.automation_hooks),
-        &app,
-    )
-    .await
-    .map_err(|e| e.to_string())
+        project_record.as_ref(),
+    );
+    let (daemon_worktree_path, daemon_branch, daemon_base, daemon_fetch_first) = match &target {
+        svc::SessionTarget::Repo => (None, None, None, false),
+        svc::SessionTarget::ExistingWorktree { path } => {
+            (Some(path.to_string()), None, None, false)
+        }
+        svc::SessionTarget::NewWorktree { branch, start_point, fetch_first } => {
+            (None, Some(branch.to_string()), start_point.map(str::to_string), *fetch_first)
+        }
+    };
+
+    client
+        .create_session_shell(crate::daemon_client::DaemonCreateSessionShellRequest {
+            id: session_id,
+            repo_path,
+            name,
+            worktree_path: daemon_worktree_path,
+            branch: daemon_branch,
+            base: daemon_base,
+            fetch_first: daemon_fetch_first,
+            profile: opts.profile,
+            nono_profile: nono.as_ref().map(|config| config.profile.clone()),
+            nono_allow_dirs: nono
+                .as_ref()
+                .map(|config| config.allow_dirs.clone())
+                .unwrap_or_default(),
+            initial_size,
+            project_id: opts.project_id,
+            blueprint_id: opts.blueprint_id,
+            smol_machine_name,
+            notes: Some(notes),
+        })
+        .await
+        .map_err(|e| e.to_string())
 }
 
 /// Respawns a plain shell in the session's primary PTY. The frontend
@@ -848,61 +565,42 @@ pub(crate) async fn reconnect_session_shell(
     profile: Option<String>,
     initial_size: Option<(u16, u16)>,
     state: tauri::State<'_, AppState>,
-    app: tauri::AppHandle,
+    _app: tauri::AppHandle,
 ) -> Result<Session, String> {
     use crate::pty::NonoConfig;
     let nono = nono_profile
         .map(|profile| NonoConfig { profile, allow_dirs: nono_allow_dirs.unwrap_or_default() });
     let settings = state.settings.lock().map_err(|e| e.to_string())?.clone();
-    if let Some(client) = state.daemon_client.clone() {
-        match client.get_session(id.clone()).await {
-            Ok(session) => {
-                let project_record = match session.project_id.as_deref() {
-                    Some(pid) => client.list_projects().await.ok().and_then(|projects| {
-                        projects.into_iter().find(|project| project.id == pid)
-                    }),
-                    None => None,
-                };
-                let notes = svc::build_notes_env_for_new_session(
-                    &settings,
-                    &session.id,
-                    &session.branch,
-                    &session.repo_root,
-                    project_record.as_ref(),
-                );
-                return client
-                    .reconnect_session_shell(
-                        crate::daemon_client::DaemonReconnectSessionShellRequest {
-                            id,
-                            profile,
-                            nono_profile: nono.as_ref().map(|config| config.profile.clone()),
-                            nono_allow_dirs: nono
-                                .as_ref()
-                                .map(|config| config.allow_dirs.clone())
-                                .unwrap_or_default(),
-                            initial_size,
-                            notes: Some(notes),
-                        },
-                    )
-                    .await;
-            }
-            Err(err) if err.contains("session not found") => {}
-            Err(err) => return Err(err),
-        }
-    }
-    svc::reconnect_session_shell(
-        &state.pty_manager,
-        &state.runtime.session_handle,
-        &state.runtime.project_handle,
+    let client = required_daemon_client(&state)?;
+    let session = client.get_session(id.clone()).await?;
+    let project_record = match session.project_id.as_deref() {
+        Some(pid) => client
+            .list_projects()
+            .await
+            .ok()
+            .and_then(|projects| projects.into_iter().find(|project| project.id == pid)),
+        None => None,
+    };
+    let notes = svc::build_notes_env_for_new_session(
         &settings,
-        &id,
-        nono.as_ref(),
-        profile.as_deref(),
-        initial_size,
-        &app,
-    )
-    .await
-    .map_err(|e| e.to_string())
+        &session.id,
+        &session.branch,
+        &session.repo_root,
+        project_record.as_ref(),
+    );
+    client
+        .reconnect_session_shell(crate::daemon_client::DaemonReconnectSessionShellRequest {
+            id,
+            profile,
+            nono_profile: nono.as_ref().map(|config| config.profile.clone()),
+            nono_allow_dirs: nono
+                .as_ref()
+                .map(|config| config.allow_dirs.clone())
+                .unwrap_or_default(),
+            initial_size,
+            notes: Some(notes),
+        })
+        .await
 }
 
 /// Active sessions only — archived rows are excluded. The history view
@@ -912,19 +610,8 @@ pub(crate) async fn reconnect_session_shell(
 pub(crate) async fn list_sessions(
     state: tauri::State<'_, AppState>,
 ) -> Result<Vec<Session>, String> {
-    if let Some(client) = &state.daemon_client {
-        return client
-            .list_sessions()
-            .await
-            .map(|all| all.into_iter().filter(|s| !s.archived).collect());
-    }
-    state
-        .runtime
-        .session_handle
-        .list()
-        .await
-        .map(|all| all.into_iter().filter(|s| !s.archived).collect())
-        .map_err(|e| e.to_string())
+    let client = required_daemon_client_ref(&state)?;
+    client.list_sessions().await.map(|all| all.into_iter().filter(|s| !s.archived).collect())
 }
 
 /// Archived sessions, sorted newest-first by `ended_at` so the history
@@ -934,23 +621,11 @@ pub(crate) async fn list_sessions(
 pub(crate) async fn list_archived_sessions(
     state: tauri::State<'_, AppState>,
 ) -> Result<Vec<Session>, String> {
-    if let Some(client) = &state.daemon_client {
-        let mut archived: Vec<Session> =
-            client.list_sessions().await?.into_iter().filter(|s| s.archived).collect();
-        archived.sort_by_key(|s| std::cmp::Reverse(s.ended_at.unwrap_or(0)));
-        return Ok(archived);
-    }
-    state
-        .runtime
-        .session_handle
-        .list()
-        .await
-        .map(|all| {
-            let mut archived: Vec<Session> = all.into_iter().filter(|s| s.archived).collect();
-            archived.sort_by_key(|s| std::cmp::Reverse(s.ended_at.unwrap_or(0)));
-            archived
-        })
-        .map_err(|e| e.to_string())
+    let client = required_daemon_client_ref(&state)?;
+    let mut archived: Vec<Session> =
+        client.list_sessions().await?.into_iter().filter(|s| s.archived).collect();
+    archived.sort_by_key(|s| std::cmp::Reverse(s.ended_at.unwrap_or(0)));
+    Ok(archived)
 }
 
 #[tauri::command]
@@ -959,7 +634,9 @@ pub(crate) async fn refresh_session_git_status(
     id: String,
     state: tauri::State<'_, AppState>,
 ) -> Result<bool, String> {
-    svc::refresh_git_status(&state.runtime.session_handle, &id).await.map_err(|e| e.to_string())
+    let client = required_daemon_client_ref(&state)?;
+    let session = client.get_session(id).await?;
+    Ok(svc::is_git_repo(&session.worktree_path))
 }
 
 #[tauri::command]
@@ -990,4 +667,20 @@ pub(crate) fn list_claude_sessions(cwd: String) -> Result<Vec<svc::ClaudeSession
 pub(crate) fn get_builtin_profiles(state: tauri::State<AppState>) -> Vec<roux_core::SpawnProfile> {
     let settings = state.settings.lock().unwrap().clone();
     crate::providers::builtin_profiles(&settings)
+}
+
+fn required_daemon_client(state: &AppState) -> Result<crate::daemon_client::DaemonClient, String> {
+    state
+        .daemon_client
+        .clone()
+        .ok_or_else(|| "Roux daemon is required but not connected".to_string())
+}
+
+fn required_daemon_client_ref(
+    state: &AppState,
+) -> Result<&crate::daemon_client::DaemonClient, String> {
+    state
+        .daemon_client
+        .as_ref()
+        .ok_or_else(|| "Roux daemon is required but not connected".to_string())
 }

--- a/src-tauri/src/daemon_client.rs
+++ b/src-tauri/src/daemon_client.rs
@@ -58,7 +58,7 @@ pub(crate) struct DaemonClient {
 
 #[derive(Debug, Clone)]
 pub(crate) enum DaemonStartup {
-    Connected(DaemonClient),
+    Connected(Box<DaemonClient>),
     LocalFallbackDisabled(String),
     Failed(String),
 }
@@ -121,7 +121,7 @@ impl DaemonClient {
 
     pub(crate) fn ensure_local() -> DaemonStartup {
         if let Some(client) = Self::detect() {
-            return DaemonStartup::Connected(client);
+            return DaemonStartup::Connected(Box::new(client));
         }
 
         if let Some(endpoint) = configured_socket_endpoint_that_blocks_autostart() {
@@ -144,7 +144,7 @@ impl DaemonClient {
         }
 
         match wait_for_daemon(STARTUP_TIMEOUT, STARTUP_POLL_INTERVAL) {
-            Some(client) => DaemonStartup::Connected(client),
+            Some(client) => DaemonStartup::Connected(Box::new(client)),
             None => DaemonStartup::Failed(format!(
                 "started roux daemon but it did not become ready within {}ms",
                 STARTUP_TIMEOUT.as_millis()
@@ -154,10 +154,6 @@ impl DaemonClient {
 
     pub(crate) fn status(&self) -> &DaemonStatus {
         &self.status
-    }
-
-    pub(crate) fn sdk(&self) -> roux_sdk::Roux {
-        self.sdk.clone()
     }
 
     pub(crate) fn supports(&self, capability: &str) -> bool {
@@ -1246,6 +1242,7 @@ fn daemon_process_start_request(command: String, working_dir: Option<String>) ->
     })
 }
 
+#[cfg(test)]
 fn daemon_session_create_shell_request(request: DaemonCreateSessionShellRequest) -> Value {
     let mut args = serde_json::Map::new();
     args.insert("id".to_string(), Value::String(request.id));
@@ -1303,6 +1300,7 @@ fn daemon_session_create_shell_request(request: DaemonCreateSessionShellRequest)
     })
 }
 
+#[cfg(test)]
 fn daemon_session_reconnect_shell_request(request: DaemonReconnectSessionShellRequest) -> Value {
     let mut args = serde_json::Map::new();
     if let Some(profile) = request.profile {
@@ -1873,6 +1871,7 @@ fn daemon_process_kill_request(id: String) -> Value {
     })
 }
 
+#[cfg(test)]
 fn daemon_pty_spawn_shell_request(
     id: Option<String>,
     working_dir: Option<String>,
@@ -1898,6 +1897,7 @@ fn daemon_pty_spawn_shell_request(
     })
 }
 
+#[cfg(test)]
 fn daemon_pty_spawn_task_request(
     command: String,
     id: Option<String>,
@@ -1924,6 +1924,7 @@ fn daemon_pty_spawn_task_request(
     })
 }
 
+#[cfg(test)]
 fn daemon_pty_spawn_args(
     id: Option<String>,
     working_dir: Option<String>,
@@ -1962,6 +1963,7 @@ fn daemon_pty_spawn_args(
     args
 }
 
+#[cfg(test)]
 fn daemon_pty_output_request(id: String, max_bytes: Option<usize>) -> Value {
     let mut args = serde_json::Map::new();
     args.insert("id".to_string(), Value::String(id));
@@ -1974,6 +1976,7 @@ fn daemon_pty_output_request(id: String, max_bytes: Option<usize>) -> Value {
     })
 }
 
+#[cfg(test)]
 fn daemon_pty_attach_request(id: String, max_bytes: Option<usize>) -> Value {
     let mut args = serde_json::Map::new();
     args.insert("id".to_string(), Value::String(id));
@@ -1986,10 +1989,12 @@ fn daemon_pty_attach_request(id: String, max_bytes: Option<usize>) -> Value {
     })
 }
 
+#[cfg(test)]
 fn daemon_pty_list_request() -> Value {
     serde_json::json!({ "command": "daemon-pty-list" })
 }
 
+#[cfg(test)]
 fn daemon_pty_write_request(id: String, data: String) -> Value {
     serde_json::json!({
         "command": "daemon-pty-write",
@@ -1997,6 +2002,7 @@ fn daemon_pty_write_request(id: String, data: String) -> Value {
     })
 }
 
+#[cfg(test)]
 fn daemon_pty_resize_request(id: String, cols: u16, rows: u16) -> Value {
     serde_json::json!({
         "command": "daemon-pty-resize",
@@ -2004,6 +2010,7 @@ fn daemon_pty_resize_request(id: String, cols: u16, rows: u16) -> Value {
     })
 }
 
+#[cfg(test)]
 fn daemon_pty_detach_request(id: String) -> Value {
     serde_json::json!({
         "command": "daemon-pty-detach",
@@ -2011,6 +2018,7 @@ fn daemon_pty_detach_request(id: String) -> Value {
     })
 }
 
+#[cfg(test)]
 fn daemon_pty_attach_pane_request(id: String, pane_id: String) -> Value {
     serde_json::json!({
         "command": "daemon-pty-attach-pane",
@@ -2018,6 +2026,7 @@ fn daemon_pty_attach_pane_request(id: String, pane_id: String) -> Value {
     })
 }
 
+#[cfg(test)]
 fn daemon_pty_mark_read_request(id: String) -> Value {
     serde_json::json!({
         "command": "daemon-pty-mark-read",
@@ -2025,6 +2034,7 @@ fn daemon_pty_mark_read_request(id: String) -> Value {
     })
 }
 
+#[cfg(test)]
 fn daemon_pty_set_name_request(id: String, name: Option<String>) -> Value {
     serde_json::json!({
         "command": "daemon-pty-set-name",
@@ -2032,6 +2042,7 @@ fn daemon_pty_set_name_request(id: String, name: Option<String>) -> Value {
     })
 }
 
+#[cfg(test)]
 fn daemon_pty_kill_request(id: String) -> Value {
     serde_json::json!({
         "command": "daemon-pty-kill",
@@ -2170,28 +2181,6 @@ fn connect_daemon_stream_tcp(addr: String, request: Value) -> Result<Box<dyn Rea
         .map_err(|err| format!("set daemon write timeout: {err}"))?;
     write_request(&mut stream, request)?;
     Ok(Box::new(stream))
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(tag = "type")]
-enum PtyAttachStreamFrame {
-    #[serde(rename = "ready")]
-    Ready {
-        #[allow(dead_code)]
-        id: String,
-        #[allow(dead_code)]
-        record: Box<PtyRecord>,
-        #[serde(rename = "replayOffset")]
-        replay_offset: u64,
-        #[serde(rename = "replayBytes")]
-        replay_bytes: Vec<u8>,
-    },
-    #[serde(rename = "output")]
-    Output { offset: u64, bytes: Vec<u8> },
-    #[serde(rename = "exit")]
-    Exit { code: Option<i32>, generation: u64 },
-    #[serde(rename = "error")]
-    Error { error: String },
 }
 
 #[derive(Debug, Deserialize)]
@@ -2406,84 +2395,6 @@ fn handle_subscription_event_frame(
             Ok(())
         }
         SubscriptionEventStreamFrame::Error { error } => Err(error),
-    }
-}
-
-fn attach_daemon_pty_output_blocking(
-    id: String,
-    channel: Channel<IpcResponse>,
-    app: AppHandle,
-) -> Result<(), String> {
-    let stream = connect_daemon_stream(daemon_pty_attach_request(
-        id.clone(),
-        Some(roux_runtime::pty_service::PTY_OUTPUT_LIMIT_BYTES),
-    ))?;
-    read_pty_attach_stream(id, stream, channel, app)
-}
-
-fn read_pty_attach_stream(
-    id: String,
-    stream: impl Read,
-    channel: Channel<IpcResponse>,
-    app: AppHandle,
-) -> Result<(), String> {
-    let mut reader = BufReader::new(stream);
-    let mut line = String::new();
-    let mut sent_until = 0_u64;
-    loop {
-        line.clear();
-        let read = reader
-            .read_line(&mut line)
-            .map_err(|err| format!("read daemon pty attach frame: {err}"))?;
-        if read == 0 {
-            return Ok(());
-        }
-        let frame: PtyAttachStreamFrame = serde_json::from_str(line.trim())
-            .map_err(|err| format!("decode daemon pty attach frame: {err}"))?;
-        if !handle_pty_attach_frame(&id, frame, &channel, &app, &mut sent_until)? {
-            return Ok(());
-        }
-    }
-}
-
-fn handle_pty_attach_frame(
-    id: &str,
-    frame: PtyAttachStreamFrame,
-    channel: &Channel<IpcResponse>,
-    app: &AppHandle,
-    sent_until: &mut u64,
-) -> Result<bool, String> {
-    match frame {
-        PtyAttachStreamFrame::Ready { replay_offset, replay_bytes, .. } => {
-            let replay_end = replay_offset.saturating_add(replay_bytes.len() as u64);
-            if !replay_bytes.is_empty() {
-                channel
-                    .send(IpcResponse::new(replay_bytes))
-                    .map_err(|err| format!("send daemon pty replay to frontend: {err}"))?;
-            }
-            *sent_until = (*sent_until).max(replay_end);
-            Ok(true)
-        }
-        PtyAttachStreamFrame::Output { offset, bytes } => {
-            let frame_end = offset.saturating_add(bytes.len() as u64);
-            if frame_end <= *sent_until {
-                return Ok(true);
-            }
-            let start = if offset < *sent_until { (*sent_until - offset) as usize } else { 0 };
-            let bytes = bytes[start..].to_vec();
-            if !bytes.is_empty() {
-                channel
-                    .send(IpcResponse::new(bytes))
-                    .map_err(|err| format!("send daemon pty output to frontend: {err}"))?;
-            }
-            *sent_until = (*sent_until).max(frame_end);
-            Ok(true)
-        }
-        PtyAttachStreamFrame::Exit { code, generation } => {
-            emit_daemon_pty_exit(app, id, code, generation);
-            Ok(false)
-        }
-        PtyAttachStreamFrame::Error { error } => Err(error),
     }
 }
 

--- a/src-tauri/src/daemon_client.rs
+++ b/src-tauri/src/daemon_client.rs
@@ -17,8 +17,8 @@ use roux_runtime::automation_hooks::{
     HookListItem, HookLogEntry, HookPreviewItem, HookRunRequest, HookRunSummary,
 };
 use roux_runtime::process_service::{ProcessRecord, ProcessSnapshot};
-use roux_runtime::pty_service::{PtyRecord, PtySnapshot};
 use roux_runtime::terminal_env::NotesEnvInputs;
+use roux_sdk::{CommandRequest, PtyAttachFrame, PtyRecord, PtySnapshot};
 
 use crate::platform;
 use crate::watches::WatchManager;
@@ -53,6 +53,7 @@ pub(crate) struct DaemonStatus {
 #[derive(Debug, Clone)]
 pub(crate) struct DaemonClient {
     status: DaemonStatus,
+    sdk: roux_sdk::Roux,
 }
 
 #[derive(Debug, Clone)]
@@ -111,7 +112,8 @@ impl DaemonClient {
                 .ok()?;
         let status: DaemonStatus = serde_json::from_value(data).ok()?;
         if status.kind == "roux-daemon" {
-            Some(Self { status })
+            let sdk = roux_sdk::Roux::connect().ok()?;
+            Some(Self { status, sdk })
         } else {
             None
         }
@@ -154,6 +156,10 @@ impl DaemonClient {
         &self.status
     }
 
+    pub(crate) fn sdk(&self) -> roux_sdk::Roux {
+        self.sdk.clone()
+    }
+
     pub(crate) fn supports(&self, capability: &str) -> bool {
         self.status.capabilities.iter().any(|candidate| candidate == capability)
     }
@@ -170,17 +176,14 @@ impl DaemonClient {
     }
 
     pub(crate) async fn list_sessions(&self) -> Result<Vec<Session>, String> {
-        let value = send_command_async(serde_json::json!({ "command": "session-list" })).await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon session-list: {err}"))
+        self.sdk.sessions().await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn get_session(&self, id: String) -> Result<Session, String> {
-        let value = send_command_async(serde_json::json!({
-            "command": "session-poll",
-            "session_id": id,
-        }))
-        .await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon session-poll: {err}"))
+        self.sdk
+            .command(CommandRequest::new("session-poll").session_id(id))
+            .await
+            .map_err(|err| err.to_string())
     }
 
     pub(crate) async fn list_projects(&self) -> Result<Vec<Project>, String> {
@@ -646,18 +649,43 @@ impl DaemonClient {
         &self,
         request: DaemonCreateSessionShellRequest,
     ) -> Result<Session, String> {
-        let value = send_command_async(daemon_session_create_shell_request(request)).await?;
-        serde_json::from_value(value)
-            .map_err(|err| format!("decode daemon session-create-shell: {err}"))
+        self.sdk
+            .create_session_shell(roux_sdk::CreateSessionShell {
+                id: request.id,
+                repo_path: request.repo_path,
+                name: request.name,
+                worktree_path: request.worktree_path,
+                branch: request.branch,
+                base: request.base,
+                fetch_first: request.fetch_first,
+                profile: request.profile,
+                nono_profile: request.nono_profile,
+                nono_allow_dirs: request.nono_allow_dirs,
+                initial_size: request.initial_size,
+                project_id: request.project_id,
+                blueprint_id: request.blueprint_id,
+                smol_machine_name: request.smol_machine_name,
+                notes: request.notes.map(sdk_notes_env),
+            })
+            .await
+            .map_err(|err| err.to_string())
     }
 
     pub(crate) async fn reconnect_session_shell(
         &self,
         request: DaemonReconnectSessionShellRequest,
     ) -> Result<Session, String> {
-        let value = send_command_async(daemon_session_reconnect_shell_request(request)).await?;
-        serde_json::from_value(value)
-            .map_err(|err| format!("decode daemon session-reconnect-shell: {err}"))
+        self.sdk
+            .reconnect_session_shell(roux_sdk::ReconnectSessionShell {
+                id: request.id,
+                profile: request.profile,
+                nono_profile: request.nono_profile,
+                nono_allow_dirs: request.nono_allow_dirs,
+                initial_size: request.initial_size,
+                notes: request.notes.map(sdk_notes_env),
+            })
+            .await
+            .map_err(|err| err.to_string())
     }
 
     pub(crate) async fn archive_session(&self, id: String) -> Result<Session, String> {
@@ -842,18 +870,32 @@ impl DaemonClient {
         nono_allow_dirs: Vec<String>,
         initial_size: Option<(u16, u16)>,
     ) -> Result<PtyRecord, String> {
-        let value = send_command_async(daemon_pty_spawn_shell_request(
-            id,
-            working_dir,
-            session_id,
-            pane_id,
-            profile,
-            nono_profile,
-            nono_allow_dirs,
-            initial_size,
-        ))
-        .await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon pty spawn shell: {err}"))
+        let mut spawn = self.sdk.spawn_shell();
+        if let Some(id) = id {
+            spawn = spawn.id(id);
+        }
+        if let Some(working_dir) = working_dir {
+            spawn = spawn.working_dir(working_dir);
+        }
+        if let Some(session_id) = session_id {
+            spawn = spawn.session_id(session_id);
+        }
+        if let Some(pane_id) = pane_id {
+            spawn = spawn.pane_id(pane_id);
+        }
+        if let Some(profile) = profile {
+            spawn = spawn.profile(profile);
+        }
+        if let Some(nono_profile) = nono_profile {
+            spawn = spawn.nono_profile(nono_profile);
+        }
+        if !nono_allow_dirs.is_empty() {
+            spawn = spawn.nono_allow_dirs(nono_allow_dirs);
+        }
+        if let Some((cols, rows)) = initial_size {
+            spawn = spawn.initial_size(cols, rows);
+        }
+        spawn.spawn_record().await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn spawn_daemon_pty_task(
@@ -866,17 +908,26 @@ impl DaemonClient {
         profile: Option<String>,
         initial_size: Option<(u16, u16)>,
     ) -> Result<PtyRecord, String> {
-        let value = send_command_async(daemon_pty_spawn_task_request(
-            command,
-            id,
-            working_dir,
-            session_id,
-            pane_id,
-            profile,
-            initial_size,
-        ))
-        .await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon pty spawn task: {err}"))
+        let mut spawn = self.sdk.spawn_task(command);
+        if let Some(id) = id {
+            spawn = spawn.id(id);
+        }
+        if let Some(working_dir) = working_dir {
+            spawn = spawn.working_dir(working_dir);
+        }
+        if let Some(session_id) = session_id {
+            spawn = spawn.session_id(session_id);
+        }
+        if let Some(pane_id) = pane_id {
+            spawn = spawn.pane_id(pane_id);
+        }
+        if let Some(profile) = profile {
+            spawn = spawn.profile(profile);
+        }
+        if let Some((cols, rows)) = initial_size {
+            spawn = spawn.initial_size(cols, rows);
+        }
+        spawn.spawn_record().await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn daemon_pty_output(
@@ -884,18 +935,19 @@ impl DaemonClient {
         id: String,
         max_bytes: Option<usize>,
     ) -> Result<PtySnapshot, String> {
-        let value = send_command_async(daemon_pty_output_request(id, max_bytes)).await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon pty output: {err}"))
+        self.sdk
+            .pty(id)
+            .snapshot(max_bytes.unwrap_or(roux_runtime::pty_service::PTY_OUTPUT_DEFAULT_POLL_BYTES))
+            .await
+            .map_err(|err| err.to_string())
     }
 
     pub(crate) async fn list_daemon_ptys(&self) -> Result<Vec<PtyRecord>, String> {
-        let value = send_command_async(daemon_pty_list_request()).await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon pty list: {err}"))
+        self.sdk.ptys().await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn write_daemon_pty(&self, id: String, data: String) -> Result<(), String> {
-        let _ = send_command_async(daemon_pty_write_request(id, data)).await?;
-        Ok(())
+        self.sdk.pty(id).write(data).await.map(|_| ()).map_err(|err| err.to_string())
     }
 
     pub(crate) async fn resize_daemon_pty(
@@ -904,18 +956,25 @@ impl DaemonClient {
         cols: u16,
         rows: u16,
     ) -> Result<PtyRecord, String> {
-        let value = send_command_async(daemon_pty_resize_request(id, cols, rows)).await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon pty resize: {err}"))
+        self.sdk.pty(id).resize(cols, rows).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn kill_daemon_pty(&self, id: String) -> Result<PtyRecord, String> {
-        let value = send_command_async(daemon_pty_kill_request(id)).await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon pty kill: {err}"))
+        self.sdk
+            .pty(id)
+            .kill()
+            .await
+            .map_err(|err| err.to_string())?
+            .ok_or_else(|| "daemon pty not found".to_string())
     }
 
     pub(crate) async fn detach_daemon_pty(&self, id: String) -> Result<PtyRecord, String> {
-        let value = send_command_async(daemon_pty_detach_request(id)).await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon pty detach: {err}"))
+        self.sdk
+            .pty(id)
+            .detach()
+            .await
+            .map_err(|err| err.to_string())?
+            .ok_or_else(|| "daemon pty not found".to_string())
     }
 
     pub(crate) async fn attach_daemon_pty_to_pane(
@@ -923,13 +982,21 @@ impl DaemonClient {
         id: String,
         pane_id: String,
     ) -> Result<PtyRecord, String> {
-        let value = send_command_async(daemon_pty_attach_pane_request(id, pane_id)).await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon pty attach pane: {err}"))
+        self.sdk
+            .pty(id)
+            .attach_to_pane(pane_id)
+            .await
+            .map_err(|err| err.to_string())?
+            .ok_or_else(|| "daemon pty not found".to_string())
     }
 
     pub(crate) async fn mark_daemon_pty_read(&self, id: String) -> Result<PtyRecord, String> {
-        let value = send_command_async(daemon_pty_mark_read_request(id)).await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon pty mark read: {err}"))
+        self.sdk
+            .pty(id)
+            .mark_read()
+            .await
+            .map_err(|err| err.to_string())?
+            .ok_or_else(|| "daemon pty not found".to_string())
     }
 
     pub(crate) async fn set_daemon_pty_name(
@@ -937,8 +1004,12 @@ impl DaemonClient {
         id: String,
         name: Option<String>,
     ) -> Result<PtyRecord, String> {
-        let value = send_command_async(daemon_pty_set_name_request(id, name)).await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon pty set name: {err}"))
+        self.sdk
+            .pty(id)
+            .set_name(name)
+            .await
+            .map_err(|err| err.to_string())?
+            .ok_or_else(|| "daemon pty not found".to_string())
     }
 
     pub(crate) fn spawn_daemon_pty_output_bridge(
@@ -947,9 +1018,23 @@ impl DaemonClient {
         channel: Channel<IpcResponse>,
         app: AppHandle,
     ) -> tauri::async_runtime::JoinHandle<()> {
-        tauri::async_runtime::spawn_blocking(move || {
-            if let Err(err) = attach_daemon_pty_output_blocking(id.clone(), channel, app) {
-                rlog!("Daemon PTY output bridge for {id} stopped: {err}");
+        let pty = self.sdk.pty(id.clone());
+        tauri::async_runtime::spawn(async move {
+            let log_id = id.clone();
+            let mut sent_until = 0_u64;
+            let result = pty
+                .attach(roux_runtime::pty_service::PTY_OUTPUT_LIMIT_BYTES, move |frame| {
+                    match handle_sdk_pty_attach_frame(&id, frame, &channel, &app, &mut sent_until) {
+                        Ok(keep_reading) => keep_reading,
+                        Err(err) => {
+                            rlog!("Daemon PTY output bridge for {id} stopped: {err}");
+                            false
+                        }
+                    }
+                })
+                .await;
+            if let Err(err) = result {
+                rlog!("Daemon PTY output bridge for {log_id} stopped: {err}");
             }
         })
     }
@@ -1063,6 +1148,17 @@ fn wait_for_daemon(timeout: Duration, interval: Duration) -> Option<DaemonClient
             return None;
         }
         std::thread::sleep(interval);
+    }
+}
+
+fn sdk_notes_env(notes: NotesEnvInputs) -> roux_sdk::NotesEnv {
+    roux_sdk::NotesEnv {
+        vault_root: notes.vault_root,
+        session_slug: notes.session_slug,
+        repo_slug: notes.repo_slug,
+        project_slug: notes.project_slug,
+        context_paths: notes.context_paths,
+        project_prompt: notes.project_prompt,
     }
 }
 
@@ -2388,6 +2484,47 @@ fn handle_pty_attach_frame(
             Ok(false)
         }
         PtyAttachStreamFrame::Error { error } => Err(error),
+    }
+}
+
+fn handle_sdk_pty_attach_frame(
+    id: &str,
+    frame: PtyAttachFrame,
+    channel: &Channel<IpcResponse>,
+    app: &AppHandle,
+    sent_until: &mut u64,
+) -> Result<bool, String> {
+    match frame {
+        PtyAttachFrame::Ready { replay_offset, replay_bytes, .. } => {
+            let replay_end = replay_offset.saturating_add(replay_bytes.len() as u64);
+            if !replay_bytes.is_empty() {
+                channel
+                    .send(IpcResponse::new(replay_bytes))
+                    .map_err(|err| format!("send daemon pty replay to frontend: {err}"))?;
+            }
+            *sent_until = (*sent_until).max(replay_end);
+            Ok(true)
+        }
+        PtyAttachFrame::Output { offset, bytes } => {
+            let frame_end = offset.saturating_add(bytes.len() as u64);
+            if frame_end <= *sent_until {
+                return Ok(true);
+            }
+            let start = if offset < *sent_until { (*sent_until - offset) as usize } else { 0 };
+            let bytes = bytes[start..].to_vec();
+            if !bytes.is_empty() {
+                channel
+                    .send(IpcResponse::new(bytes))
+                    .map_err(|err| format!("send daemon pty output to frontend: {err}"))?;
+            }
+            *sent_until = (*sent_until).max(frame_end);
+            Ok(true)
+        }
+        PtyAttachFrame::Exit { code, generation } => {
+            emit_daemon_pty_exit(app, id, code, generation);
+            Ok(false)
+        }
+        PtyAttachFrame::Error { error } => Err(error),
     }
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -67,31 +67,31 @@ fn main() {
         rlog!("Claude binary path: (default, resolved via PATH)");
     }
 
-    let mut daemon_startup_error = None;
     let daemon_client = match daemon_client::DaemonClient::ensure_local() {
-        daemon_client::DaemonStartup::Connected(client) => Some(client),
+        daemon_client::DaemonStartup::Connected(client) => client,
         daemon_client::DaemonStartup::LocalFallbackDisabled(reason) => {
-            rlog!("Daemon autostart disabled; desktop will self-host runtime state: {reason}");
-            None
-        }
-        daemon_client::DaemonStartup::Failed(err) => {
             let message = format!(
-                "Roux daemon startup failed; desktop will self-host runtime state. Set ROUX_DAEMON_AUTOSTART=0 to make local fallback explicit. {err}"
+                "Roux daemon startup is required, but daemon autostart is disabled. {reason}"
             );
             rlog!("{message}");
-            daemon_startup_error = Some(message);
-            None
+            eprintln!("{message}");
+            std::process::exit(1);
+        }
+        daemon_client::DaemonStartup::Failed(err) => {
+            let message =
+                format!("Roux daemon startup failed and desktop local fallback is disabled. {err}");
+            rlog!("{message}");
+            eprintln!("{message}");
+            std::process::exit(1);
         }
     };
-    if let Some(client) = daemon_client.as_ref() {
-        rlog!(
-            "Connected to roux daemon pid={} socket={}",
-            client.status().pid,
-            client.status().socket
-        );
-    } else {
-        rlog!("No roux daemon available; desktop will self-host runtime state");
-    }
+    rlog!(
+        "Connected to roux daemon pid={} socket={}",
+        daemon_client.status().pid,
+        daemon_client.status().socket
+    );
+    let daemon_client = Some(daemon_client);
+    let daemon_startup_error = None;
     let daemon_owns_watches =
         daemon_client.as_ref().map(|client| client.supports("watch-list")).unwrap_or(false);
     let persisted_watches = if daemon_owns_watches {
@@ -561,12 +561,7 @@ fn main() {
                 eprintln!("Warning: failed to start file status source: {}", e);
             }
             {
-                let state = app.state::<AppState>();
-                if state.daemon_client.is_some() {
-                    rlog!("Skipping desktop socket server because roux daemon owns the socket");
-                } else {
-                    socket::start_socket_server(app.handle().clone());
-                }
+                rlog!("Skipping desktop socket server because roux daemon owns the socket");
             }
 
             // System tray: shows active sessions + status, plus Show/Quit.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -18,8 +18,12 @@ mod pr;
 mod project_service;
 mod projects;
 mod providers;
+// Local PTY runtime is retained while desktop session/PTTY access routes through the daemon.
+#[allow(dead_code)]
 mod pty;
+#[allow(dead_code)]
 mod pty_lifecycle;
+#[allow(dead_code)]
 mod pty_logger;
 mod pty_ready_gate;
 mod services;
@@ -27,6 +31,8 @@ mod session;
 mod session_service;
 mod settings;
 mod skill;
+// Desktop no longer starts this socket server, but the implementation stays until the CLI bridge is fully migrated.
+#[allow(dead_code)]
 mod socket;
 mod state;
 mod tasks;
@@ -68,7 +74,7 @@ fn main() {
     }
 
     let daemon_client = match daemon_client::DaemonClient::ensure_local() {
-        daemon_client::DaemonStartup::Connected(client) => client,
+        daemon_client::DaemonStartup::Connected(client) => *client,
         daemon_client::DaemonStartup::LocalFallbackDisabled(reason) => {
             let message = format!(
                 "Roux daemon startup is required, but daemon autostart is disabled. {reason}"
@@ -91,7 +97,6 @@ fn main() {
         daemon_client.status().socket
     );
     let daemon_client = Some(daemon_client);
-    let daemon_startup_error = None;
     let daemon_owns_watches =
         daemon_client.as_ref().map(|client| client.supports("watch-list")).unwrap_or(false);
     let persisted_watches = if daemon_owns_watches {
@@ -116,11 +121,6 @@ fn main() {
     let (runtime, _runtime_joins) = runtime_services.spawn_with(tauri::async_runtime::spawn);
     let watch_manager =
         watches::WatchManager::new(runtime.watch_handle.clone(), daemon_client.clone());
-    let runtime_started_at_ms = {
-        use std::time::{SystemTime, UNIX_EPOCH};
-        SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_millis() as u64
-    };
-
     #[cfg(debug_assertions)]
     let builder = Builder::<tauri::Wry>::new().commands(collect_commands![
         commands::misc::get_log_path,
@@ -292,8 +292,6 @@ fn main() {
         .manage(AppState {
             settings: Mutex::new(initial_settings),
             daemon_client,
-            daemon_startup_error,
-            runtime_started_at_ms,
             daemon_pty_attach_tasks: Mutex::new(std::collections::HashMap::new()),
             pty_manager: std::sync::Arc::new(PtyManager::new()),
             runtime,

--- a/src-tauri/src/notifications/mod.rs
+++ b/src-tauri/src/notifications/mod.rs
@@ -7,6 +7,8 @@
 //! OS notification center when focus policy allows.
 
 pub mod manager;
+// OSC sniffing belongs to the retained local PTY path.
+#[allow(dead_code)]
 pub mod osc_parser;
 pub mod policy;
 pub mod store;

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -6,6 +6,8 @@ pub(crate) mod managed_proxy;
 pub(crate) mod mcp_config;
 pub(crate) mod notes;
 pub(crate) mod projects;
+// Local session service remains for tests and staged daemon migration cleanup.
+#[allow(dead_code)]
 pub(crate) mod sessions;
 pub(crate) mod settings;
 pub(crate) mod setup;

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -24,8 +24,6 @@ pub(crate) struct DaemonPtyAttachTask {
 pub(crate) struct AppState {
     pub(crate) settings: Mutex<crate::settings::RouxSettings>,
     pub(crate) daemon_client: Option<crate::daemon_client::DaemonClient>,
-    pub(crate) daemon_startup_error: Option<String>,
-    pub(crate) runtime_started_at_ms: u64,
     pub(crate) daemon_pty_attach_tasks: Mutex<HashMap<String, DaemonPtyAttachTask>>,
     pub(crate) pty_manager: Arc<PtyManager>,
     pub(crate) runtime: RuntimeHost,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -36,3 +36,21 @@ pub(crate) struct AppState {
     pub(crate) pending_replies: PendingReplies,
     pub(crate) managed_proxy: Arc<crate::services::managed_proxy::ManagedProxyState>,
 }
+
+pub(crate) fn required_daemon_client(
+    state: &AppState,
+) -> Result<crate::daemon_client::DaemonClient, String> {
+    state
+        .daemon_client
+        .clone()
+        .ok_or_else(|| "Roux daemon is required but not connected".to_string())
+}
+
+pub(crate) fn required_daemon_client_ref(
+    state: &AppState,
+) -> Result<&crate::daemon_client::DaemonClient, String> {
+    state
+        .daemon_client
+        .as_ref()
+        .ok_or_else(|| "Roux daemon is required but not connected".to_string())
+}


### PR DESCRIPTION
## Summary
- add typed roux-sdk APIs for desktop session create/reconnect shell flows
- route desktop session and PTY commands through the SDK-backed daemon client
- make desktop startup fail clearly when daemon startup/connect fails and stop starting the desktop socket fallback

## Validation
- cargo test -p roux-sdk
- cargo test -p roux-cli
- CI=1 cargo test -p roux-desktop --lib

## Notes
- CI mode is used for the desktop lib check so Tauri creates ignored externalBin placeholders locally.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes the daemon-first migration for desktop session and PTY management: `create_session_shell` and `reconnect_session_shell` are routed through new typed roux-sdk APIs, and the desktop now fails fast at startup when the daemon cannot be connected rather than falling back to a local service layer.

- **roux-sdk**: Adds `CreateSessionShell`, `ReconnectSessionShell`, and `NotesEnv` typed request structs with builder-style SDK methods and comprehensive tests covering the full daemon wire protocol shape.
- **Desktop startup**: `main.rs` calls `DaemonClient::ensure_local()` and exits with code 1 on any non-`Connected` result; the desktop socket fallback server is skipped unconditionally.
- **Consolidation**: `required_daemon_client` / `required_daemon_client_ref` helpers are moved to `state.rs`, eliminating the duplication that existed across command modules.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The daemon-required startup path is straightforward and the SDK wire-protocol tests confirm the new session shell flows match what the daemon handler parses.

All session and PTY commands correctly flow through the required-daemon client. The sdk_notes_env field mapping is 1-to-1 and verified against both the SDK serializer and daemon parser. The only finding is that daemon_process_* retain a local fallback that is now unreachable — dead code with no behavioral impact.

src-tauri/src/commands/daemon.rs — daemon_process_start/output/list/kill retain unreachable local-fallback branches worth cleaning up.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/roux-sdk/src/lib.rs | Adds typed CreateSessionShell, ReconnectSessionShell, and NotesEnv SDK types with full unit tests covering the daemon wire protocol shape |
| src-tauri/src/daemon_client.rs | Routes create_session_shell and reconnect_session_shell through the SDK; adds sdk_notes_env mapping from NotesEnvInputs to roux_sdk::NotesEnv with correct field-by-field mapping |
| src-tauri/src/commands/sessions.rs | create_session_shell and reconnect_session_shell now delegate entirely to the daemon client; all session commands use required_daemon_client helpers from state.rs |
| src-tauri/src/commands/daemon.rs | Adds required-daemon PTY commands and updates get_runtime_status to require daemon; daemon_process_* commands retain a local process_handle fallback that is now unreachable |
| src-tauri/src/main.rs | Desktop startup now exits (code 1) on all daemon failure paths instead of starting a local fallback socket server; daemon connection is logged on success |
| src-tauri/src/state.rs | Consolidates required_daemon_client and required_daemon_client_ref helpers into a single location, removing the duplication across command modules |
| crates/roux-cli/src/daemon.rs | Adds session-create-shell and session-reconnect-shell to the daemon capabilities list; adds is_git_repo sync in handle_session_refresh_branch with a new test covering the update path |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Desktop as Desktop (main.rs)
    participant DC as DaemonClient
    participant SDK as roux-sdk
    participant Daemon as roux daemon

    Desktop->>DC: ensure_local()
    alt daemon already running
        DC->>Daemon: probe daemon-status
        Daemon-->>DC: DaemonStatus
        DC-->>Desktop: Connected(client)
    else daemon not running
        DC->>Daemon: launch + wait_for_daemon()
        Daemon-->>DC: DaemonStatus (after startup)
        DC-->>Desktop: Connected(client)
    else failure
        DC-->>Desktop: "LocalFallbackDisabled | Failed"
        Desktop->>Desktop: eprintln + exit(1)
    end

    Desktop->>SDK: Roux::connect()
    note over Desktop: AppState { daemon_client: Some(_) }

    Desktop->>DC: create_session_shell(DaemonCreateSessionShellRequest)
    DC->>SDK: sdk.create_session_shell(CreateSessionShell)
    SDK->>Daemon: "session-create-shell { id, repoPath, notesEnv, ... }"
    Daemon-->>SDK: Session
    SDK-->>DC: Session
    DC-->>Desktop: Session

    Desktop->>DC: reconnect_session_shell(DaemonReconnectSessionShellRequest)
    DC->>SDK: sdk.reconnect_session_shell(ReconnectSessionShell)
    SDK->>Daemon: "session-reconnect-shell { session_id, notesEnv, ... }"
    Daemon-->>SDK: Session
    SDK-->>DC: Session
    DC-->>Desktop: Session
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src-tauri/src/commands/daemon.rs`, line 80-85 ([link](https://github.com/phin-tech/roux/blob/27503d7993007bf476d25761daa865102499e0d5/src-tauri/src/commands/daemon.rs#L80-L85)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Unused function left behind after fallback removal**

   `unix_now_ms` was used exclusively in the removed `LocalFallback` branch to compute `uptime_ms: now.saturating_sub(runtime_started_at_ms)`. That branch is gone, so this private function is now dead code and will produce a Rust `dead_code` warning. It should be removed alongside the fallback logic.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src-tauri%2Fsrc%2Fcommands%2Fdaemon.rs%0ALine%3A%2080-85%0A%0AComment%3A%0A**Unused%20function%20left%20behind%20after%20fallback%20removal**%0A%0A%60unix_now_ms%60%20was%20used%20exclusively%20in%20the%20removed%20%60LocalFallback%60%20branch%20to%20compute%20%60uptime_ms%3A%20now.saturating_sub%28runtime_started_at_ms%29%60.%20That%20branch%20is%20gone%2C%20so%20this%20private%20function%20is%20now%20dead%20code%20and%20will%20produce%20a%20Rust%20%60dead_code%60%20warning.%20It%20should%20be%20removed%20alongside%20the%20fallback%20logic.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=phin-tech%2Froux&pr=199&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22codex%2Fdaemon-required-desktop-sdk%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fdaemon-required-desktop-sdk%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src-tauri%2Fsrc%2Fcommands%2Fdaemon.rs%0ALine%3A%2080-85%0A%0AComment%3A%0A**Unused%20function%20left%20behind%20after%20fallback%20removal**%0A%0A%60unix_now_ms%60%20was%20used%20exclusively%20in%20the%20removed%20%60LocalFallback%60%20branch%20to%20compute%20%60uptime_ms%3A%20now.saturating_sub%28runtime_started_at_ms%29%60.%20That%20branch%20is%20gone%2C%20so%20this%20private%20function%20is%20now%20dead%20code%20and%20will%20produce%20a%20Rust%20%60dead_code%60%20warning.%20It%20should%20be%20removed%20alongside%20the%20fallback%20logic.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

2. `src-tauri/src/commands/daemon.rs`, line 26-35 ([link](https://github.com/phin-tech/roux/blob/27503d7993007bf476d25761daa865102499e0d5/src-tauri/src/commands/daemon.rs#L26-L35)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`RuntimeStatus.local` and `RuntimeCounts` are now permanently dead**

   `RuntimeStatus.local` is set to `None` unconditionally after this PR, and `RuntimeCounts` is never constructed. The `local: Option<RuntimeCounts>` field (and the `RuntimeCounts` struct itself) are now dead code because the daemon is always required — there is no longer a local-fallback mode that would populate this field. These can be removed to keep the contract clean and avoid confusing future readers of the struct serialization.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src-tauri%2Fsrc%2Fcommands%2Fdaemon.rs%0ALine%3A%2026-35%0A%0AComment%3A%0A**%60RuntimeStatus.local%60%20and%20%60RuntimeCounts%60%20are%20now%20permanently%20dead**%0A%0A%60RuntimeStatus.local%60%20is%20set%20to%20%60None%60%20unconditionally%20after%20this%20PR%2C%20and%20%60RuntimeCounts%60%20is%20never%20constructed.%20The%20%60local%3A%20Option%3CRuntimeCounts%3E%60%20field%20%28and%20the%20%60RuntimeCounts%60%20struct%20itself%29%20are%20now%20dead%20code%20because%20the%20daemon%20is%20always%20required%20%E2%80%94%20there%20is%20no%20longer%20a%20local-fallback%20mode%20that%20would%20populate%20this%20field.%20These%20can%20be%20removed%20to%20keep%20the%20contract%20clean%20and%20avoid%20confusing%20future%20readers%20of%20the%20struct%20serialization.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=phin-tech%2Froux&pr=199&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22codex%2Fdaemon-required-desktop-sdk%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fdaemon-required-desktop-sdk%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src-tauri%2Fsrc%2Fcommands%2Fdaemon.rs%0ALine%3A%2026-35%0A%0AComment%3A%0A**%60RuntimeStatus.local%60%20and%20%60RuntimeCounts%60%20are%20now%20permanently%20dead**%0A%0A%60RuntimeStatus.local%60%20is%20set%20to%20%60None%60%20unconditionally%20after%20this%20PR%2C%20and%20%60RuntimeCounts%60%20is%20never%20constructed.%20The%20%60local%3A%20Option%3CRuntimeCounts%3E%60%20field%20%28and%20the%20%60RuntimeCounts%60%20struct%20itself%29%20are%20now%20dead%20code%20because%20the%20daemon%20is%20always%20required%20%E2%80%94%20there%20is%20no%20longer%20a%20local-fallback%20mode%20that%20would%20populate%20this%20field.%20These%20can%20be%20removed%20to%20keep%20the%20contract%20clean%20and%20avoid%20confusing%20future%20readers%20of%20the%20struct%20serialization.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc-tauri%2Fsrc%2Fcommands%2Fdaemon.rs%3A63-129%0A**Process%20command%20fallback%20branches%20are%20now%20unreachable**%0A%0A%60daemon_process_start%60%2C%20%60daemon_process_output%60%2C%20%60daemon_process_list%60%2C%20and%20%60daemon_process_kill%60%20all%20check%20%60if%20let%20Some%28client%29%20%3D%20%26state.daemon_client%60%20and%20fall%20back%20to%20%60state.runtime.process_handle%60%20when%20none%20is%20found.%20Since%20%60main.rs%60%20now%20calls%20%60std%3A%3Aprocess%3A%3Aexit%281%29%60%20whenever%20%60ensure_local%28%29%60%20returns%20anything%20other%20than%20%60Connected%60%2C%20%60state.daemon_client%60%20is%20unconditionally%20%60Some%60%20at%20runtime.%20The%20four%20%60else%60%2Ffall-through%20branches%20to%20%60state.runtime.process_handle%60%20are%20unreachable%20and%20will%20mislead%20readers%20into%20thinking%20process%20operations%20have%20a%20working%20local%20fallback%2C%20which%20they%20don't.%0A%0A&repo=phin-tech%2Froux&pr=199&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22codex%2Fdaemon-required-desktop-sdk%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fdaemon-required-desktop-sdk%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc-tauri%2Fsrc%2Fcommands%2Fdaemon.rs%3A63-129%0A**Process%20command%20fallback%20branches%20are%20now%20unreachable**%0A%0A%60daemon_process_start%60%2C%20%60daemon_process_output%60%2C%20%60daemon_process_list%60%2C%20and%20%60daemon_process_kill%60%20all%20check%20%60if%20let%20Some%28client%29%20%3D%20%26state.daemon_client%60%20and%20fall%20back%20to%20%60state.runtime.process_handle%60%20when%20none%20is%20found.%20Since%20%60main.rs%60%20now%20calls%20%60std%3A%3Aprocess%3A%3Aexit%281%29%60%20whenever%20%60ensure_local%28%29%60%20returns%20anything%20other%20than%20%60Connected%60%2C%20%60state.daemon_client%60%20is%20unconditionally%20%60Some%60%20at%20runtime.%20The%20four%20%60else%60%2Ffall-through%20branches%20to%20%60state.runtime.process_handle%60%20are%20unreachable%20and%20will%20mislead%20readers%20into%20thinking%20process%20operations%20have%20a%20working%20local%20fallback%2C%20which%20they%20don't.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["fix: address daemon review findings"](https://github.com/phin-tech/roux/commit/fd39e9cbf4be6d33af55ce3c8d9dea31b95e0127) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33614306)</sub>

<!-- /greptile_comment -->