### PR TITLE
[codex] move desktop daemon access into roux-sdk

### DIFF
--- a/crates/roux-sdk/src/lib.rs
+++ b/crates/roux-sdk/src/lib.rs
@@ -12,7 +12,7 @@ pub use error::{RouxError, RouxResult};
 pub use protocol::{CommandRequest, CommandResponse};
 pub use types::{DaemonStatus, PtyAttachFrame, PtyKind, PtyRecord, PtySnapshot};
 
-use serde::de::DeserializeOwned;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value;
 use std::time::Duration;
 
@@ -106,6 +106,71 @@ pub struct ReconnectSessionShell {
     pub notes: Option<NotesEnv>,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct MailboxPost {
+    pub to: Option<String>,
+    pub topic: Option<String>,
+    pub body: String,
+    pub subject: Option<String>,
+    pub kind: Option<String>,
+    pub project_id: Option<String>,
+    pub correlation_id: Option<String>,
+    pub structured: Option<Value>,
+    pub from: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+pub enum WatchEventStreamFrame {
+    #[serde(rename = "ready")]
+    Ready,
+    #[serde(rename = "update")]
+    Update { event: Box<roux_core::WatchUpdateEvent> },
+    #[serde(rename = "warning")]
+    Warning { message: String },
+    #[serde(rename = "error")]
+    Error { error: String },
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+pub enum MailboxEventStreamFrame {
+    #[serde(rename = "ready")]
+    Ready,
+    #[serde(rename = "event")]
+    Event { event: Box<roux_core::MailboxEvent> },
+    #[serde(rename = "warning")]
+    Warning { message: String },
+    #[serde(rename = "error")]
+    Error { error: String },
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+pub enum AliasEventStreamFrame {
+    #[serde(rename = "ready")]
+    Ready,
+    #[serde(rename = "event")]
+    Event { event: roux_core::AliasEvent },
+    #[serde(rename = "warning")]
+    Warning { message: String },
+    #[serde(rename = "error")]
+    Error { error: String },
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+pub enum SubscriptionEventStreamFrame {
+    #[serde(rename = "ready")]
+    Ready,
+    #[serde(rename = "event")]
+    Event { event: roux_core::BusSubscriptionEvent },
+    #[serde(rename = "warning")]
+    Warning { message: String },
+    #[serde(rename = "error")]
+    Error { error: String },
+}
+
 impl Roux {
     pub fn builder() -> RouxBuilder {
         RouxBuilder::default()
@@ -119,8 +184,20 @@ impl Roux {
         self.command(CommandRequest::new("daemon-status")).await
     }
 
+    pub async fn status_value(&self) -> RouxResult<Value> {
+        self.command(CommandRequest::new("daemon-status")).await
+    }
+
+    pub fn status_blocking(&self) -> RouxResult<Value> {
+        self.command_blocking(CommandRequest::new("daemon-status"))
+    }
+
     pub async fn sessions(&self) -> RouxResult<Vec<roux_core::Session>> {
         self.command(CommandRequest::new("session-list")).await
+    }
+
+    pub async fn get_session(&self, id: impl Into<String>) -> RouxResult<roux_core::Session> {
+        self.command(CommandRequest::new("session-poll").session_id(id.into())).await
     }
 
     pub async fn ptys(&self) -> RouxResult<Vec<PtyRecord>> {
@@ -133,6 +210,323 @@ impl Roux {
 
     pub async fn watches(&self) -> RouxResult<Vec<roux_core::Watch>> {
         self.command(CommandRequest::new("watch-list")).await
+    }
+
+    pub async fn create_project(&self, name: impl Into<String>) -> RouxResult<roux_core::Project> {
+        self.command(CommandRequest::new("project-create").args(serde_json::json!({
+            "name": name.into(),
+        })))
+        .await
+    }
+
+    pub async fn remove_project(&self, id: impl Into<String>) -> RouxResult<()> {
+        let _: Value =
+            self.command(CommandRequest::new("project-remove").args(id_arg(id.into()))).await?;
+        Ok(())
+    }
+
+    pub async fn rename_project(
+        &self,
+        id: impl Into<String>,
+        name: impl Into<String>,
+    ) -> RouxResult<()> {
+        let _: Value = self
+            .command(CommandRequest::new("project-rename").args(serde_json::json!({
+                "id": id.into(),
+                "name": name.into(),
+            })))
+            .await?;
+        Ok(())
+    }
+
+    pub async fn update_project(
+        &self,
+        id: impl Into<String>,
+        patch: roux_core::ProjectUpdate,
+    ) -> RouxResult<roux_core::Project> {
+        self.command(CommandRequest::new("project-update").args(serde_json::json!({
+            "id": id.into(),
+            "patch": patch,
+        })))
+        .await
+    }
+
+    pub async fn list_aliases(
+        &self,
+        project_id: Option<String>,
+        global: bool,
+        only_unbound: bool,
+    ) -> RouxResult<Vec<roux_core::AgentAlias>> {
+        self.command(CommandRequest::new("alias-list").args(alias_list_args(
+            project_id,
+            global,
+            only_unbound,
+        )))
+        .await
+    }
+
+    pub async fn get_alias(
+        &self,
+        alias: impl Into<String>,
+        project_id: Option<String>,
+    ) -> RouxResult<Option<roux_core::AgentAlias>> {
+        let alias = alias.into();
+        match self
+            .command(
+                CommandRequest::new("alias-get").args(alias_get_args(alias.clone(), project_id)),
+            )
+            .await
+        {
+            Ok(alias) => Ok(Some(alias)),
+            Err(err) if err.to_string().contains(&format!("alias '{alias}' not found")) => Ok(None),
+            Err(err) => Err(err),
+        }
+    }
+
+    pub async fn whoami_aliases(
+        &self,
+        session_id: impl Into<String>,
+    ) -> RouxResult<Vec<roux_core::AgentAlias>> {
+        self.command(
+            CommandRequest::new("alias-whoami")
+                .session_id(session_id.into())
+                .args(serde_json::json!({})),
+        )
+        .await
+    }
+
+    pub async fn add_alias_member(
+        &self,
+        alias: impl Into<String>,
+        pane_id: impl Into<String>,
+        project_id: Option<String>,
+    ) -> RouxResult<roux_core::AgentAlias> {
+        self.command(CommandRequest::new("alias-add-member").args(alias_member_args(
+            alias.into(),
+            pane_id.into(),
+            project_id,
+        )))
+        .await
+    }
+
+    pub async fn remove_alias_member(
+        &self,
+        alias: impl Into<String>,
+        pane_id: impl Into<String>,
+        project_id: Option<String>,
+    ) -> RouxResult<bool> {
+        let value: Value = self
+            .command(CommandRequest::new("alias-remove-member").args(alias_member_args(
+                alias.into(),
+                pane_id.into(),
+                project_id,
+            )))
+            .await?;
+        bool_field(value, "removed")
+    }
+
+    pub async fn set_alias_mode(
+        &self,
+        alias: impl Into<String>,
+        mode: impl Into<String>,
+        project_id: Option<String>,
+    ) -> RouxResult<roux_core::AgentAlias> {
+        self.command(CommandRequest::new("alias-mode").args(alias_mode_args(
+            alias.into(),
+            mode.into(),
+            project_id,
+        )))
+        .await
+    }
+
+    pub async fn list_subscriptions(
+        &self,
+        alias: Option<String>,
+        project_id: Option<String>,
+        global: bool,
+    ) -> RouxResult<Vec<roux_core::BusSubscription>> {
+        self.command(
+            CommandRequest::new("bus-subscriptions")
+                .args(subscription_list_args(alias, project_id, global)),
+        )
+        .await
+    }
+
+    pub async fn create_subscription(
+        &self,
+        alias: impl Into<String>,
+        pattern: impl Into<String>,
+        project_id: Option<String>,
+    ) -> RouxResult<roux_core::BusSubscription> {
+        self.command(CommandRequest::new("bus-subscribe").args(subscription_create_args(
+            alias.into(),
+            pattern.into(),
+            project_id,
+        )))
+        .await
+    }
+
+    pub async fn delete_subscription(&self, id: impl Into<String>) -> RouxResult<bool> {
+        let value: Value =
+            self.command(CommandRequest::new("bus-unsubscribe").args(id_arg(id.into()))).await?;
+        bool_field(value, "removed")
+    }
+
+    pub async fn mailbox_list_for_recipient(
+        &self,
+        alias: impl Into<String>,
+        unread_only: bool,
+        project_id: Option<String>,
+        global: bool,
+    ) -> RouxResult<Vec<roux_core::Event>> {
+        self.command(CommandRequest::new("mailbox-peek").args(mailbox_peek_args(
+            alias.into(),
+            unread_only,
+            project_id,
+            global,
+            None,
+        )))
+        .await
+    }
+
+    pub async fn mailbox_list_for_topic(
+        &self,
+        topic: impl Into<String>,
+        project_id: Option<String>,
+        global: bool,
+    ) -> RouxResult<Vec<roux_core::Event>> {
+        self.command(CommandRequest::new("bus-tail").args(bus_tail_args(
+            Some(topic.into()),
+            project_id,
+            global,
+            None,
+        )))
+        .await
+    }
+
+    pub async fn mailbox_list_all(
+        &self,
+        project_id: Option<String>,
+        global: bool,
+        limit: Option<u32>,
+    ) -> RouxResult<Vec<roux_core::Event>> {
+        self.command(
+            CommandRequest::new("bus-tail").args(bus_tail_args(None, project_id, global, limit)),
+        )
+        .await
+    }
+
+    pub async fn mailbox_unread_count(
+        &self,
+        alias: impl Into<String>,
+        project_id: Option<String>,
+        global: bool,
+    ) -> RouxResult<u32> {
+        let value: Value = self
+            .command(CommandRequest::new("mailbox-count").args(mailbox_count_args(
+                alias.into(),
+                project_id,
+                global,
+            )))
+            .await?;
+        u32_field(value, "unread")
+    }
+
+    pub async fn mailbox_get_event(
+        &self,
+        event_id: impl Into<String>,
+    ) -> RouxResult<Option<roux_core::Event>> {
+        self.command(CommandRequest::new("mailbox-get").args(event_id_arg(event_id.into()))).await
+    }
+
+    pub async fn mailbox_read_state(
+        &self,
+        event_id: impl Into<String>,
+        recipient: impl Into<String>,
+    ) -> RouxResult<Option<roux_core::ReadState>> {
+        self.command(CommandRequest::new("mailbox-read-state").args(serde_json::json!({
+            "event_id": event_id.into(),
+            "recipient": recipient.into(),
+        })))
+        .await
+    }
+
+    pub async fn mailbox_post(&self, request: MailboxPost) -> RouxResult<roux_core::Event> {
+        self.command(CommandRequest::new("mailbox-post").args(request.into_args())).await
+    }
+
+    pub async fn mailbox_mark_read(
+        &self,
+        event_id: impl Into<String>,
+        recipient: impl Into<String>,
+    ) -> RouxResult<bool> {
+        let value: Value = self
+            .command(CommandRequest::new("mailbox-mark-read").args(serde_json::json!({
+                "event_id": event_id.into(),
+                "recipient": recipient.into(),
+            })))
+            .await?;
+        bool_field(value, "changed")
+    }
+
+    pub async fn mailbox_ack(
+        &self,
+        event_id: impl Into<String>,
+        recipient: impl Into<String>,
+        result: Option<String>,
+    ) -> RouxResult<bool> {
+        let value: Value = self
+            .command(CommandRequest::new("mailbox-ack").args(mailbox_alias_event_args(
+                event_id.into(),
+                recipient.into(),
+                result,
+            )))
+            .await?;
+        bool_field(value, "changed")
+    }
+
+    pub async fn mailbox_clear_read(
+        &self,
+        recipient: impl Into<String>,
+        project_id: Option<String>,
+        global: bool,
+    ) -> RouxResult<u32> {
+        let value: Value = self
+            .command(CommandRequest::new("mailbox-clear").args(mailbox_clear_args(
+                recipient.into(),
+                project_id,
+                global,
+            )))
+            .await?;
+        u32_field(value, "cleared")
+    }
+
+    pub async fn mailbox_retract(
+        &self,
+        event_id: impl Into<String>,
+        sender: impl Into<String>,
+    ) -> RouxResult<roux_core::Event> {
+        self.command(CommandRequest::new("mailbox-retract").args(mailbox_alias_event_args(
+            event_id.into(),
+            sender.into(),
+            None,
+        )))
+        .await
+    }
+
+    pub async fn mailbox_dismiss(
+        &self,
+        event_id: impl Into<String>,
+        recipient: impl Into<String>,
+    ) -> RouxResult<bool> {
+        let value: Value = self
+            .command(CommandRequest::new("mailbox-dismiss").args(mailbox_alias_event_args(
+                event_id.into(),
+                recipient.into(),
+                None,
+            )))
+            .await?;
+        bool_field(value, "changed")
     }
 
     pub async fn create_session_shell(
@@ -153,6 +547,392 @@ impl Roux {
                 .args(request.into_args()),
         )
         .await
+    }
+
+    pub async fn read_notes<Target, Output>(&self, target: Target) -> RouxResult<Output>
+    where
+        Target: Serialize,
+        Output: DeserializeOwned + Send + 'static,
+    {
+        self.command(CommandRequest::new("notes-read").args(to_value(target)?)).await
+    }
+
+    pub async fn write_notes<Target>(
+        &self,
+        target: Target,
+        content: impl Into<String>,
+        tags: Vec<String>,
+    ) -> RouxResult<()>
+    where
+        Target: Serialize,
+    {
+        let _: Value = self
+            .command(CommandRequest::new("notes-write").args(serde_json::json!({
+                "target": to_value(target)?,
+                "content": content.into(),
+                "tags": tags,
+            })))
+            .await?;
+        Ok(())
+    }
+
+    pub async fn append_notes<Target>(
+        &self,
+        target: Target,
+        content: impl Into<String>,
+        timestamped: bool,
+        tags: Vec<String>,
+    ) -> RouxResult<()>
+    where
+        Target: Serialize,
+    {
+        let _: Value = self
+            .command(CommandRequest::new("notes-append").args(serde_json::json!({
+                "target": to_value(target)?,
+                "content": content.into(),
+                "timestamped": timestamped,
+                "tags": tags,
+            })))
+            .await?;
+        Ok(())
+    }
+
+    pub async fn notes_path<Target>(&self, target: Target, dir: bool) -> RouxResult<String>
+    where
+        Target: Serialize,
+    {
+        self.command(CommandRequest::new("notes-path").args(serde_json::json!({
+            "target": to_value(target)?,
+            "dir": dir,
+        })))
+        .await
+    }
+
+    pub async fn search_notes<Query>(&self, query: Query) -> RouxResult<Vec<String>>
+    where
+        Query: Serialize,
+    {
+        self.command(CommandRequest::new("notes-search").args(to_value(query)?)).await
+    }
+
+    pub async fn notes_vault_root(&self) -> RouxResult<String> {
+        self.command(CommandRequest::new("notes-vault-root")).await
+    }
+
+    pub async fn list_automation_hooks<Output>(
+        &self,
+        repo_path: Option<String>,
+    ) -> RouxResult<Output>
+    where
+        Output: DeserializeOwned + Send + 'static,
+    {
+        self.command(CommandRequest::new("hook-show").args(optional_repo_path_args(repo_path)))
+            .await
+    }
+
+    pub async fn preview_automation_hooks<Request, Output>(
+        &self,
+        request: Request,
+    ) -> RouxResult<Output>
+    where
+        Request: Serialize,
+        Output: DeserializeOwned + Send + 'static,
+    {
+        self.command(CommandRequest::new("hook-preview").args(to_value(request)?)).await
+    }
+
+    pub async fn run_automation_hook<Request, Output>(&self, request: Request) -> RouxResult<Output>
+    where
+        Request: Serialize,
+        Output: DeserializeOwned + Send + 'static,
+    {
+        self.command(CommandRequest::new("hook-run").args(to_value(request)?)).await
+    }
+
+    pub async fn approve_automation_hook(&self, approval_id: impl Into<String>) -> RouxResult<()> {
+        let _: Value = self
+            .command(CommandRequest::new("hook-approve").args(serde_json::json!({
+                "approvalId": approval_id.into(),
+            })))
+            .await?;
+        Ok(())
+    }
+
+    pub async fn clear_automation_hook_approvals(&self) -> RouxResult<()> {
+        let _: Value = self.command(CommandRequest::new("hook-clear-approvals")).await?;
+        Ok(())
+    }
+
+    pub async fn list_automation_hook_logs<Output>(&self) -> RouxResult<Output>
+    where
+        Output: DeserializeOwned + Send + 'static,
+    {
+        self.command(CommandRequest::new("hook-log-list")).await
+    }
+
+    pub async fn read_automation_hook_log(&self, path: impl Into<String>) -> RouxResult<String> {
+        self.command(CommandRequest::new("hook-log-read").args(serde_json::json!({
+            "path": path.into(),
+        })))
+        .await
+    }
+
+    pub async fn set_session_name_override(
+        &self,
+        session_id: impl Into<String>,
+        name_override: Option<String>,
+    ) -> RouxResult<()> {
+        let _: Value = self
+            .command(
+                CommandRequest::new("session-rename")
+                    .session_id(session_id.into())
+                    .args(serde_json::json!({ "name": name_override.unwrap_or_default() })),
+            )
+            .await?;
+        Ok(())
+    }
+
+    pub async fn set_session_project(
+        &self,
+        session_id: impl Into<String>,
+        project_id: Option<String>,
+    ) -> RouxResult<()> {
+        self.session_optional_value(
+            session_id.into(),
+            "session-set-project",
+            "projectId",
+            project_id,
+        )
+        .await
+    }
+
+    pub async fn set_session_pinned_pr_url(
+        &self,
+        session_id: impl Into<String>,
+        url: Option<String>,
+    ) -> RouxResult<()> {
+        self.session_optional_value(session_id.into(), "session-set-pinned-pr-url", "url", url)
+            .await
+    }
+
+    pub async fn set_session_smol_machine(
+        &self,
+        session_id: impl Into<String>,
+        machine_name: Option<String>,
+    ) -> RouxResult<()> {
+        self.session_optional_value(
+            session_id.into(),
+            "session-set-smol-machine",
+            "machineName",
+            machine_name,
+        )
+        .await
+    }
+
+    async fn session_optional_value(
+        &self,
+        session_id: String,
+        command: &'static str,
+        key: &'static str,
+        value: Option<String>,
+    ) -> RouxResult<()> {
+        let _: Value = self
+            .command(
+                CommandRequest::new(command)
+                    .session_id(session_id)
+                    .args(optional_string_arg(key, value)),
+            )
+            .await?;
+        Ok(())
+    }
+
+    pub async fn archive_session(&self, id: impl Into<String>) -> RouxResult<roux_core::Session> {
+        self.command(CommandRequest::new("session-archive").session_id(id.into())).await
+    }
+
+    pub async fn restore_session(&self, id: impl Into<String>) -> RouxResult<roux_core::Session> {
+        self.command(CommandRequest::new("session-restore").session_id(id.into())).await
+    }
+
+    pub async fn delete_session(&self, id: impl Into<String>) -> RouxResult<()> {
+        let _: Value =
+            self.command(CommandRequest::new("session-delete").session_id(id.into())).await?;
+        Ok(())
+    }
+
+    pub async fn session_worktree_exists(&self, id: impl Into<String>) -> RouxResult<bool> {
+        let value: Value = self
+            .command(CommandRequest::new("session-worktree-exists").session_id(id.into()))
+            .await?;
+        bool_field(value, "exists")
+    }
+
+    pub async fn refresh_session_branch(
+        &self,
+        id: impl Into<String>,
+    ) -> RouxResult<Option<String>> {
+        let value: Value = self
+            .command(CommandRequest::new("session-refresh-branch").session_id(id.into()))
+            .await?;
+        Ok(value.get("branch").and_then(|branch| branch.as_str()).map(str::to_string))
+    }
+
+    pub async fn list_worktrees(
+        &self,
+        repo_path: impl Into<String>,
+    ) -> RouxResult<Vec<roux_core::Worktree>> {
+        self.command(CommandRequest::new("worktree-list").args(repo_path_arg(repo_path.into())))
+            .await
+    }
+
+    pub async fn create_worktree(
+        &self,
+        repo_path: impl Into<String>,
+        branch: impl Into<String>,
+        start_point: Option<String>,
+        fetch_first: bool,
+    ) -> RouxResult<String> {
+        let value: Value = self
+            .command(CommandRequest::new("worktree-create").args(worktree_create_args(
+                repo_path.into(),
+                branch.into(),
+                start_point,
+                fetch_first,
+            )))
+            .await?;
+        string_field(value, "path")
+    }
+
+    pub async fn remove_worktree(
+        &self,
+        repo_path: impl Into<String>,
+        worktree_path: impl Into<String>,
+        also_branch: bool,
+        force: bool,
+    ) -> RouxResult<()> {
+        let _: Value = self
+            .command(CommandRequest::new("worktree-remove").args(serde_json::json!({
+                "repoPath": repo_path.into(),
+                "worktreePath": worktree_path.into(),
+                "alsoBranch": also_branch,
+                "force": force,
+            })))
+            .await?;
+        Ok(())
+    }
+
+    pub async fn list_branches(&self, repo_path: impl Into<String>) -> RouxResult<Vec<String>> {
+        self.command(
+            CommandRequest::new("worktree-list-branches").args(repo_path_arg(repo_path.into())),
+        )
+        .await
+    }
+
+    pub async fn git_init(&self, path: impl Into<String>) -> RouxResult<()> {
+        let _: Value = self
+            .command(CommandRequest::new("git-init").args(serde_json::json!({
+                "path": path.into(),
+            })))
+            .await?;
+        Ok(())
+    }
+
+    pub async fn create_watch(
+        &self,
+        config: roux_core::CreateWatchConfig,
+    ) -> RouxResult<roux_core::Watch> {
+        self.command(CommandRequest::new("watch-create").args(watch_config_arg(config))).await
+    }
+
+    pub async fn find_or_create_watch(
+        &self,
+        config: roux_core::CreateWatchConfig,
+    ) -> RouxResult<roux_core::Watch> {
+        self.command(CommandRequest::new("watch-find-or-create").args(watch_config_arg(config)))
+            .await
+    }
+
+    pub async fn remove_watch(&self, id: impl Into<String>) -> RouxResult<()> {
+        let _: Value =
+            self.command(CommandRequest::new("watch-remove").args(id_arg(id.into()))).await?;
+        Ok(())
+    }
+
+    pub async fn pause_watch(&self, id: impl Into<String>) -> RouxResult<roux_core::Watch> {
+        self.command(CommandRequest::new("watch-pause").args(id_arg(id.into()))).await
+    }
+
+    pub async fn resume_watch(&self, id: impl Into<String>) -> RouxResult<roux_core::Watch> {
+        self.command(CommandRequest::new("watch-resume").args(id_arg(id.into()))).await
+    }
+
+    pub async fn replace_watch(&self, watch: roux_core::Watch) -> RouxResult<()> {
+        let _: Value = self
+            .command(CommandRequest::new("watch-replace").args(serde_json::json!({
+                "watch": watch,
+            })))
+            .await?;
+        Ok(())
+    }
+
+    pub async fn remove_watches_for_session(
+        &self,
+        session_id: impl Into<String>,
+    ) -> RouxResult<()> {
+        let _: Value = self
+            .command(CommandRequest::new("watch-remove-for-session").args(serde_json::json!({
+                "sessionId": session_id.into(),
+            })))
+            .await?;
+        Ok(())
+    }
+
+    pub async fn cleanup_watch_orphans(&self) -> RouxResult<()> {
+        let _: Value = self.command(CommandRequest::new("watch-cleanup-orphans")).await?;
+        Ok(())
+    }
+
+    pub async fn start_daemon_process<Output>(
+        &self,
+        command: impl Into<String>,
+        working_dir: Option<String>,
+    ) -> RouxResult<Output>
+    where
+        Output: DeserializeOwned + Send + 'static,
+    {
+        self.command(
+            CommandRequest::new("daemon-process-start")
+                .args(process_start_args(command.into(), working_dir)),
+        )
+        .await
+    }
+
+    pub async fn daemon_process_output<Output>(
+        &self,
+        id: impl Into<String>,
+        max_bytes: Option<usize>,
+    ) -> RouxResult<Output>
+    where
+        Output: DeserializeOwned + Send + 'static,
+    {
+        self.command(
+            CommandRequest::new("daemon-process-output").args(max_bytes_args(id.into(), max_bytes)),
+        )
+        .await
+    }
+
+    pub async fn list_daemon_processes<Output>(&self) -> RouxResult<Output>
+    where
+        Output: DeserializeOwned + Send + 'static,
+    {
+        self.command(CommandRequest::new("daemon-process-list")).await
+    }
+
+    pub async fn kill_daemon_process<Output>(&self, id: impl Into<String>) -> RouxResult<Output>
+    where
+        Output: DeserializeOwned + Send + 'static,
+    {
+        self.command(CommandRequest::new("daemon-process-kill").args(id_arg(id.into()))).await
     }
 
     pub fn session(&self, session: roux_core::Session) -> Session {
@@ -211,6 +991,82 @@ impl Roux {
             request,
         )?;
         response.into_result()
+    }
+
+    pub fn stream_lines_blocking<F>(&self, request: CommandRequest, on_line: F) -> RouxResult<()>
+    where
+        F: FnMut(&str) -> bool,
+    {
+        blocking::stream_client_request(
+            &self.endpoint,
+            self.auth_token.as_deref(),
+            request,
+            on_line,
+        )
+    }
+
+    pub async fn stream_lines<F>(&self, request: CommandRequest, on_line: F) -> RouxResult<()>
+    where
+        F: FnMut(&str) -> bool + Send + 'static,
+    {
+        let client = self.clone();
+        tokio::task::spawn_blocking(move || client.stream_lines_blocking(request, on_line))
+            .await
+            .map_err(|err| RouxError::Transport(format!("SDK task join failed: {err}")))?
+    }
+
+    pub fn watch_events_blocking<F>(&self, backlog: bool, on_frame: F) -> RouxResult<()>
+    where
+        F: FnMut(WatchEventStreamFrame) -> bool,
+    {
+        self.stream_json_frames_blocking(
+            CommandRequest::new("watch-events").args(serde_json::json!({ "backlog": backlog })),
+            on_frame,
+        )
+    }
+
+    pub fn mailbox_events_blocking<F>(&self, on_frame: F) -> RouxResult<()>
+    where
+        F: FnMut(MailboxEventStreamFrame) -> bool,
+    {
+        self.stream_json_frames_blocking(CommandRequest::new("mailbox-events"), on_frame)
+    }
+
+    pub fn alias_events_blocking<F>(&self, on_frame: F) -> RouxResult<()>
+    where
+        F: FnMut(AliasEventStreamFrame) -> bool,
+    {
+        self.stream_json_frames_blocking(CommandRequest::new("alias-events"), on_frame)
+    }
+
+    pub fn subscription_events_blocking<F>(&self, on_frame: F) -> RouxResult<()>
+    where
+        F: FnMut(SubscriptionEventStreamFrame) -> bool,
+    {
+        self.stream_json_frames_blocking(CommandRequest::new("subscription-events"), on_frame)
+    }
+
+    fn stream_json_frames_blocking<T, F>(
+        &self,
+        request: CommandRequest,
+        mut on_frame: F,
+    ) -> RouxResult<()>
+    where
+        T: DeserializeOwned,
+        F: FnMut(T) -> bool,
+    {
+        let mut parse_error = None;
+        let result = self.stream_lines_blocking(request, |line| match serde_json::from_str(line) {
+            Ok(frame) => on_frame(frame),
+            Err(err) => {
+                parse_error = Some(RouxError::Decode(err));
+                false
+            }
+        });
+        result.and(match parse_error {
+            Some(err) => Err(err),
+            None => Ok(()),
+        })
     }
 }
 
@@ -282,6 +1138,229 @@ impl ReconnectSessionShell {
         insert_notes_env(&mut args, self.notes);
         Value::Object(args)
     }
+}
+
+impl MailboxPost {
+    fn into_args(self) -> Value {
+        let mut args = serde_json::Map::new();
+        insert_optional_string(&mut args, "to", self.to);
+        insert_optional_string(&mut args, "topic", self.topic);
+        args.insert("body".into(), Value::String(self.body));
+        insert_optional_string(&mut args, "subject", self.subject);
+        insert_optional_string(&mut args, "kind", self.kind);
+        insert_optional_string(&mut args, "project_id", self.project_id);
+        insert_optional_string(&mut args, "correlation_id", self.correlation_id);
+        if let Some(structured) = self.structured {
+            args.insert("structured".into(), structured);
+        }
+        insert_optional_string(&mut args, "from", self.from);
+        Value::Object(args)
+    }
+}
+
+fn to_value<T: Serialize>(value: T) -> RouxResult<Value> {
+    serde_json::to_value(value).map_err(RouxError::Decode)
+}
+
+fn id_arg(id: String) -> Value {
+    serde_json::json!({ "id": id })
+}
+
+fn event_id_arg(event_id: String) -> Value {
+    serde_json::json!({ "event_id": event_id })
+}
+
+fn repo_path_arg(repo_path: String) -> Value {
+    serde_json::json!({ "repoPath": repo_path })
+}
+
+fn optional_repo_path_args(repo_path: Option<String>) -> Value {
+    let mut args = serde_json::Map::new();
+    insert_optional_string(&mut args, "repoPath", repo_path);
+    Value::Object(args)
+}
+
+fn optional_string_arg(key: &'static str, value: Option<String>) -> Value {
+    let mut args = serde_json::Map::new();
+    args.insert(key.into(), value.map(Value::String).unwrap_or(Value::Null));
+    Value::Object(args)
+}
+
+fn bool_field(value: Value, key: &'static str) -> RouxResult<bool> {
+    value
+        .get(key)
+        .and_then(Value::as_bool)
+        .ok_or_else(|| RouxError::Transport(format!("daemon response missing boolean `{key}`")))
+}
+
+fn u32_field(value: Value, key: &'static str) -> RouxResult<u32> {
+    value
+        .get(key)
+        .and_then(Value::as_u64)
+        .and_then(|value| u32::try_from(value).ok())
+        .ok_or_else(|| RouxError::Transport(format!("daemon response missing u32 `{key}`")))
+}
+
+fn string_field(value: Value, key: &'static str) -> RouxResult<String> {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| RouxError::Transport(format!("daemon response missing string `{key}`")))
+}
+
+fn insert_project_filter_args(
+    args: &mut serde_json::Map<String, Value>,
+    project_id: Option<String>,
+    global: bool,
+) {
+    insert_optional_string(args, "project_id", project_id);
+    if global {
+        args.insert("global".into(), Value::Bool(true));
+    }
+}
+
+fn alias_list_args(project_id: Option<String>, global: bool, only_unbound: bool) -> Value {
+    let mut args = serde_json::Map::new();
+    insert_project_filter_args(&mut args, project_id, global);
+    if only_unbound {
+        args.insert("only_unbound".into(), Value::Bool(true));
+    }
+    Value::Object(args)
+}
+
+fn alias_get_args(alias: String, project_id: Option<String>) -> Value {
+    let mut args = serde_json::Map::new();
+    args.insert("alias".into(), Value::String(alias));
+    insert_optional_string(&mut args, "project_id", project_id);
+    Value::Object(args)
+}
+
+fn alias_member_args(alias: String, pane_id: String, project_id: Option<String>) -> Value {
+    let mut args = serde_json::Map::new();
+    args.insert("alias".into(), Value::String(alias));
+    args.insert("pane_id".into(), Value::String(pane_id));
+    insert_optional_string(&mut args, "project_id", project_id);
+    Value::Object(args)
+}
+
+fn alias_mode_args(alias: String, mode: String, project_id: Option<String>) -> Value {
+    let mut args = serde_json::Map::new();
+    args.insert("alias".into(), Value::String(alias));
+    args.insert("mode".into(), Value::String(mode));
+    insert_optional_string(&mut args, "project_id", project_id);
+    Value::Object(args)
+}
+
+fn subscription_list_args(
+    alias: Option<String>,
+    project_id: Option<String>,
+    global: bool,
+) -> Value {
+    let mut args = serde_json::Map::new();
+    insert_optional_string(&mut args, "alias", alias);
+    insert_project_filter_args(&mut args, project_id, global);
+    Value::Object(args)
+}
+
+fn subscription_create_args(alias: String, pattern: String, project_id: Option<String>) -> Value {
+    let mut args = serde_json::Map::new();
+    args.insert("alias".into(), Value::String(alias));
+    args.insert("pattern".into(), Value::String(pattern));
+    insert_optional_string(&mut args, "project_id", project_id);
+    Value::Object(args)
+}
+
+fn mailbox_peek_args(
+    alias: String,
+    unread_only: bool,
+    project_id: Option<String>,
+    global: bool,
+    limit: Option<u32>,
+) -> Value {
+    let mut args = serde_json::Map::new();
+    args.insert("alias".into(), Value::String(alias));
+    if unread_only {
+        args.insert("unread".into(), Value::Bool(true));
+    }
+    insert_project_filter_args(&mut args, project_id, global);
+    if let Some(limit) = limit {
+        args.insert("limit".into(), serde_json::json!(limit));
+    }
+    Value::Object(args)
+}
+
+fn bus_tail_args(
+    topic: Option<String>,
+    project_id: Option<String>,
+    global: bool,
+    limit: Option<u32>,
+) -> Value {
+    let mut args = serde_json::Map::new();
+    insert_optional_string(&mut args, "topic", topic);
+    insert_project_filter_args(&mut args, project_id, global);
+    if let Some(limit) = limit {
+        args.insert("limit".into(), serde_json::json!(limit));
+    }
+    Value::Object(args)
+}
+
+fn mailbox_count_args(alias: String, project_id: Option<String>, global: bool) -> Value {
+    let mut args = serde_json::Map::new();
+    args.insert("alias".into(), Value::String(alias));
+    insert_project_filter_args(&mut args, project_id, global);
+    Value::Object(args)
+}
+
+fn mailbox_alias_event_args(event_id: String, alias: String, result: Option<String>) -> Value {
+    let mut args = serde_json::Map::new();
+    args.insert("event_id".into(), Value::String(event_id));
+    args.insert("alias".into(), Value::String(alias));
+    insert_optional_string(&mut args, "result", result);
+    Value::Object(args)
+}
+
+fn mailbox_clear_args(alias: String, project_id: Option<String>, global: bool) -> Value {
+    let mut args = serde_json::Map::new();
+    args.insert("alias".into(), Value::String(alias));
+    insert_project_filter_args(&mut args, project_id, global);
+    Value::Object(args)
+}
+
+fn worktree_create_args(
+    repo_path: String,
+    branch: String,
+    start_point: Option<String>,
+    fetch_first: bool,
+) -> Value {
+    let mut args = serde_json::Map::new();
+    args.insert("repoPath".into(), Value::String(repo_path));
+    args.insert("branch".into(), Value::String(branch));
+    insert_optional_string(&mut args, "startPoint", start_point);
+    if fetch_first {
+        args.insert("fetchFirst".into(), Value::Bool(true));
+    }
+    Value::Object(args)
+}
+
+fn watch_config_arg(config: roux_core::CreateWatchConfig) -> Value {
+    serde_json::json!({ "config": config })
+}
+
+fn process_start_args(command: String, working_dir: Option<String>) -> Value {
+    let mut args = serde_json::Map::new();
+    args.insert("command".into(), Value::String(command));
+    insert_optional_string(&mut args, "workingDir", working_dir);
+    Value::Object(args)
+}
+
+fn max_bytes_args(id: String, max_bytes: Option<usize>) -> Value {
+    let mut args = serde_json::Map::new();
+    args.insert("id".into(), Value::String(id));
+    if let Some(max_bytes) = max_bytes {
+        args.insert("maxBytes".into(), serde_json::json!(max_bytes));
+    }
+    Value::Object(args)
 }
 
 fn insert_optional_string(
@@ -759,18 +1838,56 @@ mod tests {
         assert_eq!(response["seen"], true);
     }
 
+    #[cfg(not(windows))]
     #[test]
-    fn typed_status_decodes_from_daemon_response() {
+    fn stream_lines_blocking_uses_unix_sock_without_auth() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("roux.sock");
+        let listener = UnixListener::bind(&sock).unwrap();
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut line = String::new();
+            BufReader::new(stream.try_clone().unwrap()).read_line(&mut line).unwrap();
+            let request: Value = serde_json::from_str(line.trim()).unwrap();
+            stream.write_all(br#"{"type":"ready"}"#).unwrap();
+            stream.write_all(b"\n").unwrap();
+            stream.write_all(br#"{"type":"event","id":"one"}"#).unwrap();
+            stream.write_all(b"\n").unwrap();
+            request
+        });
+
+        let client = Roux::builder().endpoint(SocketEndpoint::Unix(sock)).connect().unwrap();
+        let lines = Arc::new(Mutex::new(Vec::new()));
+        let lines_for_callback = lines.clone();
+        client
+            .stream_lines_blocking(CommandRequest::new("watch-events"), move |line| {
+                lines_for_callback.lock().unwrap().push(line.to_string());
+                true
+            })
+            .unwrap();
+        let request = handle.join().unwrap();
+
+        assert_eq!(request["auth_token"], Value::Null);
+        assert_eq!(
+            *lines.lock().unwrap(),
+            vec![r#"{"type":"ready"}"#, r#"{"type":"event","id":"one"}"#]
+        );
+    }
+
+    #[test]
+    fn typed_watch_events_stream_uses_daemon_command_shape() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap().to_string();
         let handle = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let mut line = String::new();
             BufReader::new(stream.try_clone().unwrap()).read_line(&mut line).unwrap();
-            stream
-                .write_all(br#"{"ok":true,"data":{"kind":"roux-daemon","pid":42,"socket":"tcp://test","startedAtMs":10,"uptimeMs":20,"sessionCount":1,"projectCount":2,"watchCount":3,"processCount":4,"ptyCount":5,"capabilities":["daemon-status","daemon-pty-list"]}}"#)
-                .unwrap();
+            let request: Value = serde_json::from_str(line.trim()).unwrap();
+            stream.write_all(br#"{"type":"ready"}"#).unwrap();
             stream.write_all(b"\n").unwrap();
+            stream.write_all(br#"{"type":"warning","message":"heads up"}"#).unwrap();
+            stream.write_all(b"\n").unwrap();
+            request
         });
 
         let client = Roux::builder()
@@ -778,13 +1895,90 @@ mod tests {
             .auth_token("secret")
             .connect()
             .unwrap();
+        let frames = Arc::new(Mutex::new(Vec::new()));
+        let frames_for_callback = frames.clone();
+        client
+            .watch_events_blocking(true, move |frame| {
+                let label = match frame {
+                    WatchEventStreamFrame::Ready => "ready",
+                    WatchEventStreamFrame::Warning { .. } => "warning",
+                    WatchEventStreamFrame::Update { .. } => "update",
+                    WatchEventStreamFrame::Error { .. } => "error",
+                };
+                frames_for_callback.lock().unwrap().push(label);
+                true
+            })
+            .unwrap();
+        let request = handle.join().unwrap();
+
+        assert_eq!(request["command"], "watch-events");
+        assert_eq!(request["args"]["backlog"], true);
+        assert_eq!(*frames.lock().unwrap(), vec!["ready", "warning"]);
+    }
+
+    #[test]
+    fn typed_status_decodes_from_daemon_response() {
+        let (client, handle) = tcp_client_with_response(
+            r#"{"ok":true,"data":{"kind":"roux-daemon","pid":42,"socket":"tcp://test","startedAtMs":10,"uptimeMs":20,"sessionCount":1,"projectCount":2,"watchCount":3,"processCount":4,"ptyCount":5,"capabilities":["daemon-status","daemon-pty-list"]}}"#
+                .to_string(),
+        );
         let rt = tokio::runtime::Builder::new_current_thread().build().unwrap();
         let status = rt.block_on(client.status()).unwrap();
-        handle.join().unwrap();
+        let request = handle.join().unwrap();
 
+        assert_eq!(request["command"], "daemon-status");
         assert_eq!(status.kind, "roux-daemon");
         assert_eq!(status.pty_count, 5);
         assert!(status.capabilities.iter().any(|capability| capability == "daemon-pty-list"));
+    }
+
+    #[test]
+    fn typed_project_create_uses_daemon_command_shape() {
+        let (client, handle) = tcp_client_with_response(
+            r#"{"ok":true,"data":{"id":"project-a","name":"Alpha"}}"#.to_string(),
+        );
+        let rt = tokio::runtime::Builder::new_current_thread().build().unwrap();
+        let project = rt.block_on(client.create_project("Alpha")).unwrap();
+        let request = handle.join().unwrap();
+
+        assert_eq!(project.id, "project-a");
+        assert_eq!(request["command"], "project-create");
+        assert_eq!(request["args"]["name"], "Alpha");
+    }
+
+    #[test]
+    fn typed_mailbox_post_uses_daemon_command_shape() {
+        let (client, handle) = tcp_client_with_response(
+            r#"{"ok":true,"data":{"id":"event-a","createdAt":1,"to":"reviewer","topic":"build.done","from":"runner","kind":"fyi","correlationId":"corr-a","projectId":"project-a","subject":"Build","body":"ready","structured":{"ok":true}}}"#
+                .to_string(),
+        );
+        let rt = tokio::runtime::Builder::new_current_thread().build().unwrap();
+        let event = rt
+            .block_on(client.mailbox_post(MailboxPost {
+                to: Some("reviewer".to_string()),
+                topic: Some("build.done".to_string()),
+                body: "ready".to_string(),
+                subject: Some("Build".to_string()),
+                kind: Some("fyi".to_string()),
+                project_id: Some("project-a".to_string()),
+                correlation_id: Some("corr-a".to_string()),
+                structured: Some(serde_json::json!({ "ok": true })),
+                from: Some("runner".to_string()),
+            }))
+            .unwrap();
+        let request = handle.join().unwrap();
+
+        assert_eq!(event.id, "event-a");
+        assert_eq!(request["command"], "mailbox-post");
+        assert_eq!(request["args"]["to"], "reviewer");
+        assert_eq!(request["args"]["topic"], "build.done");
+        assert_eq!(request["args"]["body"], "ready");
+        assert_eq!(request["args"]["subject"], "Build");
+        assert_eq!(request["args"]["kind"], "fyi");
+        assert_eq!(request["args"]["project_id"], "project-a");
+        assert_eq!(request["args"]["correlation_id"], "corr-a");
+        assert_eq!(request["args"]["structured"]["ok"], true);
+        assert_eq!(request["args"]["from"], "runner");
     }
 
     #[test]
@@ -1008,6 +2202,26 @@ mod tests {
         assert_eq!(request["command"], "daemon-pty-attach");
         assert_eq!(request["args"]["id"], "pty-1");
         assert_eq!(*frames.lock().unwrap(), vec!["ready", "exit"]);
+    }
+
+    fn tcp_client_with_response(response: String) -> (Roux, thread::JoinHandle<Value>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut line = String::new();
+            BufReader::new(stream.try_clone().unwrap()).read_line(&mut line).unwrap();
+            let request: Value = serde_json::from_str(line.trim()).unwrap();
+            stream.write_all(response.as_bytes()).unwrap();
+            stream.write_all(b"\n").unwrap();
+            request
+        });
+        let client = Roux::builder()
+            .endpoint(SocketEndpoint::Tcp(addr))
+            .auth_token("secret")
+            .connect()
+            .unwrap();
+        (client, handle)
     }
 
     fn sample_session_json(id: &str, archived: bool) -> String {

--- a/crates/roux-sdk/src/lib.rs
+++ b/crates/roux-sdk/src/lib.rs
@@ -16,6 +16,8 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value;
 use std::time::Duration;
 
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
+
 #[derive(Debug, Clone)]
 pub struct Roux {
     endpoint: SocketEndpoint,
@@ -178,6 +180,18 @@ impl Roux {
 
     pub fn connect() -> RouxResult<Self> {
         Self::builder().connect()
+    }
+
+    pub fn with_timeout(&self, timeout: Duration) -> Self {
+        Self { endpoint: self.endpoint.clone(), auth_token: self.auth_token.clone(), timeout }
+    }
+
+    pub fn with_default_timeout(&self) -> Self {
+        self.with_timeout(DEFAULT_TIMEOUT)
+    }
+
+    pub fn request_timeout(&self) -> Duration {
+        self.timeout
     }
 
     pub async fn status(&self) -> RouxResult<DaemonStatus> {
@@ -1072,7 +1086,7 @@ impl Roux {
 
 impl Default for RouxBuilder {
     fn default() -> Self {
-        Self { endpoint: None, auth_token: None, timeout: Duration::from_secs(5) }
+        Self { endpoint: None, auth_token: None, timeout: DEFAULT_TIMEOUT }
     }
 }
 

--- a/src-tauri/src/daemon_client.rs
+++ b/src-tauri/src/daemon_client.rs
@@ -1,6 +1,4 @@
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
-use std::io::{BufRead, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::Duration;
@@ -9,22 +7,23 @@ use tauri::{AppHandle, Emitter};
 
 use crate::commands::notes::{NotesRead, NotesSearchQuery, NotesTarget};
 use roux_core::{
-    AgentAlias, AliasEvent, BusSubscription, BusSubscriptionEvent, CreateWatchConfig, Event,
-    MailboxEvent, Project, ProjectUpdate, ReadState, Session, SessionExitPayload,
-    SessionExitReason, Watch, WatchUpdateEvent, Worktree,
+    AgentAlias, BusSubscription, CreateWatchConfig, Event, Project, ProjectUpdate, ReadState,
+    Session, SessionExitPayload, SessionExitReason, Watch, Worktree,
 };
 use roux_runtime::automation_hooks::{
     HookListItem, HookLogEntry, HookPreviewItem, HookRunRequest, HookRunSummary,
 };
 use roux_runtime::process_service::{ProcessRecord, ProcessSnapshot};
 use roux_runtime::terminal_env::NotesEnvInputs;
-use roux_sdk::{CommandRequest, PtyAttachFrame, PtyRecord, PtySnapshot};
+use roux_sdk::{
+    AliasEventStreamFrame, MailboxEventStreamFrame, PtyAttachFrame, PtyRecord, PtySnapshot,
+    SubscriptionEventStreamFrame, WatchEventStreamFrame,
+};
 
 use crate::platform;
 use crate::watches::WatchManager;
 
 const PROBE_TIMEOUT: Duration = Duration::from_millis(250);
-const COMMAND_TIMEOUT: Duration = Duration::from_secs(5);
 const STARTUP_TIMEOUT: Duration = Duration::from_secs(3);
 const STARTUP_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const EVENT_BRIDGE_RECONNECT_DELAY: Duration = Duration::from_secs(1);
@@ -92,27 +91,14 @@ pub(crate) struct DaemonReconnectSessionShellRequest {
     pub(crate) notes: Option<NotesEnvInputs>,
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct DaemonMailboxPostRequest {
-    pub(crate) to: Option<String>,
-    pub(crate) topic: Option<String>,
-    pub(crate) body: String,
-    pub(crate) subject: Option<String>,
-    pub(crate) kind: Option<String>,
-    pub(crate) project_id: Option<String>,
-    pub(crate) correlation_id: Option<String>,
-    pub(crate) structured: Option<Value>,
-    pub(crate) from: Option<String>,
-}
+pub(crate) type DaemonMailboxPostRequest = roux_sdk::MailboxPost;
 
 impl DaemonClient {
     pub(crate) fn detect() -> Option<Self> {
-        let data =
-            send_command_blocking(serde_json::json!({ "command": "daemon-status" }), PROBE_TIMEOUT)
-                .ok()?;
+        let sdk = roux_sdk::Roux::builder().timeout(PROBE_TIMEOUT).connect().ok()?;
+        let data = sdk.status_blocking().ok()?;
         let status: DaemonStatus = serde_json::from_value(data).ok()?;
         if status.kind == "roux-daemon" {
-            let sdk = roux_sdk::Roux::connect().ok()?;
             Some(Self { status, sdk })
         } else {
             None
@@ -161,9 +147,8 @@ impl DaemonClient {
     }
 
     pub(crate) async fn refresh_status(&self) -> Result<DaemonStatus, String> {
-        let value = send_command_async(serde_json::json!({ "command": "daemon-status" })).await?;
-        let status: DaemonStatus =
-            serde_json::from_value(value).map_err(|err| format!("decode daemon-status: {err}"))?;
+        let status = self.sdk.status_value().await.map_err(|err| err.to_string())?;
+        let status: DaemonStatus = serde_json::from_value(status).map_err(|err| err.to_string())?;
         if status.kind == "roux-daemon" {
             Ok(status)
         } else {
@@ -176,30 +161,23 @@ impl DaemonClient {
     }
 
     pub(crate) async fn get_session(&self, id: String) -> Result<Session, String> {
-        self.sdk
-            .command(CommandRequest::new("session-poll").session_id(id))
-            .await
-            .map_err(|err| err.to_string())
+        self.sdk.get_session(id).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn list_projects(&self) -> Result<Vec<Project>, String> {
-        let value = send_command_async(serde_json::json!({ "command": "project-list" })).await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon project-list: {err}"))
+        self.sdk.projects().await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn create_project(&self, name: String) -> Result<Project, String> {
-        let value = send_command_async(daemon_project_create_request(name)).await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon project-create: {err}"))
+        self.sdk.create_project(name).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn remove_project(&self, id: String) -> Result<(), String> {
-        let _ = send_command_async(daemon_project_id_request("project-remove", id)).await?;
-        Ok(())
+        self.sdk.remove_project(id).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn rename_project(&self, id: String, name: String) -> Result<(), String> {
-        let _ = send_command_async(daemon_project_rename_request(id, name)).await?;
-        Ok(())
+        self.sdk.rename_project(id, name).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn update_project(
@@ -207,8 +185,7 @@ impl DaemonClient {
         id: String,
         patch: ProjectUpdate,
     ) -> Result<Project, String> {
-        let value = send_command_async(daemon_project_update_request(id, patch)).await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon project-update: {err}"))
+        self.sdk.update_project(id, patch).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn list_aliases(
@@ -217,9 +194,7 @@ impl DaemonClient {
         global: bool,
         only_unbound: bool,
     ) -> Result<Vec<AgentAlias>, String> {
-        let value =
-            send_command_async(daemon_alias_list_request(project_id, global, only_unbound)).await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon alias-list: {err}"))
+        self.sdk.list_aliases(project_id, global, only_unbound).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn get_alias(
@@ -227,23 +202,14 @@ impl DaemonClient {
         alias: String,
         project_id: Option<String>,
     ) -> Result<Option<AgentAlias>, String> {
-        let value =
-            match send_command_async(daemon_alias_get_request(alias.clone(), project_id)).await {
-                Ok(value) => value,
-                Err(err) if err.contains(&format!("alias '{alias}' not found")) => return Ok(None),
-                Err(err) => return Err(err),
-            };
-        serde_json::from_value(value)
-            .map(Some)
-            .map_err(|err| format!("decode daemon alias-get: {err}"))
+        self.sdk.get_alias(alias, project_id).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn whoami_aliases(
         &self,
         session_id: String,
     ) -> Result<Vec<AgentAlias>, String> {
-        let value = send_command_async(daemon_alias_whoami_request(session_id)).await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon alias-whoami: {err}"))
+        self.sdk.whoami_aliases(session_id).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn add_alias_member(
@@ -252,15 +218,7 @@ impl DaemonClient {
         pane_id: String,
         project_id: Option<String>,
     ) -> Result<AgentAlias, String> {
-        let value = send_command_async(daemon_alias_member_request(
-            "alias-add-member",
-            alias,
-            pane_id,
-            project_id,
-        ))
-        .await?;
-        serde_json::from_value(value)
-            .map_err(|err| format!("decode daemon alias-add-member: {err}"))
+        self.sdk.add_alias_member(alias, pane_id, project_id).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn remove_alias_member(
@@ -269,17 +227,10 @@ impl DaemonClient {
         pane_id: String,
         project_id: Option<String>,
     ) -> Result<bool, String> {
-        let value = send_command_async(daemon_alias_member_request(
-            "alias-remove-member",
-            alias,
-            pane_id,
-            project_id,
-        ))
-        .await?;
-        value
-            .get("removed")
-            .and_then(|removed| removed.as_bool())
-            .ok_or_else(|| "decode daemon alias-remove-member: missing removed".to_string())
+        self.sdk
+            .remove_alias_member(alias, pane_id, project_id)
+            .await
+            .map_err(|err| err.to_string())
     }
 
     pub(crate) async fn set_alias_mode(
@@ -288,8 +239,7 @@ impl DaemonClient {
         mode: String,
         project_id: Option<String>,
     ) -> Result<AgentAlias, String> {
-        let value = send_command_async(daemon_alias_mode_request(alias, mode, project_id)).await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon alias-mode: {err}"))
+        self.sdk.set_alias_mode(alias, mode, project_id).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn list_subscriptions(
@@ -298,10 +248,7 @@ impl DaemonClient {
         project_id: Option<String>,
         global: bool,
     ) -> Result<Vec<BusSubscription>, String> {
-        let value =
-            send_command_async(daemon_bus_subscriptions_request(alias, project_id, global)).await?;
-        serde_json::from_value(value)
-            .map_err(|err| format!("decode daemon bus-subscriptions: {err}"))
+        self.sdk.list_subscriptions(alias, project_id, global).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn create_subscription(
@@ -310,17 +257,14 @@ impl DaemonClient {
         pattern: String,
         project_id: Option<String>,
     ) -> Result<BusSubscription, String> {
-        let value =
-            send_command_async(daemon_bus_subscribe_request(alias, pattern, project_id)).await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon bus-subscribe: {err}"))
+        self.sdk
+            .create_subscription(alias, pattern, project_id)
+            .await
+            .map_err(|err| err.to_string())
     }
 
     pub(crate) async fn delete_subscription(&self, id: String) -> Result<bool, String> {
-        let value = send_command_async(daemon_bus_unsubscribe_request(id)).await?;
-        value
-            .get("removed")
-            .and_then(|removed| removed.as_bool())
-            .ok_or_else(|| "decode daemon bus-unsubscribe: missing removed".to_string())
+        self.sdk.delete_subscription(id).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn mailbox_list_for_recipient(
@@ -330,15 +274,10 @@ impl DaemonClient {
         project_id: Option<String>,
         global: bool,
     ) -> Result<Vec<Event>, String> {
-        let value = send_command_async(daemon_mailbox_peek_request(
-            alias,
-            unread_only,
-            project_id,
-            global,
-            None,
-        ))
-        .await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon mailbox-peek: {err}"))
+        self.sdk
+            .mailbox_list_for_recipient(alias, unread_only, project_id, global)
+            .await
+            .map_err(|err| err.to_string())
     }
 
     pub(crate) async fn mailbox_list_for_topic(
@@ -347,10 +286,10 @@ impl DaemonClient {
         project_id: Option<String>,
         global: bool,
     ) -> Result<Vec<Event>, String> {
-        let value =
-            send_command_async(daemon_bus_tail_request(Some(topic), project_id, global, None))
-                .await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon bus-tail: {err}"))
+        self.sdk
+            .mailbox_list_for_topic(topic, project_id, global)
+            .await
+            .map_err(|err| err.to_string())
     }
 
     pub(crate) async fn mailbox_list_all(
@@ -359,9 +298,7 @@ impl DaemonClient {
         global: bool,
         limit: Option<u32>,
     ) -> Result<Vec<Event>, String> {
-        let value =
-            send_command_async(daemon_bus_tail_request(None, project_id, global, limit)).await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon bus-tail: {err}"))
+        self.sdk.mailbox_list_all(project_id, global, limit).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn mailbox_unread_count(
@@ -370,22 +307,17 @@ impl DaemonClient {
         project_id: Option<String>,
         global: bool,
     ) -> Result<u32, String> {
-        let value =
-            send_command_async(daemon_mailbox_count_request(alias, project_id, global)).await?;
-        value
-            .get("unread")
-            .and_then(|unread| unread.as_u64())
-            .and_then(|unread| u32::try_from(unread).ok())
-            .ok_or_else(|| "decode daemon mailbox-count: missing unread".to_string())
+        self.sdk
+            .mailbox_unread_count(alias, project_id, global)
+            .await
+            .map_err(|err| err.to_string())
     }
 
     pub(crate) async fn mailbox_get_event(
         &self,
         event_id: String,
     ) -> Result<Option<Event>, String> {
-        let value =
-            send_command_async(daemon_mailbox_event_id_request("mailbox-get", event_id)).await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon mailbox-get: {err}"))
+        self.sdk.mailbox_get_event(event_id).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn mailbox_read_state(
@@ -393,18 +325,14 @@ impl DaemonClient {
         event_id: String,
         recipient: String,
     ) -> Result<Option<ReadState>, String> {
-        let value =
-            send_command_async(daemon_mailbox_read_state_request(event_id, recipient)).await?;
-        serde_json::from_value(value)
-            .map_err(|err| format!("decode daemon mailbox-read-state: {err}"))
+        self.sdk.mailbox_read_state(event_id, recipient).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn mailbox_post(
         &self,
         request: DaemonMailboxPostRequest,
     ) -> Result<Event, String> {
-        let value = send_command_async(daemon_mailbox_post_request(request)).await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon mailbox-post: {err}"))
+        self.sdk.mailbox_post(request).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn mailbox_mark_read(
@@ -412,12 +340,7 @@ impl DaemonClient {
         event_id: String,
         recipient: String,
     ) -> Result<bool, String> {
-        let value =
-            send_command_async(daemon_mailbox_mark_read_request(event_id, recipient)).await?;
-        value
-            .get("changed")
-            .and_then(|changed| changed.as_bool())
-            .ok_or_else(|| "decode daemon mailbox-mark-read: missing changed".to_string())
+        self.sdk.mailbox_mark_read(event_id, recipient).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn mailbox_ack(
@@ -426,17 +349,7 @@ impl DaemonClient {
         recipient: String,
         result: Option<String>,
     ) -> Result<bool, String> {
-        let value = send_command_async(daemon_mailbox_alias_event_request(
-            "mailbox-ack",
-            event_id,
-            recipient,
-            result,
-        ))
-        .await?;
-        value
-            .get("changed")
-            .and_then(|changed| changed.as_bool())
-            .ok_or_else(|| "decode daemon mailbox-ack: missing changed".to_string())
+        self.sdk.mailbox_ack(event_id, recipient, result).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn mailbox_clear_read(
@@ -445,13 +358,10 @@ impl DaemonClient {
         project_id: Option<String>,
         global: bool,
     ) -> Result<u32, String> {
-        let value =
-            send_command_async(daemon_mailbox_clear_request(recipient, project_id, global)).await?;
-        value
-            .get("cleared")
-            .and_then(|cleared| cleared.as_u64())
-            .and_then(|cleared| u32::try_from(cleared).ok())
-            .ok_or_else(|| "decode daemon mailbox-clear: missing cleared".to_string())
+        self.sdk
+            .mailbox_clear_read(recipient, project_id, global)
+            .await
+            .map_err(|err| err.to_string())
     }
 
     pub(crate) async fn mailbox_retract(
@@ -459,14 +369,7 @@ impl DaemonClient {
         event_id: String,
         sender: String,
     ) -> Result<Event, String> {
-        let value = send_command_async(daemon_mailbox_alias_event_request(
-            "mailbox-retract",
-            event_id,
-            sender,
-            None,
-        ))
-        .await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon mailbox-retract: {err}"))
+        self.sdk.mailbox_retract(event_id, sender).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn mailbox_dismiss(
@@ -474,22 +377,11 @@ impl DaemonClient {
         event_id: String,
         recipient: String,
     ) -> Result<bool, String> {
-        let value = send_command_async(daemon_mailbox_alias_event_request(
-            "mailbox-dismiss",
-            event_id,
-            recipient,
-            None,
-        ))
-        .await?;
-        value
-            .get("changed")
-            .and_then(|changed| changed.as_bool())
-            .ok_or_else(|| "decode daemon mailbox-dismiss: missing changed".to_string())
+        self.sdk.mailbox_dismiss(event_id, recipient).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn read_notes(&self, target: NotesTarget) -> Result<NotesRead, String> {
-        let value = send_command_async(daemon_notes_read_request(target)).await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon notes-read: {err}"))
+        self.sdk.read_notes(target).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn write_notes(
@@ -498,8 +390,7 @@ impl DaemonClient {
         content: String,
         tags: Vec<String>,
     ) -> Result<(), String> {
-        let _ = send_command_async(daemon_notes_write_request(target, content, tags)).await?;
-        Ok(())
+        self.sdk.write_notes(target, content, tags).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn append_notes(
@@ -509,9 +400,10 @@ impl DaemonClient {
         timestamped: bool,
         tags: Vec<String>,
     ) -> Result<(), String> {
-        let _ = send_command_async(daemon_notes_append_request(target, content, timestamped, tags))
-            .await?;
-        Ok(())
+        self.sdk
+            .append_notes(target, content, timestamped, tags)
+            .await
+            .map_err(|err| err.to_string())
     }
 
     pub(crate) async fn notes_path(
@@ -519,66 +411,55 @@ impl DaemonClient {
         target: NotesTarget,
         dir: bool,
     ) -> Result<String, String> {
-        let value = send_command_async(daemon_notes_path_request(target, dir)).await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon notes-path: {err}"))
+        self.sdk.notes_path(target, dir).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn search_notes(
         &self,
         query: NotesSearchQuery,
     ) -> Result<Vec<String>, String> {
-        let value = send_command_async(daemon_notes_search_request(query)).await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon notes-search: {err}"))
+        self.sdk.search_notes(query).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn notes_vault_root(&self) -> Result<String, String> {
-        let value = send_command_async(daemon_notes_vault_root_request()).await?;
-        serde_json::from_value(value)
-            .map_err(|err| format!("decode daemon notes-vault-root: {err}"))
+        self.sdk.notes_vault_root().await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn list_automation_hooks(
         &self,
         repo_path: Option<String>,
     ) -> Result<Vec<HookListItem>, String> {
-        let value = send_command_async(daemon_hook_show_request(repo_path)).await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon hook-show: {err}"))
+        self.sdk.list_automation_hooks(repo_path).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn preview_automation_hooks(
         &self,
         request: HookRunRequest,
     ) -> Result<Vec<HookPreviewItem>, String> {
-        let value = send_command_async(daemon_hook_run_request("hook-preview", request)?).await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon hook-preview: {err}"))
+        self.sdk.preview_automation_hooks(request).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn run_automation_hook(
         &self,
         request: HookRunRequest,
     ) -> Result<HookRunSummary, String> {
-        let value = send_command_async(daemon_hook_run_request("hook-run", request)?).await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon hook-run: {err}"))
+        self.sdk.run_automation_hook(request).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn approve_automation_hook(&self, approval_id: String) -> Result<(), String> {
-        let _ = send_command_async(daemon_hook_approve_request(approval_id)).await?;
-        Ok(())
+        self.sdk.approve_automation_hook(approval_id).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn clear_automation_hook_approvals(&self) -> Result<(), String> {
-        let _ = send_command_async(daemon_hook_clear_approvals_request()).await?;
-        Ok(())
+        self.sdk.clear_automation_hook_approvals().await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn list_automation_hook_logs(&self) -> Result<Vec<HookLogEntry>, String> {
-        let value = send_command_async(daemon_hook_log_list_request()).await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon hook-log-list: {err}"))
+        self.sdk.list_automation_hook_logs().await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn read_automation_hook_log(&self, path: String) -> Result<String, String> {
-        let value = send_command_async(daemon_hook_log_read_request(path)).await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon hook-log-read: {err}"))
+        self.sdk.read_automation_hook_log(path).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn set_session_name_override(
@@ -586,14 +467,10 @@ impl DaemonClient {
         session_id: String,
         name_override: Option<String>,
     ) -> Result<(), String> {
-        let name = name_override.unwrap_or_default();
-        let _ = send_command_async(serde_json::json!({
-            "command": "session-rename",
-            "session_id": session_id,
-            "args": { "name": name },
-        }))
-        .await?;
-        Ok(())
+        self.sdk
+            .set_session_name_override(session_id, name_override)
+            .await
+            .map_err(|err| err.to_string())
     }
 
     pub(crate) async fn set_session_project(
@@ -601,14 +478,7 @@ impl DaemonClient {
         session_id: String,
         project_id: Option<String>,
     ) -> Result<(), String> {
-        let _ = send_command_async(daemon_session_optional_value_request(
-            "session-set-project",
-            session_id,
-            "projectId",
-            project_id,
-        ))
-        .await?;
-        Ok(())
+        self.sdk.set_session_project(session_id, project_id).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn set_session_pinned_pr_url(
@@ -616,14 +486,7 @@ impl DaemonClient {
         session_id: String,
         url: Option<String>,
     ) -> Result<(), String> {
-        let _ = send_command_async(daemon_session_optional_value_request(
-            "session-set-pinned-pr-url",
-            session_id,
-            "url",
-            url,
-        ))
-        .await?;
-        Ok(())
+        self.sdk.set_session_pinned_pr_url(session_id, url).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn set_session_smol_machine(
@@ -631,14 +494,10 @@ impl DaemonClient {
         session_id: String,
         machine_name: Option<String>,
     ) -> Result<(), String> {
-        let _ = send_command_async(daemon_session_optional_value_request(
-            "session-set-smol-machine",
-            session_id,
-            "machineName",
-            machine_name,
-        ))
-        .await?;
-        Ok(())
+        self.sdk
+            .set_session_smol_machine(session_id, machine_name)
+            .await
+            .map_err(|err| err.to_string())
     }
 
     pub(crate) async fn create_session_shell(
@@ -685,42 +544,30 @@ impl DaemonClient {
     }
 
     pub(crate) async fn archive_session(&self, id: String) -> Result<Session, String> {
-        let value = send_command_async(daemon_session_id_request("session-archive", id)).await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon session-archive: {err}"))
+        self.sdk.archive_session(id).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn restore_session(&self, id: String) -> Result<Session, String> {
-        let value = send_command_async(daemon_session_id_request("session-restore", id)).await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon session-restore: {err}"))
+        self.sdk.restore_session(id).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn delete_session(&self, id: String) -> Result<(), String> {
-        let _ = send_command_async(daemon_session_id_request("session-delete", id)).await?;
-        Ok(())
+        self.sdk.delete_session(id).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn session_worktree_exists(&self, id: String) -> Result<bool, String> {
-        let value =
-            send_command_async(daemon_session_id_request("session-worktree-exists", id)).await?;
-        value
-            .get("exists")
-            .and_then(|exists| exists.as_bool())
-            .ok_or_else(|| "decode daemon session-worktree-exists: missing exists".to_string())
+        self.sdk.session_worktree_exists(id).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn refresh_session_branch(
         &self,
         id: String,
     ) -> Result<Option<String>, String> {
-        let value =
-            send_command_async(daemon_session_id_request("session-refresh-branch", id)).await?;
-        Ok(value.get("branch").and_then(|branch| branch.as_str()).map(str::to_string))
+        self.sdk.refresh_session_branch(id).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn list_worktrees(&self, repo_path: String) -> Result<Vec<Worktree>, String> {
-        let value =
-            send_command_async(daemon_repo_path_request("worktree-list", repo_path)).await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon worktree-list: {err}"))
+        self.sdk.list_worktrees(repo_path).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn create_worktree(
@@ -730,18 +577,10 @@ impl DaemonClient {
         start_point: Option<String>,
         fetch_first: bool,
     ) -> Result<String, String> {
-        let value = send_command_async(daemon_worktree_create_request(
-            repo_path,
-            branch,
-            start_point,
-            fetch_first,
-        ))
-        .await?;
-        value
-            .get("path")
-            .and_then(|path| path.as_str())
-            .map(str::to_string)
-            .ok_or_else(|| "decode daemon worktree-create: missing path".to_string())
+        self.sdk
+            .create_worktree(repo_path, branch, start_point, fetch_first)
+            .await
+            .map_err(|err| err.to_string())
     }
 
     pub(crate) async fn remove_worktree(
@@ -751,80 +590,60 @@ impl DaemonClient {
         also_branch: bool,
         force: bool,
     ) -> Result<(), String> {
-        let _ = send_command_async(daemon_worktree_remove_request(
-            repo_path,
-            worktree_path,
-            also_branch,
-            force,
-        ))
-        .await?;
-        Ok(())
+        self.sdk
+            .remove_worktree(repo_path, worktree_path, also_branch, force)
+            .await
+            .map_err(|err| err.to_string())
     }
 
     pub(crate) async fn list_branches(&self, repo_path: String) -> Result<Vec<String>, String> {
-        let value =
-            send_command_async(daemon_repo_path_request("worktree-list-branches", repo_path))
-                .await?;
-        serde_json::from_value(value)
-            .map_err(|err| format!("decode daemon worktree-list-branches: {err}"))
+        self.sdk.list_branches(repo_path).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn git_init(&self, path: String) -> Result<(), String> {
-        let _ = send_command_async(daemon_path_request("git-init", path)).await?;
-        Ok(())
+        self.sdk.git_init(path).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn list_watches(&self) -> Result<Vec<Watch>, String> {
-        let value = send_command_async(daemon_watch_list_request()).await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon watch-list: {err}"))
+        self.sdk.watches().await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn create_watch(&self, config: CreateWatchConfig) -> Result<Watch, String> {
-        let value = send_command_async(daemon_watch_config_request("watch-create", config)).await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon watch-create: {err}"))
+        self.sdk.create_watch(config).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn find_or_create_watch(
         &self,
         config: CreateWatchConfig,
     ) -> Result<Watch, String> {
-        let value =
-            send_command_async(daemon_watch_config_request("watch-find-or-create", config)).await?;
-        serde_json::from_value(value)
-            .map_err(|err| format!("decode daemon watch-find-or-create: {err}"))
+        self.sdk.find_or_create_watch(config).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn remove_watch(&self, id: String) -> Result<(), String> {
-        let _ = send_command_async(daemon_watch_id_request("watch-remove", id)).await?;
-        Ok(())
+        self.sdk.remove_watch(id).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn pause_watch(&self, id: String) -> Result<Watch, String> {
-        let value = send_command_async(daemon_watch_id_request("watch-pause", id)).await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon watch-pause: {err}"))
+        self.sdk.pause_watch(id).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn resume_watch(&self, id: String) -> Result<Watch, String> {
-        let value = send_command_async(daemon_watch_id_request("watch-resume", id)).await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon watch-resume: {err}"))
+        self.sdk.resume_watch(id).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn replace_watch(&self, watch: Watch) -> Result<(), String> {
-        let _ = send_command_async(daemon_watch_replace_request(watch)).await?;
-        Ok(())
+        self.sdk.replace_watch(watch).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn remove_watches_for_session(
         &self,
         session_id: String,
     ) -> Result<(), String> {
-        let _ = send_command_async(daemon_watch_session_request(session_id)).await?;
-        Ok(())
+        self.sdk.remove_watches_for_session(session_id).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn cleanup_watch_orphans(&self) -> Result<(), String> {
-        let _ = send_command_async(daemon_watch_cleanup_orphans_request()).await?;
-        Ok(())
+        self.sdk.cleanup_watch_orphans().await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn start_daemon_process(
@@ -832,8 +651,7 @@ impl DaemonClient {
         command: String,
         working_dir: Option<String>,
     ) -> Result<ProcessRecord, String> {
-        let value = send_command_async(daemon_process_start_request(command, working_dir)).await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon process start: {err}"))
+        self.sdk.start_daemon_process(command, working_dir).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn daemon_process_output(
@@ -841,18 +659,15 @@ impl DaemonClient {
         id: String,
         max_bytes: Option<usize>,
     ) -> Result<ProcessSnapshot, String> {
-        let value = send_command_async(daemon_process_output_request(id, max_bytes)).await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon process output: {err}"))
+        self.sdk.daemon_process_output(id, max_bytes).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn list_daemon_processes(&self) -> Result<Vec<ProcessRecord>, String> {
-        let value = send_command_async(daemon_process_list_request()).await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon process list: {err}"))
+        self.sdk.list_daemon_processes().await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn kill_daemon_process(&self, id: String) -> Result<ProcessRecord, String> {
-        let value = send_command_async(daemon_process_kill_request(id)).await?;
-        serde_json::from_value(value).map_err(|err| format!("decode daemon process kill: {err}"))
+        self.sdk.kill_daemon_process(id).await.map_err(|err| err.to_string())
     }
 
     pub(crate) async fn spawn_daemon_pty_shell(
@@ -1040,10 +855,11 @@ impl DaemonClient {
         app: AppHandle,
         watch_manager: WatchManager,
     ) -> tauri::async_runtime::JoinHandle<()> {
+        let sdk = self.sdk.clone();
         tauri::async_runtime::spawn_blocking(move || {
             run_reconnecting_event_bridge(
                 "watch",
-                move || read_watch_events_blocking(app.clone(), watch_manager.clone()),
+                move || read_watch_events_blocking(&sdk, app.clone(), watch_manager.clone()),
                 std::thread::sleep,
                 None,
             );
@@ -1054,10 +870,11 @@ impl DaemonClient {
         &self,
         app: AppHandle,
     ) -> tauri::async_runtime::JoinHandle<()> {
+        let sdk = self.sdk.clone();
         tauri::async_runtime::spawn_blocking(move || {
             run_reconnecting_event_bridge(
                 "mailbox",
-                move || read_mailbox_events_blocking(app.clone()),
+                move || read_mailbox_events_blocking(&sdk, app.clone()),
                 std::thread::sleep,
                 None,
             );
@@ -1068,10 +885,11 @@ impl DaemonClient {
         &self,
         app: AppHandle,
     ) -> tauri::async_runtime::JoinHandle<()> {
+        let sdk = self.sdk.clone();
         tauri::async_runtime::spawn_blocking(move || {
             run_reconnecting_event_bridge(
                 "alias",
-                move || read_alias_events_blocking(app.clone()),
+                move || read_alias_events_blocking(&sdk, app.clone()),
                 std::thread::sleep,
                 None,
             );
@@ -1082,10 +900,11 @@ impl DaemonClient {
         &self,
         app: AppHandle,
     ) -> tauri::async_runtime::JoinHandle<()> {
+        let sdk = self.sdk.clone();
         tauri::async_runtime::spawn_blocking(move || {
             run_reconnecting_event_bridge(
                 "subscription",
-                move || read_subscription_events_blocking(app.clone()),
+                move || read_subscription_events_blocking(&sdk, app.clone()),
                 std::thread::sleep,
                 None,
             );
@@ -1230,1035 +1049,22 @@ fn daemon_spawn_command(binary: &Path) -> Command {
     command
 }
 
-fn daemon_process_start_request(command: String, working_dir: Option<String>) -> Value {
-    let mut args = serde_json::Map::new();
-    args.insert("command".to_string(), Value::String(command));
-    if let Some(working_dir) = working_dir {
-        args.insert("workingDir".to_string(), Value::String(working_dir));
-    }
-    serde_json::json!({
-        "command": "daemon-process-start",
-        "args": args,
-    })
-}
-
-#[cfg(test)]
-fn daemon_session_create_shell_request(request: DaemonCreateSessionShellRequest) -> Value {
-    let mut args = serde_json::Map::new();
-    args.insert("id".to_string(), Value::String(request.id));
-    args.insert("repoPath".to_string(), Value::String(request.repo_path));
-    args.insert("name".to_string(), Value::String(request.name));
-    if let Some(worktree_path) = request.worktree_path {
-        args.insert("worktreePath".to_string(), Value::String(worktree_path));
-    }
-    if let Some(branch) = request.branch {
-        args.insert("branch".to_string(), Value::String(branch));
-    }
-    if let Some(base) = request.base {
-        args.insert("base".to_string(), Value::String(base));
-    }
-    if request.fetch_first {
-        args.insert("fetchFirst".to_string(), Value::Bool(true));
-    }
-    if let Some(profile) = request.profile {
-        args.insert("profile".to_string(), Value::String(profile));
-    }
-    if let Some(nono_profile) = request.nono_profile {
-        args.insert("nonoProfile".to_string(), Value::String(nono_profile));
-    }
-    if !request.nono_allow_dirs.is_empty() {
-        args.insert("nonoAllowDirs".to_string(), serde_json::json!(request.nono_allow_dirs));
-    }
-    if let Some((cols, rows)) = request.initial_size {
-        args.insert("initialSize".to_string(), serde_json::json!([cols, rows]));
-    }
-    if let Some(project_id) = request.project_id {
-        args.insert("projectId".to_string(), Value::String(project_id));
-    }
-    if let Some(blueprint_id) = request.blueprint_id {
-        args.insert("blueprintId".to_string(), Value::String(blueprint_id));
-    }
-    if let Some(smol_machine_name) = request.smol_machine_name {
-        args.insert("smolMachineName".to_string(), Value::String(smol_machine_name));
-    }
-    if let Some(notes) = request.notes {
-        args.insert(
-            "notesEnv".to_string(),
-            serde_json::json!({
-                "vaultRoot": notes.vault_root,
-                "sessionSlug": notes.session_slug,
-                "repoSlug": notes.repo_slug,
-                "projectSlug": notes.project_slug,
-                "contextPaths": notes.context_paths,
-                "projectPrompt": notes.project_prompt,
-            }),
-        );
-    }
-    serde_json::json!({
-        "command": "session-create-shell",
-        "args": args,
-    })
-}
-
-#[cfg(test)]
-fn daemon_session_reconnect_shell_request(request: DaemonReconnectSessionShellRequest) -> Value {
-    let mut args = serde_json::Map::new();
-    if let Some(profile) = request.profile {
-        args.insert("profile".to_string(), Value::String(profile));
-    }
-    if let Some(nono_profile) = request.nono_profile {
-        args.insert("nonoProfile".to_string(), Value::String(nono_profile));
-    }
-    if !request.nono_allow_dirs.is_empty() {
-        args.insert("nonoAllowDirs".to_string(), serde_json::json!(request.nono_allow_dirs));
-    }
-    if let Some((cols, rows)) = request.initial_size {
-        args.insert("initialSize".to_string(), serde_json::json!([cols, rows]));
-    }
-    if let Some(notes) = request.notes {
-        args.insert(
-            "notesEnv".to_string(),
-            serde_json::json!({
-                "vaultRoot": notes.vault_root,
-                "sessionSlug": notes.session_slug,
-                "repoSlug": notes.repo_slug,
-                "projectSlug": notes.project_slug,
-                "contextPaths": notes.context_paths,
-                "projectPrompt": notes.project_prompt,
-            }),
-        );
-    }
-    serde_json::json!({
-        "command": "session-reconnect-shell",
-        "session_id": request.id,
-        "args": args,
-    })
-}
-
-fn daemon_session_id_request(command: &str, id: String) -> Value {
-    serde_json::json!({
-        "command": command,
-        "session_id": id,
-    })
-}
-
-fn daemon_session_optional_value_request(
-    command: &str,
-    session_id: String,
-    key: &str,
-    value: Option<String>,
-) -> Value {
-    let mut args = serde_json::Map::new();
-    args.insert(key.to_string(), value.map(Value::String).unwrap_or(Value::Null));
-    serde_json::json!({
-        "command": command,
-        "session_id": session_id,
-        "args": args,
-    })
-}
-
-fn daemon_project_create_request(name: String) -> Value {
-    serde_json::json!({
-        "command": "project-create",
-        "args": { "name": name },
-    })
-}
-
-fn daemon_project_id_request(command: &str, id: String) -> Value {
-    serde_json::json!({
-        "command": command,
-        "args": { "id": id },
-    })
-}
-
-fn daemon_project_rename_request(id: String, name: String) -> Value {
-    serde_json::json!({
-        "command": "project-rename",
-        "args": { "id": id, "name": name },
-    })
-}
-
-fn daemon_project_update_request(id: String, patch: ProjectUpdate) -> Value {
-    serde_json::json!({
-        "command": "project-update",
-        "args": { "id": id, "patch": patch },
-    })
-}
-
-fn daemon_repo_path_request(command: &str, repo_path: String) -> Value {
-    serde_json::json!({
-        "command": command,
-        "args": { "repoPath": repo_path },
-    })
-}
-
-fn daemon_path_request(command: &str, path: String) -> Value {
-    serde_json::json!({
-        "command": command,
-        "args": { "path": path },
-    })
-}
-
-fn daemon_alias_list_request(
-    project_id: Option<String>,
-    global: bool,
-    only_unbound: bool,
-) -> Value {
-    let mut args = serde_json::Map::new();
-    if let Some(project_id) = project_id {
-        args.insert("project_id".to_string(), Value::String(project_id));
-    }
-    if global {
-        args.insert("global".to_string(), Value::Bool(true));
-    }
-    if only_unbound {
-        args.insert("only_unbound".to_string(), Value::Bool(true));
-    }
-    serde_json::json!({
-        "command": "alias-list",
-        "args": args,
-    })
-}
-
-fn daemon_alias_get_request(alias: String, project_id: Option<String>) -> Value {
-    let mut args = serde_json::Map::new();
-    args.insert("alias".to_string(), Value::String(alias));
-    if let Some(project_id) = project_id {
-        args.insert("project_id".to_string(), Value::String(project_id));
-    }
-    serde_json::json!({
-        "command": "alias-get",
-        "args": args,
-    })
-}
-
-fn daemon_alias_whoami_request(session_id: String) -> Value {
-    serde_json::json!({
-        "command": "alias-whoami",
-        "session_id": session_id,
-        "args": {},
-    })
-}
-
-fn daemon_alias_member_request(
-    command: &str,
-    alias: String,
-    pane_id: String,
-    project_id: Option<String>,
-) -> Value {
-    let mut args = serde_json::Map::new();
-    args.insert("alias".to_string(), Value::String(alias));
-    args.insert("pane_id".to_string(), Value::String(pane_id));
-    if let Some(project_id) = project_id {
-        args.insert("project_id".to_string(), Value::String(project_id));
-    }
-    serde_json::json!({
-        "command": command,
-        "args": args,
-    })
-}
-
-fn daemon_alias_mode_request(alias: String, mode: String, project_id: Option<String>) -> Value {
-    let mut args = serde_json::Map::new();
-    args.insert("alias".to_string(), Value::String(alias));
-    args.insert("mode".to_string(), Value::String(mode));
-    if let Some(project_id) = project_id {
-        args.insert("project_id".to_string(), Value::String(project_id));
-    }
-    serde_json::json!({
-        "command": "alias-mode",
-        "args": args,
-    })
-}
-
-fn daemon_bus_subscriptions_request(
-    alias: Option<String>,
-    project_id: Option<String>,
-    global: bool,
-) -> Value {
-    let mut args = serde_json::Map::new();
-    if let Some(alias) = alias {
-        args.insert("alias".to_string(), Value::String(alias));
-    }
-    insert_project_filter_args(&mut args, project_id, global);
-    serde_json::json!({
-        "command": "bus-subscriptions",
-        "args": args,
-    })
-}
-
-fn daemon_bus_subscribe_request(
-    alias: String,
-    pattern: String,
-    project_id: Option<String>,
-) -> Value {
-    let mut args = serde_json::Map::new();
-    args.insert("alias".to_string(), Value::String(alias));
-    args.insert("pattern".to_string(), Value::String(pattern));
-    if let Some(project_id) = project_id {
-        args.insert("project_id".to_string(), Value::String(project_id));
-    }
-    serde_json::json!({
-        "command": "bus-subscribe",
-        "args": args,
-    })
-}
-
-fn daemon_bus_unsubscribe_request(id: String) -> Value {
-    serde_json::json!({
-        "command": "bus-unsubscribe",
-        "args": { "id": id },
-    })
-}
-
-fn daemon_mailbox_peek_request(
-    alias: String,
-    unread_only: bool,
-    project_id: Option<String>,
-    global: bool,
-    limit: Option<u32>,
-) -> Value {
-    let mut args = serde_json::Map::new();
-    args.insert("alias".to_string(), Value::String(alias));
-    if unread_only {
-        args.insert("unread".to_string(), Value::Bool(true));
-    }
-    insert_project_filter_args(&mut args, project_id, global);
-    if let Some(limit) = limit {
-        args.insert("limit".to_string(), serde_json::json!(limit));
-    }
-    serde_json::json!({
-        "command": "mailbox-peek",
-        "args": args,
-    })
-}
-
-fn daemon_bus_tail_request(
-    topic: Option<String>,
-    project_id: Option<String>,
-    global: bool,
-    limit: Option<u32>,
-) -> Value {
-    let mut args = serde_json::Map::new();
-    if let Some(topic) = topic {
-        args.insert("topic".to_string(), Value::String(topic));
-    }
-    insert_project_filter_args(&mut args, project_id, global);
-    if let Some(limit) = limit {
-        args.insert("limit".to_string(), serde_json::json!(limit));
-    }
-    serde_json::json!({
-        "command": "bus-tail",
-        "args": args,
-    })
-}
-
-fn daemon_mailbox_count_request(alias: String, project_id: Option<String>, global: bool) -> Value {
-    let mut args = serde_json::Map::new();
-    args.insert("alias".to_string(), Value::String(alias));
-    insert_project_filter_args(&mut args, project_id, global);
-    serde_json::json!({
-        "command": "mailbox-count",
-        "args": args,
-    })
-}
-
-fn daemon_mailbox_post_request(request: DaemonMailboxPostRequest) -> Value {
-    let mut args = serde_json::Map::new();
-    if let Some(to) = request.to {
-        args.insert("to".to_string(), Value::String(to));
-    }
-    if let Some(topic) = request.topic {
-        args.insert("topic".to_string(), Value::String(topic));
-    }
-    args.insert("body".to_string(), Value::String(request.body));
-    if let Some(subject) = request.subject {
-        args.insert("subject".to_string(), Value::String(subject));
-    }
-    if let Some(kind) = request.kind {
-        args.insert("kind".to_string(), Value::String(kind));
-    }
-    if let Some(project_id) = request.project_id {
-        args.insert("project_id".to_string(), Value::String(project_id));
-    }
-    if let Some(correlation_id) = request.correlation_id {
-        args.insert("correlation_id".to_string(), Value::String(correlation_id));
-    }
-    if let Some(structured) = request.structured {
-        args.insert("structured".to_string(), structured);
-    }
-    if let Some(from) = request.from {
-        args.insert("from".to_string(), Value::String(from));
-    }
-    serde_json::json!({
-        "command": "mailbox-post",
-        "args": args,
-    })
-}
-
-fn daemon_mailbox_event_id_request(command: &str, event_id: String) -> Value {
-    serde_json::json!({
-        "command": command,
-        "args": { "event_id": event_id },
-    })
-}
-
-fn daemon_mailbox_read_state_request(event_id: String, recipient: String) -> Value {
-    serde_json::json!({
-        "command": "mailbox-read-state",
-        "args": { "event_id": event_id, "recipient": recipient },
-    })
-}
-
-fn daemon_mailbox_mark_read_request(event_id: String, recipient: String) -> Value {
-    serde_json::json!({
-        "command": "mailbox-mark-read",
-        "args": { "event_id": event_id, "recipient": recipient },
-    })
-}
-
-fn daemon_mailbox_alias_event_request(
-    command: &str,
-    event_id: String,
-    alias: String,
-    result: Option<String>,
-) -> Value {
-    let mut args = serde_json::Map::new();
-    args.insert("event_id".to_string(), Value::String(event_id));
-    args.insert("alias".to_string(), Value::String(alias));
-    if let Some(result) = result {
-        args.insert("result".to_string(), Value::String(result));
-    }
-    serde_json::json!({
-        "command": command,
-        "args": args,
-    })
-}
-
-fn daemon_mailbox_clear_request(alias: String, project_id: Option<String>, global: bool) -> Value {
-    let mut args = serde_json::Map::new();
-    args.insert("alias".to_string(), Value::String(alias));
-    insert_project_filter_args(&mut args, project_id, global);
-    serde_json::json!({
-        "command": "mailbox-clear",
-        "args": args,
-    })
-}
-
-fn daemon_notes_read_request(target: NotesTarget) -> Value {
-    serde_json::json!({
-        "command": "notes-read",
-        "args": target,
-    })
-}
-
-fn daemon_notes_write_request(target: NotesTarget, content: String, tags: Vec<String>) -> Value {
-    serde_json::json!({
-        "command": "notes-write",
-        "args": {
-            "target": target,
-            "content": content,
-            "tags": tags,
-        },
-    })
-}
-
-fn daemon_notes_append_request(
-    target: NotesTarget,
-    content: String,
-    timestamped: bool,
-    tags: Vec<String>,
-) -> Value {
-    serde_json::json!({
-        "command": "notes-append",
-        "args": {
-            "target": target,
-            "content": content,
-            "timestamped": timestamped,
-            "tags": tags,
-        },
-    })
-}
-
-fn daemon_notes_path_request(target: NotesTarget, dir: bool) -> Value {
-    serde_json::json!({
-        "command": "notes-path",
-        "args": {
-            "target": target,
-            "dir": dir,
-        },
-    })
-}
-
-fn daemon_notes_search_request(query: NotesSearchQuery) -> Value {
-    serde_json::json!({
-        "command": "notes-search",
-        "args": query,
-    })
-}
-
-fn daemon_notes_vault_root_request() -> Value {
-    serde_json::json!({ "command": "notes-vault-root" })
-}
-
-fn daemon_hook_show_request(repo_path: Option<String>) -> Value {
-    let mut args = serde_json::Map::new();
-    if let Some(repo_path) = repo_path {
-        args.insert("repoPath".to_string(), Value::String(repo_path));
-    }
-    serde_json::json!({
-        "command": "hook-show",
-        "args": args,
-    })
-}
-
-fn daemon_hook_run_request(command: &str, request: HookRunRequest) -> Result<Value, String> {
-    Ok(serde_json::json!({
-        "command": command,
-        "args": serde_json::to_value(request)
-            .map_err(|err| format!("encode daemon {command} request: {err}"))?,
-    }))
-}
-
-fn daemon_hook_approve_request(approval_id: String) -> Value {
-    serde_json::json!({
-        "command": "hook-approve",
-        "args": { "approvalId": approval_id },
-    })
-}
-
-fn daemon_hook_clear_approvals_request() -> Value {
-    serde_json::json!({ "command": "hook-clear-approvals" })
-}
-
-fn daemon_hook_log_list_request() -> Value {
-    serde_json::json!({ "command": "hook-log-list" })
-}
-
-fn daemon_hook_log_read_request(path: String) -> Value {
-    serde_json::json!({
-        "command": "hook-log-read",
-        "args": { "path": path },
-    })
-}
-
-fn insert_project_filter_args(
-    args: &mut serde_json::Map<String, Value>,
-    project_id: Option<String>,
-    global: bool,
-) {
-    if let Some(project_id) = project_id {
-        args.insert("project_id".to_string(), Value::String(project_id));
-    }
-    if global {
-        args.insert("global".to_string(), Value::Bool(true));
-    }
-}
-
-fn daemon_watch_list_request() -> Value {
-    serde_json::json!({ "command": "watch-list" })
-}
-
-fn daemon_watch_config_request(command: &str, config: CreateWatchConfig) -> Value {
-    serde_json::json!({
-        "command": command,
-        "args": { "config": config },
-    })
-}
-
-fn daemon_watch_id_request(command: &str, id: String) -> Value {
-    serde_json::json!({
-        "command": command,
-        "args": { "id": id },
-    })
-}
-
-fn daemon_watch_replace_request(watch: Watch) -> Value {
-    serde_json::json!({
-        "command": "watch-replace",
-        "args": { "watch": watch },
-    })
-}
-
-fn daemon_watch_session_request(session_id: String) -> Value {
-    serde_json::json!({
-        "command": "watch-remove-for-session",
-        "args": { "sessionId": session_id },
-    })
-}
-
-fn daemon_watch_cleanup_orphans_request() -> Value {
-    serde_json::json!({ "command": "watch-cleanup-orphans" })
-}
-
-fn daemon_watch_events_request(backlog: bool) -> Value {
-    serde_json::json!({
-        "command": "watch-events",
-        "args": { "backlog": backlog },
-    })
-}
-
-fn daemon_mailbox_events_request() -> Value {
-    serde_json::json!({ "command": "mailbox-events" })
-}
-
-fn daemon_alias_events_request() -> Value {
-    serde_json::json!({ "command": "alias-events" })
-}
-
-fn daemon_subscription_events_request() -> Value {
-    serde_json::json!({ "command": "subscription-events" })
-}
-
-fn daemon_worktree_create_request(
-    repo_path: String,
-    branch: String,
-    start_point: Option<String>,
-    fetch_first: bool,
-) -> Value {
-    let mut args = serde_json::Map::new();
-    args.insert("repoPath".to_string(), Value::String(repo_path));
-    args.insert("branch".to_string(), Value::String(branch));
-    if let Some(start_point) = start_point {
-        args.insert("startPoint".to_string(), Value::String(start_point));
-    }
-    if fetch_first {
-        args.insert("fetchFirst".to_string(), Value::Bool(true));
-    }
-    serde_json::json!({
-        "command": "worktree-create",
-        "args": args,
-    })
-}
-
-fn daemon_worktree_remove_request(
-    repo_path: String,
-    worktree_path: String,
-    also_branch: bool,
-    force: bool,
-) -> Value {
-    serde_json::json!({
-        "command": "worktree-remove",
-        "args": {
-            "repoPath": repo_path,
-            "worktreePath": worktree_path,
-            "alsoBranch": also_branch,
-            "force": force,
-        },
-    })
-}
-
-fn daemon_process_output_request(id: String, max_bytes: Option<usize>) -> Value {
-    let mut args = serde_json::Map::new();
-    args.insert("id".to_string(), Value::String(id));
-    if let Some(max_bytes) = max_bytes {
-        args.insert("maxBytes".to_string(), serde_json::json!(max_bytes));
-    }
-    serde_json::json!({
-        "command": "daemon-process-output",
-        "args": args,
-    })
-}
-
-fn daemon_process_list_request() -> Value {
-    serde_json::json!({ "command": "daemon-process-list" })
-}
-
-fn daemon_process_kill_request(id: String) -> Value {
-    serde_json::json!({
-        "command": "daemon-process-kill",
-        "args": { "id": id },
-    })
-}
-
-#[cfg(test)]
-fn daemon_pty_spawn_shell_request(
-    id: Option<String>,
-    working_dir: Option<String>,
-    session_id: Option<String>,
-    pane_id: Option<String>,
-    profile: Option<String>,
-    nono_profile: Option<String>,
-    nono_allow_dirs: Vec<String>,
-    initial_size: Option<(u16, u16)>,
-) -> Value {
-    serde_json::json!({
-        "command": "daemon-pty-spawn-shell",
-        "args": daemon_pty_spawn_args(
-            id,
-            working_dir,
-            session_id,
-            pane_id,
-            profile,
-            nono_profile,
-            nono_allow_dirs,
-            initial_size,
-        ),
-    })
-}
-
-#[cfg(test)]
-fn daemon_pty_spawn_task_request(
-    command: String,
-    id: Option<String>,
-    working_dir: Option<String>,
-    session_id: Option<String>,
-    pane_id: Option<String>,
-    profile: Option<String>,
-    initial_size: Option<(u16, u16)>,
-) -> Value {
-    let mut args = daemon_pty_spawn_args(
-        id,
-        working_dir,
-        session_id,
-        pane_id,
-        profile,
-        None,
-        Vec::new(),
-        initial_size,
-    );
-    args.insert("command".to_string(), Value::String(command));
-    serde_json::json!({
-        "command": "daemon-pty-spawn-task",
-        "args": args,
-    })
-}
-
-#[cfg(test)]
-fn daemon_pty_spawn_args(
-    id: Option<String>,
-    working_dir: Option<String>,
-    session_id: Option<String>,
-    pane_id: Option<String>,
-    profile: Option<String>,
-    nono_profile: Option<String>,
-    nono_allow_dirs: Vec<String>,
-    initial_size: Option<(u16, u16)>,
-) -> serde_json::Map<String, Value> {
-    let mut args = serde_json::Map::new();
-    if let Some(id) = id {
-        args.insert("id".to_string(), Value::String(id));
-    }
-    if let Some(working_dir) = working_dir {
-        args.insert("workingDir".to_string(), Value::String(working_dir));
-    }
-    if let Some(session_id) = session_id {
-        args.insert("sessionId".to_string(), Value::String(session_id));
-    }
-    if let Some(pane_id) = pane_id {
-        args.insert("paneId".to_string(), Value::String(pane_id));
-    }
-    if let Some(profile) = profile {
-        args.insert("profile".to_string(), Value::String(profile));
-    }
-    if let Some(nono_profile) = nono_profile {
-        args.insert("nonoProfile".to_string(), Value::String(nono_profile));
-    }
-    if !nono_allow_dirs.is_empty() {
-        args.insert("nonoAllowDirs".to_string(), serde_json::json!(nono_allow_dirs));
-    }
-    if let Some((cols, rows)) = initial_size {
-        args.insert("initialSize".to_string(), serde_json::json!([cols, rows]));
-    }
-    args
-}
-
-#[cfg(test)]
-fn daemon_pty_output_request(id: String, max_bytes: Option<usize>) -> Value {
-    let mut args = serde_json::Map::new();
-    args.insert("id".to_string(), Value::String(id));
-    if let Some(max_bytes) = max_bytes {
-        args.insert("maxBytes".to_string(), serde_json::json!(max_bytes));
-    }
-    serde_json::json!({
-        "command": "daemon-pty-output",
-        "args": args,
-    })
-}
-
-#[cfg(test)]
-fn daemon_pty_attach_request(id: String, max_bytes: Option<usize>) -> Value {
-    let mut args = serde_json::Map::new();
-    args.insert("id".to_string(), Value::String(id));
-    if let Some(max_bytes) = max_bytes {
-        args.insert("maxBytes".to_string(), serde_json::json!(max_bytes));
-    }
-    serde_json::json!({
-        "command": "daemon-pty-attach",
-        "args": args,
-    })
-}
-
-#[cfg(test)]
-fn daemon_pty_list_request() -> Value {
-    serde_json::json!({ "command": "daemon-pty-list" })
-}
-
-#[cfg(test)]
-fn daemon_pty_write_request(id: String, data: String) -> Value {
-    serde_json::json!({
-        "command": "daemon-pty-write",
-        "args": { "id": id, "data": data },
-    })
-}
-
-#[cfg(test)]
-fn daemon_pty_resize_request(id: String, cols: u16, rows: u16) -> Value {
-    serde_json::json!({
-        "command": "daemon-pty-resize",
-        "args": { "id": id, "cols": cols, "rows": rows },
-    })
-}
-
-#[cfg(test)]
-fn daemon_pty_detach_request(id: String) -> Value {
-    serde_json::json!({
-        "command": "daemon-pty-detach",
-        "args": { "id": id },
-    })
-}
-
-#[cfg(test)]
-fn daemon_pty_attach_pane_request(id: String, pane_id: String) -> Value {
-    serde_json::json!({
-        "command": "daemon-pty-attach-pane",
-        "args": { "id": id, "paneId": pane_id },
-    })
-}
-
-#[cfg(test)]
-fn daemon_pty_mark_read_request(id: String) -> Value {
-    serde_json::json!({
-        "command": "daemon-pty-mark-read",
-        "args": { "id": id },
-    })
-}
-
-#[cfg(test)]
-fn daemon_pty_set_name_request(id: String, name: Option<String>) -> Value {
-    serde_json::json!({
-        "command": "daemon-pty-set-name",
-        "args": { "id": id, "name": name },
-    })
-}
-
-#[cfg(test)]
-fn daemon_pty_kill_request(id: String) -> Value {
-    serde_json::json!({
-        "command": "daemon-pty-kill",
-        "args": { "id": id },
-    })
-}
-
-async fn send_command_async(request: Value) -> Result<Value, String> {
-    tokio::task::spawn_blocking(move || send_command_blocking(request, COMMAND_TIMEOUT))
-        .await
-        .map_err(|err| format!("daemon client task failed: {err}"))?
-}
-
-#[derive(Debug, Deserialize)]
-struct Response {
-    ok: bool,
-    data: Option<Value>,
-    error: Option<String>,
-}
-
-fn decode_response(raw: &str) -> Result<Value, String> {
-    let response: Response = serde_json::from_str(raw.trim())
-        .map_err(|err| format!("invalid daemon response: {err}"))?;
-    if response.ok {
-        Ok(response.data.unwrap_or(Value::Null))
-    } else {
-        Err(response.error.unwrap_or_else(|| "daemon command failed".to_string()))
-    }
-}
-
-fn send_command_blocking(request: Value, timeout: Duration) -> Result<Value, String> {
-    let endpoint = platform::resolve_socket_endpoint_spec()
-        .ok_or_else(|| "daemon socket endpoint not found".to_string())?;
-    match endpoint {
-        platform::SocketEndpoint::Unix(path) => send_unix_command(path, request, timeout),
-        platform::SocketEndpoint::Tcp(addr) => send_tcp_command(addr, request, timeout),
-    }
-}
-
-#[cfg(not(windows))]
-fn send_unix_command(path: PathBuf, request: Value, timeout: Duration) -> Result<Value, String> {
-    use std::os::unix::net::UnixStream;
-
-    let mut stream = UnixStream::connect(&path)
-        .map_err(|err| format!("connect daemon socket {}: {err}", path.display()))?;
-    stream
-        .set_read_timeout(Some(timeout))
-        .map_err(|err| format!("set daemon read timeout: {err}"))?;
-    stream
-        .set_write_timeout(Some(timeout))
-        .map_err(|err| format!("set daemon write timeout: {err}"))?;
-
-    write_request(&mut stream, request)?;
-    let mut raw = String::new();
-    stream.read_to_string(&mut raw).map_err(|err| format!("read daemon response: {err}"))?;
-    decode_response(&raw)
-}
-
-#[cfg(windows)]
-fn send_unix_command(_path: PathBuf, _request: Value, _timeout: Duration) -> Result<Value, String> {
-    Err("Unix socket endpoints are not supported on Windows".to_string())
-}
-
-fn send_tcp_command(addr: String, request: Value, timeout: Duration) -> Result<Value, String> {
-    use std::net::{Shutdown, TcpStream};
-
-    let request = add_socket_auth_token(request)?;
-    let mut stream =
-        TcpStream::connect(&addr).map_err(|err| format!("connect daemon socket {addr}: {err}"))?;
-    stream
-        .set_read_timeout(Some(timeout))
-        .map_err(|err| format!("set daemon read timeout: {err}"))?;
-    stream
-        .set_write_timeout(Some(timeout))
-        .map_err(|err| format!("set daemon write timeout: {err}"))?;
-
-    write_request(&mut stream, request)?;
-    let _ = stream.shutdown(Shutdown::Write);
-    let mut raw = String::new();
-    stream.read_to_string(&mut raw).map_err(|err| format!("read daemon response: {err}"))?;
-    decode_response(&raw)
-}
-
-fn add_socket_auth_token(mut request: Value) -> Result<Value, String> {
-    let auth_token = platform::load_socket_auth_token()
-        .ok_or_else(|| "daemon socket auth token not found".to_string())?;
-    if let Some(obj) = request.as_object_mut() {
-        obj.insert("auth_token".to_string(), Value::String(auth_token));
-    }
-    Ok(request)
-}
-
-fn write_request(stream: &mut impl Write, request: Value) -> Result<(), String> {
-    let json = serde_json::to_string(&request).map_err(|err| format!("encode request: {err}"))?;
-    stream
-        .write_all(json.as_bytes())
-        .and_then(|_| stream.write_all(b"\n"))
-        .map_err(|err| format!("write daemon request: {err}"))
-}
-
-fn connect_daemon_stream(request: Value) -> Result<Box<dyn Read>, String> {
-    let endpoint = platform::resolve_socket_endpoint_spec()
-        .ok_or_else(|| "daemon socket endpoint not found".to_string())?;
-    match endpoint {
-        platform::SocketEndpoint::Unix(path) => connect_daemon_stream_unix(path, request),
-        platform::SocketEndpoint::Tcp(addr) => connect_daemon_stream_tcp(addr, request),
-    }
-}
-
-#[cfg(not(windows))]
-fn connect_daemon_stream_unix(path: PathBuf, request: Value) -> Result<Box<dyn Read>, String> {
-    use std::os::unix::net::UnixStream;
-
-    let mut stream = UnixStream::connect(&path)
-        .map_err(|err| format!("connect daemon socket {}: {err}", path.display()))?;
-    stream
-        .set_write_timeout(Some(COMMAND_TIMEOUT))
-        .map_err(|err| format!("set daemon write timeout: {err}"))?;
-    write_request(&mut stream, request)?;
-    Ok(Box::new(stream))
-}
-
-#[cfg(windows)]
-fn connect_daemon_stream_unix(_path: PathBuf, _request: Value) -> Result<Box<dyn Read>, String> {
-    Err("Unix socket endpoints are not supported on Windows".to_string())
-}
-
-fn connect_daemon_stream_tcp(addr: String, request: Value) -> Result<Box<dyn Read>, String> {
-    use std::net::TcpStream;
-
-    let request = add_socket_auth_token(request)?;
-    let mut stream =
-        TcpStream::connect(&addr).map_err(|err| format!("connect daemon socket {addr}: {err}"))?;
-    stream
-        .set_write_timeout(Some(COMMAND_TIMEOUT))
-        .map_err(|err| format!("set daemon write timeout: {err}"))?;
-    write_request(&mut stream, request)?;
-    Ok(Box::new(stream))
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(tag = "type")]
-enum WatchEventStreamFrame {
-    #[serde(rename = "ready")]
-    Ready,
-    #[serde(rename = "update")]
-    Update { event: Box<WatchUpdateEvent> },
-    #[serde(rename = "warning")]
-    Warning { message: String },
-    #[serde(rename = "error")]
-    Error { error: String },
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(tag = "type")]
-enum MailboxEventStreamFrame {
-    #[serde(rename = "ready")]
-    Ready,
-    #[serde(rename = "event")]
-    Event { event: Box<MailboxEvent> },
-    #[serde(rename = "warning")]
-    Warning { message: String },
-    #[serde(rename = "error")]
-    Error { error: String },
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(tag = "type")]
-enum AliasEventStreamFrame {
-    #[serde(rename = "ready")]
-    Ready,
-    #[serde(rename = "event")]
-    Event { event: AliasEvent },
-    #[serde(rename = "warning")]
-    Warning { message: String },
-    #[serde(rename = "error")]
-    Error { error: String },
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(tag = "type")]
-enum SubscriptionEventStreamFrame {
-    #[serde(rename = "ready")]
-    Ready,
-    #[serde(rename = "event")]
-    Event { event: BusSubscriptionEvent },
-    #[serde(rename = "warning")]
-    Warning { message: String },
-    #[serde(rename = "error")]
-    Error { error: String },
-}
-
-fn read_watch_events_blocking(app: AppHandle, watch_manager: WatchManager) -> Result<(), String> {
-    let stream = connect_daemon_stream(daemon_watch_events_request(true))?;
-    read_watch_event_stream(stream, app, watch_manager)
-}
-
-fn read_watch_event_stream(
-    stream: impl Read,
+fn read_watch_events_blocking(
+    sdk: &roux_sdk::Roux,
     app: AppHandle,
     watch_manager: WatchManager,
 ) -> Result<(), String> {
-    let mut reader = BufReader::new(stream);
-    let mut line = String::new();
-    loop {
-        line.clear();
-        let read = reader
-            .read_line(&mut line)
-            .map_err(|err| format!("read daemon watch event frame: {err}"))?;
-        if read == 0 {
-            return Ok(());
+    let mut stream_error = None;
+    let result = sdk.watch_events_blocking(true, |frame| {
+        match handle_watch_event_frame(frame, &app, &watch_manager) {
+            Ok(()) => true,
+            Err(err) => {
+                stream_error = Some(err);
+                false
+            }
         }
-        let frame: WatchEventStreamFrame = serde_json::from_str(line.trim())
-            .map_err(|err| format!("decode daemon watch event frame: {err}"))?;
-        handle_watch_event_frame(frame, &app, &watch_manager)?;
-    }
+    });
+    stream_error.map_or_else(|| result.map_err(|err| err.to_string()), Err)
 }
 
 fn handle_watch_event_frame(
@@ -2284,26 +1090,17 @@ fn handle_watch_event_frame(
     }
 }
 
-fn read_mailbox_events_blocking(app: AppHandle) -> Result<(), String> {
-    let stream = connect_daemon_stream(daemon_mailbox_events_request())?;
-    read_mailbox_event_stream(stream, app)
-}
-
-fn read_mailbox_event_stream(stream: impl Read, app: AppHandle) -> Result<(), String> {
-    let mut reader = BufReader::new(stream);
-    let mut line = String::new();
-    loop {
-        line.clear();
-        let read = reader
-            .read_line(&mut line)
-            .map_err(|err| format!("read daemon mailbox event frame: {err}"))?;
-        if read == 0 {
-            return Ok(());
-        }
-        let frame: MailboxEventStreamFrame = serde_json::from_str(line.trim())
-            .map_err(|err| format!("decode daemon mailbox event frame: {err}"))?;
-        handle_mailbox_event_frame(frame, &app)?;
-    }
+fn read_mailbox_events_blocking(sdk: &roux_sdk::Roux, app: AppHandle) -> Result<(), String> {
+    let mut stream_error = None;
+    let result =
+        sdk.mailbox_events_blocking(|frame| match handle_mailbox_event_frame(frame, &app) {
+            Ok(()) => true,
+            Err(err) => {
+                stream_error = Some(err);
+                false
+            }
+        });
+    stream_error.map_or_else(|| result.map_err(|err| err.to_string()), Err)
 }
 
 fn handle_mailbox_event_frame(
@@ -2323,26 +1120,16 @@ fn handle_mailbox_event_frame(
     }
 }
 
-fn read_alias_events_blocking(app: AppHandle) -> Result<(), String> {
-    let stream = connect_daemon_stream(daemon_alias_events_request())?;
-    read_alias_event_stream(stream, app)
-}
-
-fn read_alias_event_stream(stream: impl Read, app: AppHandle) -> Result<(), String> {
-    let mut reader = BufReader::new(stream);
-    let mut line = String::new();
-    loop {
-        line.clear();
-        let read = reader
-            .read_line(&mut line)
-            .map_err(|err| format!("read daemon alias event frame: {err}"))?;
-        if read == 0 {
-            return Ok(());
+fn read_alias_events_blocking(sdk: &roux_sdk::Roux, app: AppHandle) -> Result<(), String> {
+    let mut stream_error = None;
+    let result = sdk.alias_events_blocking(|frame| match handle_alias_event_frame(frame, &app) {
+        Ok(()) => true,
+        Err(err) => {
+            stream_error = Some(err);
+            false
         }
-        let frame: AliasEventStreamFrame = serde_json::from_str(line.trim())
-            .map_err(|err| format!("decode daemon alias event frame: {err}"))?;
-        handle_alias_event_frame(frame, &app)?;
-    }
+    });
+    stream_error.map_or_else(|| result.map_err(|err| err.to_string()), Err)
 }
 
 fn handle_alias_event_frame(frame: AliasEventStreamFrame, app: &AppHandle) -> Result<(), String> {
@@ -2359,26 +1146,18 @@ fn handle_alias_event_frame(frame: AliasEventStreamFrame, app: &AppHandle) -> Re
     }
 }
 
-fn read_subscription_events_blocking(app: AppHandle) -> Result<(), String> {
-    let stream = connect_daemon_stream(daemon_subscription_events_request())?;
-    read_subscription_event_stream(stream, app)
-}
-
-fn read_subscription_event_stream(stream: impl Read, app: AppHandle) -> Result<(), String> {
-    let mut reader = BufReader::new(stream);
-    let mut line = String::new();
-    loop {
-        line.clear();
-        let read = reader
-            .read_line(&mut line)
-            .map_err(|err| format!("read daemon subscription event frame: {err}"))?;
-        if read == 0 {
-            return Ok(());
+fn read_subscription_events_blocking(sdk: &roux_sdk::Roux, app: AppHandle) -> Result<(), String> {
+    let mut stream_error = None;
+    let result = sdk.subscription_events_blocking(|frame| {
+        match handle_subscription_event_frame(frame, &app) {
+            Ok(()) => true,
+            Err(err) => {
+                stream_error = Some(err);
+                false
+            }
         }
-        let frame: SubscriptionEventStreamFrame = serde_json::from_str(line.trim())
-            .map_err(|err| format!("decode daemon subscription event frame: {err}"))?;
-        handle_subscription_event_frame(frame, &app)?;
-    }
+    });
+    stream_error.map_or_else(|| result.map_err(|err| err.to_string()), Err)
 }
 
 fn handle_subscription_event_frame(
@@ -2453,18 +1232,6 @@ mod tests {
     use std::cell::Cell;
 
     #[test]
-    fn decode_response_returns_data_on_success() {
-        let data = decode_response(r#"{"ok":true,"data":{"kind":"roux-daemon"}}"#).unwrap();
-        assert_eq!(data["kind"], "roux-daemon");
-    }
-
-    #[test]
-    fn decode_response_returns_error_message() {
-        let err = decode_response(r#"{"ok":false,"error":"nope"}"#).unwrap_err();
-        assert_eq!(err, "nope");
-    }
-
-    #[test]
     fn event_bridge_reconnects_after_eof_and_error() {
         let calls = Cell::new(0);
         let sleeps = Cell::new(0);
@@ -2482,573 +1249,6 @@ mod tests {
 
         assert_eq!(calls.get(), 3);
         assert_eq!(sleeps.get(), 2);
-    }
-
-    #[test]
-    fn daemon_process_start_request_uses_daemon_command_shape() {
-        let request =
-            daemon_process_start_request("printf hi".to_string(), Some("/tmp".to_string()));
-
-        assert_eq!(request["command"], "daemon-process-start");
-        assert_eq!(request["args"]["command"], "printf hi");
-        assert_eq!(request["args"]["workingDir"], "/tmp");
-    }
-
-    #[test]
-    fn daemon_session_create_shell_request_uses_daemon_command_shape() {
-        let request = daemon_session_create_shell_request(DaemonCreateSessionShellRequest {
-            id: "session-a".to_string(),
-            repo_path: "/repo".to_string(),
-            name: "Daemon Session".to_string(),
-            worktree_path: None,
-            branch: Some("feature/demo".to_string()),
-            base: Some("origin/main".to_string()),
-            fetch_first: true,
-            profile: Some("plain-shell".to_string()),
-            nono_profile: Some("strict".to_string()),
-            nono_allow_dirs: vec!["/tmp".to_string()],
-            initial_size: Some((100, 30)),
-            project_id: Some("project-a".to_string()),
-            blueprint_id: Some("blueprint-a".to_string()),
-            smol_machine_name: Some("vm-a".to_string()),
-            notes: Some(NotesEnvInputs {
-                vault_root: "/vault".to_string(),
-                session_slug: "feature-demo--sessio".to_string(),
-                repo_slug: "repo-a".to_string(),
-                project_slug: Some("project-a".to_string()),
-                context_paths: vec!["/repo/docs".to_string()],
-                project_prompt: "Use project notes".to_string(),
-            }),
-        });
-
-        assert_eq!(request["command"], "session-create-shell");
-        assert_eq!(request["args"]["id"], "session-a");
-        assert_eq!(request["args"]["repoPath"], "/repo");
-        assert_eq!(request["args"]["branch"], "feature/demo");
-        assert_eq!(request["args"]["base"], "origin/main");
-        assert_eq!(request["args"]["fetchFirst"], true);
-        assert_eq!(request["args"]["profile"], "plain-shell");
-        assert_eq!(request["args"]["nonoProfile"], "strict");
-        assert_eq!(request["args"]["nonoAllowDirs"][0], "/tmp");
-        assert_eq!(request["args"]["initialSize"], serde_json::json!([100, 30]));
-        assert_eq!(request["args"]["projectId"], "project-a");
-        assert_eq!(request["args"]["smolMachineName"], "vm-a");
-        assert_eq!(request["args"]["notesEnv"]["vaultRoot"], "/vault");
-        assert_eq!(request["args"]["notesEnv"]["contextPaths"][0], "/repo/docs");
-    }
-
-    #[test]
-    fn daemon_session_lifecycle_requests_use_daemon_command_shape() {
-        let reconnect =
-            daemon_session_reconnect_shell_request(DaemonReconnectSessionShellRequest {
-                id: "session-a".to_string(),
-                profile: Some("plain-shell".to_string()),
-                nono_profile: Some("strict".to_string()),
-                nono_allow_dirs: vec!["/tmp".to_string()],
-                initial_size: Some((120, 40)),
-                notes: None,
-            });
-        assert_eq!(reconnect["command"], "session-reconnect-shell");
-        assert_eq!(reconnect["session_id"], "session-a");
-        assert_eq!(reconnect["args"]["profile"], "plain-shell");
-        assert_eq!(reconnect["args"]["nonoProfile"], "strict");
-        assert_eq!(reconnect["args"]["nonoAllowDirs"][0], "/tmp");
-        assert_eq!(reconnect["args"]["initialSize"], serde_json::json!([120, 40]));
-
-        let archive = daemon_session_id_request("session-archive", "session-a".to_string());
-        assert_eq!(archive["command"], "session-archive");
-        assert_eq!(archive["session_id"], "session-a");
-
-        let restore = daemon_session_id_request("session-restore", "session-a".to_string());
-        assert_eq!(restore["command"], "session-restore");
-
-        let delete = daemon_session_id_request("session-delete", "session-a".to_string());
-        assert_eq!(delete["command"], "session-delete");
-
-        let exists = daemon_session_id_request("session-worktree-exists", "session-a".to_string());
-        assert_eq!(exists["command"], "session-worktree-exists");
-
-        let refresh = daemon_session_id_request("session-refresh-branch", "session-a".to_string());
-        assert_eq!(refresh["command"], "session-refresh-branch");
-
-        let project = daemon_session_optional_value_request(
-            "session-set-project",
-            "session-a".to_string(),
-            "projectId",
-            Some("project-a".to_string()),
-        );
-        assert_eq!(project["command"], "session-set-project");
-        assert_eq!(project["session_id"], "session-a");
-        assert_eq!(project["args"]["projectId"], "project-a");
-
-        let clear_smol = daemon_session_optional_value_request(
-            "session-set-smol-machine",
-            "session-a".to_string(),
-            "machineName",
-            None,
-        );
-        assert_eq!(clear_smol["command"], "session-set-smol-machine");
-        assert!(clear_smol["args"]["machineName"].is_null());
-    }
-
-    #[test]
-    fn daemon_project_requests_use_daemon_command_shape() {
-        let create = daemon_project_create_request("Alpha".to_string());
-        assert_eq!(create["command"], "project-create");
-        assert_eq!(create["args"]["name"], "Alpha");
-
-        let remove = daemon_project_id_request("project-remove", "project-a".to_string());
-        assert_eq!(remove["command"], "project-remove");
-        assert_eq!(remove["args"]["id"], "project-a");
-
-        let rename = daemon_project_rename_request("project-a".to_string(), "Beta".to_string());
-        assert_eq!(rename["command"], "project-rename");
-        assert_eq!(rename["args"]["name"], "Beta");
-
-        let update = daemon_project_update_request(
-            "project-a".to_string(),
-            ProjectUpdate {
-                name: Some("Gamma".to_string()),
-                repo_roots: None,
-                context_paths: Some(vec!["/docs".to_string()]),
-                session_blueprints: None,
-                project_prompt: None,
-            },
-        );
-        assert_eq!(update["command"], "project-update");
-        assert_eq!(update["args"]["id"], "project-a");
-        assert_eq!(update["args"]["patch"]["name"], "Gamma");
-        assert_eq!(update["args"]["patch"]["contextPaths"][0], "/docs");
-    }
-
-    #[test]
-    fn daemon_worktree_requests_use_daemon_command_shape() {
-        let create = daemon_worktree_create_request(
-            "/repo".to_string(),
-            "feature/demo".to_string(),
-            Some("origin/main".to_string()),
-            true,
-        );
-        assert_eq!(create["command"], "worktree-create");
-        assert_eq!(create["args"]["repoPath"], "/repo");
-        assert_eq!(create["args"]["branch"], "feature/demo");
-        assert_eq!(create["args"]["startPoint"], "origin/main");
-        assert_eq!(create["args"]["fetchFirst"], true);
-
-        let remove = daemon_worktree_remove_request(
-            "/repo".to_string(),
-            "/repo-feature".to_string(),
-            true,
-            false,
-        );
-        assert_eq!(remove["command"], "worktree-remove");
-        assert_eq!(remove["args"]["repoPath"], "/repo");
-        assert_eq!(remove["args"]["worktreePath"], "/repo-feature");
-        assert_eq!(remove["args"]["alsoBranch"], true);
-        assert_eq!(remove["args"]["force"], false);
-
-        let list = daemon_repo_path_request("worktree-list", "/repo".to_string());
-        assert_eq!(list["command"], "worktree-list");
-        assert_eq!(list["args"]["repoPath"], "/repo");
-
-        let branches = daemon_repo_path_request("worktree-list-branches", "/repo".to_string());
-        assert_eq!(branches["command"], "worktree-list-branches");
-
-        let init = daemon_path_request("git-init", "/new-repo".to_string());
-        assert_eq!(init["command"], "git-init");
-        assert_eq!(init["args"]["path"], "/new-repo");
-    }
-
-    #[test]
-    fn daemon_alias_requests_use_daemon_command_shape() {
-        let list = daemon_alias_list_request(Some("project-a".to_string()), false, true);
-        assert_eq!(list["command"], "alias-list");
-        assert_eq!(list["args"]["project_id"], "project-a");
-        assert_eq!(list["args"]["only_unbound"], true);
-        assert!(list["args"].get("global").is_none());
-
-        let get = daemon_alias_get_request("reviewer".to_string(), None);
-        assert_eq!(get["command"], "alias-get");
-        assert_eq!(get["args"]["alias"], "reviewer");
-
-        let whoami = daemon_alias_whoami_request("session-a".to_string());
-        assert_eq!(whoami["command"], "alias-whoami");
-        assert_eq!(whoami["session_id"], "session-a");
-
-        let add = daemon_alias_member_request(
-            "alias-add-member",
-            "team".to_string(),
-            "pane-a".to_string(),
-            None,
-        );
-        assert_eq!(add["command"], "alias-add-member");
-        assert_eq!(add["args"]["alias"], "team");
-        assert_eq!(add["args"]["pane_id"], "pane-a");
-
-        let mode = daemon_alias_mode_request(
-            "team".to_string(),
-            "broadcast".to_string(),
-            Some("project-a".to_string()),
-        );
-        assert_eq!(mode["command"], "alias-mode");
-        assert_eq!(mode["args"]["mode"], "broadcast");
-        assert_eq!(mode["args"]["project_id"], "project-a");
-    }
-
-    #[test]
-    fn daemon_bus_requests_use_daemon_command_shape() {
-        let list = daemon_bus_subscriptions_request(
-            Some("reviewer".to_string()),
-            Some("project-a".to_string()),
-            false,
-        );
-        assert_eq!(list["command"], "bus-subscriptions");
-        assert_eq!(list["args"]["alias"], "reviewer");
-        assert_eq!(list["args"]["project_id"], "project-a");
-        assert!(list["args"].get("global").is_none());
-
-        let global = daemon_bus_subscriptions_request(None, None, true);
-        assert_eq!(global["command"], "bus-subscriptions");
-        assert_eq!(global["args"]["global"], true);
-
-        let subscribe = daemon_bus_subscribe_request(
-            "reviewer".to_string(),
-            "build.**".to_string(),
-            Some("project-a".to_string()),
-        );
-        assert_eq!(subscribe["command"], "bus-subscribe");
-        assert_eq!(subscribe["args"]["alias"], "reviewer");
-        assert_eq!(subscribe["args"]["pattern"], "build.**");
-        assert_eq!(subscribe["args"]["project_id"], "project-a");
-
-        let unsubscribe = daemon_bus_unsubscribe_request("sub-a".to_string());
-        assert_eq!(unsubscribe["command"], "bus-unsubscribe");
-        assert_eq!(unsubscribe["args"]["id"], "sub-a");
-    }
-
-    #[test]
-    fn daemon_mailbox_requests_use_daemon_command_shape() {
-        let peek = daemon_mailbox_peek_request(
-            "reviewer".to_string(),
-            true,
-            Some("project-a".to_string()),
-            false,
-            Some(20),
-        );
-        assert_eq!(peek["command"], "mailbox-peek");
-        assert_eq!(peek["args"]["alias"], "reviewer");
-        assert_eq!(peek["args"]["unread"], true);
-        assert_eq!(peek["args"]["project_id"], "project-a");
-        assert_eq!(peek["args"]["limit"], 20);
-
-        let tail = daemon_bus_tail_request(Some("build.done".to_string()), None, true, Some(5));
-        assert_eq!(tail["command"], "bus-tail");
-        assert_eq!(tail["args"]["topic"], "build.done");
-        assert_eq!(tail["args"]["global"], true);
-        assert_eq!(tail["args"]["limit"], 5);
-
-        let count = daemon_mailbox_count_request("reviewer".to_string(), None, false);
-        assert_eq!(count["command"], "mailbox-count");
-        assert_eq!(count["args"]["alias"], "reviewer");
-        assert!(count["args"].get("project_id").is_none());
-
-        let post = daemon_mailbox_post_request(DaemonMailboxPostRequest {
-            to: Some("reviewer".to_string()),
-            topic: Some("build.done".to_string()),
-            body: "ready".to_string(),
-            subject: Some("Build".to_string()),
-            kind: Some("fyi".to_string()),
-            project_id: Some("project-a".to_string()),
-            correlation_id: Some("corr-a".to_string()),
-            structured: Some(serde_json::json!({ "ok": true })),
-            from: Some("runner".to_string()),
-        });
-        assert_eq!(post["command"], "mailbox-post");
-        assert_eq!(post["args"]["to"], "reviewer");
-        assert_eq!(post["args"]["topic"], "build.done");
-        assert_eq!(post["args"]["body"], "ready");
-        assert_eq!(post["args"]["subject"], "Build");
-        assert_eq!(post["args"]["kind"], "fyi");
-        assert_eq!(post["args"]["project_id"], "project-a");
-        assert_eq!(post["args"]["correlation_id"], "corr-a");
-        assert_eq!(post["args"]["structured"]["ok"], true);
-        assert_eq!(post["args"]["from"], "runner");
-
-        let get = daemon_mailbox_event_id_request("mailbox-get", "event-a".to_string());
-        assert_eq!(get["command"], "mailbox-get");
-        assert_eq!(get["args"]["event_id"], "event-a");
-
-        let read_state =
-            daemon_mailbox_read_state_request("event-a".to_string(), "reviewer".to_string());
-        assert_eq!(read_state["command"], "mailbox-read-state");
-        assert_eq!(read_state["args"]["recipient"], "reviewer");
-
-        let mark_read =
-            daemon_mailbox_mark_read_request("event-a".to_string(), "reviewer".to_string());
-        assert_eq!(mark_read["command"], "mailbox-mark-read");
-        assert_eq!(mark_read["args"]["event_id"], "event-a");
-
-        let ack = daemon_mailbox_alias_event_request(
-            "mailbox-ack",
-            "event-a".to_string(),
-            "reviewer".to_string(),
-            Some("done".to_string()),
-        );
-        assert_eq!(ack["command"], "mailbox-ack");
-        assert_eq!(ack["args"]["alias"], "reviewer");
-        assert_eq!(ack["args"]["result"], "done");
-
-        let clear = daemon_mailbox_clear_request("reviewer".to_string(), None, true);
-        assert_eq!(clear["command"], "mailbox-clear");
-        assert_eq!(clear["args"]["global"], true);
-    }
-
-    #[test]
-    fn daemon_notes_requests_use_daemon_command_shape() {
-        let target = crate::commands::notes::NotesTarget {
-            scope: "session".to_string(),
-            session_id: Some("session-a".to_string()),
-            topic: Some("plan".to_string()),
-            override_slug: None,
-        };
-
-        let read = daemon_notes_read_request(target.clone());
-        assert_eq!(read["command"], "notes-read");
-        assert_eq!(read["args"]["scope"], "session");
-        assert_eq!(read["args"]["sessionId"], "session-a");
-        assert_eq!(read["args"]["topic"], "plan");
-
-        let write =
-            daemon_notes_write_request(target.clone(), "body".to_string(), vec!["tag".to_string()]);
-        assert_eq!(write["command"], "notes-write");
-        assert_eq!(write["args"]["target"]["scope"], "session");
-        assert_eq!(write["args"]["content"], "body");
-        assert_eq!(write["args"]["tags"][0], "tag");
-
-        let append = daemon_notes_append_request(target.clone(), "more".to_string(), true, vec![]);
-        assert_eq!(append["command"], "notes-append");
-        assert_eq!(append["args"]["timestamped"], true);
-
-        let path = daemon_notes_path_request(target, true);
-        assert_eq!(path["command"], "notes-path");
-        assert_eq!(path["args"]["dir"], true);
-
-        let search = daemon_notes_search_request(crate::commands::notes::NotesSearchQuery {
-            tags: vec!["tag".to_string()],
-            scope: Some("global".to_string()),
-            exact: true,
-        });
-        assert_eq!(search["command"], "notes-search");
-        assert_eq!(search["args"]["tags"][0], "tag");
-        assert_eq!(search["args"]["scope"], "global");
-        assert_eq!(search["args"]["exact"], true);
-
-        assert_eq!(daemon_notes_vault_root_request()["command"], "notes-vault-root");
-    }
-
-    #[test]
-    fn daemon_hook_requests_use_daemon_command_shape() {
-        let show = daemon_hook_show_request(Some("/repo".to_string()));
-        assert_eq!(show["command"], "hook-show");
-        assert_eq!(show["args"]["repoPath"], "/repo");
-
-        let request = HookRunRequest {
-            event: "pre-watch-run".to_string(),
-            repo_path: Some("/repo".to_string()),
-            worktree_path: Some("/repo/wt".to_string()),
-            branch: Some("feature/demo".to_string()),
-            session_id: Some("session-a".to_string()),
-            project_id: Some("project-a".to_string()),
-            task_id: Some("task-a".to_string()),
-            scope: Some("project".to_string()),
-            provider: Some("git".to_string()),
-            args: Some(vec!["one".to_string(), "two".to_string()]),
-        };
-        let preview = daemon_hook_run_request("hook-preview", request.clone()).unwrap();
-        assert_eq!(preview["command"], "hook-preview");
-        assert_eq!(preview["args"]["event"], "pre-watch-run");
-        assert_eq!(preview["args"]["repoPath"], "/repo");
-        assert_eq!(preview["args"]["worktreePath"], "/repo/wt");
-        assert_eq!(preview["args"]["sessionId"], "session-a");
-        assert_eq!(preview["args"]["args"][0], "one");
-
-        let run = daemon_hook_run_request("hook-run", request).unwrap();
-        assert_eq!(run["command"], "hook-run");
-
-        let approve = daemon_hook_approve_request("approval-a".to_string());
-        assert_eq!(approve["command"], "hook-approve");
-        assert_eq!(approve["args"]["approvalId"], "approval-a");
-
-        assert_eq!(daemon_hook_clear_approvals_request()["command"], "hook-clear-approvals");
-        assert_eq!(daemon_hook_log_list_request()["command"], "hook-log-list");
-
-        let read = daemon_hook_log_read_request("/tmp/hook.json".to_string());
-        assert_eq!(read["command"], "hook-log-read");
-        assert_eq!(read["args"]["path"], "/tmp/hook.json");
-    }
-
-    #[test]
-    fn daemon_watch_requests_use_daemon_command_shape() {
-        let config = CreateWatchConfig {
-            name: "HTTP".to_string(),
-            kind: roux_core::WatchKind::HttpHealth {
-                url: "http://localhost".to_string(),
-                expected_status: 200,
-            },
-            mode: roux_core::WatchMode::Recurring { interval_secs: 30 },
-            scope: roux_core::WatchScope::Global,
-            notify: None,
-        };
-
-        assert_eq!(daemon_watch_list_request()["command"], "watch-list");
-
-        let create = daemon_watch_config_request("watch-create", config.clone());
-        assert_eq!(create["command"], "watch-create");
-        assert_eq!(create["args"]["config"]["name"], "HTTP");
-        assert_eq!(create["args"]["config"]["kind"]["type"], "httpHealth");
-
-        let find_or_create = daemon_watch_config_request("watch-find-or-create", config);
-        assert_eq!(find_or_create["command"], "watch-find-or-create");
-
-        let remove = daemon_watch_id_request("watch-remove", "watch-a".to_string());
-        assert_eq!(remove["command"], "watch-remove");
-        assert_eq!(remove["args"]["id"], "watch-a");
-
-        let watch = Watch {
-            id: "watch-a".to_string(),
-            name: "HTTP".to_string(),
-            kind: roux_core::WatchKind::HttpHealth {
-                url: "http://localhost".to_string(),
-                expected_status: 200,
-            },
-            mode: roux_core::WatchMode::Recurring { interval_secs: 30 },
-            scope: roux_core::WatchScope::Global,
-            runtime_state: roux_core::RuntimeState::Active,
-            last_result: None,
-            last_checked: None,
-            notify: roux_core::NotifyConfig::default(),
-            created_at: 0,
-        };
-        let replace = daemon_watch_replace_request(watch);
-        assert_eq!(replace["command"], "watch-replace");
-        assert_eq!(replace["args"]["watch"]["id"], "watch-a");
-
-        let session_cleanup = daemon_watch_session_request("session-a".to_string());
-        assert_eq!(session_cleanup["command"], "watch-remove-for-session");
-        assert_eq!(session_cleanup["args"]["sessionId"], "session-a");
-
-        let events = daemon_watch_events_request(true);
-        assert_eq!(events["command"], "watch-events");
-        assert_eq!(events["args"]["backlog"], true);
-
-        assert_eq!(daemon_mailbox_events_request()["command"], "mailbox-events");
-        assert_eq!(daemon_alias_events_request()["command"], "alias-events");
-        assert_eq!(daemon_subscription_events_request()["command"], "subscription-events");
-
-        assert_eq!(daemon_watch_cleanup_orphans_request()["command"], "watch-cleanup-orphans");
-    }
-
-    #[test]
-    fn daemon_process_output_request_uses_max_bytes() {
-        let request = daemon_process_output_request("daemon-process-1".to_string(), Some(42));
-
-        assert_eq!(request["command"], "daemon-process-output");
-        assert_eq!(request["args"]["id"], "daemon-process-1");
-        assert_eq!(request["args"]["maxBytes"], 42);
-    }
-
-    #[test]
-    fn daemon_process_list_and_kill_requests_use_daemon_commands() {
-        assert_eq!(daemon_process_list_request()["command"], "daemon-process-list");
-
-        let kill = daemon_process_kill_request("daemon-process-1".to_string());
-        assert_eq!(kill["command"], "daemon-process-kill");
-        assert_eq!(kill["args"]["id"], "daemon-process-1");
-    }
-
-    #[test]
-    fn daemon_pty_spawn_shell_request_includes_nono_config() {
-        let request = daemon_pty_spawn_shell_request(
-            Some("pty-a".to_string()),
-            Some("/tmp".to_string()),
-            Some("session-a".to_string()),
-            Some("pane-a".to_string()),
-            Some("plain-shell".to_string()),
-            Some("strict".to_string()),
-            vec!["/tmp".to_string()],
-            Some((120, 40)),
-        );
-
-        assert_eq!(request["command"], "daemon-pty-spawn-shell");
-        assert_eq!(request["args"]["nonoProfile"], "strict");
-        assert_eq!(request["args"]["nonoAllowDirs"][0], "/tmp");
-    }
-
-    #[test]
-    fn daemon_pty_spawn_task_request_uses_daemon_command_shape() {
-        let request = daemon_pty_spawn_task_request(
-            "printf hi".to_string(),
-            Some("pty-a".to_string()),
-            Some("/tmp".to_string()),
-            Some("session-a".to_string()),
-            Some("pane-a".to_string()),
-            Some("task".to_string()),
-            Some((120, 40)),
-        );
-
-        assert_eq!(request["command"], "daemon-pty-spawn-task");
-        assert_eq!(request["args"]["command"], "printf hi");
-        assert_eq!(request["args"]["id"], "pty-a");
-        assert_eq!(request["args"]["workingDir"], "/tmp");
-        assert_eq!(request["args"]["sessionId"], "session-a");
-        assert_eq!(request["args"]["paneId"], "pane-a");
-        assert_eq!(request["args"]["profile"], "task");
-        assert_eq!(request["args"]["initialSize"], serde_json::json!([120, 40]));
-    }
-
-    #[test]
-    fn daemon_pty_control_requests_use_daemon_commands() {
-        let output = daemon_pty_output_request("pty-a".to_string(), Some(42));
-        assert_eq!(output["command"], "daemon-pty-output");
-        assert_eq!(output["args"]["id"], "pty-a");
-        assert_eq!(output["args"]["maxBytes"], 42);
-
-        let attach = daemon_pty_attach_request("pty-a".to_string(), Some(1024));
-        assert_eq!(attach["command"], "daemon-pty-attach");
-        assert_eq!(attach["args"]["id"], "pty-a");
-        assert_eq!(attach["args"]["maxBytes"], 1024);
-
-        assert_eq!(daemon_pty_list_request()["command"], "daemon-pty-list");
-
-        let write = daemon_pty_write_request("pty-a".to_string(), "input\n".to_string());
-        assert_eq!(write["command"], "daemon-pty-write");
-        assert_eq!(write["args"]["data"], "input\n");
-
-        let resize = daemon_pty_resize_request("pty-a".to_string(), 100, 30);
-        assert_eq!(resize["command"], "daemon-pty-resize");
-        assert_eq!(resize["args"]["cols"], 100);
-        assert_eq!(resize["args"]["rows"], 30);
-
-        let detach = daemon_pty_detach_request("pty-a".to_string());
-        assert_eq!(detach["command"], "daemon-pty-detach");
-        assert_eq!(detach["args"]["id"], "pty-a");
-
-        let attach_pane = daemon_pty_attach_pane_request("pty-a".to_string(), "pane-b".to_string());
-        assert_eq!(attach_pane["command"], "daemon-pty-attach-pane");
-        assert_eq!(attach_pane["args"]["paneId"], "pane-b");
-
-        let mark_read = daemon_pty_mark_read_request("pty-a".to_string());
-        assert_eq!(mark_read["command"], "daemon-pty-mark-read");
-
-        let set_name = daemon_pty_set_name_request("pty-a".to_string(), Some("Build".to_string()));
-        assert_eq!(set_name["command"], "daemon-pty-set-name");
-        assert_eq!(set_name["args"]["name"], "Build");
-        let clear_name = daemon_pty_set_name_request("pty-a".to_string(), None);
-        assert!(clear_name["args"]["name"].is_null());
-
-        let kill = daemon_pty_kill_request("pty-a".to_string());
-        assert_eq!(kill["command"], "daemon-pty-kill");
-        assert_eq!(kill["args"]["id"], "pty-a");
     }
 
     #[test]

--- a/src-tauri/src/daemon_client.rs
+++ b/src-tauri/src/daemon_client.rs
@@ -96,10 +96,18 @@ pub(crate) type DaemonMailboxPostRequest = roux_sdk::MailboxPost;
 impl DaemonClient {
     pub(crate) fn detect() -> Option<Self> {
         let sdk = roux_sdk::Roux::builder().timeout(PROBE_TIMEOUT).connect().ok()?;
+        Self::detect_from_probe_sdk(sdk)
+    }
+
+    fn detect_from_probe_sdk(sdk: roux_sdk::Roux) -> Option<Self> {
         let data = sdk.status_blocking().ok()?;
         let status: DaemonStatus = serde_json::from_value(data).ok()?;
+        Self::from_detected_status(status, sdk)
+    }
+
+    fn from_detected_status(status: DaemonStatus, sdk: roux_sdk::Roux) -> Option<Self> {
         if status.kind == "roux-daemon" {
-            Some(Self { status, sdk })
+            Some(Self { status, sdk: sdk.with_default_timeout() })
         } else {
             None
         }
@@ -855,11 +863,11 @@ impl DaemonClient {
         app: AppHandle,
         watch_manager: WatchManager,
     ) -> tauri::async_runtime::JoinHandle<()> {
-        let sdk = self.sdk.clone();
         tauri::async_runtime::spawn_blocking(move || {
-            run_reconnecting_event_bridge(
+            run_reconnecting_resolved_event_bridge(
                 "watch",
-                move || read_watch_events_blocking(&sdk, app.clone(), watch_manager.clone()),
+                connect_current_sdk,
+                move |sdk| read_watch_events_blocking(&sdk, app.clone(), watch_manager.clone()),
                 std::thread::sleep,
                 None,
             );
@@ -870,11 +878,11 @@ impl DaemonClient {
         &self,
         app: AppHandle,
     ) -> tauri::async_runtime::JoinHandle<()> {
-        let sdk = self.sdk.clone();
         tauri::async_runtime::spawn_blocking(move || {
-            run_reconnecting_event_bridge(
+            run_reconnecting_resolved_event_bridge(
                 "mailbox",
-                move || read_mailbox_events_blocking(&sdk, app.clone()),
+                connect_current_sdk,
+                move |sdk| read_mailbox_events_blocking(&sdk, app.clone()),
                 std::thread::sleep,
                 None,
             );
@@ -885,11 +893,11 @@ impl DaemonClient {
         &self,
         app: AppHandle,
     ) -> tauri::async_runtime::JoinHandle<()> {
-        let sdk = self.sdk.clone();
         tauri::async_runtime::spawn_blocking(move || {
-            run_reconnecting_event_bridge(
+            run_reconnecting_resolved_event_bridge(
                 "alias",
-                move || read_alias_events_blocking(&sdk, app.clone()),
+                connect_current_sdk,
+                move |sdk| read_alias_events_blocking(&sdk, app.clone()),
                 std::thread::sleep,
                 None,
             );
@@ -900,11 +908,11 @@ impl DaemonClient {
         &self,
         app: AppHandle,
     ) -> tauri::async_runtime::JoinHandle<()> {
-        let sdk = self.sdk.clone();
         tauri::async_runtime::spawn_blocking(move || {
-            run_reconnecting_event_bridge(
+            run_reconnecting_resolved_event_bridge(
                 "subscription",
-                move || read_subscription_events_blocking(&sdk, app.clone()),
+                connect_current_sdk,
+                move |sdk| read_subscription_events_blocking(&sdk, app.clone()),
                 std::thread::sleep,
                 None,
             );
@@ -912,19 +920,25 @@ impl DaemonClient {
     }
 }
 
-fn run_reconnecting_event_bridge<F, S>(
+fn connect_current_sdk() -> Result<roux_sdk::Roux, String> {
+    roux_sdk::Roux::connect().map_err(|err| err.to_string())
+}
+
+fn run_reconnecting_resolved_event_bridge<C, T, F, S>(
     label: &'static str,
+    mut resolve: C,
     mut read_once: F,
     mut sleep: S,
     max_attempts: Option<usize>,
 ) where
-    F: FnMut() -> Result<(), String>,
+    C: FnMut() -> Result<T, String>,
+    F: FnMut(T) -> Result<(), String>,
     S: FnMut(Duration),
 {
     let mut attempts = 0_usize;
     loop {
         attempts += 1;
-        match read_once() {
+        match resolve().and_then(&mut read_once) {
             Ok(()) => rlog!("Daemon {label} event bridge disconnected; reconnecting"),
             Err(err) => rlog!("Daemon {label} event bridge stopped: {err}; reconnecting"),
         }
@@ -1229,7 +1243,24 @@ fn emit_daemon_pty_exit(app: &AppHandle, id: &str, code: Option<i32>, generation
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::cell::Cell;
+    use std::cell::{Cell, RefCell};
+
+    fn daemon_status() -> DaemonStatus {
+        DaemonStatus {
+            kind: "roux-daemon".to_string(),
+            pid: 1,
+            socket: "unix:///tmp/roux.sock".to_string(),
+            log_path: None,
+            started_at_ms: 1,
+            uptime_ms: 2,
+            session_count: 0,
+            project_count: 0,
+            watch_count: 0,
+            process_count: 0,
+            pty_count: 0,
+            capabilities: vec!["daemon-status".to_string()],
+        }
+    }
 
     #[test]
     fn event_bridge_reconnects_after_eof_and_error() {
@@ -1237,9 +1268,10 @@ mod tests {
         let sleeps = Cell::new(0);
         let mut results = vec![Ok(()), Err("socket closed".to_string()), Ok(())].into_iter();
 
-        run_reconnecting_event_bridge(
+        run_reconnecting_resolved_event_bridge(
             "test",
-            || {
+            || Ok(()),
+            |()| {
                 calls.set(calls.get() + 1);
                 results.next().unwrap()
             },
@@ -1249,6 +1281,47 @@ mod tests {
 
         assert_eq!(calls.get(), 3);
         assert_eq!(sleeps.get(), 2);
+    }
+
+    #[test]
+    fn event_bridge_resolves_sdk_for_each_reconnect_attempt() {
+        let resolves = Cell::new(0);
+        let reads = RefCell::new(Vec::new());
+        let sleeps = Cell::new(0);
+        let mut results = vec![Ok(()), Err("socket closed".to_string()), Ok(())].into_iter();
+
+        run_reconnecting_resolved_event_bridge(
+            "test",
+            || {
+                let attempt = resolves.get() + 1;
+                resolves.set(attempt);
+                Ok(attempt)
+            },
+            |attempt| {
+                reads.borrow_mut().push(attempt);
+                results.next().unwrap()
+            },
+            |_| sleeps.set(sleeps.get() + 1),
+            Some(3),
+        );
+
+        assert_eq!(resolves.get(), 3);
+        assert_eq!(*reads.borrow(), vec![1, 2, 3]);
+        assert_eq!(sleeps.get(), 2);
+    }
+
+    #[test]
+    fn detected_client_uses_default_timeout_after_probe() {
+        let probe_sdk = roux_sdk::Roux::builder()
+            .endpoint(roux_sdk::SocketEndpoint::Unix(std::path::PathBuf::from(
+                "/tmp/roux-probe.sock",
+            )))
+            .timeout(PROBE_TIMEOUT)
+            .connect()
+            .unwrap();
+        let client = DaemonClient::from_detected_status(daemon_status(), probe_sdk).unwrap();
+
+        assert_eq!(client.sdk.request_timeout(), Duration::from_secs(5));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Move remaining desktop daemon request/response helpers into `roux-sdk`.
- Add SDK-owned daemon APIs for projects, aliases, subscriptions, mailbox, notes, hooks, sessions, worktrees, watches, processes, PTYs, and event streams.
- Add SDK coverage for Unix `.sock` streaming transport.
- Shrink `src-tauri/src/daemon_client.rs` into a Tauri adapter over `roux-sdk` with no direct daemon command construction left.

## Validation

- `cargo test -p roux-sdk`
- `cargo test -p roux-cli`
- `CI=1 cargo test -p roux-desktop --lib`
- `CI=1 cargo test -p roux-desktop --bin roux-desktop`
- `cargo clippy --all-targets -- -D warnings`
- `rustfmt --check crates/roux-sdk/src/lib.rs src-tauri/src/daemon_client.rs`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced mailbox operations: list, peek, read state, post, mark, acknowledge, clear, retract, and dismiss messages.
  * Notes management: read, write, append, and search capabilities.
  * Automation hook management: list, preview, run, approve, and log viewing.
  * Improved project, alias, and subscription lifecycle management.
  * Session and worktree management enhancements.
  * New streaming support for watch and subscription events.

* **Refactor**
  * Standardized error handling across APIs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phin-tech/roux/pull/200?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates all remaining daemon command construction out of `src-tauri/src/daemon_client.rs` into `crates/roux-sdk/src/lib.rs`, making `DaemonClient` a thin Tauri adapter that delegates every operation to the SDK. It also fixes the previously reported probe-timeout bug by calling `sdk.with_default_timeout()` in `from_detected_status`, backed by a new unit test.

- **SDK expansion**: adds typed methods for projects, aliases, subscriptions, mailbox, notes, automation hooks, sessions, worktrees, watches, processes, and PTYs; introduces four typed event-stream frame enums (`WatchEventStreamFrame`, `MailboxEventStreamFrame`, `AliasEventStreamFrame`, `SubscriptionEventStreamFrame`) each with comprehensive unit tests.
- **Probe-timeout fix**: `DaemonClient::from_detected_status` now calls `sdk.with_default_timeout()` before storing the SDK instance, ensuring subsequent daemon operations use the 5 s default rather than the 250 ms probe value.
- **`daemon_client.rs` refactor**: all direct `CommandRequest` construction removed; the file is now a mapping layer between Tauri-local request structs and the SDK types, plus the event-bridge threading infrastructure.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The probe-timeout regression from the previous review is properly addressed, all new SDK methods are unit-tested, and the DaemonClient refactor is a clean delegation layer with no direct command construction remaining.

The two changed files are well-tested: roux-sdk gains extensive new unit tests covering TCP and Unix socket transports, typed frame decoding, and the full command/response cycle for every major new method. The daemon_client refactor is mechanical delegation, and the previously flagged timeout issue is now provably fixed by the new test. The single remaining concern (fragile error-string matching in get_alias) is a pre-existing pattern that was already in production via the old daemon_client.rs.

No files require special attention. Both changed files have good test coverage, and the migration is consistent throughout.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/roux-sdk/src/lib.rs | Large expansion adding typed SDK methods for mailbox, notes, hooks, projects, aliases, subscriptions, sessions, worktrees, watches, processes, and PTYs. Also adds DEFAULT_TIMEOUT constant, with_timeout/with_default_timeout helpers, and four typed event-stream frame enums backed by new unit tests. Logic is sound; one fragile error-string match in get_alias is a pre-existing pattern now surfaced as a public API. |
| src-tauri/src/daemon_client.rs | Shrunk to a Tauri adapter: all daemon command construction removed, every method now delegates to roux_sdk::Roux. The previously reported probe-timeout bug is fixed — from_detected_status now calls sdk.with_default_timeout() before storing the SDK, and a new unit test (detected_client_uses_default_timeout_after_probe) directly verifies the 5 s timeout is restored after the 250 ms probe. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Desktop as Tauri Desktop
    participant DC as DaemonClient
    participant SDK as roux_sdk::Roux
    participant Daemon as roux daemon (socket)

    Note over DC,SDK: detect() — probe phase
    DC->>SDK: builder().timeout(250ms).connect()
    DC->>SDK: status_blocking()
    SDK->>Daemon: daemon-status (250ms timeout)
    Daemon-->>SDK: DaemonStatus JSON
    SDK-->>DC: Value
    DC->>DC: from_detected_status(status, sdk)
    Note right of DC: sdk.with_default_timeout() → 5s
    DC-->>Desktop: "DaemonClient { sdk(5s timeout) }"

    Note over DC,SDK: Normal operations (5s timeout)
    Desktop->>DC: create_session_shell(...)
    DC->>SDK: sdk.create_session_shell(...)
    SDK->>Daemon: session-create-shell (5s timeout)
    Daemon-->>SDK: Session JSON
    SDK-->>DC: Session
    DC-->>Desktop: "Result<Session, String>"

    Note over DC,Daemon: Event bridges (unlimited reconnect)
    DC->>DC: spawn_watch_event_bridge(app)
    loop reconnect on disconnect
        DC->>SDK: connect_current_sdk()
        SDK->>Daemon: watch-events stream
        Daemon-->>SDK: WatchEventStreamFrame (ndjson)
        SDK-->>DC: on_frame callback
        DC->>Desktop: app.emit(watch-update)
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src-tauri/src/daemon_client.rs`, line 97-106 ([link](https://github.com/phin-tech/roux/blob/7c5d6cf6da380a7e7afd4b4ef040c3bdc4d39635/src-tauri/src/daemon_client.rs#L97-L106)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Probe timeout inherited by all subsequent commands**

   `detect()` builds the SDK with `PROBE_TIMEOUT = 250 ms` and then stores that same instance in `Self { status, sdk }`. Because `blocking.rs` calls `stream.set_read_timeout(Some(timeout))` and `stream.set_write_timeout(Some(timeout))` for every command request, every subsequent daemon operation (project creation, session management, worktree ops, etc.) will now time out after 250 ms instead of the 5 s default.

   The pre-refactor code probed with `send_command_blocking(..., PROBE_TIMEOUT)` and then separately called `roux_sdk::Roux::connect()` (which uses the 5 s `RouxBuilder::default()` timeout) for the stored SDK instance. That separation has been lost here, so any command whose round-trip exceeds 250 ms — which is common for git, worktree, or session-creation operations — will fail with a timeout error.

   

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src-tauri%2Fsrc%2Fdaemon_client.rs%0ALine%3A%2097-106%0A%0AComment%3A%0A**Probe%20timeout%20inherited%20by%20all%20subsequent%20commands**%0A%0A%60detect%28%29%60%20builds%20the%20SDK%20with%20%60PROBE_TIMEOUT%20%3D%20250%20ms%60%20and%20then%20stores%20that%20same%20instance%20in%20%60Self%20%7B%20status%2C%20sdk%20%7D%60.%20Because%20%60blocking.rs%60%20calls%20%60stream.set_read_timeout%28Some%28timeout%29%29%60%20and%20%60stream.set_write_timeout%28Some%28timeout%29%29%60%20for%20every%20command%20request%2C%20every%20subsequent%20daemon%20operation%20%28project%20creation%2C%20session%20management%2C%20worktree%20ops%2C%20etc.%29%20will%20now%20time%20out%20after%20250%20ms%20instead%20of%20the%205%20s%20default.%0A%0AThe%20pre-refactor%20code%20probed%20with%20%60send_command_blocking%28...%2C%20PROBE_TIMEOUT%29%60%20and%20then%20separately%20called%20%60roux_sdk%3A%3ARoux%3A%3Aconnect%28%29%60%20%28which%20uses%20the%205%20s%20%60RouxBuilder%3A%3Adefault%28%29%60%20timeout%29%20for%20the%20stored%20SDK%20instance.%20That%20separation%20has%20been%20lost%20here%2C%20so%20any%20command%20whose%20round-trip%20exceeds%20250%20ms%20%E2%80%94%20which%20is%20common%20for%20git%2C%20worktree%2C%20or%20session-creation%20operations%20%E2%80%94%20will%20fail%20with%20a%20timeout%20error.%0A%0A%60%60%60suggestion%0A%20%20%20%20pub%28crate%29%20fn%20detect%28%29%20-%3E%20Option%3CSelf%3E%20%7B%0A%20%20%20%20%20%20%20%20let%20probe%20%3D%20roux_sdk%3A%3ARoux%3A%3Abuilder%28%29.timeout%28PROBE_TIMEOUT%29.connect%28%29.ok%28%29%3F%3B%0A%20%20%20%20%20%20%20%20let%20data%20%3D%20probe.status_blocking%28%29.ok%28%29%3F%3B%0A%20%20%20%20%20%20%20%20let%20status%3A%20DaemonStatus%20%3D%20serde_json%3A%3Afrom_value%28data%29.ok%28%29%3F%3B%0A%20%20%20%20%20%20%20%20if%20status.kind%20%3D%3D%20%22roux-daemon%22%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20let%20sdk%20%3D%20roux_sdk%3A%3ARoux%3A%3Aconnect%28%29.ok%28%29%3F%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20Some%28Self%20%7B%20status%2C%20sdk%20%7D%29%0A%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20None%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=phin-tech%2Froux&pr=200&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22codex%2Fsdk-daemon-client%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fsdk-daemon-client%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src-tauri%2Fsrc%2Fdaemon_client.rs%0ALine%3A%2097-106%0A%0AComment%3A%0A**Probe%20timeout%20inherited%20by%20all%20subsequent%20commands**%0A%0A%60detect%28%29%60%20builds%20the%20SDK%20with%20%60PROBE_TIMEOUT%20%3D%20250%20ms%60%20and%20then%20stores%20that%20same%20instance%20in%20%60Self%20%7B%20status%2C%20sdk%20%7D%60.%20Because%20%60blocking.rs%60%20calls%20%60stream.set_read_timeout%28Some%28timeout%29%29%60%20and%20%60stream.set_write_timeout%28Some%28timeout%29%29%60%20for%20every%20command%20request%2C%20every%20subsequent%20daemon%20operation%20%28project%20creation%2C%20session%20management%2C%20worktree%20ops%2C%20etc.%29%20will%20now%20time%20out%20after%20250%20ms%20instead%20of%20the%205%20s%20default.%0A%0AThe%20pre-refactor%20code%20probed%20with%20%60send_command_blocking%28...%2C%20PROBE_TIMEOUT%29%60%20and%20then%20separately%20called%20%60roux_sdk%3A%3ARoux%3A%3Aconnect%28%29%60%20%28which%20uses%20the%205%20s%20%60RouxBuilder%3A%3Adefault%28%29%60%20timeout%29%20for%20the%20stored%20SDK%20instance.%20That%20separation%20has%20been%20lost%20here%2C%20so%20any%20command%20whose%20round-trip%20exceeds%20250%20ms%20%E2%80%94%20which%20is%20common%20for%20git%2C%20worktree%2C%20or%20session-creation%20operations%20%E2%80%94%20will%20fail%20with%20a%20timeout%20error.%0A%0A%60%60%60suggestion%0A%20%20%20%20pub%28crate%29%20fn%20detect%28%29%20-%3E%20Option%3CSelf%3E%20%7B%0A%20%20%20%20%20%20%20%20let%20probe%20%3D%20roux_sdk%3A%3ARoux%3A%3Abuilder%28%29.timeout%28PROBE_TIMEOUT%29.connect%28%29.ok%28%29%3F%3B%0A%20%20%20%20%20%20%20%20let%20data%20%3D%20probe.status_blocking%28%29.ok%28%29%3F%3B%0A%20%20%20%20%20%20%20%20let%20status%3A%20DaemonStatus%20%3D%20serde_json%3A%3Afrom_value%28data%29.ok%28%29%3F%3B%0A%20%20%20%20%20%20%20%20if%20status.kind%20%3D%3D%20%22roux-daemon%22%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20let%20sdk%20%3D%20roux_sdk%3A%3ARoux%3A%3Aconnect%28%29.ok%28%29%3F%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20Some%28Self%20%7B%20status%2C%20sdk%20%7D%29%0A%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20None%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

2. `crates/roux-sdk/src/lib.rs`, line 183-193 ([link](https://github.com/phin-tech/roux/blob/7c5d6cf6da380a7e7afd4b4ef040c3bdc4d39635/crates/roux-sdk/src/lib.rs#L183-L193)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`status()` and `status_value()` duplicate the same daemon call**

   Both `status()` and `status_value()` send an identical `"daemon-status"` command and differ only in their return type (`DaemonStatus` vs `Value`). The `status_value()` method was added specifically so `daemon_client.rs` could decode into its own `DaemonStatus` type, but the same result could be achieved by calling `status()` and re-serializing, or by adding an explicit escape hatch. Having two public methods that issue the same wire command is surprising and may confuse future callers.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Froux-sdk%2Fsrc%2Flib.rs%0ALine%3A%20183-193%0A%0AComment%3A%0A**%60status%28%29%60%20and%20%60status_value%28%29%60%20duplicate%20the%20same%20daemon%20call**%0A%0ABoth%20%60status%28%29%60%20and%20%60status_value%28%29%60%20send%20an%20identical%20%60%22daemon-status%22%60%20command%20and%20differ%20only%20in%20their%20return%20type%20%28%60DaemonStatus%60%20vs%20%60Value%60%29.%20The%20%60status_value%28%29%60%20method%20was%20added%20specifically%20so%20%60daemon_client.rs%60%20could%20decode%20into%20its%20own%20%60DaemonStatus%60%20type%2C%20but%20the%20same%20result%20could%20be%20achieved%20by%20calling%20%60status%28%29%60%20and%20re-serializing%2C%20or%20by%20adding%20an%20explicit%20escape%20hatch.%20Having%20two%20public%20methods%20that%20issue%20the%20same%20wire%20command%20is%20surprising%20and%20may%20confuse%20future%20callers.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=phin-tech%2Froux&pr=200&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22codex%2Fsdk-daemon-client%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fsdk-daemon-client%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Froux-sdk%2Fsrc%2Flib.rs%0ALine%3A%20183-193%0A%0AComment%3A%0A**%60status%28%29%60%20and%20%60status_value%28%29%60%20duplicate%20the%20same%20daemon%20call**%0A%0ABoth%20%60status%28%29%60%20and%20%60status_value%28%29%60%20send%20an%20identical%20%60%22daemon-status%22%60%20command%20and%20differ%20only%20in%20their%20return%20type%20%28%60DaemonStatus%60%20vs%20%60Value%60%29.%20The%20%60status_value%28%29%60%20method%20was%20added%20specifically%20so%20%60daemon_client.rs%60%20could%20decode%20into%20its%20own%20%60DaemonStatus%60%20type%2C%20but%20the%20same%20result%20could%20be%20achieved%20by%20calling%20%60status%28%29%60%20and%20re-serializing%2C%20or%20by%20adding%20an%20explicit%20escape%20hatch.%20Having%20two%20public%20methods%20that%20issue%20the%20same%20wire%20command%20is%20surprising%20and%20may%20confuse%20future%20callers.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Froux-sdk%2Fsrc%2Flib.rs%3A288-297%0A**Fragile%20error-string%20matching%20on%20public%20SDK%20method**%0A%0A%60get_alias%60%20maps%20an%20%60Err%60%20whose%20message%20contains%20%60%22alias%20'%7Balias%7D'%20not%20found%22%60%20to%20%60Ok%28None%29%60.%20This%20is%20now%20a%20public%20SDK%20contract%3A%20if%20the%20daemon%20ever%20rewords%20that%20error%20%28e.g.%2C%20changes%20punctuation%2C%20capitalises%20%22Alias%22%2C%20or%20includes%20additional%20context%29%2C%20callers%20silently%20get%20%60Err%60%20instead%20of%20%60Ok%28None%29%60%20for%20a%20legitimate%20%22not%20found%22%20case.%20A%20protocol-level%20%22not%20found%22%20status%20code%20would%20be%20safer%20than%20matching%20a%20human-readable%20string.%0A%0A&repo=phin-tech%2Froux&pr=200&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22codex%2Fsdk-daemon-client%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fsdk-daemon-client%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Froux-sdk%2Fsrc%2Flib.rs%3A288-297%0A**Fragile%20error-string%20matching%20on%20public%20SDK%20method**%0A%0A%60get_alias%60%20maps%20an%20%60Err%60%20whose%20message%20contains%20%60%22alias%20'%7Balias%7D'%20not%20found%22%60%20to%20%60Ok%28None%29%60.%20This%20is%20now%20a%20public%20SDK%20contract%3A%20if%20the%20daemon%20ever%20rewords%20that%20error%20%28e.g.%2C%20changes%20punctuation%2C%20capitalises%20%22Alias%22%2C%20or%20includes%20additional%20context%29%2C%20callers%20silently%20get%20%60Err%60%20instead%20of%20%60Ok%28None%29%60%20for%20a%20legitimate%20%22not%20found%22%20case.%20A%20protocol-level%20%22not%20found%22%20status%20code%20would%20be%20safer%20than%20matching%20a%20human-readable%20string.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix daemon sdk timeout and event reconne..."](https://github.com/phin-tech/roux/commit/fc915dc29b0cbca62cea604ec0af2d7e025e3a0d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33626685)</sub>

<!-- /greptile_comment -->