### PR TITLE
[codex] type daemon client errors

### DIFF
--- a/src-tauri/src/automation_hooks/mod.rs
+++ b/src-tauri/src/automation_hooks/mod.rs
@@ -12,7 +12,7 @@ pub(crate) async fn cmd_list_automation_hooks(
 ) -> Result<Vec<HookListItem>, String> {
     if let Some(client) = state.daemon_client.clone().filter(|client| client.supports("hook-show"))
     {
-        return client.list_automation_hooks(repo_path).await;
+        return client.list_automation_hooks(repo_path).await.map_err(Into::into);
     }
     state.automation_hooks.list_hooks(repo_path.as_deref()).map_err(|e| e.to_string())
 }
@@ -26,7 +26,7 @@ pub(crate) async fn cmd_preview_automation_hooks(
     if let Some(client) =
         state.daemon_client.clone().filter(|client| client.supports("hook-preview"))
     {
-        return client.preview_automation_hooks(request).await;
+        return client.preview_automation_hooks(request).await.map_err(Into::into);
     }
     let settings = state.settings.lock().map_err(|e| e.to_string())?.clone();
     let wt_available = crate::services::setup::resolve_wt_binary().is_some();
@@ -43,7 +43,7 @@ pub(crate) async fn cmd_run_automation_hook(
     state: tauri::State<'_, crate::state::AppState>,
 ) -> Result<HookRunSummary, String> {
     if let Some(client) = state.daemon_client.clone().filter(|client| client.supports("hook-run")) {
-        return client.run_automation_hook(request).await;
+        return client.run_automation_hook(request).await.map_err(Into::into);
     }
     let settings = state.settings.lock().map_err(|e| e.to_string())?.clone();
     let wt_available = crate::services::setup::resolve_wt_binary().is_some();
@@ -67,7 +67,7 @@ pub(crate) async fn cmd_approve_automation_hook(
     if let Some(client) =
         state.daemon_client.clone().filter(|client| client.supports("hook-approve"))
     {
-        return client.approve_automation_hook(approval_id).await;
+        return client.approve_automation_hook(approval_id).await.map_err(Into::into);
     }
     state.automation_hooks.approve(&approval_id).map_err(|e| e.to_string())
 }
@@ -80,7 +80,7 @@ pub(crate) async fn cmd_clear_automation_hook_approvals(
     if let Some(client) =
         state.daemon_client.clone().filter(|client| client.supports("hook-clear-approvals"))
     {
-        return client.clear_automation_hook_approvals().await;
+        return client.clear_automation_hook_approvals().await.map_err(Into::into);
     }
     state.automation_hooks.clear_approvals().map_err(|e| e.to_string())
 }
@@ -93,7 +93,7 @@ pub(crate) async fn cmd_list_automation_hook_logs(
     if let Some(client) =
         state.daemon_client.clone().filter(|client| client.supports("hook-log-list"))
     {
-        return client.list_automation_hook_logs().await;
+        return client.list_automation_hook_logs().await.map_err(Into::into);
     }
     Ok(state.automation_hooks.list_logs())
 }
@@ -107,7 +107,7 @@ pub(crate) async fn cmd_read_automation_hook_log(
     if let Some(client) =
         state.daemon_client.clone().filter(|client| client.supports("hook-log-read"))
     {
-        return client.read_automation_hook_log(path).await;
+        return client.read_automation_hook_log(path).await.map_err(Into::into);
     }
     state.automation_hooks.read_log(&path).map_err(|e| e.to_string())
 }

--- a/src-tauri/src/commands/aliases.rs
+++ b/src-tauri/src/commands/aliases.rs
@@ -33,7 +33,8 @@ pub async fn aliases_list(
                 global.unwrap_or(false),
                 only_unbound.unwrap_or(false),
             )
-            .await;
+            .await
+            .map_err(Into::into);
     }
     Ok(state.alias_manager.list(
         project_filter(project_id.as_deref(), global.unwrap_or(false)),
@@ -49,7 +50,7 @@ pub async fn aliases_get(
 ) -> Result<Option<AgentAlias>, String> {
     if let Some(client) = state.daemon_client.clone().filter(|client| client.supports("alias-get"))
     {
-        return client.get_alias(alias.clone(), project_id.clone()).await;
+        return client.get_alias(alias.clone(), project_id.clone()).await.map_err(Into::into);
     }
     Ok(state.alias_manager.get(&alias, project_id.as_deref()))
 }
@@ -62,7 +63,7 @@ pub async fn aliases_whoami(
     if let Some(client) =
         state.daemon_client.clone().filter(|client| client.supports("alias-whoami"))
     {
-        return client.whoami_aliases(session_id.clone()).await;
+        return client.whoami_aliases(session_id.clone()).await.map_err(Into::into);
     }
     Ok(state.alias_manager.whoami(&session_id))
 }
@@ -81,7 +82,8 @@ pub async fn aliases_add_member(
     {
         return client
             .add_alias_member(canonical.clone(), pane_id.clone(), project_id.clone())
-            .await;
+            .await
+            .map_err(Into::into);
     }
     state
         .alias_manager
@@ -103,7 +105,8 @@ pub async fn aliases_remove_member(
     {
         return client
             .remove_alias_member(canonical.clone(), pane_id.clone(), project_id.clone())
-            .await;
+            .await
+            .map_err(Into::into);
     }
     state
         .alias_manager
@@ -131,7 +134,10 @@ pub async fn aliases_set_mode(
     };
     if let Some(client) = state.daemon_client.clone().filter(|client| client.supports("alias-mode"))
     {
-        return client.set_alias_mode(canonical.clone(), mode, project_id.clone()).await;
+        return client
+            .set_alias_mode(canonical.clone(), mode, project_id.clone())
+            .await
+            .map_err(Into::into);
     }
     state
         .alias_manager

--- a/src-tauri/src/commands/daemon.rs
+++ b/src-tauri/src/commands/daemon.rs
@@ -46,7 +46,7 @@ pub(crate) async fn get_runtime_status(
     let client = required_daemon_client_ref(&state)?;
     let (daemon, status_error) = match client.refresh_status().await {
         Ok(status) => (status, None),
-        Err(err) => (client.status().clone(), Some(err)),
+        Err(err) => (client.status().clone(), Some(err.into())),
     };
     Ok(RuntimeStatus {
         mode: RuntimeMode::Daemon,
@@ -66,7 +66,7 @@ pub(crate) async fn daemon_process_start(
     state: tauri::State<'_, AppState>,
 ) -> Result<ProcessRecord, String> {
     if let Some(client) = &state.daemon_client {
-        return client.start_daemon_process(command, working_dir).await;
+        return client.start_daemon_process(command, working_dir).await.map_err(Into::into);
     }
 
     state
@@ -84,7 +84,7 @@ pub(crate) async fn daemon_process_output(
     state: tauri::State<'_, AppState>,
 ) -> Result<ProcessSnapshot, String> {
     if let Some(client) = &state.daemon_client {
-        return client.daemon_process_output(id, max_bytes).await;
+        return client.daemon_process_output(id, max_bytes).await.map_err(Into::into);
     }
 
     state
@@ -104,7 +104,7 @@ pub(crate) async fn daemon_process_list(
     state: tauri::State<'_, AppState>,
 ) -> Result<Vec<ProcessRecord>, String> {
     if let Some(client) = &state.daemon_client {
-        return client.list_daemon_processes().await;
+        return client.list_daemon_processes().await.map_err(Into::into);
     }
 
     state.runtime.process_handle.list().await.map_err(|err| err.to_string())
@@ -116,7 +116,7 @@ pub(crate) async fn daemon_process_kill(
     state: tauri::State<'_, AppState>,
 ) -> Result<ProcessRecord, String> {
     if let Some(client) = &state.daemon_client {
-        return client.kill_daemon_process(id).await;
+        return client.kill_daemon_process(id).await.map_err(Into::into);
     }
 
     state
@@ -151,6 +151,7 @@ pub(crate) async fn daemon_pty_spawn_shell(
             initial_size,
         )
         .await
+        .map_err(Into::into)
 }
 
 #[tauri::command]
@@ -168,6 +169,7 @@ pub(crate) async fn daemon_pty_spawn_task(
     client
         .spawn_daemon_pty_task(command, id, working_dir, session_id, pane_id, profile, initial_size)
         .await
+        .map_err(Into::into)
 }
 
 #[tauri::command]
@@ -177,7 +179,7 @@ pub(crate) async fn daemon_pty_output(
     state: tauri::State<'_, AppState>,
 ) -> Result<PtySnapshot, String> {
     let client = required_daemon_client_ref(&state)?;
-    client.daemon_pty_output(id, max_bytes).await
+    client.daemon_pty_output(id, max_bytes).await.map_err(Into::into)
 }
 
 #[tauri::command]
@@ -185,7 +187,7 @@ pub(crate) async fn daemon_pty_list(
     state: tauri::State<'_, AppState>,
 ) -> Result<Vec<PtyRecord>, String> {
     let client = required_daemon_client_ref(&state)?;
-    client.list_daemon_ptys().await
+    client.list_daemon_ptys().await.map_err(Into::into)
 }
 
 #[tauri::command]
@@ -195,7 +197,7 @@ pub(crate) async fn daemon_pty_write(
     state: tauri::State<'_, AppState>,
 ) -> Result<(), String> {
     let client = required_daemon_client_ref(&state)?;
-    client.write_daemon_pty(id, data).await
+    client.write_daemon_pty(id, data).await.map_err(Into::into)
 }
 
 #[tauri::command]
@@ -206,7 +208,7 @@ pub(crate) async fn daemon_pty_resize(
     state: tauri::State<'_, AppState>,
 ) -> Result<PtyRecord, String> {
     let client = required_daemon_client_ref(&state)?;
-    client.resize_daemon_pty(id, cols, rows).await
+    client.resize_daemon_pty(id, cols, rows).await.map_err(Into::into)
 }
 
 #[tauri::command]
@@ -215,5 +217,5 @@ pub(crate) async fn daemon_pty_kill(
     state: tauri::State<'_, AppState>,
 ) -> Result<PtyRecord, String> {
     let client = required_daemon_client_ref(&state)?;
-    client.kill_daemon_pty(id).await
+    client.kill_daemon_pty(id).await.map_err(Into::into)
 }

--- a/src-tauri/src/commands/mailbox.rs
+++ b/src-tauri/src/commands/mailbox.rs
@@ -65,7 +65,8 @@ pub async fn mailbox_list_for_recipient(
                 project_id.clone(),
                 global.unwrap_or(false),
             )
-            .await;
+            .await
+            .map_err(Into::into);
     }
     Ok(state.mailbox_manager.list_for_recipient(
         &alias,
@@ -84,7 +85,8 @@ pub async fn mailbox_list_for_topic(
     if let Some(client) = state.daemon_client.clone().filter(|client| client.supports("bus-tail")) {
         return client
             .mailbox_list_for_topic(topic.clone(), project_id.clone(), global.unwrap_or(false))
-            .await;
+            .await
+            .map_err(Into::into);
     }
     Ok(state
         .mailbox_manager
@@ -99,7 +101,10 @@ pub async fn mailbox_list_all(
     state: tauri::State<'_, AppState>,
 ) -> Result<Vec<Event>, String> {
     if let Some(client) = state.daemon_client.clone().filter(|client| client.supports("bus-tail")) {
-        return client.mailbox_list_all(project_id.clone(), global.unwrap_or(false), limit).await;
+        return client
+            .mailbox_list_all(project_id.clone(), global.unwrap_or(false), limit)
+            .await
+            .map_err(Into::into);
     }
     Ok(state.mailbox_manager.list_all(
         project_filter(project_id.as_deref(), global.unwrap_or(false)),
@@ -119,7 +124,8 @@ pub async fn mailbox_unread_count(
     {
         return client
             .mailbox_unread_count(alias.clone(), project_id.clone(), global.unwrap_or(false))
-            .await;
+            .await
+            .map_err(Into::into);
     }
     Ok(state
         .mailbox_manager
@@ -135,7 +141,7 @@ pub async fn mailbox_get_event(
     if let Some(client) =
         state.daemon_client.clone().filter(|client| client.supports("mailbox-get"))
     {
-        return client.mailbox_get_event(event_id.clone()).await;
+        return client.mailbox_get_event(event_id.clone()).await.map_err(Into::into);
     }
     Ok(state.mailbox_manager.get(&event_id))
 }
@@ -149,7 +155,10 @@ pub async fn mailbox_read_state(
     if let Some(client) =
         state.daemon_client.clone().filter(|client| client.supports("mailbox-read-state"))
     {
-        return client.mailbox_read_state(event_id.clone(), recipient.clone()).await;
+        return client
+            .mailbox_read_state(event_id.clone(), recipient.clone())
+            .await
+            .map_err(Into::into);
     }
     Ok(state.mailbox_manager.read_state(&event_id, &recipient))
 }
@@ -175,7 +184,8 @@ pub async fn mailbox_post(
                 structured: input.structured,
                 from: input.from,
             })
-            .await;
+            .await
+            .map_err(Into::into);
     }
 
     if input.to.is_none() && input.topic.is_none() {
@@ -233,7 +243,10 @@ pub async fn mailbox_mark_read(
     if let Some(client) =
         state.daemon_client.clone().filter(|client| client.supports("mailbox-mark-read"))
     {
-        return client.mailbox_mark_read(event_id.clone(), recipient.clone()).await;
+        return client
+            .mailbox_mark_read(event_id.clone(), recipient.clone())
+            .await
+            .map_err(Into::into);
     }
     Ok(state.mailbox_manager.mark_read(&event_id, &recipient, Some(&app)))
 }
@@ -249,7 +262,10 @@ pub async fn mailbox_ack(
     if let Some(client) =
         state.daemon_client.clone().filter(|client| client.supports("mailbox-ack"))
     {
-        return client.mailbox_ack(event_id.clone(), recipient.clone(), result.clone()).await;
+        return client
+            .mailbox_ack(event_id.clone(), recipient.clone(), result.clone())
+            .await
+            .map_err(Into::into);
     }
     Ok(state.mailbox_manager.ack(&event_id, &recipient, result, Some(&app)))
 }
@@ -267,7 +283,8 @@ pub async fn mailbox_clear_read(
     {
         return client
             .mailbox_clear_read(recipient.clone(), project_id.clone(), global.unwrap_or(false))
-            .await;
+            .await
+            .map_err(Into::into);
     }
     Ok(state.mailbox_manager.clear_read(
         &recipient,
@@ -286,7 +303,7 @@ pub async fn mailbox_retract(
     if let Some(client) =
         state.daemon_client.clone().filter(|client| client.supports("mailbox-retract"))
     {
-        return client.mailbox_retract(event_id.clone(), sender.clone()).await;
+        return client.mailbox_retract(event_id.clone(), sender.clone()).await.map_err(Into::into);
     }
     state.mailbox_manager.retract(&event_id, &sender, Some(&app)).map_err(|e| e.to_string())
 }
@@ -301,7 +318,10 @@ pub async fn mailbox_dismiss(
     if let Some(client) =
         state.daemon_client.clone().filter(|client| client.supports("mailbox-dismiss"))
     {
-        return client.mailbox_dismiss(event_id.clone(), recipient.clone()).await;
+        return client
+            .mailbox_dismiss(event_id.clone(), recipient.clone())
+            .await
+            .map_err(Into::into);
     }
     Ok(state.mailbox_manager.dismiss(&event_id, &recipient, Some(&app)))
 }
@@ -366,7 +386,7 @@ pub async fn mailbox_deliver_to_pane(
                     .write(&pty_id, data.as_bytes())
                     .map_err(|e| format!("failed to write to pane: {e}"))?;
             }
-            Err(err) => return Err(err),
+            Err(err) => return Err(err.into()),
         }
     } else {
         state
@@ -385,6 +405,6 @@ pub async fn mailbox_deliver_to_pane(
     Ok(())
 }
 
-fn is_daemon_pty_not_found(err: &str) -> bool {
-    err.contains("daemon pty not found")
+fn is_daemon_pty_not_found(err: &impl std::fmt::Display) -> bool {
+    err.to_string().contains("daemon pty not found")
 }

--- a/src-tauri/src/commands/mailbox.rs
+++ b/src-tauri/src/commands/mailbox.rs
@@ -11,7 +11,7 @@ use roux_lib::aliases::ProjectFilter;
 use serde::Deserialize;
 use serde_json::Value;
 
-use crate::daemon_client::DaemonMailboxPostRequest;
+use crate::daemon_client::{DaemonClientError, DaemonMailboxPostRequest};
 use crate::state::AppState;
 
 #[derive(Debug, Deserialize)]
@@ -405,6 +405,6 @@ pub async fn mailbox_deliver_to_pane(
     Ok(())
 }
 
-fn is_daemon_pty_not_found(err: &impl std::fmt::Display) -> bool {
-    err.to_string().contains("daemon pty not found")
+fn is_daemon_pty_not_found(err: &DaemonClientError) -> bool {
+    matches!(err, DaemonClientError::DaemonPtyNotFound)
 }

--- a/src-tauri/src/commands/notes.rs
+++ b/src-tauri/src/commands/notes.rs
@@ -33,10 +33,7 @@ fn emit_notes_changed(app: &tauri::AppHandle, path: &std::path::Path) {
 }
 
 fn emit_notes_changed_path(app: &tauri::AppHandle, path: String) {
-    let _ = app.emit(
-        "notes-changed",
-        NotesChangedEvent { path },
-    );
+    let _ = app.emit("notes-changed", NotesChangedEvent { path });
 }
 
 /// Scope + addressing info for a single note file. Sent verbatim from the
@@ -81,9 +78,7 @@ fn vault_root(state: &AppState) -> std::path::PathBuf {
         .ok()
         .and_then(|s| s.notes_vault_root.clone())
         .filter(|p| !p.is_empty());
-    override_path
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(default_notes_vault_root)
+    override_path.map(std::path::PathBuf::from).unwrap_or_else(default_notes_vault_root)
 }
 
 /// Return the best-effort git origin URL for `repo_root`. `None` if git
@@ -160,9 +155,8 @@ pub(crate) async fn do_notes_read(
 ) -> Result<NotesRead, String> {
     let mut svc = build_service(state);
     let (scope, topic, session_slug) = resolve(&mut svc, state, &target).await?;
-    let content = svc
-        .read_file(&scope, topic.as_deref(), &session_slug)
-        .map_err(|e| e.to_string())?;
+    let content =
+        svc.read_file(&scope, topic.as_deref(), &session_slug).map_err(|e| e.to_string())?;
     let path = svc
         .file_path(&scope, topic.as_deref(), &session_slug)
         .map_err(|e| e.to_string())?
@@ -179,7 +173,7 @@ pub(crate) async fn notes_read(
 ) -> Result<NotesRead, String> {
     if let Some(client) = state.daemon_client.clone().filter(|client| client.supports("notes-read"))
     {
-        return client.read_notes(target).await;
+        return client.read_notes(target).await.map_err(Into::into);
     }
     do_notes_read(target, &state).await
 }
@@ -194,15 +188,8 @@ pub(crate) async fn do_notes_write(
     let mut svc = build_service(state);
     let (scope, topic, session_slug) = resolve(&mut svc, state, &target).await?;
     let now = now_iso8601();
-    svc.write_file(
-        &scope,
-        topic.as_deref(),
-        &session_slug,
-        &content,
-        &now,
-        &tags,
-    )
-    .map_err(|e| e.to_string())?;
+    svc.write_file(&scope, topic.as_deref(), &session_slug, &content, &now, &tags)
+        .map_err(|e| e.to_string())?;
     let path = svc.file_path(&scope, topic.as_deref(), &session_slug).map_err(|e| e.to_string())?;
     emit_notes_changed(app, &path);
     Ok(())
@@ -244,35 +231,20 @@ pub(crate) async fn do_notes_append(
     let (scope, topic, session_slug) = resolve(&mut svc, state, &target).await?;
     let now = now_iso8601();
 
-    let include_web_anchor = state
-        .settings
-        .lock()
-        .map_err(|e| e.to_string())?
-        .notes_include_web_anchors;
+    let include_web_anchor =
+        state.settings.lock().map_err(|e| e.to_string())?.notes_include_web_anchors;
 
     // Hoist the owned strings above the match so AppendOpts can borrow them.
     let ts = now_short();
     let id = short_entry_id();
     let opts = if timestamped {
-        AppendOpts::Timestamped {
-            timestamp: &ts,
-            id: &id,
-            include_web_anchor,
-        }
+        AppendOpts::Timestamped { timestamp: &ts, id: &id, include_web_anchor }
     } else {
         AppendOpts::Plain
     };
 
-    svc.append_file(
-        &scope,
-        topic.as_deref(),
-        &session_slug,
-        &content,
-        opts,
-        &now,
-        &tags,
-    )
-    .map_err(|e| e.to_string())?;
+    svc.append_file(&scope, topic.as_deref(), &session_slug, &content, opts, &now, &tags)
+        .map_err(|e| e.to_string())?;
     let path = svc.file_path(&scope, topic.as_deref(), &session_slug).map_err(|e| e.to_string())?;
     emit_notes_changed(app, &path);
     Ok(())
@@ -327,7 +299,7 @@ pub(crate) async fn notes_path(
 ) -> Result<String, String> {
     if let Some(client) = state.daemon_client.clone().filter(|client| client.supports("notes-path"))
     {
-        return client.notes_path(target, dir).await;
+        return client.notes_path(target, dir).await.map_err(Into::into);
     }
     do_notes_path(target, dir, &state).await
 }
@@ -353,7 +325,7 @@ pub(crate) async fn notes_search(
     if let Some(client) =
         state.daemon_client.clone().filter(|client| client.supports("notes-search"))
     {
-        return client.search_notes(query).await;
+        return client.search_notes(query).await.map_err(Into::into);
     }
     do_notes_search(query, &state)
 }
@@ -368,7 +340,7 @@ pub(crate) async fn notes_vault_root(state: tauri::State<'_, AppState>) -> Resul
     if let Some(client) =
         state.daemon_client.clone().filter(|client| client.supports("notes-vault-root"))
     {
-        return client.notes_vault_root().await;
+        return client.notes_vault_root().await.map_err(Into::into);
     }
     Ok(do_notes_vault_root(&state))
 }
@@ -377,10 +349,7 @@ fn now_iso8601() -> String {
     // Best-effort local-ish ISO-8601 via std::time. For v1, seconds resolution
     // is fine and we avoid pulling in chrono.
     use std::time::{SystemTime, UNIX_EPOCH};
-    let secs = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
+    let secs = SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or(0);
     format_epoch_seconds_iso8601(secs)
 }
 
@@ -389,10 +358,7 @@ fn now_short() -> String {
     // std, so this is a best-effort UTC rendering until we pull in chrono
     // or time. v1 acceptable per the spec's timestamp format notes.
     use std::time::{SystemTime, UNIX_EPOCH};
-    let secs = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
+    let secs = SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or(0);
     format_epoch_seconds_short(secs)
 }
 

--- a/src-tauri/src/commands/projects.rs
+++ b/src-tauri/src/commands/projects.rs
@@ -10,7 +10,7 @@ pub(crate) async fn list_projects(
     state: tauri::State<'_, AppState>,
 ) -> Result<Vec<Project>, String> {
     if let Some(client) = &state.daemon_client {
-        return client.list_projects().await;
+        return client.list_projects().await.map_err(Into::into);
     }
     state.runtime.project_handle.list().await.map_err(|e| e.to_string())
 }
@@ -22,7 +22,7 @@ pub(crate) async fn create_project(
     state: tauri::State<'_, AppState>,
 ) -> Result<Project, String> {
     if let Some(client) = &state.daemon_client {
-        return client.create_project(name).await;
+        return client.create_project(name).await.map_err(Into::into);
     }
     let project = Project {
         id: uuid::Uuid::new_v4().to_string(),
@@ -43,7 +43,7 @@ pub(crate) async fn remove_project(
     state: tauri::State<'_, AppState>,
 ) -> Result<(), String> {
     if let Some(client) = &state.daemon_client {
-        return client.remove_project(id).await;
+        return client.remove_project(id).await.map_err(Into::into);
     }
     let removed = state.runtime.project_handle.get(&id).await.map_err(|e| e.to_string())?;
     state.runtime.project_handle.remove(&id).await.map_err(|e| e.to_string())?;
@@ -64,7 +64,7 @@ pub(crate) async fn rename_project(
     state: tauri::State<'_, AppState>,
 ) -> Result<(), String> {
     if let Some(client) = &state.daemon_client {
-        return client.rename_project(id, name).await;
+        return client.rename_project(id, name).await.map_err(Into::into);
     }
     state.runtime.project_handle.rename(&id, &name).await.map_err(|e| e.to_string())
 }
@@ -77,7 +77,7 @@ pub(crate) async fn update_project(
     state: tauri::State<'_, AppState>,
 ) -> Result<Project, String> {
     if let Some(client) = &state.daemon_client {
-        return client.update_project(id, patch).await;
+        return client.update_project(id, patch).await.map_err(Into::into);
     }
     state
         .runtime
@@ -96,7 +96,7 @@ pub(crate) async fn set_session_project(
     state: tauri::State<'_, AppState>,
 ) -> Result<(), String> {
     if let Some(client) = &state.daemon_client {
-        return client.set_session_project(session_id, project_id).await;
+        return client.set_session_project(session_id, project_id).await.map_err(Into::into);
     }
     svc::set_session_project(&state.runtime.session_handle, &session_id, project_id)
         .await

--- a/src-tauri/src/commands/sessions.rs
+++ b/src-tauri/src/commands/sessions.rs
@@ -67,7 +67,7 @@ pub(crate) async fn write_to_session(
     state: tauri::State<'_, AppState>,
 ) -> Result<(), String> {
     let client = required_daemon_client(&state)?;
-    client.write_daemon_pty(id, data).await
+    client.write_daemon_pty(id, data).await.map_err(Into::into)
 }
 
 /// Frontend reply for a socket-initiated round-trip (e.g. panes list / create).
@@ -365,7 +365,7 @@ pub(crate) async fn session_worktree_exists(
     state: tauri::State<'_, AppState>,
 ) -> Result<bool, String> {
     let client = required_daemon_client_ref(&state)?;
-    client.session_worktree_exists(id).await
+    client.session_worktree_exists(id).await.map_err(Into::into)
 }
 
 /// Kill only the PTY for `id`, leaving session state, pane-state files, and
@@ -396,7 +396,7 @@ pub(crate) async fn set_session_name_override(
     state: tauri::State<'_, AppState>,
 ) -> Result<(), String> {
     let client = required_daemon_client_ref(&state)?;
-    client.set_session_name_override(session_id, name_override).await
+    client.set_session_name_override(session_id, name_override).await.map_err(Into::into)
 }
 
 /// Pin (or clear) a PR for a session. The status bar uses this when set
@@ -418,7 +418,7 @@ pub(crate) async fn set_session_pinned_pr_url(
         }
     });
     let client = required_daemon_client_ref(&state)?;
-    client.set_session_pinned_pr_url(session_id, normalized).await
+    client.set_session_pinned_pr_url(session_id, normalized).await.map_err(Into::into)
 }
 
 /// Bind (or clear) a smol machine for a session. When set, every PTY
@@ -435,7 +435,7 @@ pub(crate) async fn set_session_smol_machine(
     state: tauri::State<'_, AppState>,
 ) -> Result<(), String> {
     let client = required_daemon_client_ref(&state)?;
-    client.set_session_smol_machine(session_id, machine_name).await
+    client.set_session_smol_machine(session_id, machine_name).await.map_err(Into::into)
 }
 
 /// Re-read the session's worktree branch via `git rev-parse` and update the
@@ -449,7 +449,7 @@ pub(crate) async fn refresh_session_branch(
     state: tauri::State<'_, AppState>,
 ) -> Result<Option<String>, String> {
     let client = required_daemon_client_ref(&state)?;
-    client.refresh_session_branch(session_id).await
+    client.refresh_session_branch(session_id).await.map_err(Into::into)
 }
 
 /// Spawns a plain shell in the session's
@@ -551,7 +551,7 @@ pub(crate) async fn create_session_shell(
             notes: Some(notes),
         })
         .await
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 /// Respawns a plain shell in the session's primary PTY. The frontend
@@ -603,6 +603,7 @@ pub(crate) async fn reconnect_session_shell(
             notes: Some(notes),
         })
         .await
+        .map_err(Into::into)
 }
 
 /// Active sessions only — archived rows are excluded. The history view
@@ -613,7 +614,11 @@ pub(crate) async fn list_sessions(
     state: tauri::State<'_, AppState>,
 ) -> Result<Vec<Session>, String> {
     let client = required_daemon_client_ref(&state)?;
-    client.list_sessions().await.map(|all| all.into_iter().filter(|s| !s.archived).collect())
+    client
+        .list_sessions()
+        .await
+        .map(|all| all.into_iter().filter(|s| !s.archived).collect())
+        .map_err(Into::into)
 }
 
 /// Archived sessions, sorted newest-first by `ended_at` so the history

--- a/src-tauri/src/commands/subscriptions.rs
+++ b/src-tauri/src/commands/subscriptions.rs
@@ -31,7 +31,8 @@ pub async fn subscriptions_list(
     {
         return client
             .list_subscriptions(alias.clone(), project_id.clone(), global.unwrap_or(false))
-            .await;
+            .await
+            .map_err(Into::into);
     }
     let filter = project_filter(project_id.as_deref(), global.unwrap_or(false));
     Ok(match alias {
@@ -53,7 +54,8 @@ pub async fn subscriptions_create(
     {
         return client
             .create_subscription(alias.clone(), pattern.clone(), project_id.clone())
-            .await;
+            .await
+            .map_err(Into::into);
     }
     state
         .subscription_manager
@@ -70,7 +72,7 @@ pub async fn subscriptions_delete(
     if let Some(client) =
         state.daemon_client.clone().filter(|client| client.supports("bus-unsubscribe"))
     {
-        return client.delete_subscription(id.clone()).await;
+        return client.delete_subscription(id.clone()).await.map_err(Into::into);
     }
     state.subscription_manager.unsubscribe(&id, Some(&app)).map_err(|e| e.to_string())
 }

--- a/src-tauri/src/commands/worktrees.rs
+++ b/src-tauri/src/commands/worktrees.rs
@@ -47,8 +47,8 @@ fn build_post_worktree_remove_context(
     context
 }
 
-fn daemon_command_unsupported(err: &str) -> bool {
-    err.contains("unknown daemon command")
+fn daemon_command_unsupported(err: &impl std::fmt::Display) -> bool {
+    err.to_string().contains("unknown daemon command")
 }
 
 async fn create_worktree_local(
@@ -137,7 +137,7 @@ pub(crate) async fn cmd_create_worktree(
         {
             Ok(path) => return Ok(path),
             Err(err) if daemon_command_unsupported(&err) => {}
-            Err(err) => return Err(err),
+            Err(err) => return Err(err.into()),
         }
     }
 
@@ -195,7 +195,7 @@ pub(crate) async fn cmd_remove_worktree(
         {
             Ok(()) => return Ok(()),
             Err(err) if daemon_command_unsupported(&err) => {}
-            Err(err) => return Err(err),
+            Err(err) => return Err(err.into()),
         }
     }
 
@@ -236,7 +236,7 @@ pub(crate) async fn cmd_list_worktrees(
         match client.list_worktrees(repo_path.clone()).await {
             Ok(worktrees) => return Ok(worktrees),
             Err(err) if daemon_command_unsupported(&err) => {}
-            Err(err) => return Err(err),
+            Err(err) => return Err(err.into()),
         }
     }
     list_worktrees_local(repo_path).await
@@ -254,7 +254,7 @@ pub(crate) async fn cmd_list_branches(
         match client.list_branches(repo_path.clone()).await {
             Ok(branches) => return Ok(branches),
             Err(err) if daemon_command_unsupported(&err) => {}
-            Err(err) => return Err(err),
+            Err(err) => return Err(err.into()),
         }
     }
     tauri::async_runtime::spawn_blocking(move || {
@@ -274,7 +274,7 @@ pub(crate) async fn git_init(
         match client.git_init(path.clone()).await {
             Ok(()) => return Ok(()),
             Err(err) if daemon_command_unsupported(&err) => {}
-            Err(err) => return Err(err),
+            Err(err) => return Err(err.into()),
         }
     }
     tauri::async_runtime::spawn_blocking(move || svc::git_init(&path).map_err(|e| e.to_string()))

--- a/src-tauri/src/daemon_client.rs
+++ b/src-tauri/src/daemon_client.rs
@@ -93,6 +93,34 @@ pub(crate) struct DaemonReconnectSessionShellRequest {
 
 pub(crate) type DaemonMailboxPostRequest = roux_sdk::MailboxPost;
 
+type DaemonClientResult<T> = std::result::Result<T, DaemonClientError>;
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum DaemonClientError {
+    #[error(transparent)]
+    Sdk(#[from] roux_sdk::RouxError),
+    #[error(transparent)]
+    Decode(#[from] serde_json::Error),
+    #[error("unexpected daemon kind: {0}")]
+    UnexpectedDaemonKind(String),
+    #[error("daemon pty not found")]
+    DaemonPtyNotFound,
+    #[error("{0}")]
+    Adapter(String),
+}
+
+impl DaemonClientError {
+    fn adapter(message: impl Into<String>) -> Self {
+        Self::Adapter(message.into())
+    }
+}
+
+impl From<DaemonClientError> for String {
+    fn from(error: DaemonClientError) -> Self {
+        error.to_string()
+    }
+}
+
 impl DaemonClient {
     pub(crate) fn detect() -> Option<Self> {
         let sdk = roux_sdk::Roux::builder().timeout(PROBE_TIMEOUT).connect().ok()?;
@@ -154,46 +182,47 @@ impl DaemonClient {
         self.status.capabilities.iter().any(|candidate| candidate == capability)
     }
 
-    pub(crate) async fn refresh_status(&self) -> Result<DaemonStatus, String> {
-        let status = self.sdk.status_value().await.map_err(|err| err.to_string())?;
-        let status: DaemonStatus = serde_json::from_value(status).map_err(|err| err.to_string())?;
+    pub(crate) async fn refresh_status(&self) -> DaemonClientResult<DaemonStatus> {
+        let status = self.sdk.status_value().await.map_err(DaemonClientError::from)?;
+        let status: DaemonStatus =
+            serde_json::from_value(status).map_err(DaemonClientError::from)?;
         if status.kind == "roux-daemon" {
             Ok(status)
         } else {
-            Err(format!("unexpected daemon kind: {}", status.kind))
+            Err(DaemonClientError::UnexpectedDaemonKind(status.kind))
         }
     }
 
-    pub(crate) async fn list_sessions(&self) -> Result<Vec<Session>, String> {
-        self.sdk.sessions().await.map_err(|err| err.to_string())
+    pub(crate) async fn list_sessions(&self) -> DaemonClientResult<Vec<Session>> {
+        self.sdk.sessions().await.map_err(DaemonClientError::from)
     }
 
-    pub(crate) async fn get_session(&self, id: String) -> Result<Session, String> {
-        self.sdk.get_session(id).await.map_err(|err| err.to_string())
+    pub(crate) async fn get_session(&self, id: String) -> DaemonClientResult<Session> {
+        self.sdk.get_session(id).await.map_err(DaemonClientError::from)
     }
 
-    pub(crate) async fn list_projects(&self) -> Result<Vec<Project>, String> {
-        self.sdk.projects().await.map_err(|err| err.to_string())
+    pub(crate) async fn list_projects(&self) -> DaemonClientResult<Vec<Project>> {
+        self.sdk.projects().await.map_err(DaemonClientError::from)
     }
 
-    pub(crate) async fn create_project(&self, name: String) -> Result<Project, String> {
-        self.sdk.create_project(name).await.map_err(|err| err.to_string())
+    pub(crate) async fn create_project(&self, name: String) -> DaemonClientResult<Project> {
+        self.sdk.create_project(name).await.map_err(DaemonClientError::from)
     }
 
-    pub(crate) async fn remove_project(&self, id: String) -> Result<(), String> {
-        self.sdk.remove_project(id).await.map_err(|err| err.to_string())
+    pub(crate) async fn remove_project(&self, id: String) -> DaemonClientResult<()> {
+        self.sdk.remove_project(id).await.map_err(DaemonClientError::from)
     }
 
-    pub(crate) async fn rename_project(&self, id: String, name: String) -> Result<(), String> {
-        self.sdk.rename_project(id, name).await.map_err(|err| err.to_string())
+    pub(crate) async fn rename_project(&self, id: String, name: String) -> DaemonClientResult<()> {
+        self.sdk.rename_project(id, name).await.map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn update_project(
         &self,
         id: String,
         patch: ProjectUpdate,
-    ) -> Result<Project, String> {
-        self.sdk.update_project(id, patch).await.map_err(|err| err.to_string())
+    ) -> DaemonClientResult<Project> {
+        self.sdk.update_project(id, patch).await.map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn list_aliases(
@@ -201,23 +230,26 @@ impl DaemonClient {
         project_id: Option<String>,
         global: bool,
         only_unbound: bool,
-    ) -> Result<Vec<AgentAlias>, String> {
-        self.sdk.list_aliases(project_id, global, only_unbound).await.map_err(|err| err.to_string())
+    ) -> DaemonClientResult<Vec<AgentAlias>> {
+        self.sdk
+            .list_aliases(project_id, global, only_unbound)
+            .await
+            .map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn get_alias(
         &self,
         alias: String,
         project_id: Option<String>,
-    ) -> Result<Option<AgentAlias>, String> {
-        self.sdk.get_alias(alias, project_id).await.map_err(|err| err.to_string())
+    ) -> DaemonClientResult<Option<AgentAlias>> {
+        self.sdk.get_alias(alias, project_id).await.map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn whoami_aliases(
         &self,
         session_id: String,
-    ) -> Result<Vec<AgentAlias>, String> {
-        self.sdk.whoami_aliases(session_id).await.map_err(|err| err.to_string())
+    ) -> DaemonClientResult<Vec<AgentAlias>> {
+        self.sdk.whoami_aliases(session_id).await.map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn add_alias_member(
@@ -225,8 +257,8 @@ impl DaemonClient {
         alias: String,
         pane_id: String,
         project_id: Option<String>,
-    ) -> Result<AgentAlias, String> {
-        self.sdk.add_alias_member(alias, pane_id, project_id).await.map_err(|err| err.to_string())
+    ) -> DaemonClientResult<AgentAlias> {
+        self.sdk.add_alias_member(alias, pane_id, project_id).await.map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn remove_alias_member(
@@ -234,11 +266,11 @@ impl DaemonClient {
         alias: String,
         pane_id: String,
         project_id: Option<String>,
-    ) -> Result<bool, String> {
+    ) -> DaemonClientResult<bool> {
         self.sdk
             .remove_alias_member(alias, pane_id, project_id)
             .await
-            .map_err(|err| err.to_string())
+            .map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn set_alias_mode(
@@ -246,8 +278,8 @@ impl DaemonClient {
         alias: String,
         mode: String,
         project_id: Option<String>,
-    ) -> Result<AgentAlias, String> {
-        self.sdk.set_alias_mode(alias, mode, project_id).await.map_err(|err| err.to_string())
+    ) -> DaemonClientResult<AgentAlias> {
+        self.sdk.set_alias_mode(alias, mode, project_id).await.map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn list_subscriptions(
@@ -255,8 +287,11 @@ impl DaemonClient {
         alias: Option<String>,
         project_id: Option<String>,
         global: bool,
-    ) -> Result<Vec<BusSubscription>, String> {
-        self.sdk.list_subscriptions(alias, project_id, global).await.map_err(|err| err.to_string())
+    ) -> DaemonClientResult<Vec<BusSubscription>> {
+        self.sdk
+            .list_subscriptions(alias, project_id, global)
+            .await
+            .map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn create_subscription(
@@ -264,15 +299,15 @@ impl DaemonClient {
         alias: String,
         pattern: String,
         project_id: Option<String>,
-    ) -> Result<BusSubscription, String> {
+    ) -> DaemonClientResult<BusSubscription> {
         self.sdk
             .create_subscription(alias, pattern, project_id)
             .await
-            .map_err(|err| err.to_string())
+            .map_err(DaemonClientError::from)
     }
 
-    pub(crate) async fn delete_subscription(&self, id: String) -> Result<bool, String> {
-        self.sdk.delete_subscription(id).await.map_err(|err| err.to_string())
+    pub(crate) async fn delete_subscription(&self, id: String) -> DaemonClientResult<bool> {
+        self.sdk.delete_subscription(id).await.map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn mailbox_list_for_recipient(
@@ -281,11 +316,11 @@ impl DaemonClient {
         unread_only: bool,
         project_id: Option<String>,
         global: bool,
-    ) -> Result<Vec<Event>, String> {
+    ) -> DaemonClientResult<Vec<Event>> {
         self.sdk
             .mailbox_list_for_recipient(alias, unread_only, project_id, global)
             .await
-            .map_err(|err| err.to_string())
+            .map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn mailbox_list_for_topic(
@@ -293,11 +328,11 @@ impl DaemonClient {
         topic: String,
         project_id: Option<String>,
         global: bool,
-    ) -> Result<Vec<Event>, String> {
+    ) -> DaemonClientResult<Vec<Event>> {
         self.sdk
             .mailbox_list_for_topic(topic, project_id, global)
             .await
-            .map_err(|err| err.to_string())
+            .map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn mailbox_list_all(
@@ -305,8 +340,8 @@ impl DaemonClient {
         project_id: Option<String>,
         global: bool,
         limit: Option<u32>,
-    ) -> Result<Vec<Event>, String> {
-        self.sdk.mailbox_list_all(project_id, global, limit).await.map_err(|err| err.to_string())
+    ) -> DaemonClientResult<Vec<Event>> {
+        self.sdk.mailbox_list_all(project_id, global, limit).await.map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn mailbox_unread_count(
@@ -314,41 +349,41 @@ impl DaemonClient {
         alias: String,
         project_id: Option<String>,
         global: bool,
-    ) -> Result<u32, String> {
+    ) -> DaemonClientResult<u32> {
         self.sdk
             .mailbox_unread_count(alias, project_id, global)
             .await
-            .map_err(|err| err.to_string())
+            .map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn mailbox_get_event(
         &self,
         event_id: String,
-    ) -> Result<Option<Event>, String> {
-        self.sdk.mailbox_get_event(event_id).await.map_err(|err| err.to_string())
+    ) -> DaemonClientResult<Option<Event>> {
+        self.sdk.mailbox_get_event(event_id).await.map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn mailbox_read_state(
         &self,
         event_id: String,
         recipient: String,
-    ) -> Result<Option<ReadState>, String> {
-        self.sdk.mailbox_read_state(event_id, recipient).await.map_err(|err| err.to_string())
+    ) -> DaemonClientResult<Option<ReadState>> {
+        self.sdk.mailbox_read_state(event_id, recipient).await.map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn mailbox_post(
         &self,
         request: DaemonMailboxPostRequest,
-    ) -> Result<Event, String> {
-        self.sdk.mailbox_post(request).await.map_err(|err| err.to_string())
+    ) -> DaemonClientResult<Event> {
+        self.sdk.mailbox_post(request).await.map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn mailbox_mark_read(
         &self,
         event_id: String,
         recipient: String,
-    ) -> Result<bool, String> {
-        self.sdk.mailbox_mark_read(event_id, recipient).await.map_err(|err| err.to_string())
+    ) -> DaemonClientResult<bool> {
+        self.sdk.mailbox_mark_read(event_id, recipient).await.map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn mailbox_ack(
@@ -356,8 +391,8 @@ impl DaemonClient {
         event_id: String,
         recipient: String,
         result: Option<String>,
-    ) -> Result<bool, String> {
-        self.sdk.mailbox_ack(event_id, recipient, result).await.map_err(|err| err.to_string())
+    ) -> DaemonClientResult<bool> {
+        self.sdk.mailbox_ack(event_id, recipient, result).await.map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn mailbox_clear_read(
@@ -365,31 +400,31 @@ impl DaemonClient {
         recipient: String,
         project_id: Option<String>,
         global: bool,
-    ) -> Result<u32, String> {
+    ) -> DaemonClientResult<u32> {
         self.sdk
             .mailbox_clear_read(recipient, project_id, global)
             .await
-            .map_err(|err| err.to_string())
+            .map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn mailbox_retract(
         &self,
         event_id: String,
         sender: String,
-    ) -> Result<Event, String> {
-        self.sdk.mailbox_retract(event_id, sender).await.map_err(|err| err.to_string())
+    ) -> DaemonClientResult<Event> {
+        self.sdk.mailbox_retract(event_id, sender).await.map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn mailbox_dismiss(
         &self,
         event_id: String,
         recipient: String,
-    ) -> Result<bool, String> {
-        self.sdk.mailbox_dismiss(event_id, recipient).await.map_err(|err| err.to_string())
+    ) -> DaemonClientResult<bool> {
+        self.sdk.mailbox_dismiss(event_id, recipient).await.map_err(DaemonClientError::from)
     }
 
-    pub(crate) async fn read_notes(&self, target: NotesTarget) -> Result<NotesRead, String> {
-        self.sdk.read_notes(target).await.map_err(|err| err.to_string())
+    pub(crate) async fn read_notes(&self, target: NotesTarget) -> DaemonClientResult<NotesRead> {
+        self.sdk.read_notes(target).await.map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn write_notes(
@@ -397,8 +432,8 @@ impl DaemonClient {
         target: NotesTarget,
         content: String,
         tags: Vec<String>,
-    ) -> Result<(), String> {
-        self.sdk.write_notes(target, content, tags).await.map_err(|err| err.to_string())
+    ) -> DaemonClientResult<()> {
+        self.sdk.write_notes(target, content, tags).await.map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn append_notes(
@@ -407,111 +442,117 @@ impl DaemonClient {
         content: String,
         timestamped: bool,
         tags: Vec<String>,
-    ) -> Result<(), String> {
+    ) -> DaemonClientResult<()> {
         self.sdk
             .append_notes(target, content, timestamped, tags)
             .await
-            .map_err(|err| err.to_string())
+            .map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn notes_path(
         &self,
         target: NotesTarget,
         dir: bool,
-    ) -> Result<String, String> {
-        self.sdk.notes_path(target, dir).await.map_err(|err| err.to_string())
+    ) -> DaemonClientResult<String> {
+        self.sdk.notes_path(target, dir).await.map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn search_notes(
         &self,
         query: NotesSearchQuery,
-    ) -> Result<Vec<String>, String> {
-        self.sdk.search_notes(query).await.map_err(|err| err.to_string())
+    ) -> DaemonClientResult<Vec<String>> {
+        self.sdk.search_notes(query).await.map_err(DaemonClientError::from)
     }
 
-    pub(crate) async fn notes_vault_root(&self) -> Result<String, String> {
-        self.sdk.notes_vault_root().await.map_err(|err| err.to_string())
+    pub(crate) async fn notes_vault_root(&self) -> DaemonClientResult<String> {
+        self.sdk.notes_vault_root().await.map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn list_automation_hooks(
         &self,
         repo_path: Option<String>,
-    ) -> Result<Vec<HookListItem>, String> {
-        self.sdk.list_automation_hooks(repo_path).await.map_err(|err| err.to_string())
+    ) -> DaemonClientResult<Vec<HookListItem>> {
+        self.sdk.list_automation_hooks(repo_path).await.map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn preview_automation_hooks(
         &self,
         request: HookRunRequest,
-    ) -> Result<Vec<HookPreviewItem>, String> {
-        self.sdk.preview_automation_hooks(request).await.map_err(|err| err.to_string())
+    ) -> DaemonClientResult<Vec<HookPreviewItem>> {
+        self.sdk.preview_automation_hooks(request).await.map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn run_automation_hook(
         &self,
         request: HookRunRequest,
-    ) -> Result<HookRunSummary, String> {
-        self.sdk.run_automation_hook(request).await.map_err(|err| err.to_string())
+    ) -> DaemonClientResult<HookRunSummary> {
+        self.sdk.run_automation_hook(request).await.map_err(DaemonClientError::from)
     }
 
-    pub(crate) async fn approve_automation_hook(&self, approval_id: String) -> Result<(), String> {
-        self.sdk.approve_automation_hook(approval_id).await.map_err(|err| err.to_string())
+    pub(crate) async fn approve_automation_hook(
+        &self,
+        approval_id: String,
+    ) -> DaemonClientResult<()> {
+        self.sdk.approve_automation_hook(approval_id).await.map_err(DaemonClientError::from)
     }
 
-    pub(crate) async fn clear_automation_hook_approvals(&self) -> Result<(), String> {
-        self.sdk.clear_automation_hook_approvals().await.map_err(|err| err.to_string())
+    pub(crate) async fn clear_automation_hook_approvals(&self) -> DaemonClientResult<()> {
+        self.sdk.clear_automation_hook_approvals().await.map_err(DaemonClientError::from)
     }
 
-    pub(crate) async fn list_automation_hook_logs(&self) -> Result<Vec<HookLogEntry>, String> {
-        self.sdk.list_automation_hook_logs().await.map_err(|err| err.to_string())
+    pub(crate) async fn list_automation_hook_logs(&self) -> DaemonClientResult<Vec<HookLogEntry>> {
+        self.sdk.list_automation_hook_logs().await.map_err(DaemonClientError::from)
     }
 
-    pub(crate) async fn read_automation_hook_log(&self, path: String) -> Result<String, String> {
-        self.sdk.read_automation_hook_log(path).await.map_err(|err| err.to_string())
+    pub(crate) async fn read_automation_hook_log(
+        &self,
+        path: String,
+    ) -> DaemonClientResult<String> {
+        self.sdk.read_automation_hook_log(path).await.map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn set_session_name_override(
         &self,
         session_id: String,
         name_override: Option<String>,
-    ) -> Result<(), String> {
+    ) -> DaemonClientResult<()> {
         self.sdk
             .set_session_name_override(session_id, name_override)
             .await
-            .map_err(|err| err.to_string())
+            .map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn set_session_project(
         &self,
         session_id: String,
         project_id: Option<String>,
-    ) -> Result<(), String> {
-        self.sdk.set_session_project(session_id, project_id).await.map_err(|err| err.to_string())
+    ) -> DaemonClientResult<()> {
+        self.sdk.set_session_project(session_id, project_id).await.map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn set_session_pinned_pr_url(
         &self,
         session_id: String,
         url: Option<String>,
-    ) -> Result<(), String> {
-        self.sdk.set_session_pinned_pr_url(session_id, url).await.map_err(|err| err.to_string())
+    ) -> DaemonClientResult<()> {
+        self.sdk.set_session_pinned_pr_url(session_id, url).await.map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn set_session_smol_machine(
         &self,
         session_id: String,
         machine_name: Option<String>,
-    ) -> Result<(), String> {
+    ) -> DaemonClientResult<()> {
         self.sdk
             .set_session_smol_machine(session_id, machine_name)
             .await
-            .map_err(|err| err.to_string())
+            .map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn create_session_shell(
         &self,
         request: DaemonCreateSessionShellRequest,
-    ) -> Result<Session, String> {
+    ) -> DaemonClientResult<Session> {
         self.sdk
             .create_session_shell(roux_sdk::CreateSessionShell {
                 id: request.id,
@@ -531,13 +572,13 @@ impl DaemonClient {
                 notes: request.notes.map(sdk_notes_env),
             })
             .await
-            .map_err(|err| err.to_string())
+            .map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn reconnect_session_shell(
         &self,
         request: DaemonReconnectSessionShellRequest,
-    ) -> Result<Session, String> {
+    ) -> DaemonClientResult<Session> {
         self.sdk
             .reconnect_session_shell(roux_sdk::ReconnectSessionShell {
                 id: request.id,
@@ -548,34 +589,37 @@ impl DaemonClient {
                 notes: request.notes.map(sdk_notes_env),
             })
             .await
-            .map_err(|err| err.to_string())
+            .map_err(DaemonClientError::from)
     }
 
-    pub(crate) async fn archive_session(&self, id: String) -> Result<Session, String> {
-        self.sdk.archive_session(id).await.map_err(|err| err.to_string())
+    pub(crate) async fn archive_session(&self, id: String) -> DaemonClientResult<Session> {
+        self.sdk.archive_session(id).await.map_err(DaemonClientError::from)
     }
 
-    pub(crate) async fn restore_session(&self, id: String) -> Result<Session, String> {
-        self.sdk.restore_session(id).await.map_err(|err| err.to_string())
+    pub(crate) async fn restore_session(&self, id: String) -> DaemonClientResult<Session> {
+        self.sdk.restore_session(id).await.map_err(DaemonClientError::from)
     }
 
-    pub(crate) async fn delete_session(&self, id: String) -> Result<(), String> {
-        self.sdk.delete_session(id).await.map_err(|err| err.to_string())
+    pub(crate) async fn delete_session(&self, id: String) -> DaemonClientResult<()> {
+        self.sdk.delete_session(id).await.map_err(DaemonClientError::from)
     }
 
-    pub(crate) async fn session_worktree_exists(&self, id: String) -> Result<bool, String> {
-        self.sdk.session_worktree_exists(id).await.map_err(|err| err.to_string())
+    pub(crate) async fn session_worktree_exists(&self, id: String) -> DaemonClientResult<bool> {
+        self.sdk.session_worktree_exists(id).await.map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn refresh_session_branch(
         &self,
         id: String,
-    ) -> Result<Option<String>, String> {
-        self.sdk.refresh_session_branch(id).await.map_err(|err| err.to_string())
+    ) -> DaemonClientResult<Option<String>> {
+        self.sdk.refresh_session_branch(id).await.map_err(DaemonClientError::from)
     }
 
-    pub(crate) async fn list_worktrees(&self, repo_path: String) -> Result<Vec<Worktree>, String> {
-        self.sdk.list_worktrees(repo_path).await.map_err(|err| err.to_string())
+    pub(crate) async fn list_worktrees(
+        &self,
+        repo_path: String,
+    ) -> DaemonClientResult<Vec<Worktree>> {
+        self.sdk.list_worktrees(repo_path).await.map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn create_worktree(
@@ -584,11 +628,11 @@ impl DaemonClient {
         branch: String,
         start_point: Option<String>,
         fetch_first: bool,
-    ) -> Result<String, String> {
+    ) -> DaemonClientResult<String> {
         self.sdk
             .create_worktree(repo_path, branch, start_point, fetch_first)
             .await
-            .map_err(|err| err.to_string())
+            .map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn remove_worktree(
@@ -597,85 +641,91 @@ impl DaemonClient {
         worktree_path: String,
         also_branch: bool,
         force: bool,
-    ) -> Result<(), String> {
+    ) -> DaemonClientResult<()> {
         self.sdk
             .remove_worktree(repo_path, worktree_path, also_branch, force)
             .await
-            .map_err(|err| err.to_string())
+            .map_err(DaemonClientError::from)
     }
 
-    pub(crate) async fn list_branches(&self, repo_path: String) -> Result<Vec<String>, String> {
-        self.sdk.list_branches(repo_path).await.map_err(|err| err.to_string())
+    pub(crate) async fn list_branches(&self, repo_path: String) -> DaemonClientResult<Vec<String>> {
+        self.sdk.list_branches(repo_path).await.map_err(DaemonClientError::from)
     }
 
-    pub(crate) async fn git_init(&self, path: String) -> Result<(), String> {
-        self.sdk.git_init(path).await.map_err(|err| err.to_string())
+    pub(crate) async fn git_init(&self, path: String) -> DaemonClientResult<()> {
+        self.sdk.git_init(path).await.map_err(DaemonClientError::from)
     }
 
-    pub(crate) async fn list_watches(&self) -> Result<Vec<Watch>, String> {
-        self.sdk.watches().await.map_err(|err| err.to_string())
+    pub(crate) async fn list_watches(&self) -> DaemonClientResult<Vec<Watch>> {
+        self.sdk.watches().await.map_err(DaemonClientError::from)
     }
 
-    pub(crate) async fn create_watch(&self, config: CreateWatchConfig) -> Result<Watch, String> {
-        self.sdk.create_watch(config).await.map_err(|err| err.to_string())
+    pub(crate) async fn create_watch(
+        &self,
+        config: CreateWatchConfig,
+    ) -> DaemonClientResult<Watch> {
+        self.sdk.create_watch(config).await.map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn find_or_create_watch(
         &self,
         config: CreateWatchConfig,
-    ) -> Result<Watch, String> {
-        self.sdk.find_or_create_watch(config).await.map_err(|err| err.to_string())
+    ) -> DaemonClientResult<Watch> {
+        self.sdk.find_or_create_watch(config).await.map_err(DaemonClientError::from)
     }
 
-    pub(crate) async fn remove_watch(&self, id: String) -> Result<(), String> {
-        self.sdk.remove_watch(id).await.map_err(|err| err.to_string())
+    pub(crate) async fn remove_watch(&self, id: String) -> DaemonClientResult<()> {
+        self.sdk.remove_watch(id).await.map_err(DaemonClientError::from)
     }
 
-    pub(crate) async fn pause_watch(&self, id: String) -> Result<Watch, String> {
-        self.sdk.pause_watch(id).await.map_err(|err| err.to_string())
+    pub(crate) async fn pause_watch(&self, id: String) -> DaemonClientResult<Watch> {
+        self.sdk.pause_watch(id).await.map_err(DaemonClientError::from)
     }
 
-    pub(crate) async fn resume_watch(&self, id: String) -> Result<Watch, String> {
-        self.sdk.resume_watch(id).await.map_err(|err| err.to_string())
+    pub(crate) async fn resume_watch(&self, id: String) -> DaemonClientResult<Watch> {
+        self.sdk.resume_watch(id).await.map_err(DaemonClientError::from)
     }
 
-    pub(crate) async fn replace_watch(&self, watch: Watch) -> Result<(), String> {
-        self.sdk.replace_watch(watch).await.map_err(|err| err.to_string())
+    pub(crate) async fn replace_watch(&self, watch: Watch) -> DaemonClientResult<()> {
+        self.sdk.replace_watch(watch).await.map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn remove_watches_for_session(
         &self,
         session_id: String,
-    ) -> Result<(), String> {
-        self.sdk.remove_watches_for_session(session_id).await.map_err(|err| err.to_string())
+    ) -> DaemonClientResult<()> {
+        self.sdk.remove_watches_for_session(session_id).await.map_err(DaemonClientError::from)
     }
 
-    pub(crate) async fn cleanup_watch_orphans(&self) -> Result<(), String> {
-        self.sdk.cleanup_watch_orphans().await.map_err(|err| err.to_string())
+    pub(crate) async fn cleanup_watch_orphans(&self) -> DaemonClientResult<()> {
+        self.sdk.cleanup_watch_orphans().await.map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn start_daemon_process(
         &self,
         command: String,
         working_dir: Option<String>,
-    ) -> Result<ProcessRecord, String> {
-        self.sdk.start_daemon_process(command, working_dir).await.map_err(|err| err.to_string())
+    ) -> DaemonClientResult<ProcessRecord> {
+        self.sdk.start_daemon_process(command, working_dir).await.map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn daemon_process_output(
         &self,
         id: String,
         max_bytes: Option<usize>,
-    ) -> Result<ProcessSnapshot, String> {
-        self.sdk.daemon_process_output(id, max_bytes).await.map_err(|err| err.to_string())
+    ) -> DaemonClientResult<ProcessSnapshot> {
+        self.sdk.daemon_process_output(id, max_bytes).await.map_err(DaemonClientError::from)
     }
 
-    pub(crate) async fn list_daemon_processes(&self) -> Result<Vec<ProcessRecord>, String> {
-        self.sdk.list_daemon_processes().await.map_err(|err| err.to_string())
+    pub(crate) async fn list_daemon_processes(&self) -> DaemonClientResult<Vec<ProcessRecord>> {
+        self.sdk.list_daemon_processes().await.map_err(DaemonClientError::from)
     }
 
-    pub(crate) async fn kill_daemon_process(&self, id: String) -> Result<ProcessRecord, String> {
-        self.sdk.kill_daemon_process(id).await.map_err(|err| err.to_string())
+    pub(crate) async fn kill_daemon_process(
+        &self,
+        id: String,
+    ) -> DaemonClientResult<ProcessRecord> {
+        self.sdk.kill_daemon_process(id).await.map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn spawn_daemon_pty_shell(
@@ -688,7 +738,7 @@ impl DaemonClient {
         nono_profile: Option<String>,
         nono_allow_dirs: Vec<String>,
         initial_size: Option<(u16, u16)>,
-    ) -> Result<PtyRecord, String> {
+    ) -> DaemonClientResult<PtyRecord> {
         let mut spawn = self.sdk.spawn_shell();
         if let Some(id) = id {
             spawn = spawn.id(id);
@@ -714,7 +764,7 @@ impl DaemonClient {
         if let Some((cols, rows)) = initial_size {
             spawn = spawn.initial_size(cols, rows);
         }
-        spawn.spawn_record().await.map_err(|err| err.to_string())
+        spawn.spawn_record().await.map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn spawn_daemon_pty_task(
@@ -726,7 +776,7 @@ impl DaemonClient {
         pane_id: Option<String>,
         profile: Option<String>,
         initial_size: Option<(u16, u16)>,
-    ) -> Result<PtyRecord, String> {
+    ) -> DaemonClientResult<PtyRecord> {
         let mut spawn = self.sdk.spawn_task(command);
         if let Some(id) = id {
             spawn = spawn.id(id);
@@ -746,27 +796,31 @@ impl DaemonClient {
         if let Some((cols, rows)) = initial_size {
             spawn = spawn.initial_size(cols, rows);
         }
-        spawn.spawn_record().await.map_err(|err| err.to_string())
+        spawn.spawn_record().await.map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn daemon_pty_output(
         &self,
         id: String,
         max_bytes: Option<usize>,
-    ) -> Result<PtySnapshot, String> {
+    ) -> DaemonClientResult<PtySnapshot> {
         self.sdk
             .pty(id)
             .snapshot(max_bytes.unwrap_or(roux_runtime::pty_service::PTY_OUTPUT_DEFAULT_POLL_BYTES))
             .await
-            .map_err(|err| err.to_string())
+            .map_err(DaemonClientError::from)
     }
 
-    pub(crate) async fn list_daemon_ptys(&self) -> Result<Vec<PtyRecord>, String> {
-        self.sdk.ptys().await.map_err(|err| err.to_string())
+    pub(crate) async fn list_daemon_ptys(&self) -> DaemonClientResult<Vec<PtyRecord>> {
+        self.sdk.ptys().await.map_err(DaemonClientError::from)
     }
 
-    pub(crate) async fn write_daemon_pty(&self, id: String, data: String) -> Result<(), String> {
-        self.sdk.pty(id).write(data).await.map(|_| ()).map_err(|err| err.to_string())
+    pub(crate) async fn write_daemon_pty(
+        &self,
+        id: String,
+        data: String,
+    ) -> DaemonClientResult<()> {
+        self.sdk.pty(id).write(data).await.map(|_| ()).map_err(DaemonClientError::from)
     }
 
     pub(crate) async fn resize_daemon_pty(
@@ -774,61 +828,61 @@ impl DaemonClient {
         id: String,
         cols: u16,
         rows: u16,
-    ) -> Result<PtyRecord, String> {
-        self.sdk.pty(id).resize(cols, rows).await.map_err(|err| err.to_string())
+    ) -> DaemonClientResult<PtyRecord> {
+        self.sdk.pty(id).resize(cols, rows).await.map_err(DaemonClientError::from)
     }
 
-    pub(crate) async fn kill_daemon_pty(&self, id: String) -> Result<PtyRecord, String> {
+    pub(crate) async fn kill_daemon_pty(&self, id: String) -> DaemonClientResult<PtyRecord> {
         self.sdk
             .pty(id)
             .kill()
             .await
-            .map_err(|err| err.to_string())?
-            .ok_or_else(|| "daemon pty not found".to_string())
+            .map_err(DaemonClientError::from)?
+            .ok_or(DaemonClientError::DaemonPtyNotFound)
     }
 
-    pub(crate) async fn detach_daemon_pty(&self, id: String) -> Result<PtyRecord, String> {
+    pub(crate) async fn detach_daemon_pty(&self, id: String) -> DaemonClientResult<PtyRecord> {
         self.sdk
             .pty(id)
             .detach()
             .await
-            .map_err(|err| err.to_string())?
-            .ok_or_else(|| "daemon pty not found".to_string())
+            .map_err(DaemonClientError::from)?
+            .ok_or(DaemonClientError::DaemonPtyNotFound)
     }
 
     pub(crate) async fn attach_daemon_pty_to_pane(
         &self,
         id: String,
         pane_id: String,
-    ) -> Result<PtyRecord, String> {
+    ) -> DaemonClientResult<PtyRecord> {
         self.sdk
             .pty(id)
             .attach_to_pane(pane_id)
             .await
-            .map_err(|err| err.to_string())?
-            .ok_or_else(|| "daemon pty not found".to_string())
+            .map_err(DaemonClientError::from)?
+            .ok_or(DaemonClientError::DaemonPtyNotFound)
     }
 
-    pub(crate) async fn mark_daemon_pty_read(&self, id: String) -> Result<PtyRecord, String> {
+    pub(crate) async fn mark_daemon_pty_read(&self, id: String) -> DaemonClientResult<PtyRecord> {
         self.sdk
             .pty(id)
             .mark_read()
             .await
-            .map_err(|err| err.to_string())?
-            .ok_or_else(|| "daemon pty not found".to_string())
+            .map_err(DaemonClientError::from)?
+            .ok_or(DaemonClientError::DaemonPtyNotFound)
     }
 
     pub(crate) async fn set_daemon_pty_name(
         &self,
         id: String,
         name: Option<String>,
-    ) -> Result<PtyRecord, String> {
+    ) -> DaemonClientResult<PtyRecord> {
         self.sdk
             .pty(id)
             .set_name(name)
             .await
-            .map_err(|err| err.to_string())?
-            .ok_or_else(|| "daemon pty not found".to_string())
+            .map_err(DaemonClientError::from)?
+            .ok_or(DaemonClientError::DaemonPtyNotFound)
     }
 
     pub(crate) fn spawn_daemon_pty_output_bridge(
@@ -920,8 +974,8 @@ impl DaemonClient {
     }
 }
 
-fn connect_current_sdk() -> Result<roux_sdk::Roux, String> {
-    roux_sdk::Roux::connect().map_err(|err| err.to_string())
+fn connect_current_sdk() -> DaemonClientResult<roux_sdk::Roux> {
+    roux_sdk::Roux::connect().map_err(DaemonClientError::from)
 }
 
 fn run_reconnecting_resolved_event_bridge<C, T, F, S>(
@@ -931,8 +985,8 @@ fn run_reconnecting_resolved_event_bridge<C, T, F, S>(
     mut sleep: S,
     max_attempts: Option<usize>,
 ) where
-    C: FnMut() -> Result<T, String>,
-    F: FnMut(T) -> Result<(), String>,
+    C: FnMut() -> DaemonClientResult<T>,
+    F: FnMut(T) -> DaemonClientResult<()>,
     S: FnMut(Duration),
 {
     let mut attempts = 0_usize;
@@ -955,11 +1009,11 @@ struct StartedDaemon {
     pid: u32,
 }
 
-fn launch_local_daemon() -> Result<StartedDaemon, String> {
+fn launch_local_daemon() -> DaemonClientResult<StartedDaemon> {
     let binary = resolve_daemon_binary()?;
-    let mut child = daemon_spawn_command(&binary)
-        .spawn()
-        .map_err(|err| format!("spawn {} daemon: {err}", binary.display()))?;
+    let mut child = daemon_spawn_command(&binary).spawn().map_err(|err| {
+        DaemonClientError::adapter(format!("spawn {} daemon: {err}", binary.display()))
+    })?;
     let pid = child.id();
     std::thread::spawn(move || {
         let _ = child.wait();
@@ -1027,13 +1081,13 @@ fn parse_env_enabled(value: &str) -> Option<bool> {
     }
 }
 
-fn resolve_daemon_binary() -> Result<PathBuf, String> {
+fn resolve_daemon_binary() -> DaemonClientResult<PathBuf> {
     let current_exe = std::env::current_exe().ok();
     resolve_daemon_binary_from(current_exe.as_deref()).ok_or_else(|| {
-        format!(
+        DaemonClientError::adapter(format!(
             "{} not found next to the desktop binary or on PATH",
             platform::roux_cli_file_name()
-        )
+        ))
     })
 }
 
@@ -1067,7 +1121,7 @@ fn read_watch_events_blocking(
     sdk: &roux_sdk::Roux,
     app: AppHandle,
     watch_manager: WatchManager,
-) -> Result<(), String> {
+) -> DaemonClientResult<()> {
     let mut stream_error = None;
     let result = sdk.watch_events_blocking(true, |frame| {
         match handle_watch_event_frame(frame, &app, &watch_manager) {
@@ -1078,14 +1132,14 @@ fn read_watch_events_blocking(
             }
         }
     });
-    stream_error.map_or_else(|| result.map_err(|err| err.to_string()), Err)
+    stream_error.map_or_else(|| result.map_err(DaemonClientError::from), Err)
 }
 
 fn handle_watch_event_frame(
     frame: WatchEventStreamFrame,
     app: &AppHandle,
     watch_manager: &WatchManager,
-) -> Result<(), String> {
+) -> DaemonClientResult<()> {
     match frame {
         WatchEventStreamFrame::Ready => Ok(()),
         WatchEventStreamFrame::Update { event } => {
@@ -1100,11 +1154,11 @@ fn handle_watch_event_frame(
             rlog!("Daemon watch event stream warning: {message}");
             Ok(())
         }
-        WatchEventStreamFrame::Error { error } => Err(error),
+        WatchEventStreamFrame::Error { error } => Err(DaemonClientError::adapter(error)),
     }
 }
 
-fn read_mailbox_events_blocking(sdk: &roux_sdk::Roux, app: AppHandle) -> Result<(), String> {
+fn read_mailbox_events_blocking(sdk: &roux_sdk::Roux, app: AppHandle) -> DaemonClientResult<()> {
     let mut stream_error = None;
     let result =
         sdk.mailbox_events_blocking(|frame| match handle_mailbox_event_frame(frame, &app) {
@@ -1114,27 +1168,27 @@ fn read_mailbox_events_blocking(sdk: &roux_sdk::Roux, app: AppHandle) -> Result<
                 false
             }
         });
-    stream_error.map_or_else(|| result.map_err(|err| err.to_string()), Err)
+    stream_error.map_or_else(|| result.map_err(DaemonClientError::from), Err)
 }
 
 fn handle_mailbox_event_frame(
     frame: MailboxEventStreamFrame,
     app: &AppHandle,
-) -> Result<(), String> {
+) -> DaemonClientResult<()> {
     match frame {
         MailboxEventStreamFrame::Ready => Ok(()),
         MailboxEventStreamFrame::Event { event } => app
             .emit(roux_lib::mailbox::MAILBOX_EVENT, event.as_ref())
-            .map_err(|err| format!("emit daemon mailbox event: {err}")),
+            .map_err(|err| DaemonClientError::adapter(format!("emit daemon mailbox event: {err}"))),
         MailboxEventStreamFrame::Warning { message } => {
             rlog!("Daemon mailbox event stream warning: {message}");
             Ok(())
         }
-        MailboxEventStreamFrame::Error { error } => Err(error),
+        MailboxEventStreamFrame::Error { error } => Err(DaemonClientError::adapter(error)),
     }
 }
 
-fn read_alias_events_blocking(sdk: &roux_sdk::Roux, app: AppHandle) -> Result<(), String> {
+fn read_alias_events_blocking(sdk: &roux_sdk::Roux, app: AppHandle) -> DaemonClientResult<()> {
     let mut stream_error = None;
     let result = sdk.alias_events_blocking(|frame| match handle_alias_event_frame(frame, &app) {
         Ok(()) => true,
@@ -1143,24 +1197,30 @@ fn read_alias_events_blocking(sdk: &roux_sdk::Roux, app: AppHandle) -> Result<()
             false
         }
     });
-    stream_error.map_or_else(|| result.map_err(|err| err.to_string()), Err)
+    stream_error.map_or_else(|| result.map_err(DaemonClientError::from), Err)
 }
 
-fn handle_alias_event_frame(frame: AliasEventStreamFrame, app: &AppHandle) -> Result<(), String> {
+fn handle_alias_event_frame(
+    frame: AliasEventStreamFrame,
+    app: &AppHandle,
+) -> DaemonClientResult<()> {
     match frame {
         AliasEventStreamFrame::Ready => Ok(()),
         AliasEventStreamFrame::Event { event } => app
             .emit(roux_lib::aliases::ALIAS_EVENT, &event)
-            .map_err(|err| format!("emit daemon alias event: {err}")),
+            .map_err(|err| DaemonClientError::adapter(format!("emit daemon alias event: {err}"))),
         AliasEventStreamFrame::Warning { message } => {
             rlog!("Daemon alias event stream warning: {message}");
             Ok(())
         }
-        AliasEventStreamFrame::Error { error } => Err(error),
+        AliasEventStreamFrame::Error { error } => Err(DaemonClientError::adapter(error)),
     }
 }
 
-fn read_subscription_events_blocking(sdk: &roux_sdk::Roux, app: AppHandle) -> Result<(), String> {
+fn read_subscription_events_blocking(
+    sdk: &roux_sdk::Roux,
+    app: AppHandle,
+) -> DaemonClientResult<()> {
     let mut stream_error = None;
     let result = sdk.subscription_events_blocking(|frame| {
         match handle_subscription_event_frame(frame, &app) {
@@ -1171,23 +1231,25 @@ fn read_subscription_events_blocking(sdk: &roux_sdk::Roux, app: AppHandle) -> Re
             }
         }
     });
-    stream_error.map_or_else(|| result.map_err(|err| err.to_string()), Err)
+    stream_error.map_or_else(|| result.map_err(DaemonClientError::from), Err)
 }
 
 fn handle_subscription_event_frame(
     frame: SubscriptionEventStreamFrame,
     app: &AppHandle,
-) -> Result<(), String> {
+) -> DaemonClientResult<()> {
     match frame {
         SubscriptionEventStreamFrame::Ready => Ok(()),
-        SubscriptionEventStreamFrame::Event { event } => app
-            .emit(roux_lib::subscriptions::SUBSCRIPTION_EVENT, &event)
-            .map_err(|err| format!("emit daemon subscription event: {err}")),
+        SubscriptionEventStreamFrame::Event { event } => {
+            app.emit(roux_lib::subscriptions::SUBSCRIPTION_EVENT, &event).map_err(|err| {
+                DaemonClientError::adapter(format!("emit daemon subscription event: {err}"))
+            })
+        }
         SubscriptionEventStreamFrame::Warning { message } => {
             rlog!("Daemon subscription event stream warning: {message}");
             Ok(())
         }
-        SubscriptionEventStreamFrame::Error { error } => Err(error),
+        SubscriptionEventStreamFrame::Error { error } => Err(DaemonClientError::adapter(error)),
     }
 }
 
@@ -1197,14 +1259,14 @@ fn handle_sdk_pty_attach_frame(
     channel: &Channel<IpcResponse>,
     app: &AppHandle,
     sent_until: &mut u64,
-) -> Result<bool, String> {
+) -> DaemonClientResult<bool> {
     match frame {
         PtyAttachFrame::Ready { replay_offset, replay_bytes, .. } => {
             let replay_end = replay_offset.saturating_add(replay_bytes.len() as u64);
             if !replay_bytes.is_empty() {
-                channel
-                    .send(IpcResponse::new(replay_bytes))
-                    .map_err(|err| format!("send daemon pty replay to frontend: {err}"))?;
+                channel.send(IpcResponse::new(replay_bytes)).map_err(|err| {
+                    DaemonClientError::adapter(format!("send daemon pty replay to frontend: {err}"))
+                })?;
             }
             *sent_until = (*sent_until).max(replay_end);
             Ok(true)
@@ -1217,9 +1279,9 @@ fn handle_sdk_pty_attach_frame(
             let start = if offset < *sent_until { (*sent_until - offset) as usize } else { 0 };
             let bytes = bytes[start..].to_vec();
             if !bytes.is_empty() {
-                channel
-                    .send(IpcResponse::new(bytes))
-                    .map_err(|err| format!("send daemon pty output to frontend: {err}"))?;
+                channel.send(IpcResponse::new(bytes)).map_err(|err| {
+                    DaemonClientError::adapter(format!("send daemon pty output to frontend: {err}"))
+                })?;
             }
             *sent_until = (*sent_until).max(frame_end);
             Ok(true)
@@ -1228,7 +1290,7 @@ fn handle_sdk_pty_attach_frame(
             emit_daemon_pty_exit(app, id, code, generation);
             Ok(false)
         }
-        PtyAttachFrame::Error { error } => Err(error),
+        PtyAttachFrame::Error { error } => Err(DaemonClientError::adapter(error)),
     }
 }
 
@@ -1266,7 +1328,8 @@ mod tests {
     fn event_bridge_reconnects_after_eof_and_error() {
         let calls = Cell::new(0);
         let sleeps = Cell::new(0);
-        let mut results = vec![Ok(()), Err("socket closed".to_string()), Ok(())].into_iter();
+        let mut results =
+            vec![Ok(()), Err(DaemonClientError::adapter("socket closed")), Ok(())].into_iter();
 
         run_reconnecting_resolved_event_bridge(
             "test",
@@ -1288,7 +1351,8 @@ mod tests {
         let resolves = Cell::new(0);
         let reads = RefCell::new(Vec::new());
         let sleeps = Cell::new(0);
-        let mut results = vec![Ok(()), Err("socket closed".to_string()), Ok(())].into_iter();
+        let mut results =
+            vec![Ok(()), Err(DaemonClientError::adapter("socket closed")), Ok(())].into_iter();
 
         run_reconnecting_resolved_event_bridge(
             "test",
@@ -1322,6 +1386,20 @@ mod tests {
         let client = DaemonClient::from_detected_status(daemon_status(), probe_sdk).unwrap();
 
         assert_eq!(client.sdk.request_timeout(), Duration::from_secs(5));
+    }
+
+    #[test]
+    fn daemon_client_error_stringification_preserves_boundary_messages() {
+        assert_eq!(
+            DaemonClientError::UnexpectedDaemonKind("other".to_string()).to_string(),
+            "unexpected daemon kind: other"
+        );
+        assert_eq!(String::from(DaemonClientError::DaemonPtyNotFound), "daemon pty not found");
+        assert_eq!(DaemonClientError::adapter("socket closed").to_string(), "socket closed");
+        assert_eq!(
+            DaemonClientError::from(roux_sdk::RouxError::NotRunning).to_string(),
+            "Roux is not running"
+        );
     }
 
     #[test]

--- a/src-tauri/src/watches/mod.rs
+++ b/src-tauri/src/watches/mod.rs
@@ -69,7 +69,7 @@ pub async fn cmd_remove_watch(id: String, state: tauri::State<'_, AppState>) -> 
 pub async fn cmd_list_watches(state: tauri::State<'_, AppState>) -> Result<Vec<Watch>, String> {
     if let Some(client) = state.daemon_client.clone().filter(|client| client.supports("watch-list"))
     {
-        return client.list_watches().await;
+        return client.list_watches().await.map_err(Into::into);
     }
 
     state.watch_manager.store().list().await.map_err(|e| e.to_string())


### PR DESCRIPTION
## Summary

- Introduce a crate-local `DaemonClientError` / `DaemonClientResult` for the desktop daemon adapter.
- Convert `DaemonClient` internals away from eager `String` error conversion while preserving existing Tauri command `Result<_, String>` boundaries.
- Add focused coverage for boundary stringification behavior.

## Impact

This keeps the frontend-visible error contract compatible while making the desktop daemon adapter easier to extend with typed internal errors.

## Validation

- `CI=1 cargo test -p roux-desktop --bin roux-desktop`
- `CI=1 cargo test -p roux-desktop --lib`
- `cargo clippy --all-targets -- -D warnings`
- `rustfmt --check src-tauri/src/daemon_client.rs src-tauri/src/automation_hooks/mod.rs src-tauri/src/commands/aliases.rs src-tauri/src/commands/daemon.rs src-tauri/src/commands/mailbox.rs src-tauri/src/commands/notes.rs src-tauri/src/commands/projects.rs src-tauri/src/commands/sessions.rs src-tauri/src/commands/subscriptions.rs src-tauri/src/commands/worktrees.rs src-tauri/src/watches/mod.rs`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized error handling across daemon client operations to improve consistency and type safety.
  * Introduced typed error handling for daemon client interactions with better error propagation.
  * Simplified error conversion logic throughout command handlers for improved maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phin-tech/roux/pull/201?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the desktop daemon adapter to use a typed `DaemonClientError` enum internally, replacing the previous eager `String` conversion in all `DaemonClient` methods. A `From<DaemonClientError> for String` implementation preserves the `Result<_, String>` boundary that Tauri command handlers expose to the frontend.

- **`daemon_client.rs`**: introduces `DaemonClientError` (with `Sdk`, `Decode`, `UnexpectedDaemonKind`, `DaemonPtyNotFound`, and `Adapter` variants), a module-private `DaemonClientResult<T>` alias, and `From<DaemonClientError> for String`; all `DaemonClient` methods now return `DaemonClientResult<T>`.
- **Command files**: each call site gains `.map_err(Into::into)` or uses the `?` operator, both invoking the new `From` impl at the Tauri command boundary.
- **`mailbox.rs`**: `is_daemon_pty_not_found` updated from string matching to `matches!(err, DaemonClientError::DaemonPtyNotFound)`.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — purely internal refactoring, all Tauri command boundaries remain Result<_, String>, boundary messages verified by a new test.

Every DaemonClient method now returns a typed error that converts to the same string via From<DaemonClientError> for String, identical to the prior .map_err(|e| e.to_string()) pattern. No Tauri/frontend contracts changed.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src-tauri/src/daemon_client.rs | Core change: introduces DaemonClientError enum and DaemonClientResult type alias; converts all DaemonClient methods; adds From boundary impl and stringification test. |
| src-tauri/src/commands/mailbox.rs | Converts daemon client call sites to .map_err(Into::into); updates is_daemon_pty_not_found to direct variant matching on DaemonClientError::DaemonPtyNotFound. |
| src-tauri/src/commands/daemon.rs | All daemon client calls updated to .map_err(Into::into); get_runtime_status uses err.into() correctly. |
| src-tauri/src/automation_hooks/mod.rs | Adds .map_err(Into::into) to each daemon client call. Straightforward mechanical change. |
| src-tauri/src/watches/mod.rs | Uses ? operator on daemon client calls in Result<_, String> context; works correctly via From impl. |
| src-tauri/src/commands/sessions.rs | Single call site updated to .map_err(Into::into); no issues. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["match daemon pty errors by variant"](https://github.com/phin-tech/roux/commit/f8ab2bc3c5c9b064ef451dec586f081b9e0ee802) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33656294)</sub>

<!-- /greptile_comment -->