### PR TITLE
Fix CLI install silently skipping updates from older versions

### DIFF
--- a/src-tauri/src/hooks.rs
+++ b/src-tauri/src/hooks.rs
@@ -77,13 +77,36 @@ pub fn bundled_cli_version() -> &'static str {
 /// Exec the installed `roux --version` and return the semver segment of
 /// its output. Clap prints `"roux X.Y.Z"`.
 pub fn installed_cli_version() -> Option<String> {
-    let path = installed_cli_path()?;
-    let output = std::process::Command::new(&path).arg("--version").output().ok()?;
+    cli_version_at(&installed_cli_path()?)
+}
+
+/// Exec `<path> --version` and return the trailing token clap prints
+/// (`"roux X.Y.Z"` → `"X.Y.Z"`). `None` if the binary is missing or unrunnable.
+fn cli_version_at(path: &Path) -> Option<String> {
+    let output = std::process::Command::new(path).arg("--version").output().ok()?;
     if !output.status.success() {
         return None;
     }
     let stdout = String::from_utf8(output.stdout).ok()?;
     stdout.split_whitespace().last().map(str::to_string)
+}
+
+/// Decide whether the bundled CLI should be (re)written over whatever is
+/// installed at the target path.
+///
+/// Version is the source of truth — file mtime is intentionally NOT used. A
+/// freshly downloaded app bundle can carry an *older* binary mtime than a
+/// previously installed copy, so an mtime gate silently skipped real updates
+/// and left a stale CLI on disk (the "click install, it flashes, still says to
+/// install" bug). Using the bundled version here keeps the installer's notion
+/// of "current" identical to the doctor panel's, so they never disagree.
+#[cfg(not(windows))]
+fn should_install_cli(
+    target_exists: bool,
+    installed_version: Option<&str>,
+    bundled_version: &str,
+) -> bool {
+    !target_exists || installed_version != Some(bundled_version)
 }
 
 /// Where the CLI is actually installed right now, if anywhere — mirrors
@@ -143,27 +166,13 @@ fn install_cli_binary_path() -> Result<PathBuf, String> {
     let source = sibling_cli_path().ok_or("Could not find roux next to roux desktop binary")?;
 
     if source.exists() {
-        // Only copy if source is newer or target doesn't exist
-        let should_copy = if target.exists() {
-            let src_modified = fs::metadata(&source).and_then(|m| m.modified()).ok();
-            let tgt_modified = fs::metadata(&target).and_then(|m| m.modified()).ok();
-            match (src_modified, tgt_modified) {
-                (Some(s), Some(t)) => s > t,
-                _ => true,
-            }
-        } else {
-            true
-        };
-
-        if should_copy {
-            fs::copy(&source, &target).map_err(|e| format!("Failed to copy roux: {}", e))?;
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::PermissionsExt;
-                let mut perms = fs::metadata(&target).map_err(|e| e.to_string())?.permissions();
-                perms.set_mode(0o755);
-                fs::set_permissions(&target, perms).map_err(|e| e.to_string())?;
-            }
+        // Replace the installed CLI whenever its version differs from the
+        // bundled one (or it's missing). See `should_install_cli` for why mtime
+        // is deliberately not used here.
+        let target_exists = target.exists();
+        let installed = if target_exists { cli_version_at(&target) } else { None };
+        if should_install_cli(target_exists, installed.as_deref(), bundled_cli_version()) {
+            atomic_install_cli(&source, &target)?;
             eprintln!("Installed roux CLI to {}", target.display());
         }
         install_cli_compat_alias(&target, &compat_target)?;
@@ -172,6 +181,31 @@ fn install_cli_binary_path() -> Result<PathBuf, String> {
 
     // Fallback: try to find it anywhere
     roux_cli_path()
+}
+
+/// Copy `source` over `target` atomically: stage a temp file next to the
+/// target, mark it executable, then `rename` it into place. The rename is a
+/// same-filesystem atomic swap, so it's safe even when the current `roux` is
+/// running (the running process keeps its already-open inode) and never leaves
+/// a half-written binary on failure.
+#[cfg(not(windows))]
+fn atomic_install_cli(source: &Path, target: &Path) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = target.parent().ok_or("install target has no parent directory")?;
+    let staged = dir.join(format!(".{}.tmp", platform::roux_cli_file_name()));
+    let _ = fs::remove_file(&staged);
+
+    fs::copy(source, &staged).map_err(|e| format!("Failed to stage roux: {}", e))?;
+
+    let mut perms = fs::metadata(&staged).map_err(|e| e.to_string())?.permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&staged, perms).map_err(|e| e.to_string())?;
+
+    fs::rename(&staged, target).map_err(|e| {
+        let _ = fs::remove_file(&staged);
+        format!("Failed to install roux: {}", e)
+    })
 }
 
 #[cfg(not(windows))]
@@ -518,6 +552,55 @@ mod tests {
         let command =
             hook_command(Path::new("C:\\Users\\Sam\\App Data\\Roux\\roux.exe"), "working");
         assert_eq!(command, "\"C:\\\\Users\\\\Sam\\\\App Data\\\\Roux\\\\roux.exe\" hook working");
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn installs_cli_when_target_missing() {
+        assert!(should_install_cli(false, None, "0.5.3"));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn installs_cli_when_installed_version_differs() {
+        // The reported bug: an older / pre-release CLI is installed and must be
+        // replaced regardless of file mtimes.
+        assert!(should_install_cli(true, Some("0.5.2"), "0.5.3"));
+        assert!(should_install_cli(true, Some("0.5.3-pre"), "0.5.3"));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn skips_cli_install_when_versions_match() {
+        // Keeps startup idempotent: no copy when already current.
+        assert!(!should_install_cli(true, Some("0.5.3"), "0.5.3"));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn installs_cli_when_installed_version_unknown() {
+        // Present but unrunnable / corrupt → reinstall to be safe.
+        assert!(should_install_cli(true, None, "0.5.3"));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn atomic_install_cli_replaces_contents_and_sets_exec_perms() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("source-roux");
+        let target = dir.path().join(platform::roux_cli_file_name());
+        fs::write(&source, b"new-binary").unwrap();
+        fs::write(&target, b"old-binary").unwrap();
+
+        atomic_install_cli(&source, &target).unwrap();
+
+        assert_eq!(fs::read(&target).unwrap(), b"new-binary");
+        assert_eq!(fs::metadata(&target).unwrap().permissions().mode() & 0o777, 0o755);
+        // No staged temp file left behind.
+        let staged = dir.path().join(format!(".{}.tmp", platform::roux_cli_file_name()));
+        assert!(!staged.exists());
     }
 
     #[cfg(not(windows))]

--- a/src-tauri/src/hooks.rs
+++ b/src-tauri/src/hooks.rs
@@ -1,6 +1,12 @@
 use serde_json::{json, Value};
+#[cfg(not(windows))]
+use std::fmt;
 use std::fs;
 use std::path::{Path, PathBuf};
+#[cfg(not(windows))]
+use std::sync::atomic::{AtomicU64, Ordering};
+#[cfg(not(windows))]
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::platform;
 
@@ -111,6 +117,49 @@ fn should_install_cli(
     !target_exists || installed_version != Some(bundled_version)
 }
 
+#[cfg(not(windows))]
+static CLI_STAGE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+#[cfg(not(windows))]
+#[derive(Debug)]
+enum CliInstallError {
+    MissingTargetParent,
+    MissingTargetFileName,
+    Stage { path: PathBuf, source: std::io::Error },
+    Metadata { path: PathBuf, source: std::io::Error },
+    Permissions { path: PathBuf, source: std::io::Error },
+    Rename { staged: PathBuf, target: PathBuf, source: std::io::Error },
+}
+
+#[cfg(not(windows))]
+impl fmt::Display for CliInstallError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingTargetParent => write!(f, "install target has no parent directory"),
+            Self::MissingTargetFileName => write!(f, "install target has no file name"),
+            Self::Stage { path, source } => {
+                write!(f, "Failed to stage roux at {}: {}", path.display(), source)
+            }
+            Self::Metadata { path, source } => {
+                write!(f, "Failed to read staged roux metadata at {}: {}", path.display(), source)
+            }
+            Self::Permissions { path, source } => {
+                write!(f, "Failed to set staged roux permissions at {}: {}", path.display(), source)
+            }
+            Self::Rename { staged, target, source } => write!(
+                f,
+                "Failed to install roux from {} to {}: {}",
+                staged.display(),
+                target.display(),
+                source
+            ),
+        }
+    }
+}
+
+#[cfg(not(windows))]
+impl std::error::Error for CliInstallError {}
+
 /// Where the CLI is actually installed right now, if anywhere — mirrors
 /// [`cli_is_installed`] but returns the path so callers can exec it.
 fn installed_cli_path() -> Option<PathBuf> {
@@ -174,7 +223,7 @@ fn install_cli_binary_path() -> Result<PathBuf, String> {
         let target_exists = target.exists();
         let installed = if target_exists { cli_version_at(&target) } else { None };
         if should_install_cli(target_exists, installed.as_deref(), bundled_cli_version()) {
-            atomic_install_cli(&source, &target)?;
+            atomic_install_cli(&source, &target).map_err(|e| e.to_string())?;
             eprintln!("Installed roux CLI to {}", target.display());
         }
         install_cli_compat_alias(&target, &compat_target)?;
@@ -191,28 +240,40 @@ fn install_cli_binary_path() -> Result<PathBuf, String> {
 /// running (the running process keeps its already-open inode) and never leaves
 /// a half-written binary on failure.
 #[cfg(not(windows))]
-fn atomic_install_cli(source: &Path, target: &Path) -> Result<(), String> {
+fn atomic_install_cli(source: &Path, target: &Path) -> Result<(), CliInstallError> {
     use std::os::unix::fs::PermissionsExt;
 
-    let dir = target.parent().ok_or("install target has no parent directory")?;
-    let target_name =
-        target.file_name().ok_or("install target has no file name")?.to_string_lossy();
-    let staged = dir.join(format!(".{target_name}.tmp"));
-    let _ = fs::remove_file(&staged);
+    let dir = target.parent().ok_or(CliInstallError::MissingTargetParent)?;
+    let staged = unique_cli_stage_path(dir, target)?;
 
     fs::copy(source, &staged).map_err(|e| {
         let _ = fs::remove_file(&staged);
-        format!("Failed to stage roux: {}", e)
+        CliInstallError::Stage { path: staged.clone(), source: e }
     })?;
 
-    let mut perms = fs::metadata(&staged).map_err(|e| e.to_string())?.permissions();
+    let mut perms = fs::metadata(&staged)
+        .map_err(|e| CliInstallError::Metadata { path: staged.clone(), source: e })?
+        .permissions();
     perms.set_mode(0o755);
-    fs::set_permissions(&staged, perms).map_err(|e| e.to_string())?;
+    fs::set_permissions(&staged, perms).map_err(|e| {
+        let _ = fs::remove_file(&staged);
+        CliInstallError::Permissions { path: staged.clone(), source: e }
+    })?;
 
     fs::rename(&staged, target).map_err(|e| {
         let _ = fs::remove_file(&staged);
-        format!("Failed to install roux: {}", e)
+        CliInstallError::Rename { staged, target: target.to_path_buf(), source: e }
     })
+}
+
+#[cfg(not(windows))]
+fn unique_cli_stage_path(dir: &Path, target: &Path) -> Result<PathBuf, CliInstallError> {
+    let target_name =
+        target.file_name().ok_or(CliInstallError::MissingTargetFileName)?.to_string_lossy();
+    let nonce = CLI_STAGE_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_nanos();
+
+    Ok(dir.join(format!(".{target_name}.{}.{}.{}.tmp", std::process::id(), timestamp, nonce)))
 }
 
 #[cfg(not(windows))]
@@ -627,6 +688,20 @@ mod tests {
         assert_eq!(fs::read(&target).unwrap(), b"new-binary");
         assert!(!dir.path().join(".roux-custom.tmp").exists());
         assert!(!dir.path().join(format!(".{}.tmp", platform::roux_cli_file_name())).exists());
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn cli_stage_paths_are_unique_per_attempt() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("roux");
+
+        let first = unique_cli_stage_path(dir.path(), &target).unwrap();
+        let second = unique_cli_stage_path(dir.path(), &target).unwrap();
+
+        assert_ne!(first, second);
+        assert_eq!(first.parent(), Some(dir.path()));
+        assert_eq!(second.parent(), Some(dir.path()));
     }
 
     #[cfg(not(windows))]

--- a/src-tauri/src/hooks.rs
+++ b/src-tauri/src/hooks.rs
@@ -99,7 +99,9 @@ fn cli_version_at(path: &Path) -> Option<String> {
 /// previously installed copy, so an mtime gate silently skipped real updates
 /// and left a stale CLI on disk (the "click install, it flashes, still says to
 /// install" bug). Using the bundled version here keeps the installer's notion
-/// of "current" identical to the doctor panel's, so they never disagree.
+/// of "current" identical to the doctor panel's, so they never disagree. This
+/// intentionally also replaces an installed CLI with a newer version than the
+/// bundle: the desktop app owns the companion CLI version it launches.
 #[cfg(not(windows))]
 fn should_install_cli(
     target_exists: bool,
@@ -193,10 +195,15 @@ fn atomic_install_cli(source: &Path, target: &Path) -> Result<(), String> {
     use std::os::unix::fs::PermissionsExt;
 
     let dir = target.parent().ok_or("install target has no parent directory")?;
-    let staged = dir.join(format!(".{}.tmp", platform::roux_cli_file_name()));
+    let target_name =
+        target.file_name().ok_or("install target has no file name")?.to_string_lossy();
+    let staged = dir.join(format!(".{target_name}.tmp"));
     let _ = fs::remove_file(&staged);
 
-    fs::copy(source, &staged).map_err(|e| format!("Failed to stage roux: {}", e))?;
+    fs::copy(source, &staged).map_err(|e| {
+        let _ = fs::remove_file(&staged);
+        format!("Failed to stage roux: {}", e)
+    })?;
 
     let mut perms = fs::metadata(&staged).map_err(|e| e.to_string())?.permissions();
     perms.set_mode(0o755);
@@ -567,6 +574,10 @@ mod tests {
         // replaced regardless of file mtimes.
         assert!(should_install_cli(true, Some("0.5.2"), "0.5.3"));
         assert!(should_install_cli(true, Some("0.5.3-pre"), "0.5.3"));
+        // The bundled desktop version owns the installed companion CLI, so a
+        // newer installed CLI is also replaced to keep app and CLI contracts in
+        // sync.
+        assert!(should_install_cli(true, Some("0.5.4"), "0.5.3"));
     }
 
     #[cfg(not(windows))]
@@ -601,6 +612,21 @@ mod tests {
         // No staged temp file left behind.
         let staged = dir.path().join(format!(".{}.tmp", platform::roux_cli_file_name()));
         assert!(!staged.exists());
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn atomic_install_cli_stages_next_to_requested_target_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("source-roux");
+        let target = dir.path().join("roux-custom");
+        fs::write(&source, b"new-binary").unwrap();
+
+        atomic_install_cli(&source, &target).unwrap();
+
+        assert_eq!(fs::read(&target).unwrap(), b"new-binary");
+        assert!(!dir.path().join(".roux-custom.tmp").exists());
+        assert!(!dir.path().join(format!(".{}.tmp", platform::roux_cli_file_name())).exists());
     }
 
     #[cfg(not(windows))]


### PR DESCRIPTION
The CLI install gated the copy on file modification time: it only replaced ~/.local/bin/roux when the bundled binary's mtime was newer than the installed one. A freshly downloaded app bundle frequently carries an older binary mtime than a previously installed copy, so the gate evaluated false, the copy was skipped, and install_hooks still returned Ok. The doctor re-check then found the same stale binary, so clicking "install" flashed and kept reporting the CLI as stale.

Gate the copy on version instead: replace when the target is missing or its --version differs from the bundled version. This uses the same bundled_cli_version() the doctor panel compares against, so the installer and doctor never disagree. Startup stays idempotent (no copy when versions already match).

Replace the in-place fs::copy with an atomic stage-then-rename so an update can't fail with ETXTBSY or leave a half-written binary when the running roux daemon was spawned from that path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved CLI installation logic on Unix systems with more reliable atomic operations.

* **Tests**
  * Added new unit tests for CLI installation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phin-tech/roux/pull/210?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the CLI install button silently no-oping by replacing the mtime gate with a version comparison, and replaces the in-place `fs::copy` with an atomic stage-then-rename to avoid `ETXTBSY` and half-written binaries when the running daemon was spawned from the same path.

- `should_install_cli` now compares `installed_version` against `bundled_cli_version()`, matching the doctor panel's logic so installer and doctor always agree; intentional downgrade behavior is documented and tested.
- `atomic_install_cli` writes to a PID/timestamp/nonce-qualified temp file in the same directory as the target, sets `0o755`, then renames atomically — cleanup on each failure path is handled inline.
- Unit tests cover missing target, version mismatch, version match, unrunnable binary, and staged-path uniqueness; two cleanup assertions check a simplified path that never matches the actual three-component temp name, leaving the cleanup path untested.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the core install logic is correct and the atomic rename pattern is sound.

The version-gate fix is straightforward and well-tested for all major decision branches. The atomic install correctly stages in the same directory as the target, so cross-filesystem rename issues cannot occur. The one finding (vacuously-true cleanup assertions) is a test gap that does not affect production behaviour.

The two cleanup assertions in atomic_install_cli_replaces_contents_and_sets_exec_perms and atomic_install_cli_stages_next_to_requested_target_name are worth tightening before this test pattern is reused elsewhere.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src-tauri/src/hooks.rs | Replaces mtime-gated fs::copy with version-gated atomic staged-rename install for the CLI binary on non-Windows, adds should_install_cli/atomic_install_cli/unique_cli_stage_path helpers, and adds unit tests — 'no staged file' cleanup assertions check a simplified path that never matches the actual PID/timestamp/nonce-qualified temp name, making those assertions vacuously true. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[install_cli_binary_path] --> B{source.exists?}
    B -- No --> Z[roux_cli_path fallback]
    B -- Yes --> C[target_exists = target.exists]
    C --> D{target_exists?}
    D -- No --> F[installed = None]
    D -- Yes --> E[cli_version_at target]
    E --> F
    F --> G{should_install_cli
target_exists, installed, bundled}
    G -- false: versions match --> H[install_cli_compat_alias]
    G -- true: missing or version differs --> I[atomic_install_cli source to target]
    I --> I1[unique_cli_stage_path
pid + timestamp + nonce]
    I1 --> I2[fs::copy source to staged]
    I2 -- error --> I2E[remove staged, return Stage error]
    I2 --> I3[fs::metadata + set_mode 0o755]
    I3 -- error --> I3E[remove staged, return Permissions error]
    I3 --> I4[fs::rename staged to target atomic]
    I4 -- error --> I4E[remove staged, return Rename error]
    I4 --> I5[log Installed roux CLI]
    I5 --> H
    H --> J[return Ok target]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc-tauri%2Fsrc%2Fhooks.rs%3A673-675%0A**Cleanup%20assertions%20check%20a%20path%20that%20never%20matches%20the%20actual%20staged%20filename**%0A%0A%60unique_cli_stage_path%60%20produces%20a%20name%20in%20the%20form%20%60.%7Bname%7D.%7Bpid%7D.%7Btimestamp%7D.%7Bnonce%7D.tmp%60%20%28three%20extra%20components%29%2C%20but%20the%20assertion%20reconstructs%20only%20%60.%7Bname%7D.tmp%60.%20That%20path%20can%20never%20exist%2C%20so%20the%20assertion%20is%20always%20vacuously%20true%20%E2%80%94%20a%20cleanup%20bug%20would%20pass%20these%20tests%20silently.%20The%20same%20false%20negative%20applies%20to%20the%20%60atomic_install_cli_stages_next_to_requested_target_name%60%20test%20%28lines%20689-690%29.%20A%20straightforward%20fix%20is%20to%20list%20the%20temp%20directory%20entries%20after%20installation%20and%20assert%20none%20match%20%60*.tmp%60.%0A%0A&repo=phin-tech%2Froux&pr=210&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22fix%2Fcli-install-not-working%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fcli-install-not-working%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc-tauri%2Fsrc%2Fhooks.rs%3A673-675%0A**Cleanup%20assertions%20check%20a%20path%20that%20never%20matches%20the%20actual%20staged%20filename**%0A%0A%60unique_cli_stage_path%60%20produces%20a%20name%20in%20the%20form%20%60.%7Bname%7D.%7Bpid%7D.%7Btimestamp%7D.%7Bnonce%7D.tmp%60%20%28three%20extra%20components%29%2C%20but%20the%20assertion%20reconstructs%20only%20%60.%7Bname%7D.tmp%60.%20That%20path%20can%20never%20exist%2C%20so%20the%20assertion%20is%20always%20vacuously%20true%20%E2%80%94%20a%20cleanup%20bug%20would%20pass%20these%20tests%20silently.%20The%20same%20false%20negative%20applies%20to%20the%20%60atomic_install_cli_stages_next_to_requested_target_name%60%20test%20%28lines%20689-690%29.%20A%20straightforward%20fix%20is%20to%20list%20the%20temp%20directory%20entries%20after%20installation%20and%20assert%20none%20match%20%60*.tmp%60.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["fix: harden CLI install staging"](https://github.com/phin-tech/roux/commit/6089ea3c7ef040a4fc7d3a346e1f924a078d47f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34727957)</sub>

<!-- /greptile_comment -->