### PR TITLE
Unify Roux CLI install and release paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,202 @@ jobs:
           RELEASE_VERSION: ${{ steps.version.outputs.release_version }}
         run: task publish
 
+  release-cli:
+    runs-on: ${{ matrix.os }}
+    needs: release-macos
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-14
+            target: aarch64-apple-darwin
+          - os: macos-14
+            target: x86_64-apple-darwin
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-macos.outputs.release_version }}
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Add Rust target
+        run: rustup target add ${{ matrix.target }}
+      - name: Package CLI
+        env:
+          ROUX_CLI_VERSION: ${{ needs.release-macos.outputs.release_version }}
+          ROUX_CLI_TARGET: ${{ matrix.target }}
+        run: ./scripts/package-cli-release.sh
+      - name: Upload CLI assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh release upload "${{ needs.release-macos.outputs.release_version }}" \
+            target/cli-release/roux-*.tar.gz \
+            target/cli-release/roux-*.tar.gz.sha256 \
+            --clobber
+
+  update-homebrew-tap:
+    runs-on: ubuntu-latest
+    needs:
+      - release-macos
+      - release-cli
+    if: ${{ inputs.version != '' }}
+    steps:
+      - name: Require Homebrew tap token
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${HOMEBREW_TAP_TOKEN}" ]]; then
+            echo "HOMEBREW_TAP_TOKEN must be a token with contents write access to phin-tech/homebrew-tap." >&2
+            exit 1
+          fi
+
+      - name: Checkout Homebrew tap
+        uses: actions/checkout@v4
+        with:
+          repository: phin-tech/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: Update Homebrew formulae and casks
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ needs.release-macos.outputs.release_version }}
+          ROUX_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          TAG="${RELEASE_VERSION}"
+          if [[ ! "$TAG" =~ ^v[0-9] ]]; then
+            echo "Refusing to update Homebrew tap for non-release version: $TAG" >&2
+            exit 1
+          fi
+          VERSION="${TAG#v}"
+
+          RELEASE_JSON="$(gh release view "$TAG" --repo "$ROUX_REPO" --json assets,isPrerelease)"
+          IS_PRERELEASE="$(jq -r '.isPrerelease' <<< "$RELEASE_JSON")"
+
+          if [[ "$IS_PRERELEASE" == "true" ]]; then
+            CHANNEL="prerelease"
+            FORMULA_PATH="Formula/roux-pre.rb"
+            FORMULA_CLASS="RouxPre"
+            FORMULA_CONFLICT="roux"
+            CASK_PATH="Casks/roux-pre.rb"
+            CASK_TOKEN="roux-pre"
+            CASK_CONFLICT="roux"
+          else
+            CHANNEL="stable"
+            FORMULA_PATH="Formula/roux.rb"
+            FORMULA_CLASS="Roux"
+            FORMULA_CONFLICT="roux-pre"
+            CASK_PATH="Casks/roux.rb"
+            CASK_TOKEN="roux"
+            CASK_CONFLICT="roux-pre"
+          fi
+          FORMULA_FILE="homebrew-tap/${FORMULA_PATH}"
+          CASK_FILE="homebrew-tap/${CASK_PATH}"
+
+          SOURCE_URL="https://github.com/${ROUX_REPO}/archive/refs/tags/${TAG}.tar.gz"
+          SOURCE_SHA="$(curl -fsSL "$SOURCE_URL" | shasum -a 256 | awk '{print $1}')"
+
+          DMG_ASSET="Roux_${VERSION}_aarch64.dmg"
+          DMG_SHA="$(jq -r --arg name "$DMG_ASSET" '.assets[] | select(.name == $name) | .digest // ""' <<< "$RELEASE_JSON")"
+          DMG_SHA="${DMG_SHA#sha256:}"
+          if [[ -z "$DMG_SHA" || "$DMG_SHA" == "null" ]]; then
+            echo "Missing release asset digest for ${DMG_ASSET}" >&2
+            exit 1
+          fi
+
+          mkdir -p homebrew-tap/Formula homebrew-tap/Casks
+
+          cat > "$FORMULA_FILE" <<EOF
+          class ${FORMULA_CLASS} < Formula
+            desc "Command-line client and daemon entrypoint for Roux"
+            homepage "https://github.com/${ROUX_REPO}"
+            url "${SOURCE_URL}"
+            sha256 "${SOURCE_SHA}"
+            license "MIT"
+            head "https://github.com/${ROUX_REPO}.git", branch: "main"
+
+            depends_on "pkgconf" => :build
+            depends_on "rust" => :build
+            depends_on "openssl@3"
+
+            conflicts_with "${FORMULA_CONFLICT}", because: "both install the roux executable"
+
+            def install
+              ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
+              system "cargo", "install", *std_cargo_args(path: "crates/roux-cli")
+            end
+
+            test do
+              assert_match "roux #{version}", shell_output("#{bin}/roux --version")
+              assert_match "Roux terminal manager CLI", shell_output("#{bin}/roux --help")
+            end
+          end
+          EOF
+
+          cat > "$CASK_FILE" <<EOF
+          cask "${CASK_TOKEN}" do
+            version "${VERSION}"
+            sha256 "${DMG_SHA}"
+
+            url "https://github.com/${ROUX_REPO}/releases/download/v#{version}/Roux_#{version}_aarch64.dmg"
+            name "Roux"
+            desc "Desktop terminal multiplexer for Claude Code"
+            homepage "https://github.com/${ROUX_REPO}"
+
+          EOF
+
+          if [[ "$IS_PRERELEASE" == "true" ]]; then
+            cat >> "$CASK_FILE" <<'EOF'
+            livecheck do
+              url "https://github.com/phin-tech/roux/releases"
+              regex(/^v?(\d+(?:\.\d+)+-pre\.\d+)$/i)
+              strategy :github_releases
+            end
+          EOF
+          else
+            cat >> "$CASK_FILE" <<'EOF'
+            livecheck do
+              url :url
+              strategy :github_latest
+            end
+          EOF
+          fi
+
+          cat >> "$CASK_FILE" <<EOF
+
+            auto_updates true
+            conflicts_with cask: "${CASK_CONFLICT}"
+            depends_on arch: :arm64
+            depends_on :macos
+
+            app "Roux.app"
+
+            zap trash: "~/Library/Application Support/roux"
+          end
+          EOF
+
+          sed -i 's/^          //' "$FORMULA_FILE" "$CASK_FILE"
+          ruby -c "$FORMULA_FILE"
+          ruby -c "$CASK_FILE"
+
+          git -C homebrew-tap config user.name "github-actions[bot]"
+          git -C homebrew-tap config user.email "github-actions[bot]@users.noreply.github.com"
+          git -C homebrew-tap add "$FORMULA_PATH" "$CASK_PATH"
+
+          if git -C homebrew-tap diff --cached --quiet; then
+            echo "Homebrew tap already up to date for ${TAG}."
+            exit 0
+          fi
+
+          git -C homebrew-tap commit -m "Update Roux ${CHANNEL} to ${TAG}"
+          git -C homebrew-tap push
+
   build-windows:
     # Temporarily disabled; re-enable when Windows publishing is back.
     if: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,7 @@ jobs:
   release-cli:
     runs-on: ${{ matrix.os }}
     needs: release-macos
+    if: ${{ inputs.version != '' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,7 +164,7 @@ jobs:
           fi
           VERSION="${TAG#v}"
 
-          RELEASE_JSON="$(gh release view "$TAG" --repo "$ROUX_REPO" --json assets,isPrerelease)"
+          RELEASE_JSON="$(gh release view "$TAG" --repo "$ROUX_REPO" --json isPrerelease)"
           IS_PRERELEASE="$(jq -r '.isPrerelease' <<< "$RELEASE_JSON")"
 
           if [[ "$IS_PRERELEASE" == "true" ]]; then
@@ -191,12 +191,8 @@ jobs:
           SOURCE_SHA="$(curl -fsSL "$SOURCE_URL" | shasum -a 256 | awk '{print $1}')"
 
           DMG_ASSET="Roux_${VERSION}_aarch64.dmg"
-          DMG_SHA="$(jq -r --arg name "$DMG_ASSET" '.assets[] | select(.name == $name) | .digest // ""' <<< "$RELEASE_JSON")"
-          DMG_SHA="${DMG_SHA#sha256:}"
-          if [[ -z "$DMG_SHA" || "$DMG_SHA" == "null" ]]; then
-            echo "Missing release asset digest for ${DMG_ASSET}" >&2
-            exit 1
-          fi
+          DMG_URL="https://github.com/${ROUX_REPO}/releases/download/${TAG}/${DMG_ASSET}"
+          DMG_SHA="$(curl -fsSL "$DMG_URL" | shasum -a 256 | awk '{print $1}')"
 
           mkdir -p homebrew-tap/Formula homebrew-tap/Casks
 
@@ -269,7 +265,6 @@ jobs:
           end
           EOF
 
-          sed -i 's/^          //' "$FORMULA_FILE" "$CASK_FILE"
           ruby -c "$FORMULA_FILE"
           ruby -c "$CASK_FILE"
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,29 @@ A desktop terminal multiplexer for [Claude Code](https://docs.anthropic.com/en/d
 
 Roux lets you run multiple Claude Code sessions side-by-side with split panes, stacked tabs, shell terminals, and persistent layouts -- all in a single native window.
 
+## Install
+
+Install the macOS desktop app with Homebrew:
+
+```bash
+brew install --cask phin-tech/tap/roux
+```
+
+Install the standalone CLI with Homebrew:
+
+```bash
+brew install phin-tech/tap/roux
+```
+
+To install the latest prerelease builds:
+
+```bash
+brew install --cask phin-tech/tap/roux-pre
+brew install phin-tech/tap/roux-pre
+```
+
+The formula installs the `roux` CLI. The cask installs the desktop app. The desktop casks currently require Apple Silicon. Manual downloads are also available from the [GitHub releases page](https://github.com/phin-tech/roux/releases).
+
 ## Features
 
 - **Multi-session** -- Run independent Claude Code sessions, each with its own git worktree

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -56,13 +56,11 @@ tasks:
       - cmd: |
           TARGET="${TAURI_TARGET:-$(rustc -vV | sed -n 's/^host: //p')}"
           mkdir -p src-tauri/binaries
-          for NAME in roux roux-cli; do
-            if [ ! -f "src-tauri/binaries/${NAME}-${TARGET}" ]; then
-              touch "src-tauri/binaries/${NAME}-${TARGET}"
-              chmod +x "src-tauri/binaries/${NAME}-${TARGET}"
-              echo "Created placeholder for ${NAME}-${TARGET}"
-            fi
-          done
+          if [ ! -f "src-tauri/binaries/roux-${TARGET}" ]; then
+            touch "src-tauri/binaries/roux-${TARGET}"
+            chmod +x "src-tauri/binaries/roux-${TARGET}"
+            echo "Created placeholder for roux-${TARGET}"
+          fi
         platforms: [darwin, linux]
       # Task v3 runs `cmd:` blocks through bundled mvdan/sh on every
       # platform — including Windows — not through `cmd.exe`. Use POSIX
@@ -72,10 +70,8 @@ tasks:
           TARGET="${TAURI_TARGET:-$(rustc --print host-tuple)}"
           : "${TARGET:=x86_64-pc-windows-msvc}"
           mkdir -p src-tauri/binaries
-          for NAME in roux roux-cli; do
-            [ -f "src-tauri/binaries/${NAME}.exe" ] || : > "src-tauri/binaries/${NAME}.exe"
-            [ -f "src-tauri/binaries/${NAME}-${TARGET}.exe" ] || : > "src-tauri/binaries/${NAME}-${TARGET}.exe"
-          done
+          [ -f "src-tauri/binaries/roux.exe" ] || : > "src-tauri/binaries/roux.exe"
+          [ -f "src-tauri/binaries/roux-${TARGET}.exe" ] || : > "src-tauri/binaries/roux-${TARGET}.exe"
         platforms: [windows]
 
   cli:install:
@@ -89,7 +85,6 @@ tasks:
           mkdir -p ~/.local/bin
           cp target/debug/roux ~/.local/bin/roux
           chmod +x ~/.local/bin/roux
-          ln -sf ~/.local/bin/roux ~/.local/bin/roux-cli
           echo "Installed roux to ~/.local/bin/roux"
         platforms: [darwin, linux]
 
@@ -114,9 +109,7 @@ tasks:
           mkdir -p src-tauri/binaries
           cp target/debug/roux src-tauri/binaries/roux
           cp target/debug/roux "src-tauri/binaries/roux-${TARGET}"
-          cp target/debug/roux src-tauri/binaries/roux-cli
-          cp target/debug/roux "src-tauri/binaries/roux-cli-${TARGET}"
-          chmod +x src-tauri/binaries/roux src-tauri/binaries/roux-cli "src-tauri/binaries/roux-${TARGET}" "src-tauri/binaries/roux-cli-${TARGET}"
+          chmod +x src-tauri/binaries/roux "src-tauri/binaries/roux-${TARGET}"
           echo "Prepared dev Roux CLI binaries for ${TARGET}"
         platforms: [darwin, linux]
       # POSIX sh via bundled mvdan/sh — see comment on cli:ensure-placeholder.
@@ -129,8 +122,6 @@ tasks:
           mkdir -p src-tauri/binaries
           cp -f target/debug/roux.exe src-tauri/binaries/roux.exe
           cp -f target/debug/roux.exe "src-tauri/binaries/roux-${TARGET}.exe"
-          cp -f target/debug/roux.exe src-tauri/binaries/roux-cli.exe
-          cp -f target/debug/roux.exe "src-tauri/binaries/roux-cli-${TARGET}.exe"
           echo "Prepared dev Roux CLI binaries for ${TARGET}"
         platforms: [windows]
 
@@ -271,11 +262,14 @@ tasks:
           mkdir -p src-tauri/binaries
           cp target/release/roux src-tauri/binaries/roux
           cp target/release/roux "src-tauri/binaries/roux-${TARGET}"
-          cp target/release/roux src-tauri/binaries/roux-cli
-          cp target/release/roux "src-tauri/binaries/roux-cli-${TARGET}"
-          chmod +x src-tauri/binaries/roux src-tauri/binaries/roux-cli "src-tauri/binaries/roux-${TARGET}" "src-tauri/binaries/roux-cli-${TARGET}"
+          chmod +x src-tauri/binaries/roux "src-tauri/binaries/roux-${TARGET}"
           echo "Prepared bundled Roux CLI for ${TARGET}"
         platforms: [darwin, linux]
+
+  cli:package-release:
+    desc: "Build and package the standalone Roux CLI release tarball for this host"
+    cmds:
+      - ./scripts/package-cli-release.sh
 
   sign:
     desc: "Build, sign, notarize, and staple the macOS app"

--- a/crates/roux-cli/src/platform.rs
+++ b/crates/roux-cli/src/platform.rs
@@ -174,14 +174,6 @@ fn roux_cli_file_name_for_platform(is_windows: bool) -> &'static str {
     }
 }
 
-pub fn roux_cli_compat_file_name() -> &'static str {
-    if cfg!(windows) {
-        "roux-cli.exe"
-    } else {
-        "roux-cli"
-    }
-}
-
 pub fn sibling_roux_cli_path(exe_path: &Path) -> Option<PathBuf> {
     exe_path.parent().map(|dir| dir.join(roux_cli_file_name()))
 }
@@ -334,19 +326,15 @@ mod tests {
     fn roux_cli_file_name_uses_exe_extension_on_windows() {
         assert_eq!(roux_cli_file_name_for_platform(true), "roux.exe");
         assert_eq!(roux_cli_file_name_for_platform(false), "roux");
-        assert_eq!(
-            roux_cli_compat_file_name(),
-            if cfg!(windows) { "roux-cli.exe" } else { "roux-cli" }
-        );
     }
 
     #[test]
     fn quote_command_arg_quotes_spaces_and_quotes() {
-        assert_eq!(quote_command_arg("roux-cli"), "roux-cli");
+        assert_eq!(quote_command_arg("roux"), "roux");
         assert_eq!(quote_command_arg(""), "\"\"");
         assert_eq!(
-            quote_command_arg("C:\\Program Files\\Roux\\roux-cli.exe"),
-            "\"C:\\\\Program Files\\\\Roux\\\\roux-cli.exe\""
+            quote_command_arg("C:\\Program Files\\Roux\\roux.exe"),
+            "\"C:\\\\Program Files\\\\Roux\\\\roux.exe\""
         );
         assert_eq!(quote_command_arg("say \"hi\""), "\"say \\\"hi\\\"\"");
     }
@@ -354,13 +342,10 @@ mod tests {
     #[test]
     fn command_string_quotes_program_path_and_args() {
         let command = command_string(
-            Path::new("C:\\Users\\Sam\\App Data\\Roux\\roux-cli.exe"),
+            Path::new("C:\\Users\\Sam\\App Data\\Roux\\roux.exe"),
             &["hook", "working"],
         );
-        assert_eq!(
-            command,
-            "\"C:\\\\Users\\\\Sam\\\\App Data\\\\Roux\\\\roux-cli.exe\" hook working"
-        );
+        assert_eq!(command, "\"C:\\\\Users\\\\Sam\\\\App Data\\\\Roux\\\\roux.exe\" hook working");
     }
 
     #[test]

--- a/docs/features/cli.md
+++ b/docs/features/cli.md
@@ -4,7 +4,33 @@ Roux ships with a command-line tool, `roux`, that talks to the running app over 
 
 ## Installing
 
-`roux` is bundled inside `Roux.app`. The easiest way to put it on your `PATH` is to symlink it:
+`roux` is bundled inside `Roux.app`, and release builds also publish standalone CLI tarballs for terminal-only installs.
+
+To install the latest standalone CLI on macOS or Linux:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/phin-tech/roux/main/scripts/install-cli.sh | sh
+```
+
+Or install with Homebrew:
+
+```sh
+brew install phin-tech/tap/roux
+```
+
+To install the latest prerelease CLI with Homebrew:
+
+```sh
+brew install phin-tech/tap/roux-pre
+```
+
+To install a specific release:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/phin-tech/roux/main/scripts/install-cli.sh | ROUX_VERSION=v0.5.3 sh
+```
+
+You can also symlink the copy inside the app bundle:
 
 ```sh
 ln -sf /Applications/Roux.app/Contents/MacOS/roux /usr/local/bin/roux
@@ -12,14 +38,11 @@ ln -sf /Applications/Roux.app/Contents/MacOS/roux /usr/local/bin/roux
 
 Then `roux --help` should work from any terminal.
 
-Inside Roux-managed panes, both `roux` and the legacy `roux-cli` alias are injected automatically, so you can call either without adding your own PATH shim.
+Inside Roux-managed panes, `roux` is injected automatically, so you can call it without adding your own PATH shim.
 
 ## Binary layout
 
-The CLI is built from the standalone `crates/roux-cli` workspace crate. That crate produces the `roux` binary and does not link the Tauri desktop app. The desktop package lives separately under `src-tauri` as `roux-desktop` and bundles two sidecars:
-
-- `roux` — the primary CLI binary
-- `roux-cli` — compatibility alias for older hooks, scripts, and spawned panes
+The CLI is built from the standalone `crates/roux-cli` workspace crate. That crate produces the `roux` binary and does not link the Tauri desktop app. The desktop package lives separately under `src-tauri` as `roux-desktop` and bundles one CLI sidecar: `roux`.
 
 For source builds, use:
 
@@ -27,7 +50,13 @@ For source builds, use:
 cargo build -p roux-cli --bin roux
 ```
 
-For local development, `task cli:install` builds the same binary, installs `~/.local/bin/roux`, and points `~/.local/bin/roux-cli` at it on macOS/Linux.
+For local development, `task cli:install` builds the same binary and installs `~/.local/bin/roux` on macOS/Linux.
+
+Release automation uploads standalone tarballs named `roux-<target>.tar.gz` with matching `.sha256` files. The initial targets are:
+
+- `aarch64-apple-darwin`
+- `x86_64-apple-darwin`
+- `x86_64-unknown-linux-gnu`
 
 ## How it talks to Roux
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,14 +1,58 @@
 # Install
 
-Roux ships signed and notarized macOS builds. Native Windows x64 builds are also supported from source with an unsigned NSIS installer. Linux is not yet supported.
+Roux ships signed and notarized macOS desktop builds. Native Windows x64 desktop builds are also supported from source with an unsigned NSIS installer. The Linux desktop app is not yet supported, but standalone Linux CLI tarballs are published with releases.
 
 ## macOS
+
+Install the desktop app with Homebrew:
+
+```sh
+brew install --cask phin-tech/tap/roux
+```
+
+Or install manually:
 
 1. Download the latest `.dmg` from the [GitHub releases page](https://github.com/phin-tech/roux/releases).
 2. Open the `.dmg` and drag **Roux** into `/Applications`.
 3. Launch Roux from Launchpad or Spotlight.
 
 The app is code-signed and notarized, so Gatekeeper should not block the first launch.
+
+To install the latest prerelease desktop app:
+
+```sh
+brew install --cask phin-tech/tap/roux-pre
+```
+
+The Homebrew desktop casks currently require Apple Silicon.
+
+## Standalone CLI
+
+Release builds publish standalone `roux` CLI tarballs for macOS and Linux. To install the latest CLI into `~/.local/bin`:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/phin-tech/roux/main/scripts/install-cli.sh | sh
+```
+
+Or install with Homebrew:
+
+```sh
+brew install phin-tech/tap/roux
+```
+
+To install the latest prerelease CLI with Homebrew:
+
+```sh
+brew install phin-tech/tap/roux-pre
+```
+
+To install a specific release, pass the tag:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/phin-tech/roux/main/scripts/install-cli.sh | ROUX_VERSION=v0.5.3 sh
+```
+
+Published CLI assets are named by target triple, for example `roux-aarch64-apple-darwin.tar.gz`, `roux-x86_64-apple-darwin.tar.gz`, and `roux-x86_64-unknown-linux-gnu.tar.gz`, each with a matching `.sha256` file.
 
 ## Windows
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -9,7 +9,7 @@ This page tracks major shipped features across Roux's full history.
 - **Terminal + document workflows**: shell panes, markdown viewer/editor pane, command palette, pane rerun flow, and command panes for keep-open task output.
 - **Projects, themes, and notes**: project grouping, repo grouping, session UI polish, multi-theme support, and project notes sidebar.
 - **Task runner**: discover tasks from `package.json`, `Taskfile`, `Makefile`, and `Justfile`; run and manage tasks from sidebar and panes.
-- **CLI bridge**: shipped `roux-cli`, socket bridge, first-load install flow, and scripting entry points.
+- **CLI bridge**: shipped `roux`, socket bridge, first-load install flow, and scripting entry points.
 - **Watches**: long-running watch service with shell/HTTP/GitHub checks, PR watch kind, clickable PR/check/review links, and watch-focused UX.
 - **Platform + release tooling**: Windows support, macOS signing/notarization flow, release automation, and improved logging/runtime diagnostics.
 
@@ -19,7 +19,7 @@ This page tracks major shipped features across Roux's full history.
 - **Auto-updater**: in-app update checks/install flow with signed release verification and restart handling.
 - **Session restore upgrades**: reconnect restores full saved pane layouts (including shell panes/splits) and uses live shell cwd for better recovery.
 - **Shortcut upgrades**: session sidebar toggle (`cmd+\`) and quick-jump digits for sessions/panes with modifier overlays.
-- **Bundled PTY CLI aliases**: spawned shells expose `roux` / `roux-cli` directly.
+- **Bundled PTY CLI shim**: spawned shells expose `roux` directly.
 
 ## April 11, 2026
 
@@ -98,4 +98,4 @@ This page tracks major shipped features across Roux's full history.
 
 ## May 22, 2026
 
-- **Standalone CLI crate + daemon foundation**: `roux` now builds from the separate `crates/roux-cli` crate instead of the Tauri desktop package, while `roux-cli` remains as a compatibility alias for older hooks and scripts. The desktop app package/binary is `roux-desktop`, and bundles both CLI sidecar names. The new experimental `roux daemon` command starts the shared runtime service host, owns the Roux command socket when running, and exposes `roux daemon status` plus headless session/project metadata commands as a first step toward daemon-owned sessions; Roux.app still owns interactive PTYs today. See [CLI bridge](features/cli.md) and [V2 session daemon](v2/session-daemon.md).
+- **Standalone CLI crate + daemon foundation**: `roux` now builds from the separate `crates/roux-cli` crate instead of the Tauri desktop package. The desktop app package/binary is `roux-desktop`, and bundles the CLI sidecar as `roux`. The new experimental `roux daemon` command starts the shared runtime service host, owns the Roux command socket when running, and exposes `roux daemon status` plus headless session/project metadata commands as a first step toward daemon-owned sessions; Roux.app still owns interactive PTYs today. See [CLI bridge](features/cli.md) and [V2 session daemon](v2/session-daemon.md).

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env sh
+set -eu
+
+REPO="${ROUX_REPO:-phin-tech/roux}"
+VERSION="${ROUX_VERSION:-latest}"
+INSTALL_DIR="${ROUX_INSTALL_DIR:-$HOME/.local/bin}"
+
+need() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+need curl
+need tar
+
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+case "${OS}:${ARCH}" in
+  Darwin:arm64) TARGET="aarch64-apple-darwin" ;;
+  Darwin:x86_64) TARGET="x86_64-apple-darwin" ;;
+  Linux:x86_64) TARGET="x86_64-unknown-linux-gnu" ;;
+  *)
+    echo "Unsupported platform: ${OS} ${ARCH}" >&2
+    exit 1
+    ;;
+esac
+
+ASSET="roux-${TARGET}.tar.gz"
+if [ "$VERSION" = "latest" ]; then
+  BASE_URL="https://github.com/${REPO}/releases/latest/download"
+else
+  case "$VERSION" in
+    v*) TAG="$VERSION" ;;
+    *) TAG="v${VERSION}" ;;
+  esac
+  BASE_URL="https://github.com/${REPO}/releases/download/${TAG}"
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+curl -fsSL "${BASE_URL}/${ASSET}" -o "${TMP_DIR}/${ASSET}"
+if curl -fsSL "${BASE_URL}/${ASSET}.sha256" -o "${TMP_DIR}/${ASSET}.sha256"; then
+  if command -v sha256sum >/dev/null 2>&1; then
+    (cd "$TMP_DIR" && sha256sum -c "${ASSET}.sha256")
+  elif command -v shasum >/dev/null 2>&1; then
+    (cd "$TMP_DIR" && shasum -a 256 -c "${ASSET}.sha256")
+  else
+    echo "No sha256 verifier found; skipping checksum verification." >&2
+  fi
+else
+  echo "Checksum not found; skipping verification." >&2
+fi
+
+tar -xzf "${TMP_DIR}/${ASSET}" -C "$TMP_DIR"
+ROUX_BIN="$(find "$TMP_DIR" -type f -name roux | head -n 1)"
+if [ -z "$ROUX_BIN" ]; then
+  echo "roux binary not found in ${ASSET}" >&2
+  exit 1
+fi
+
+mkdir -p "$INSTALL_DIR"
+install -m 0755 "$ROUX_BIN" "${INSTALL_DIR}/roux"
+
+echo "Installed roux to ${INSTALL_DIR}/roux"

--- a/scripts/package-cli-release.sh
+++ b/scripts/package-cli-release.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if [ -n "${ROUX_CLI_VERSION:-}" ]; then
+  VERSION="$ROUX_CLI_VERSION"
+else
+  VERSION="v$(python3 -c 'import re; print(re.search(r"(?m)^version = \"([^\"]+)\"", open("crates/roux-cli/Cargo.toml").read()).group(1))')"
+fi
+
+TARGET="${ROUX_CLI_TARGET:-$(rustc -vV | sed -n 's/^host: //p')}"
+OUT_DIR="${ROUX_CLI_DIST_DIR:-target/cli-release}"
+mkdir -p "$OUT_DIR"
+
+if [ -n "${ROUX_CLI_TARGET:-}" ]; then
+  cargo build -p roux-cli --release --bin roux --target "$TARGET"
+  BIN="target/${TARGET}/release/roux"
+else
+  cargo build -p roux-cli --release --bin roux
+  BIN="target/release/roux"
+fi
+
+if [ ! -f "$BIN" ] && [ -f "${BIN}.exe" ]; then
+  BIN="${BIN}.exe"
+fi
+if [ ! -f "$BIN" ]; then
+  echo "roux binary not found at ${BIN}" >&2
+  exit 1
+fi
+
+WORK_DIR="$(mktemp -d "${OUT_DIR}/roux.XXXXXX")"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+PACKAGE_DIR="${WORK_DIR}/roux-${VERSION}-${TARGET}"
+mkdir -p "$PACKAGE_DIR"
+cp "$BIN" "$PACKAGE_DIR/roux"
+chmod +x "$PACKAGE_DIR/roux"
+
+cat > "${PACKAGE_DIR}/README.txt" <<EOF
+Roux CLI ${VERSION}
+
+Install:
+  install -m 0755 roux ~/.local/bin/roux
+EOF
+
+ARCHIVE="${OUT_DIR}/roux-${TARGET}.tar.gz"
+tar -C "$WORK_DIR" -czf "$ARCHIVE" "$(basename "$PACKAGE_DIR")"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  (cd "$OUT_DIR" && sha256sum "$(basename "$ARCHIVE")" > "$(basename "$ARCHIVE").sha256")
+else
+  (cd "$OUT_DIR" && shasum -a 256 "$(basename "$ARCHIVE")" > "$(basename "$ARCHIVE").sha256")
+fi
+
+echo "$ARCHIVE"
+echo "${ARCHIVE}.sha256"

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -24,27 +24,21 @@ fn ensure_ci_external_bin_for_host() -> std::io::Result<()> {
     let bin_dir = manifest_dir.join("binaries");
     fs::create_dir_all(&bin_dir)?;
 
-    for name in ["roux", "roux-cli"] {
-        let expected = if triple.contains("windows") {
-            bin_dir.join(format!("{name}-{triple}.exe"))
-        } else {
-            bin_dir.join(format!("{name}-{triple}"))
-        };
-        if expected.exists() {
-            continue;
-        }
-
+    let expected = if triple.contains("windows") {
+        bin_dir.join(format!("roux-{triple}.exe"))
+    } else {
+        bin_dir.join(format!("roux-{triple}"))
+    };
+    if !expected.exists() {
         if triple.contains("windows") {
             fs::write(
                 &expected,
-                format!("@echo off\r\necho {name} placeholder for CI checks 1>&2\r\nexit /b 1\r\n"),
+                "@echo off\r\necho roux placeholder for CI checks 1>&2\r\nexit /b 1\r\n",
             )?;
         } else {
             fs::write(
                 &expected,
-                format!(
-                    "#!/usr/bin/env sh\nprintf '%s\\n' '{name} placeholder for CI checks' >&2\nexit 1\n"
-                ),
+                "#!/usr/bin/env sh\nprintf '%s\\n' 'roux placeholder for CI checks' >&2\nexit 1\n",
             )?;
             #[cfg(unix)]
             fs::set_permissions(&expected, fs::Permissions::from_mode(0o755))?;

--- a/src-tauri/src/commands/setup.rs
+++ b/src-tauri/src/commands/setup.rs
@@ -265,10 +265,7 @@ pub(crate) fn check_doctor_status() -> DoctorStatus {
 #[tauri::command]
 #[specta::specta]
 pub(crate) fn reinstall_cli() -> Result<(), String> {
-    // Reinstalling the CLI is a side effect of install_hooks (it copies the
-    // binary into ~/.local/bin before wiring up settings.json), so it's the
-    // cheapest way to get a fresh CLI on disk today.
-    svc::install_hooks().map_err(|e| e.to_string())
+    svc::install_cli().map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -286,10 +283,11 @@ pub(crate) fn reinstall_skill() -> Result<(), String> {
 #[tauri::command]
 #[specta::specta]
 pub(crate) fn install_all_missing() -> Result<(), String> {
-    // install_hooks copies the CLI to ~/.local/bin as a side effect, so this
-    // also covers "CLI is stale" (version mismatch with bundled).
-    if !svc::is_cli_installed() || !svc::is_cli_current() || !svc::is_hooks_installed() {
+    let cli_needs_install = !svc::is_cli_installed() || !svc::is_cli_current();
+    if !svc::is_hooks_installed() {
         svc::install_hooks().map_err(|e| e.to_string())?;
+    } else if cli_needs_install {
+        svc::install_cli().map_err(|e| e.to_string())?;
     }
     if !svc::is_skill_installed() {
         svc::install_skill().map_err(|e| e.to_string())?;

--- a/src-tauri/src/hooks.rs
+++ b/src-tauri/src/hooks.rs
@@ -175,11 +175,9 @@ fn install_cli_binary_path() -> Result<PathBuf, String> {
     fs::create_dir_all(&bin_dir).map_err(|e| format!("Failed to create ~/.local/bin: {}", e))?;
 
     let target = bin_dir.join(platform::roux_cli_file_name());
-    // Find the bundled source binary next to the running desktop binary.
-    let source =
-        bundled_cli_source_path().ok_or("Could not find roux next to roux desktop binary")?;
-
-    if source.exists() {
+    // Prefer the bundled sidecar in packaged builds, but source/dev builds may
+    // only have roux on PATH or in Cargo's bin directory.
+    if let Some(source) = bundled_cli_source_path() {
         // Replace the installed CLI whenever its version differs from the
         // bundled one (or it's missing). See `should_install_cli` for why mtime
         // is deliberately not used here.

--- a/src-tauri/src/hooks.rs
+++ b/src-tauri/src/hooks.rs
@@ -15,29 +15,16 @@ fn unix_cli_install_path() -> Option<PathBuf> {
     dirs::home_dir().map(|h| h.join(".local").join("bin").join(platform::roux_cli_file_name()))
 }
 
-#[cfg(not(windows))]
-fn unix_cli_compat_install_path() -> Option<PathBuf> {
-    dirs::home_dir()
-        .map(|h| h.join(".local").join("bin").join(platform::roux_cli_compat_file_name()))
-}
-
 fn cargo_cli_install_path() -> Option<PathBuf> {
     dirs::home_dir().map(|h| h.join(".cargo").join("bin").join(platform::roux_cli_file_name()))
-}
-
-fn cargo_cli_compat_install_path() -> Option<PathBuf> {
-    dirs::home_dir()
-        .map(|h| h.join(".cargo").join("bin").join(platform::roux_cli_compat_file_name()))
 }
 
 fn sibling_cli_path() -> Option<PathBuf> {
     std::env::current_exe().ok().and_then(|p| platform::sibling_roux_cli_path(&p))
 }
 
-fn sibling_cli_compat_path() -> Option<PathBuf> {
-    std::env::current_exe()
-        .ok()
-        .and_then(|p| p.parent().map(|dir| dir.join(platform::roux_cli_compat_file_name())))
+fn bundled_cli_source_path() -> Option<PathBuf> {
+    sibling_cli_path().filter(|path| path.is_file())
 }
 
 fn first_existing_path(candidates: impl IntoIterator<Item = Option<PathBuf>>) -> Option<PathBuf> {
@@ -46,26 +33,13 @@ fn first_existing_path(candidates: impl IntoIterator<Item = Option<PathBuf>>) ->
 
 fn find_cli_on_path() -> Option<PathBuf> {
     platform::find_executable_on_path(platform::roux_cli_file_name())
-        .or_else(|| platform::find_executable_on_path(platform::roux_cli_compat_file_name()))
 }
 
 fn roux_cli_path() -> Result<PathBuf, String> {
     #[cfg(windows)]
-    let candidates = [
-        sibling_cli_path(),
-        sibling_cli_compat_path(),
-        cargo_cli_install_path(),
-        cargo_cli_compat_install_path(),
-    ];
+    let candidates = [sibling_cli_path(), cargo_cli_install_path()];
     #[cfg(not(windows))]
-    let candidates = [
-        unix_cli_install_path(),
-        sibling_cli_path(),
-        cargo_cli_install_path(),
-        unix_cli_compat_install_path(),
-        sibling_cli_compat_path(),
-        cargo_cli_compat_install_path(),
-    ];
+    let candidates = [unix_cli_install_path(), sibling_cli_path(), cargo_cli_install_path()];
 
     first_existing_path(candidates).or_else(find_cli_on_path).ok_or_else(|| {
         format!(
@@ -164,14 +138,9 @@ impl std::error::Error for CliInstallError {}
 /// [`cli_is_installed`] but returns the path so callers can exec it.
 fn installed_cli_path() -> Option<PathBuf> {
     #[cfg(windows)]
-    let candidates = [cargo_cli_install_path(), cargo_cli_compat_install_path()];
+    let candidates = [cargo_cli_install_path()];
     #[cfg(not(windows))]
-    let candidates = [
-        unix_cli_install_path(),
-        cargo_cli_install_path(),
-        unix_cli_compat_install_path(),
-        cargo_cli_compat_install_path(),
-    ];
+    let candidates = [unix_cli_install_path(), cargo_cli_install_path()];
 
     first_existing_path(candidates).or_else(find_cli_on_path)
 }
@@ -187,14 +156,9 @@ pub fn cli_is_current() -> bool {
 /// directory, or `PATH`.
 pub fn cli_is_installed() -> bool {
     #[cfg(windows)]
-    let candidates = [cargo_cli_install_path(), cargo_cli_compat_install_path()];
+    let candidates = [cargo_cli_install_path()];
     #[cfg(not(windows))]
-    let candidates = [
-        unix_cli_install_path(),
-        cargo_cli_install_path(),
-        unix_cli_compat_install_path(),
-        cargo_cli_compat_install_path(),
-    ];
+    let candidates = [unix_cli_install_path(), cargo_cli_install_path()];
 
     first_existing_path(candidates).or_else(find_cli_on_path).is_some()
 }
@@ -211,10 +175,9 @@ fn install_cli_binary_path() -> Result<PathBuf, String> {
     fs::create_dir_all(&bin_dir).map_err(|e| format!("Failed to create ~/.local/bin: {}", e))?;
 
     let target = bin_dir.join(platform::roux_cli_file_name());
-    let compat_target = bin_dir.join(platform::roux_cli_compat_file_name());
-
-    // Find the source binary (next to the running roux binary)
-    let source = sibling_cli_path().ok_or("Could not find roux next to roux desktop binary")?;
+    // Find the bundled source binary next to the running desktop binary.
+    let source =
+        bundled_cli_source_path().ok_or("Could not find roux next to roux desktop binary")?;
 
     if source.exists() {
         // Replace the installed CLI whenever its version differs from the
@@ -226,12 +189,15 @@ fn install_cli_binary_path() -> Result<PathBuf, String> {
             atomic_install_cli(&source, &target).map_err(|e| e.to_string())?;
             eprintln!("Installed roux CLI to {}", target.display());
         }
-        install_cli_compat_alias(&target, &compat_target)?;
         return Ok(target);
     }
 
     // Fallback: try to find it anywhere
     roux_cli_path()
+}
+
+pub fn install_cli() -> Result<(), String> {
+    install_cli_binary_path().map(|_| ())
 }
 
 /// Copy `source` over `target` atomically: stage a temp file next to the
@@ -274,15 +240,6 @@ fn unique_cli_stage_path(dir: &Path, target: &Path) -> Result<PathBuf, CliInstal
     let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_nanos();
 
     Ok(dir.join(format!(".{target_name}.{}.{}.{}.tmp", std::process::id(), timestamp, nonce)))
-}
-
-#[cfg(not(windows))]
-fn install_cli_compat_alias(target: &Path, compat_target: &Path) -> Result<(), String> {
-    if compat_target.symlink_metadata().is_ok() {
-        let _ = fs::remove_file(compat_target);
-    }
-    std::os::unix::fs::symlink(target, compat_target)
-        .map_err(|e| format!("Failed to link roux-cli compatibility alias: {e}"))
 }
 
 fn claude_settings_path() -> Result<PathBuf, String> {
@@ -702,24 +659,6 @@ mod tests {
         assert_ne!(first, second);
         assert_eq!(first.parent(), Some(dir.path()));
         assert_eq!(second.parent(), Some(dir.path()));
-    }
-
-    #[cfg(not(windows))]
-    #[test]
-    fn install_cli_compat_alias_replaces_dangling_symlink() {
-        let dir = tempfile::tempdir().unwrap();
-        let target = dir.path().join("roux");
-        let missing = dir.path().join("missing-roux");
-        let compat = dir.path().join("roux-cli");
-
-        fs::write(&target, "").unwrap();
-        std::os::unix::fs::symlink(&missing, &compat).unwrap();
-        assert!(!compat.exists());
-        assert!(compat.symlink_metadata().is_ok());
-
-        install_cli_compat_alias(&target, &compat).unwrap();
-
-        assert_eq!(fs::read_link(&compat).unwrap(), target);
     }
 
     #[test]

--- a/src-tauri/src/platform.rs
+++ b/src-tauri/src/platform.rs
@@ -170,14 +170,6 @@ fn roux_cli_file_name_for_platform(is_windows: bool) -> &'static str {
     }
 }
 
-pub fn roux_cli_compat_file_name() -> &'static str {
-    if cfg!(windows) {
-        "roux-cli.exe"
-    } else {
-        "roux-cli"
-    }
-}
-
 pub fn sibling_roux_cli_path(exe_path: &Path) -> Option<PathBuf> {
     exe_path.parent().map(|dir| dir.join(roux_cli_file_name()))
 }
@@ -330,19 +322,15 @@ mod tests {
     fn roux_cli_file_name_uses_exe_extension_on_windows() {
         assert_eq!(roux_cli_file_name_for_platform(true), "roux.exe");
         assert_eq!(roux_cli_file_name_for_platform(false), "roux");
-        assert_eq!(
-            roux_cli_compat_file_name(),
-            if cfg!(windows) { "roux-cli.exe" } else { "roux-cli" }
-        );
     }
 
     #[test]
     fn quote_command_arg_quotes_spaces_and_quotes() {
-        assert_eq!(quote_command_arg("roux-cli"), "roux-cli");
+        assert_eq!(quote_command_arg("roux"), "roux");
         assert_eq!(quote_command_arg(""), "\"\"");
         assert_eq!(
-            quote_command_arg("C:\\Program Files\\Roux\\roux-cli.exe"),
-            "\"C:\\\\Program Files\\\\Roux\\\\roux-cli.exe\""
+            quote_command_arg("C:\\Program Files\\Roux\\roux.exe"),
+            "\"C:\\\\Program Files\\\\Roux\\\\roux.exe\""
         );
         assert_eq!(quote_command_arg("say \"hi\""), "\"say \\\"hi\\\"\"");
     }
@@ -350,13 +338,10 @@ mod tests {
     #[test]
     fn command_string_quotes_program_path_and_args() {
         let command = command_string(
-            Path::new("C:\\Users\\Sam\\App Data\\Roux\\roux-cli.exe"),
+            Path::new("C:\\Users\\Sam\\App Data\\Roux\\roux.exe"),
             &["hook", "working"],
         );
-        assert_eq!(
-            command,
-            "\"C:\\\\Users\\\\Sam\\\\App Data\\\\Roux\\\\roux-cli.exe\" hook working"
-        );
+        assert_eq!(command, "\"C:\\\\Users\\\\Sam\\\\App Data\\\\Roux\\\\roux.exe\" hook working");
     }
 
     #[test]

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -967,19 +967,18 @@ pub fn ensure_roux_cli_shim() {
 
 /// Cached pair of (bin-dir-to-prepend-to-PATH, full-path-to-Roux-CLI).
 /// Set up once at first PTY spawn: creates `~/.config/roux/bin/` and places
-/// `roux` plus compatibility `roux-cli` symlinks there, both pointing at the
-/// bundled CLI binary built next to the currently running desktop exe. Returning
-/// `None` means we couldn't find the bundled CLI (e.g. a dev build where it wasn't
-/// compiled yet) — callers skip the PATH injection gracefully.
+/// a `roux` symlink pointing at the bundled CLI binary built next to the
+/// currently running desktop exe. Returning `None` means we couldn't find the
+/// bundled CLI (e.g. a dev build where it wasn't compiled yet) — callers skip
+/// the PATH injection gracefully.
 fn roux_cli_shim() -> Option<(String, String)> {
     use std::sync::OnceLock;
     static CACHE: OnceLock<Option<(String, String)>> = OnceLock::new();
     CACHE
         .get_or_init(|| {
             // 1. Find the bundled Roux CLI next to the currently running exe.
-            let source = std::env::current_exe()
-                .ok()
-                .and_then(|p| p.parent().map(|d| d.join(platform::roux_cli_file_name())))?;
+            let source =
+                std::env::current_exe().ok().and_then(|p| platform::sibling_roux_cli_path(&p))?;
             if !source.exists() {
                 rlog!("roux_cli_shim: bundled CLI not found at {}", source.display());
                 return None;
@@ -992,53 +991,46 @@ fn roux_cli_shim() -> Option<(String, String)> {
                 return None;
             }
 
-            // 3. Install symlinks: `roux` and legacy alias `roux-cli` both
-            //    pointing at the bundled source. We re-create the links every
-            //    startup so the PTY always sees the freshest binary, even
-            //    after a version bump.
+            // 3. Install a `roux` symlink pointing at the bundled source. We
+            //    re-create the link every startup so the PTY always sees the
+            //    freshest binary, even after a version bump.
             #[cfg(unix)]
             {
                 use std::os::unix::fs as unix_fs;
-                for alias in ["roux", "roux-cli"] {
-                    let link = bin_dir.join(alias);
-                    // Remove any existing symlink/file so we can re-point it.
-                    let _ = std::fs::remove_file(&link);
-                    if let Err(e) = unix_fs::symlink(&source, &link) {
-                        rlog!(
-                            "roux_cli_shim: failed to symlink {} -> {}: {}",
-                            link.display(),
-                            source.display(),
-                            e
-                        );
-                        return None;
-                    }
+                let link = bin_dir.join("roux");
+                // Remove any existing symlink/file so we can re-point it.
+                let _ = std::fs::remove_file(&link);
+                if let Err(e) = unix_fs::symlink(&source, &link) {
+                    rlog!(
+                        "roux_cli_shim: failed to symlink {} -> {}: {}",
+                        link.display(),
+                        source.display(),
+                        e
+                    );
+                    return None;
                 }
             }
 
             #[cfg(windows)]
             {
-                for alias in ["roux.exe", "roux-cli.exe"] {
-                    let target = bin_dir.join(alias);
-                    let should_copy = if target.exists() {
-                        let src_modified =
-                            std::fs::metadata(&source).and_then(|m| m.modified()).ok();
-                        let dst_modified =
-                            std::fs::metadata(&target).and_then(|m| m.modified()).ok();
-                        match (src_modified, dst_modified) {
-                            (Some(src), Some(dst)) => src > dst,
-                            _ => true,
-                        }
-                    } else {
-                        true
-                    };
-                    if should_copy && std::fs::copy(&source, &target).is_err() {
-                        rlog!(
-                            "roux_cli_shim: failed to copy {} -> {}",
-                            source.display(),
-                            target.display()
-                        );
-                        return None;
+                let target = bin_dir.join("roux.exe");
+                let should_copy = if target.exists() {
+                    let src_modified = std::fs::metadata(&source).and_then(|m| m.modified()).ok();
+                    let dst_modified = std::fs::metadata(&target).and_then(|m| m.modified()).ok();
+                    match (src_modified, dst_modified) {
+                        (Some(src), Some(dst)) => src > dst,
+                        _ => true,
                     }
+                } else {
+                    true
+                };
+                if should_copy && std::fs::copy(&source, &target).is_err() {
+                    rlog!(
+                        "roux_cli_shim: failed to copy {} -> {}",
+                        source.display(),
+                        target.display()
+                    );
+                    return None;
                 }
             }
 

--- a/src-tauri/src/services/setup.rs
+++ b/src-tauri/src/services/setup.rs
@@ -151,6 +151,11 @@ pub(crate) fn bundled_cli_version() -> &'static str {
     crate::hooks::bundled_cli_version()
 }
 
+pub(crate) fn install_cli() -> anyhow::Result<()> {
+    crate::hooks::install_cli().map_err(anyhow::Error::msg)?;
+    Ok(())
+}
+
 pub(crate) fn install_hooks() -> anyhow::Result<()> {
     crate::hooks::install_hooks().map_err(anyhow::Error::msg)?;
     Ok(())

--- a/src-tauri/src/skill/SKILL.md
+++ b/src-tauri/src/skill/SKILL.md
@@ -58,8 +58,7 @@ Always call the binary at `$ROUX_CLI`, e.g.:
 "$ROUX_CLI" session list
 ```
 
-This avoids PATH issues. `roux-cli` remains a compatibility alias, but new
-automation should use `$ROUX_CLI` / `roux`.
+This avoids PATH issues. New automation should use `$ROUX_CLI` / `roux`.
 
 ## CLI surface
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -30,8 +30,7 @@
     "active": true,
     "targets": "all",
     "externalBin": [
-      "binaries/roux",
-      "binaries/roux-cli"
+      "binaries/roux"
     ],
     "windows": {
       "nsis": {
@@ -41,8 +40,7 @@
     "createUpdaterArtifacts": true,
     "macOS": {
       "files": {
-        "MacOS/roux": "binaries/roux",
-        "MacOS/roux-cli": "binaries/roux-cli"
+        "MacOS/roux": "binaries/roux"
       },
       "hardenedRuntime": true
     },

--- a/taskfiles/Taskfile_darwin.yml
+++ b/taskfiles/Taskfile_darwin.yml
@@ -22,9 +22,7 @@ tasks:
           mkdir -p src-tauri/binaries
           cp "${SOURCE}" src-tauri/binaries/roux
           cp "${SOURCE}" "src-tauri/binaries/roux-${TARGET}"
-          cp "${SOURCE}" src-tauri/binaries/roux-cli
-          cp "${SOURCE}" "src-tauri/binaries/roux-cli-${TARGET}"
-          chmod +x src-tauri/binaries/roux src-tauri/binaries/roux-cli "src-tauri/binaries/roux-${TARGET}" "src-tauri/binaries/roux-cli-${TARGET}"
+          chmod +x src-tauri/binaries/roux "src-tauri/binaries/roux-${TARGET}"
           echo "Prepared bundled Roux CLI from ${SOURCE}"
         platforms: [darwin]
 

--- a/taskfiles/Taskfile_windows.yml
+++ b/taskfiles/Taskfile_windows.yml
@@ -17,8 +17,6 @@ tasks:
           mkdir -p src-tauri/binaries
           cp -f target/release/roux.exe src-tauri/binaries/roux.exe
           cp -f target/release/roux.exe "src-tauri/binaries/roux-${TARGET}.exe"
-          cp -f target/release/roux.exe src-tauri/binaries/roux-cli.exe
-          cp -f target/release/roux.exe "src-tauri/binaries/roux-cli-${TARGET}.exe"
           echo "Prepared bundled Roux CLI for ${TARGET}"
         platforms: [windows]
 


### PR DESCRIPTION
## Summary
- removes the split `roux`/`roux-cli` sidecar layout so the CLI is consistently installed and invoked as `roux`
- adds standalone CLI release packaging, curl install support, and Homebrew tap documentation
- publishes release automation for CLI assets and automatic Homebrew formula/cask updates
- updates setup/install behavior so CLI reinstall still falls back to an existing `roux` in dev/source environments

## Root Cause
The desktop app bundled and installed multiple CLI names, while setup/update logic expected different paths in different contexts. That made the Settings/Doctor CLI upgrade action brittle, especially when the app had a newer bundled sidecar than the user-installed CLI.

## User Impact
Users get one canonical CLI command, `roux`, plus documented install paths:

```sh
brew install phin-tech/tap/roux
brew install --cask phin-tech/tap/roux
```

Prerelease installs are documented as `roux-pre` for both formula and cask.

## Validation
- `bash -n scripts/package-cli-release.sh`
- `sh -n scripts/install-cli.sh`
- release workflow YAML parse
- extracted Homebrew workflow script `bash -n`
- `git diff --check`
- `cargo test -p roux-desktop hooks::tests`
- `brew style Formula/roux.rb Formula/roux-pre.rb Casks/roux.rb Casks/roux-pre.rb`
- `brew audit --formula phin-tech/tap/roux phin-tech/tap/roux-pre`
- `brew audit --cask phin-tech/tap/roux phin-tech/tap/roux-pre`
- `brew info` for stable/prerelease formulae and casks

Roborev job 35 findings were fixed and closed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standalone CLI distributions now available as downloadable tarballs for macOS and Linux.
  * Homebrew installation support added for both stable and prerelease CLI builds.
  * Automated release pipeline now publishes to Homebrew tap.
  * New CLI installation script simplifies setup across platforms.

* **Documentation**
  * Expanded installation guides with multiple setup options including Homebrew and prerelease channels.
  * Updated CLI documentation reflecting new distribution methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR unifies the CLI install and release paths by removing the dual `roux`/`roux-cli` sidecar layout. It adds standalone CLI release tarballs, a `curl | sh` install script, Homebrew formula/cask generation in the release workflow, and updates all internal path lookups to drop the legacy `roux-cli` compat alias.

- **Sidecar consolidation**: `tauri.conf.json`, taskfiles, `build.rs`, `hooks.rs`, and `pty.rs` all drop the `roux-cli` binary/symlink, keeping only `roux`. The `roux_cli_path` candidate lists and PTY shim are trimmed accordingly.
- **New release pipeline**: A `release-cli` job cross-compiles tarballs for macOS ARM64/x86_64 and Linux x86_64; an `update-homebrew-tap` job generates and pushes Homebrew formulae and casks to `phin-tech/homebrew-tap`, computing the source and DMG SHA256 values by downloading the assets at release time.
- **Install UX**: `scripts/install-cli.sh` supports `latest`, versioned, and repo-overridden installs with inline SHA256 verification; `setup.rs` is refactored so `reinstall_cli` calls `install_cli` directly instead of relying on the side-effect path through `install_hooks`.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The sidecar consolidation is consistent across all Rust, Tauri config, taskfile, and PTY shim layers, and the new release pipeline is logically sound.

All functional paths — hook installation, CLI reinstall, PTY shim, dev placeholders, and release packaging — are updated in lockstep. The only observations are a missing PATH notification in the install script and a known fragility with GitHub archive tarball SHAs in Homebrew formulae, neither of which affects the core desktop or CLI runtime.

`.github/workflows/release.yml` — specifically the `SOURCE_URL` used for the Homebrew formula SHA, which relies on a GitHub archive tarball that can be regenerated.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Adds `release-cli` (cross-compile + upload tarballs) and `update-homebrew-tap` (generate formula/cask, push to tap) jobs. Homebrew formula sha256 is derived from a GitHub archive tarball which can be regenerated by GitHub; cask sha256 downloads the full DMG inline. |
| scripts/install-cli.sh | New POSIX install script for the standalone CLI; handles platform detection, optional SHA256 verification, and installs to `~/.local/bin` by default. Logic is solid; no PATH notification at the end. |
| scripts/package-cli-release.sh | New packaging script that builds `roux-cli`, creates a versioned tarball, and writes a `.sha256` file. Correctly uses the env-var version in CI and extracts from Cargo.toml locally. |
| src-tauri/src/hooks.rs | Removes all `roux-cli` compat paths; exposes a standalone `install_cli()` function; `install_cli_binary_path` falls back to `roux_cli_path()` in dev builds where no bundled sidecar exists. |
| src-tauri/src/commands/setup.rs | `reinstall_cli` now calls `install_cli()` directly instead of piggy-backing on `install_hooks`; `install_all_missing` separates hook and CLI install paths cleanly. |
| src-tauri/src/pty.rs | PTY shim now creates only a `roux` symlink/copy instead of both `roux` and `roux-cli`; refactors the Unix and Windows paths from loops to single-target blocks. |
| src-tauri/tauri.conf.json | Removes `binaries/roux-cli` from `externalBin` and `MacOS/roux-cli` from the macOS files map; only `roux` remains as a bundled sidecar. |
| Taskfile.yml | Removes all `roux-cli` placeholder/copy steps from dev and release tasks; adds `cli:package-release` task delegating to the new script. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[release-macos job\nbuilds & publishes DMG] -->|outputs release_version| B[release-cli job\nmatrix: 3 targets]
    B -->|package-cli-release.sh| C[roux-TARGET.tar.gz\n+ .sha256]
    C -->|gh release upload| D[GitHub Release Assets]

    A --> E[update-homebrew-tap job]
    B --> E
    E -->|curl archive tarball| F[Compute SOURCE_SHA]
    E -->|curl DMG| G[Compute DMG_SHA]
    F --> H[Generate Formula/roux.rb\nor Formula/roux-pre.rb]
    G --> I[Generate Casks/roux.rb\nor Casks/roux-pre.rb]
    H --> J[git push to phin-tech/homebrew-tap]
    I --> J

    K[User: curl install-cli.sh] -->|download tarball\nverify SHA256\nextract & install| L[~/.local/bin/roux]
    D --> K
    M[User: brew install phin-tech/tap/roux] -->|cargo build from source| N[Homebrew prefix bin/roux]
    J --> M
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src-tauri/src/commands/setup.rs`, line 285-295 ([link](https://github.com/phin-tech/roux/blob/fa385433c6dbe6a5b295d361e13774ca2526bf18/src-tauri/src/commands/setup.rs#L285-L295)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Implicit CLI install via `install_hooks` side-effect is no longer commented**

   The `else if` structure is correct: `install_hooks()` internally calls `install_cli_binary_path()`, so the CLI still gets installed when hooks are missing. However, the comments explaining this side-effect relationship were removed (they were in the old code at this call site). A reader seeing only this function now has no signal that calling `install_hooks()` also installs the binary, which is non-obvious from the function name. If that side-effect is ever removed from `install_hooks`, the `else if cli_needs_install` branch would silently stop being reached in the fresh-install path. A brief comment here would preserve that invariant.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src-tauri%2Fsrc%2Fcommands%2Fsetup.rs%0ALine%3A%20285-295%0A%0AComment%3A%0A**Implicit%20CLI%20install%20via%20%60install_hooks%60%20side-effect%20is%20no%20longer%20commented**%0A%0AThe%20%60else%20if%60%20structure%20is%20correct%3A%20%60install_hooks%28%29%60%20internally%20calls%20%60install_cli_binary_path%28%29%60%2C%20so%20the%20CLI%20still%20gets%20installed%20when%20hooks%20are%20missing.%20However%2C%20the%20comments%20explaining%20this%20side-effect%20relationship%20were%20removed%20%28they%20were%20in%20the%20old%20code%20at%20this%20call%20site%29.%20A%20reader%20seeing%20only%20this%20function%20now%20has%20no%20signal%20that%20calling%20%60install_hooks%28%29%60%20also%20installs%20the%20binary%2C%20which%20is%20non-obvious%20from%20the%20function%20name.%20If%20that%20side-effect%20is%20ever%20removed%20from%20%60install_hooks%60%2C%20the%20%60else%20if%20cli_needs_install%60%20branch%20would%20silently%20stop%20being%20reached%20in%20the%20fresh-install%20path.%20A%20brief%20comment%20here%20would%20preserve%20that%20invariant.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=phin-tech%2Froux&pr=213&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22fix%2Finstall-cli-not-working%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Finstall-cli-not-working%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src-tauri%2Fsrc%2Fcommands%2Fsetup.rs%0ALine%3A%20285-295%0A%0AComment%3A%0A**Implicit%20CLI%20install%20via%20%60install_hooks%60%20side-effect%20is%20no%20longer%20commented**%0A%0AThe%20%60else%20if%60%20structure%20is%20correct%3A%20%60install_hooks%28%29%60%20internally%20calls%20%60install_cli_binary_path%28%29%60%2C%20so%20the%20CLI%20still%20gets%20installed%20when%20hooks%20are%20missing.%20However%2C%20the%20comments%20explaining%20this%20side-effect%20relationship%20were%20removed%20%28they%20were%20in%20the%20old%20code%20at%20this%20call%20site%29.%20A%20reader%20seeing%20only%20this%20function%20now%20has%20no%20signal%20that%20calling%20%60install_hooks%28%29%60%20also%20installs%20the%20binary%2C%20which%20is%20non-obvious%20from%20the%20function%20name.%20If%20that%20side-effect%20is%20ever%20removed%20from%20%60install_hooks%60%2C%20the%20%60else%20if%20cli_needs_install%60%20branch%20would%20silently%20stop%20being%20reached%20in%20the%20fresh-install%20path.%20A%20brief%20comment%20here%20would%20preserve%20that%20invariant.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Finstall-cli.sh%3A67%0AAfter%20installing%20into%20%60%24INSTALL_DIR%60%2C%20the%20script%20doesn't%20check%20whether%20that%20directory%20is%20on%20%60PATH%60.%20On%20fresh%20Linux%20systems%20and%20many%20macOS%20setups%20%60~%2F.local%2Fbin%60%20is%20not%20in%20%60PATH%60%20by%20default%2C%20so%20the%20installed%20binary%20would%20be%20silently%20unreachable%20until%20the%20user%20adds%20it%20manually.%20Adding%20a%20one-liner%20post-install%20note%20would%20surface%20this%20immediately.%0A%0A%60%60%60suggestion%0Aecho%20%22Installed%20roux%20to%20%24%7BINSTALL_DIR%7D%2Froux%22%0Acase%20%22%3A%24%7BPATH%7D%3A%22%20in%0A%20%20*%22%3A%24%7BINSTALL_DIR%7D%3A%22*%29%20%3B%3B%0A%20%20*%29%20echo%20%22NOTE%3A%20%24%7BINSTALL_DIR%7D%20is%20not%20in%20your%20PATH.%20Add%20it%20to%20your%20shell%20profile%20to%20use%20roux%20from%20any%20terminal.%22%20%3E%262%20%3B%3B%0Aesac%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Frelease.yml%3A108-109%0A**GitHub%20archive%20tarball%20SHA%20can%20silently%20change**%0A%0A%60SOURCE_URL%60%20points%20to%20%60archive%2Frefs%2Ftags%2F%24%7BTAG%7D.tar.gz%60.%20GitHub%20occasionally%20regenerates%20these%20on-the-fly%20%28e.g.%2C%20when%20internal%20Git%20object%20packing%20changes%29%2C%20which%20produces%20a%20different%20byte%20sequence%20and%20therefore%20a%20different%20SHA256.%20If%20that%20happens%20after%20the%20formula%20is%20pushed%2C%20%60brew%20install%20phin-tech%2Ftap%2Froux%60%20will%20fail%20with%20a%20checksum%20mismatch%20for%20any%20user%20who%20tries%20to%20install%20between%20regenerations%2C%20requiring%20a%20manual%20tap%20update.%0A%0AA%20more%20stable%20alternative%20is%20to%20upload%20a%20deterministic%20source%20tarball%20as%20a%20named%20release%20asset%20and%20use%20that%20asset%20URL%20in%20the%20formula.%20%60cargo%20package%20--no-verify%60%20can%20produce%20a%20reproducible%20%60.crate%60%20tarball%2C%20or%20a%20straightforward%20%60git%20archive%60%20at%20CI%20time%20can%20be%20uploaded%20alongside%20the%20CLI%20tarballs.%20Homebrew's%20own%20audit%20recommends%20tagged%20release%20assets%20over%20dynamic%20archive%20URLs%20for%20this%20reason.%0A%0A&repo=phin-tech%2Froux&pr=213&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22fix%2Finstall-cli-not-working%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Finstall-cli-not-working%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Finstall-cli.sh%3A67%0AAfter%20installing%20into%20%60%24INSTALL_DIR%60%2C%20the%20script%20doesn't%20check%20whether%20that%20directory%20is%20on%20%60PATH%60.%20On%20fresh%20Linux%20systems%20and%20many%20macOS%20setups%20%60~%2F.local%2Fbin%60%20is%20not%20in%20%60PATH%60%20by%20default%2C%20so%20the%20installed%20binary%20would%20be%20silently%20unreachable%20until%20the%20user%20adds%20it%20manually.%20Adding%20a%20one-liner%20post-install%20note%20would%20surface%20this%20immediately.%0A%0A%60%60%60suggestion%0Aecho%20%22Installed%20roux%20to%20%24%7BINSTALL_DIR%7D%2Froux%22%0Acase%20%22%3A%24%7BPATH%7D%3A%22%20in%0A%20%20*%22%3A%24%7BINSTALL_DIR%7D%3A%22*%29%20%3B%3B%0A%20%20*%29%20echo%20%22NOTE%3A%20%24%7BINSTALL_DIR%7D%20is%20not%20in%20your%20PATH.%20Add%20it%20to%20your%20shell%20profile%20to%20use%20roux%20from%20any%20terminal.%22%20%3E%262%20%3B%3B%0Aesac%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Frelease.yml%3A108-109%0A**GitHub%20archive%20tarball%20SHA%20can%20silently%20change**%0A%0A%60SOURCE_URL%60%20points%20to%20%60archive%2Frefs%2Ftags%2F%24%7BTAG%7D.tar.gz%60.%20GitHub%20occasionally%20regenerates%20these%20on-the-fly%20%28e.g.%2C%20when%20internal%20Git%20object%20packing%20changes%29%2C%20which%20produces%20a%20different%20byte%20sequence%20and%20therefore%20a%20different%20SHA256.%20If%20that%20happens%20after%20the%20formula%20is%20pushed%2C%20%60brew%20install%20phin-tech%2Ftap%2Froux%60%20will%20fail%20with%20a%20checksum%20mismatch%20for%20any%20user%20who%20tries%20to%20install%20between%20regenerations%2C%20requiring%20a%20manual%20tap%20update.%0A%0AA%20more%20stable%20alternative%20is%20to%20upload%20a%20deterministic%20source%20tarball%20as%20a%20named%20release%20asset%20and%20use%20that%20asset%20URL%20in%20the%20formula.%20%60cargo%20package%20--no-verify%60%20can%20produce%20a%20reproducible%20%60.crate%60%20tarball%2C%20or%20a%20straightforward%20%60git%20archive%60%20at%20CI%20time%20can%20be%20uploaded%20alongside%20the%20CLI%20tarballs.%20Homebrew's%20own%20audit%20recommends%20tagged%20release%20assets%20over%20dynamic%20archive%20URLs%20for%20this%20reason.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Fix Homebrew tap update workflow"](https://github.com/phin-tech/roux/commit/cfdb3406cdc6da616e7d52a9c575026395448d89) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34759203)</sub>

<!-- /greptile_comment -->