### PR TITLE
Allow Worktrunk panel to create worktrees without an active session

### DIFF
--- a/src/lib/components/WorktrunkPanel.svelte
+++ b/src/lib/components/WorktrunkPanel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import PinButton from "./PinButton.svelte";
+  import RepoPickerField from "./RepoPickerField.svelte";
   import { commands } from "$lib/bindings";
   import type {
     WorktrunkDiagnostics,
@@ -120,6 +121,10 @@
   let newBranch = $state("");
   let newBase = $state<WorktreeDefaultBase>("currentBranch");
   let creatingNew = $state(false);
+  // Branch name of the most-recently created worktree; drives the
+  // "Open session" prompt.  Cleared when the user acts on it or creates
+  // another worktree.
+  let justCreatedBranch = $state<string | null>(null);
 
   // Sync the base selector to the user's default whenever the form opens.
   $effect(() => {
@@ -152,12 +157,15 @@
     }
     creatingNew = true;
     worktreesError = null;
+    justCreatedBranch = null;
     try {
       const { startPoint, fetchFirst } = resolveNewWorktreeBase(newBase);
       await createWorktree(currentRepo, branch, { startPoint, fetchFirst });
       newBranch = "";
       newFormOpen = false;
       await loadWorktrees(currentRepo);
+      // Offer to open a session in the just-created worktree.
+      justCreatedBranch = branch;
     } catch (err) {
       const msg = typeof err === "string" ? err : String(err);
       worktreesError = `Failed to create worktree: ${msg}`;
@@ -174,7 +182,13 @@
   let readerError = $state<string | null>(null);
   let readerLoading = $state(false);
 
-  let currentRepo = $derived(visible ? ($activeSession?.repoRoot ?? null) : null);
+  // When there is no active session the user can pick a repo explicitly.
+  // Active session always wins by default; an explicit pick overrides it;
+  // clearing the override falls back to the active session.
+  let selectedRepoOverride = $state<string | null>(null);
+  let currentRepo = $derived(
+    visible ? (selectedRepoOverride ?? $activeSession?.repoRoot ?? null) : null,
+  );
 
   /**
    * Shorten a repo path for header display. Looks for a known forge
@@ -231,6 +245,7 @@
     contextMenuFor = null;
     contextBusy = false;
     contextError = null;
+    justCreatedBranch = null;
   }
 
   // Map of worktree path → first active (non-archived) session that
@@ -252,6 +267,14 @@
   function isRemovableWorktree(wt: Worktree): boolean {
     return !wt.isMain && !worktreePathsWithSession.has(wt.path);
   }
+
+  // Find the newly created worktree in the refreshed list so we can
+  // offer to open a session in it.
+  let justCreatedWorktree = $derived(
+    justCreatedBranch != null
+      ? (worktrees.find((wt) => wt.branch === justCreatedBranch) ?? null)
+      : null,
+  );
 
   let filteredWorktrees = $derived.by(() => {
     const q = filterText.trim().toLowerCase();
@@ -897,17 +920,39 @@
       >
       <span
         data-testid="worktrunk-repo-label"
-        class="truncate font-mono text-[10px] text-text-secondary"
+        class="min-w-0 flex-1 truncate font-mono text-[10px] text-text-secondary"
         >{currentRepoLabel}</span
       >
+      {#if selectedRepoOverride !== null && selectedRepoOverride !== $activeSession?.repoRoot}
+        <button
+          type="button"
+          data-testid="worktrunk-repo-clear"
+          class="shrink-0 cursor-pointer rounded px-1 text-[9px] text-text-muted hover:bg-bg-hover hover:text-text-primary"
+          title="Clear repo override and return to picker / active session"
+          onclick={() => { selectedRepoOverride = null; }}
+        >Change</button>
+      {/if}
     </div>
   {/if}
 
   {#if !currentRepo}
     <div
-      class="flex flex-1 items-center justify-center px-6 text-center text-sm text-text-secondary"
+      data-testid="worktrunk-repo-picker"
+      class="flex flex-1 flex-col gap-3 overflow-y-auto p-4"
     >
-      Open a session to view its worktrunk state.
+      <p class="text-[11px] text-text-muted">
+        Pick a repo to browse its worktrees, or open a session to auto-select one.
+      </p>
+      <RepoPickerField
+        value=""
+        label={null}
+        placeholder="Search repos…"
+        showRefresh={false}
+        showBrowse={false}
+        noReposText="No git repos found. Configure repo roots in Settings."
+        onselect={(path) => { selectedRepoOverride = path; }}
+        onenter={(text) => { if (text.trim()) selectedRepoOverride = text.trim(); }}
+      />
     </div>
   {:else}
     <div class="flex shrink-0 border-b border-hairline bg-bg-surface/20 text-[11px]">
@@ -1105,6 +1150,35 @@
                 onclick={handleCreateNew}
                 disabled={creatingNew || !newBranch.trim()}
               >{creatingNew ? "Creating…" : "Create"}</button>
+            </div>
+          </div>
+        {/if}
+
+        {#if justCreatedWorktree}
+          <div
+            data-testid="worktrunk-open-session-after-create"
+            class="mx-2 mb-2 flex items-center justify-between gap-2 rounded border border-accent-dim/40 bg-accent-dim/10 px-2 py-1.5 text-[11px] text-text-secondary"
+          >
+            <span class="min-w-0 truncate">
+              <span class="font-mono text-text-primary">{justCreatedWorktree.branch}</span> created.
+            </span>
+            <div class="flex shrink-0 items-center gap-1">
+              <button
+                type="button"
+                data-testid="worktrunk-open-session-after-create-btn"
+                class="inline-flex h-5 cursor-pointer items-center rounded border border-accent-dim/60 bg-accent-dim/20 px-2 text-[10px] text-accent hover:bg-accent-dim/40 disabled:opacity-40"
+                disabled={spawning === justCreatedWorktree.path}
+                onclick={() => { void handleNewSessionHere(justCreatedWorktree!); justCreatedBranch = null; }}
+              >{spawning === justCreatedWorktree.path ? "Starting…" : "Open session"}</button>
+              <button
+                type="button"
+                class="inline-flex h-5 w-5 cursor-pointer items-center justify-center rounded text-text-muted hover:bg-bg-hover hover:text-text-primary"
+                aria-label="Dismiss"
+                title="Dismiss"
+                onclick={() => { justCreatedBranch = null; }}
+              >
+                <X size={11} />
+              </button>
             </div>
           </div>
         {/if}

--- a/src/lib/components/__tests__/WorktrunkPanel.test.ts
+++ b/src/lib/components/__tests__/WorktrunkPanel.test.ts
@@ -57,7 +57,9 @@ import {
 import { revealItemInDir } from "@tauri-apps/plugin-opener";
 import WorktrunkPanel from "../WorktrunkPanel.svelte";
 import { sessionState } from "$lib/stores/sessions";
+import { settings } from "$lib/stores/settings";
 import type { Session } from "$lib/types";
+import { DEFAULT_SETTINGS } from "$lib/types";
 import { _setWorktrunkDetectionForTests } from "$lib/stores/worktrunkDetection";
 import { _resetWorktreeMetadataForTests } from "$lib/stores/worktreeMetadata";
 
@@ -1768,6 +1770,7 @@ describe("WorktrunkPanel — no-session repo picker", () => {
     vi.mocked(createWorktree).mockReset();
     invokeMock.mockReset();
     sessionState.set({ sessions: [], activeSessionId: null });
+    settings.set(DEFAULT_SETTINGS);
     _resetWorktreeMetadataForTests();
     _setWorktrunkDetectionForTests({
       binaryPath: "/opt/homebrew/bin/wt",
@@ -1778,19 +1781,28 @@ describe("WorktrunkPanel — no-session repo picker", () => {
 
   afterEach(() => {
     sessionState.set({ sessions: [], activeSessionId: null });
+    settings.set(DEFAULT_SETTINGS);
     _resetWorktreeMetadataForTests();
   });
 
   it("renders a repo picker (not dead-end) when no session is active and repo roots are configured", async () => {
+    // Set configured repo roots so RepoPickerField triggers the invoke call.
+    settings.update((s) => ({ ...s, repoRoots: ["/workspace/roux"] }));
     invokeMock.mockResolvedValue(["/workspace/roux"]);
     const { findByTestId } = render(WorktrunkPanel, {
       props: { visible: true, onclose: () => {} },
     });
-    // Should find the repo picker, not the old dead-end message
+    // Should find the repo picker, not the old dead-end message.
     expect(await findByTestId("worktrunk-repo-picker")).toBeDefined();
+    // The picker should have triggered a scan of configured roots.
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith("list_git_repos_in_roots", expect.any(Object));
+    });
   });
 
   it("selecting a repo from the picker loads worktrees for that repo", async () => {
+    // Set configured repo roots so the autocomplete dropdown is available.
+    settings.update((s) => ({ ...s, repoRoots: ["/workspace/roux"] }));
     invokeMock.mockResolvedValue(["/workspace/roux"]);
     vi.mocked(commands.cmdWorktrunkDiagnostics).mockResolvedValue(
       okDiagnostics(makeDiagnostics()),
@@ -1807,7 +1819,7 @@ describe("WorktrunkPanel — no-session repo picker", () => {
     // RepoAutoComplete renders a Command.Input (<input role="combobox">)
     const pickerInput = within(pickerContainer).getByRole("combobox") as HTMLInputElement;
     await fireEvent.input(pickerInput, { target: { value: "/workspace/roux" } });
-    // Simulate Enter to trigger onenter
+    // Simulate Enter to trigger onenter (raw text path when no dropdown match).
     await fireEvent.keyDown(pickerInput, { key: "Enter" });
     await tick();
 
@@ -1817,6 +1829,8 @@ describe("WorktrunkPanel — no-session repo picker", () => {
   });
 
   it("calls createWorktree with the picked repo path (not session repo)", async () => {
+    // Set configured repo roots so the picker can resolve the repo.
+    settings.update((s) => ({ ...s, repoRoots: ["/workspace/roux"] }));
     invokeMock.mockResolvedValue(["/workspace/roux"]);
     vi.mocked(commands.cmdWorktrunkDiagnostics).mockResolvedValue(
       okDiagnostics(makeDiagnostics()),
@@ -1852,7 +1866,6 @@ describe("WorktrunkPanel — no-session repo picker", () => {
   it("active session auto-selects its repo when no override is set", async () => {
     const s = makeSession({ repoRoot: "/project" });
     sessionState.set({ sessions: [s], activeSessionId: s.id });
-    invokeMock.mockResolvedValue(["/project"]);
     vi.mocked(commands.cmdWorktrunkDiagnostics).mockResolvedValue(
       okDiagnostics(makeDiagnostics()),
     );

--- a/src/lib/components/__tests__/WorktrunkPanel.test.ts
+++ b/src/lib/components/__tests__/WorktrunkPanel.test.ts
@@ -1,9 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { tick } from "svelte";
-import { fireEvent, render, waitFor } from "@testing-library/svelte";
+import { fireEvent, render, waitFor, within } from "@testing-library/svelte";
 import { get } from "svelte/store";
 import type { WorktrunkDiagnostics } from "$lib/bindings";
 import type { Worktree, WorktrunkMetadata } from "$lib/types";
+
+// hoisted so the mock factory can close over it
+const invokeMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: invokeMock,
+}));
 
 vi.mock("$lib/bindings", () => ({
   commands: {
@@ -153,13 +160,14 @@ describe("WorktrunkPanel", () => {
     });
   });
 
-  it("shows an empty state when no session is active", () => {
-    const { getByText } = render(WorktrunkPanel, {
+  it("shows the repo picker area (not dead-end) when no session is active", () => {
+    // DEFAULT_SETTINGS has repoRoots: [] so no roots are configured.
+    invokeMock.mockResolvedValue([]);
+    const { getByTestId } = render(WorktrunkPanel, {
       props: { visible: true, onclose: () => {} },
     });
-    expect(
-      getByText(/Open a session to view its worktrunk state/i),
-    ).toBeDefined();
+    // Should show the repo picker area, not the old dead-end message.
+    expect(getByTestId("worktrunk-repo-picker")).toBeDefined();
   });
 
   it("renders Hooks rows after switching to the Hooks tab", async () => {
@@ -1750,6 +1758,211 @@ describe("WorktrunkPanel — right-click context menu", () => {
     await fireEvent.click(await r.findByTestId("worktrunk-context-terminal"));
     const err = await r.findByTestId("worktrunk-context-error");
     expect(err.textContent).toContain("no terminal found");
+  });
+});
+
+describe("WorktrunkPanel — no-session repo picker", () => {
+  beforeEach(() => {
+    vi.mocked(commands.cmdWorktrunkDiagnostics).mockReset();
+    vi.mocked(listWorktrees).mockReset().mockResolvedValue([]);
+    vi.mocked(createWorktree).mockReset();
+    invokeMock.mockReset();
+    sessionState.set({ sessions: [], activeSessionId: null });
+    _resetWorktreeMetadataForTests();
+    _setWorktrunkDetectionForTests({
+      binaryPath: "/opt/homebrew/bin/wt",
+      version: "0.44.0",
+      probed: true,
+    });
+  });
+
+  afterEach(() => {
+    sessionState.set({ sessions: [], activeSessionId: null });
+    _resetWorktreeMetadataForTests();
+  });
+
+  it("renders a repo picker (not dead-end) when no session is active and repo roots are configured", async () => {
+    invokeMock.mockResolvedValue(["/workspace/roux"]);
+    const { findByTestId } = render(WorktrunkPanel, {
+      props: { visible: true, onclose: () => {} },
+    });
+    // Should find the repo picker, not the old dead-end message
+    expect(await findByTestId("worktrunk-repo-picker")).toBeDefined();
+  });
+
+  it("selecting a repo from the picker loads worktrees for that repo", async () => {
+    invokeMock.mockResolvedValue(["/workspace/roux"]);
+    vi.mocked(commands.cmdWorktrunkDiagnostics).mockResolvedValue(
+      okDiagnostics(makeDiagnostics()),
+    );
+    vi.mocked(listWorktrees).mockResolvedValue([
+      makeWorktree({ path: "/workspace/roux", branch: "main", isMain: true }),
+    ]);
+
+    const { findByTestId } = render(WorktrunkPanel, {
+      props: { visible: true, onclose: () => {} },
+    });
+    const pickerContainer = await findByTestId("worktrunk-repo-picker");
+
+    // RepoAutoComplete renders a Command.Input (<input role="combobox">)
+    const pickerInput = within(pickerContainer).getByRole("combobox") as HTMLInputElement;
+    await fireEvent.input(pickerInput, { target: { value: "/workspace/roux" } });
+    // Simulate Enter to trigger onenter
+    await fireEvent.keyDown(pickerInput, { key: "Enter" });
+    await tick();
+
+    await waitFor(() => {
+      expect(listWorktrees).toHaveBeenCalledWith("/workspace/roux");
+    });
+  });
+
+  it("calls createWorktree with the picked repo path (not session repo)", async () => {
+    invokeMock.mockResolvedValue(["/workspace/roux"]);
+    vi.mocked(commands.cmdWorktrunkDiagnostics).mockResolvedValue(
+      okDiagnostics(makeDiagnostics()),
+    );
+    vi.mocked(listWorktrees).mockResolvedValue([
+      makeWorktree({ path: "/workspace/roux", branch: "main", isMain: true }),
+    ]);
+    vi.mocked(createWorktree).mockResolvedValueOnce("/workspace/roux-feat-z");
+
+    const { findByTestId, getByTestId } = render(WorktrunkPanel, {
+      props: { visible: true, onclose: () => {} },
+    });
+    const pickerContainer = await findByTestId("worktrunk-repo-picker");
+
+    const pickerInput = within(pickerContainer).getByRole("combobox") as HTMLInputElement;
+    await fireEvent.input(pickerInput, { target: { value: "/workspace/roux" } });
+    await fireEvent.keyDown(pickerInput, { key: "Enter" });
+    await tick();
+
+    // Wait for worktrees to load (which signals repo is selected)
+    await waitFor(() => expect(listWorktrees).toHaveBeenCalledWith("/workspace/roux"));
+
+    await fireEvent.click(await findByTestId("worktrunk-new-worktree-open"));
+    const branchInput = (await findByTestId("worktrunk-new-worktree-branch")) as HTMLInputElement;
+    await fireEvent.input(branchInput, { target: { value: "feat-z" } });
+    await fireEvent.click(getByTestId("worktrunk-new-worktree-submit"));
+
+    await waitFor(() =>
+      expect(createWorktree).toHaveBeenCalledWith("/workspace/roux", "feat-z", expect.any(Object)),
+    );
+  });
+
+  it("active session auto-selects its repo when no override is set", async () => {
+    const s = makeSession({ repoRoot: "/project" });
+    sessionState.set({ sessions: [s], activeSessionId: s.id });
+    invokeMock.mockResolvedValue(["/project"]);
+    vi.mocked(commands.cmdWorktrunkDiagnostics).mockResolvedValue(
+      okDiagnostics(makeDiagnostics()),
+    );
+    vi.mocked(listWorktrees).mockResolvedValue([
+      makeWorktree({ path: "/project", branch: "main", isMain: true }),
+    ]);
+
+    const { findByTestId, queryByTestId } = render(WorktrunkPanel, {
+      props: { visible: true, onclose: () => {} },
+    });
+    // Repo strip should show the session's repo, not the picker
+    expect(await findByTestId("worktrunk-repo-strip")).toBeDefined();
+    expect(queryByTestId("worktrunk-repo-picker")).toBeNull();
+    expect(listWorktrees).toHaveBeenCalledWith("/project");
+  });
+});
+
+describe("WorktrunkPanel — open-session-after-create", () => {
+  let confirmSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.mocked(commands.cmdWorktrunkDiagnostics).mockReset();
+    vi.mocked(listWorktrees).mockReset().mockResolvedValue([]);
+    vi.mocked(createWorktree).mockReset();
+    vi.mocked(createSessionShell).mockReset();
+    invokeMock.mockReset();
+    sessionState.set({ sessions: [], activeSessionId: null });
+    _resetWorktreeMetadataForTests();
+    _setWorktrunkDetectionForTests({
+      binaryPath: "/opt/homebrew/bin/wt",
+      version: "0.44.0",
+      probed: true,
+    });
+    confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    confirmSpy.mockRestore();
+    sessionState.set({ sessions: [], activeSessionId: null });
+  });
+
+  it("shows an open-session prompt after creating a worktree", async () => {
+    const s = makeSession({ repoRoot: "/project" });
+    sessionState.set({ sessions: [s], activeSessionId: s.id });
+    vi.mocked(commands.cmdWorktrunkDiagnostics).mockResolvedValue(
+      okDiagnostics(makeDiagnostics()),
+    );
+    vi.mocked(listWorktrees)
+      .mockResolvedValueOnce([
+        { path: "/project", branch: "main", isMain: true, worktrunk: null },
+      ])
+      .mockResolvedValueOnce([
+        { path: "/project", branch: "main", isMain: true, worktrunk: null },
+        { path: "/project-feat-new", branch: "feat-new", isMain: false, worktrunk: null },
+      ]);
+    vi.mocked(createWorktree).mockResolvedValueOnce("/project-feat-new");
+
+    const { findByTestId, getByTestId } = render(WorktrunkPanel, {
+      props: { visible: true, onclose: () => {} },
+    });
+
+    await fireEvent.click(await findByTestId("worktrunk-new-worktree-open"));
+    const branchInput = (await findByTestId("worktrunk-new-worktree-branch")) as HTMLInputElement;
+    await fireEvent.input(branchInput, { target: { value: "feat-new" } });
+    await fireEvent.click(getByTestId("worktrunk-new-worktree-submit"));
+
+    // After create, an "Open session" button should appear
+    expect(await findByTestId("worktrunk-open-session-after-create-btn")).toBeDefined();
+  });
+
+  it("clicking open-session-after-create calls createSessionShell with the new worktree", async () => {
+    const s = makeSession({ repoRoot: "/project" });
+    sessionState.set({ sessions: [s], activeSessionId: s.id });
+    vi.mocked(commands.cmdWorktrunkDiagnostics).mockResolvedValue(
+      okDiagnostics(makeDiagnostics()),
+    );
+    vi.mocked(listWorktrees)
+      .mockResolvedValueOnce([
+        { path: "/project", branch: "main", isMain: true, worktrunk: null },
+      ])
+      .mockResolvedValueOnce([
+        { path: "/project", branch: "main", isMain: true, worktrunk: null },
+        { path: "/project-feat-new", branch: "feat-new", isMain: false, worktrunk: null },
+      ]);
+    vi.mocked(createWorktree).mockResolvedValueOnce("/project-feat-new");
+    vi.mocked(createSessionShell).mockResolvedValueOnce(
+      makeSession({ id: "new-sess", repoRoot: "/project", worktreePath: "/project-feat-new", branch: "feat-new", isWorktree: true }),
+    );
+
+    const { findByTestId, getByTestId } = render(WorktrunkPanel, {
+      props: { visible: true, onclose: () => {} },
+    });
+
+    await fireEvent.click(await findByTestId("worktrunk-new-worktree-open"));
+    const branchInput = (await findByTestId("worktrunk-new-worktree-branch")) as HTMLInputElement;
+    await fireEvent.input(branchInput, { target: { value: "feat-new" } });
+    await fireEvent.click(getByTestId("worktrunk-new-worktree-submit"));
+
+    const openBtn = await findByTestId("worktrunk-open-session-after-create-btn");
+    await fireEvent.click(openBtn);
+
+    await waitFor(() => {
+      expect(createSessionShell).toHaveBeenCalledWith(
+        "/project",
+        expect.any(String),
+        "/project-feat-new",
+        "feat-new",
+        expect.any(Object),
+      );
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Lets the Worktrunk panel create a worktree from a configured repo root **without requiring an active session**. The backend (daemon `worktree-create`/`worktree-list`, Tauri `cmd_create_worktree`/`cmd_list_worktrees`) was already session-agnostic — it accepts an arbitrary `repoPath`. The only constraint was the GUI: `WorktrunkPanel.svelte` derived its repo solely from `$activeSession?.repoRoot`, so with no session open the panel showed a dead end. This is a **frontend-only** change.

## Changes

- `currentRepo` now resolves `selectedRepoOverride ?? $activeSession?.repoRoot ?? null`. Active session wins by default; an explicit pick overrides it; clearing the override falls back to the active session.
- The no-session empty state ("Open a session to view…") is replaced by a `RepoPickerField` that enumerates repos from `settings.repoRoots` (via the existing `list_git_repos_in_roots`).
- The repo strip gains a **Change** affordance to clear the override and return to the picker / active session.
- After a worktree is created, an inline banner offers **Open session** in the new worktree (reuses the existing `handleNewSessionHere` flow).

No Rust, daemon-protocol, or docs changes — none were needed.

## Testing

- `npx vitest run src/lib/components/__tests__/WorktrunkPanel.test.ts` → PASS (52/52, 6 new)
- `npm run check` → PASS (0 errors, 0 warnings)

New tests cover: picker renders with no session + configured roots, selecting a repo loads its worktrees, create uses the picked repo, active session still auto-selects when no override, and the open-session-after-create prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Repository picker now allows overriding the active session's repository selection.
  * New "Open session" prompt appears after creating a worktree, enabling quick session activation.
  * Repository strip now includes a "Change" control for switching repositories while in override mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a frontend-only change that removes the dead-end "Open a session to view…" state in the Worktrunk panel and replaces it with a `RepoPickerField` that lets users browse worktrees for any configured repo root without an active session. A "Change" affordance lets users reset an explicit repo pick back to the active session, and a post-create banner offers to open a session directly in the newly created worktree.

- `currentRepo` now resolves as `selectedRepoOverride ?? $activeSession?.repoRoot ?? null`; all three branches (explicit override, active session fallback, no repo) are handled and tested.
- A new `justCreatedBranch`/`justCreatedWorktree` state pair drives the inline "Open session" banner after worktree creation, reusing the existing `handleNewSessionHere` flow and clearing cleanly on dismiss, context-menu open, or new creation.
- Six new tests cover the picker, repo selection triggering worktree load, create with a picked repo, active-session auto-select regression, and the open-session-after-create prompt.

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge with one fix: `handleCreateNew` needs to snapshot `currentRepo` before its first await, as the new "Change" button can trigger a mid-flight repo change that causes the post-await `loadWorktrees` call to receive the wrong (possibly null) repo.

The async `handleCreateNew` reads `currentRepo` reactively across two await points without capturing a local snapshot. Every other destructive async handler in the same file (`handleBulkRemove`, `handleRemove`) does snapshot `const repo = currentRepo` before the first await. This PR makes the gap user-accessible for the first time: the new "Change" button is never disabled while `creatingNew` is true, so a user can race a repo change against an in-flight worktree creation, potentially passing null or the wrong repo to `loadWorktrees`.

`WorktrunkPanel.svelte` — specifically `handleCreateNew` starting at line 151.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/components/WorktrunkPanel.svelte | Adds no-session repo picker, "Change" affordance, and post-create "Open session" banner. The repo-override/active-session priority logic is sound, but `handleCreateNew` reads `currentRepo` reactively across await boundaries without snapshotting it (unlike every other async handler), creating an accessible race via the new "Change" button. |
| src/lib/components/__tests__/WorktrunkPanel.test.ts | Adds 6 new tests covering picker render, repo selection, create with picked repo, active-session auto-select, and post-create open-session prompt. Test setup is thorough and follows existing patterns. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Panel opens] --> B{active session?}
    B -- yes --> C[currentRepo = activeSession.repoRoot]
    B -- no --> D[Show RepoPickerField]
    D -- user selects repo --> E[selectedRepoOverride = path]
    E --> C
    C --> F[Load worktrees + diagnostics]
    F --> G[Show worktree list]
    G --> H[User creates worktree]
    H --> I[createWorktree API call]
    I --> J[Reload worktrees]
    J --> K{branch found in list?}
    K -- yes --> L[Show Open session banner]
    K -- no --> G
    L -- Open session clicked --> M[handleNewSessionHere]
    L -- Dismiss clicked --> G
    M --> N[createSessionShell + setActiveSession]
    G --> O{Change button shown?}
    O -- selectedRepoOverride != activeSession.repoRoot --> P[User clicks Change]
    P --> Q[selectedRepoOverride = null]
    Q --> B
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/lib/components/WorktrunkPanel.svelte`, line 151-175 ([link](https://github.com/phin-tech/roux/blob/4a0240b09c850a6a9fce907a049ce5c5386d0380/src/lib/components/WorktrunkPanel.svelte#L151-L175)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Reactive `currentRepo` read across awaits — unsnapshot race**

   `handleCreateNew` reads `currentRepo` reactively at each `await` point, but the new "Change" button (which is never disabled while `creatingNew` is true) lets the user flip `selectedRepoOverride = null` mid-flight. If the user clicks Change after the `createWorktree` call resolves but before `loadWorktrees` runs: (1) `createWorktree` ran against the original repo correctly, (2) `currentRepo` is now `null` (no session) or the active session's repo, (3) `loadWorktrees(currentRepo)` receives `null` — a type-unsafe call — or loads the wrong repo, and (4) `clearRepoScopedState()` may fire and set `justCreatedBranch = null` before the `justCreatedBranch = branch` assignment at line 168 re-sets it, producing a stale banner against a repo that no longer owns the new worktree.

   All the other destructive handlers snapshot the repo first — `handleBulkRemove` does `const repo = currentRepo` on line 575 and `handleRemove` does the same. `handleCreateNew` should follow the same pattern, e.g. `const repo = currentRepo; if (!repo) return;` before the first `await`, then use `repo` throughout.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Flib%2Fcomponents%2FWorktrunkPanel.svelte%0ALine%3A%20151-175%0A%0AComment%3A%0A**Reactive%20%60currentRepo%60%20read%20across%20awaits%20%E2%80%94%20unsnapshot%20race**%0A%0A%60handleCreateNew%60%20reads%20%60currentRepo%60%20reactively%20at%20each%20%60await%60%20point%2C%20but%20the%20new%20%22Change%22%20button%20%28which%20is%20never%20disabled%20while%20%60creatingNew%60%20is%20true%29%20lets%20the%20user%20flip%20%60selectedRepoOverride%20%3D%20null%60%20mid-flight.%20If%20the%20user%20clicks%20Change%20after%20the%20%60createWorktree%60%20call%20resolves%20but%20before%20%60loadWorktrees%60%20runs%3A%20%281%29%20%60createWorktree%60%20ran%20against%20the%20original%20repo%20correctly%2C%20%282%29%20%60currentRepo%60%20is%20now%20%60null%60%20%28no%20session%29%20or%20the%20active%20session's%20repo%2C%20%283%29%20%60loadWorktrees%28currentRepo%29%60%20receives%20%60null%60%20%E2%80%94%20a%20type-unsafe%20call%20%E2%80%94%20or%20loads%20the%20wrong%20repo%2C%20and%20%284%29%20%60clearRepoScopedState%28%29%60%20may%20fire%20and%20set%20%60justCreatedBranch%20%3D%20null%60%20before%20the%20%60justCreatedBranch%20%3D%20branch%60%20assignment%20at%20line%20168%20re-sets%20it%2C%20producing%20a%20stale%20banner%20against%20a%20repo%20that%20no%20longer%20owns%20the%20new%20worktree.%0A%0AAll%20the%20other%20destructive%20handlers%20snapshot%20the%20repo%20first%20%E2%80%94%20%60handleBulkRemove%60%20does%20%60const%20repo%20%3D%20currentRepo%60%20on%20line%20575%20and%20%60handleRemove%60%20does%20the%20same.%20%60handleCreateNew%60%20should%20follow%20the%20same%20pattern%2C%20e.g.%20%60const%20repo%20%3D%20currentRepo%3B%20if%20%28!repo%29%20return%3B%60%20before%20the%20first%20%60await%60%2C%20then%20use%20%60repo%60%20throughout.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=phin-tech%2Froux&pr=214&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22feature%2Fallow-work-trunk-to-work-without-session%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fallow-work-trunk-to-work-without-session%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Flib%2Fcomponents%2FWorktrunkPanel.svelte%0ALine%3A%20151-175%0A%0AComment%3A%0A**Reactive%20%60currentRepo%60%20read%20across%20awaits%20%E2%80%94%20unsnapshot%20race**%0A%0A%60handleCreateNew%60%20reads%20%60currentRepo%60%20reactively%20at%20each%20%60await%60%20point%2C%20but%20the%20new%20%22Change%22%20button%20%28which%20is%20never%20disabled%20while%20%60creatingNew%60%20is%20true%29%20lets%20the%20user%20flip%20%60selectedRepoOverride%20%3D%20null%60%20mid-flight.%20If%20the%20user%20clicks%20Change%20after%20the%20%60createWorktree%60%20call%20resolves%20but%20before%20%60loadWorktrees%60%20runs%3A%20%281%29%20%60createWorktree%60%20ran%20against%20the%20original%20repo%20correctly%2C%20%282%29%20%60currentRepo%60%20is%20now%20%60null%60%20%28no%20session%29%20or%20the%20active%20session's%20repo%2C%20%283%29%20%60loadWorktrees%28currentRepo%29%60%20receives%20%60null%60%20%E2%80%94%20a%20type-unsafe%20call%20%E2%80%94%20or%20loads%20the%20wrong%20repo%2C%20and%20%284%29%20%60clearRepoScopedState%28%29%60%20may%20fire%20and%20set%20%60justCreatedBranch%20%3D%20null%60%20before%20the%20%60justCreatedBranch%20%3D%20branch%60%20assignment%20at%20line%20168%20re-sets%20it%2C%20producing%20a%20stale%20banner%20against%20a%20repo%20that%20no%20longer%20owns%20the%20new%20worktree.%0A%0AAll%20the%20other%20destructive%20handlers%20snapshot%20the%20repo%20first%20%E2%80%94%20%60handleBulkRemove%60%20does%20%60const%20repo%20%3D%20currentRepo%60%20on%20line%20575%20and%20%60handleRemove%60%20does%20the%20same.%20%60handleCreateNew%60%20should%20follow%20the%20same%20pattern%2C%20e.g.%20%60const%20repo%20%3D%20currentRepo%3B%20if%20%28!repo%29%20return%3B%60%20before%20the%20first%20%60await%60%2C%20then%20use%20%60repo%60%20throughout.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>


2. `src/lib/components/WorktrunkPanel.svelte`, line 222-249 ([link](https://github.com/phin-tech/roux/blob/4a0240b09c850a6a9fce907a049ce5c5386d0380/src/lib/components/WorktrunkPanel.svelte#L222-L249)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Stale repo override survives panel close/reopen**

   `clearRepoScopedState()` resets all worktree/diagnostic state but deliberately leaves `selectedRepoOverride` untouched. When the panel is closed while an override is active, then a new active session is started for a different repo, re-opening the panel will still load the overridden repo rather than following the active session. The "Change" button will appear, so the user can recover, but the panel silently ignores the newly active session until they explicitly reset. Whether this is intentional "sticky" behaviour or a gap worth addressing with a comment is worth confirming.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Flib%2Fcomponents%2FWorktrunkPanel.svelte%0ALine%3A%20222-249%0A%0AComment%3A%0A**Stale%20repo%20override%20survives%20panel%20close%2Freopen**%0A%0A%60clearRepoScopedState%28%29%60%20resets%20all%20worktree%2Fdiagnostic%20state%20but%20deliberately%20leaves%20%60selectedRepoOverride%60%20untouched.%20When%20the%20panel%20is%20closed%20while%20an%20override%20is%20active%2C%20then%20a%20new%20active%20session%20is%20started%20for%20a%20different%20repo%2C%20re-opening%20the%20panel%20will%20still%20load%20the%20overridden%20repo%20rather%20than%20following%20the%20active%20session.%20The%20%22Change%22%20button%20will%20appear%2C%20so%20the%20user%20can%20recover%2C%20but%20the%20panel%20silently%20ignores%20the%20newly%20active%20session%20until%20they%20explicitly%20reset.%20Whether%20this%20is%20intentional%20%22sticky%22%20behaviour%20or%20a%20gap%20worth%20addressing%20with%20a%20comment%20is%20worth%20confirming.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=phin-tech%2Froux&pr=214&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22feature%2Fallow-work-trunk-to-work-without-session%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fallow-work-trunk-to-work-without-session%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Flib%2Fcomponents%2FWorktrunkPanel.svelte%0ALine%3A%20222-249%0A%0AComment%3A%0A**Stale%20repo%20override%20survives%20panel%20close%2Freopen**%0A%0A%60clearRepoScopedState%28%29%60%20resets%20all%20worktree%2Fdiagnostic%20state%20but%20deliberately%20leaves%20%60selectedRepoOverride%60%20untouched.%20When%20the%20panel%20is%20closed%20while%20an%20override%20is%20active%2C%20then%20a%20new%20active%20session%20is%20started%20for%20a%20different%20repo%2C%20re-opening%20the%20panel%20will%20still%20load%20the%20overridden%20repo%20rather%20than%20following%20the%20active%20session.%20The%20%22Change%22%20button%20will%20appear%2C%20so%20the%20user%20can%20recover%2C%20but%20the%20panel%20silently%20ignores%20the%20newly%20active%20session%20until%20they%20explicitly%20reset.%20Whether%20this%20is%20intentional%20%22sticky%22%20behaviour%20or%20a%20gap%20worth%20addressing%20with%20a%20comment%20is%20worth%20confirming.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Flib%2Fcomponents%2FWorktrunkPanel.svelte%3A151-175%0A**Reactive%20%60currentRepo%60%20read%20across%20awaits%20%E2%80%94%20unsnapshot%20race**%0A%0A%60handleCreateNew%60%20reads%20%60currentRepo%60%20reactively%20at%20each%20%60await%60%20point%2C%20but%20the%20new%20%22Change%22%20button%20%28which%20is%20never%20disabled%20while%20%60creatingNew%60%20is%20true%29%20lets%20the%20user%20flip%20%60selectedRepoOverride%20%3D%20null%60%20mid-flight.%20If%20the%20user%20clicks%20Change%20after%20the%20%60createWorktree%60%20call%20resolves%20but%20before%20%60loadWorktrees%60%20runs%3A%20%281%29%20%60createWorktree%60%20ran%20against%20the%20original%20repo%20correctly%2C%20%282%29%20%60currentRepo%60%20is%20now%20%60null%60%20%28no%20session%29%20or%20the%20active%20session's%20repo%2C%20%283%29%20%60loadWorktrees%28currentRepo%29%60%20receives%20%60null%60%20%E2%80%94%20a%20type-unsafe%20call%20%E2%80%94%20or%20loads%20the%20wrong%20repo%2C%20and%20%284%29%20%60clearRepoScopedState%28%29%60%20may%20fire%20and%20set%20%60justCreatedBranch%20%3D%20null%60%20before%20the%20%60justCreatedBranch%20%3D%20branch%60%20assignment%20at%20line%20168%20re-sets%20it%2C%20producing%20a%20stale%20banner%20against%20a%20repo%20that%20no%20longer%20owns%20the%20new%20worktree.%0A%0AAll%20the%20other%20destructive%20handlers%20snapshot%20the%20repo%20first%20%E2%80%94%20%60handleBulkRemove%60%20does%20%60const%20repo%20%3D%20currentRepo%60%20on%20line%20575%20and%20%60handleRemove%60%20does%20the%20same.%20%60handleCreateNew%60%20should%20follow%20the%20same%20pattern%2C%20e.g.%20%60const%20repo%20%3D%20currentRepo%3B%20if%20%28!repo%29%20return%3B%60%20before%20the%20first%20%60await%60%2C%20then%20use%20%60repo%60%20throughout.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Flib%2Fcomponents%2FWorktrunkPanel.svelte%3A222-249%0A**Stale%20repo%20override%20survives%20panel%20close%2Freopen**%0A%0A%60clearRepoScopedState%28%29%60%20resets%20all%20worktree%2Fdiagnostic%20state%20but%20deliberately%20leaves%20%60selectedRepoOverride%60%20untouched.%20When%20the%20panel%20is%20closed%20while%20an%20override%20is%20active%2C%20then%20a%20new%20active%20session%20is%20started%20for%20a%20different%20repo%2C%20re-opening%20the%20panel%20will%20still%20load%20the%20overridden%20repo%20rather%20than%20following%20the%20active%20session.%20The%20%22Change%22%20button%20will%20appear%2C%20so%20the%20user%20can%20recover%2C%20but%20the%20panel%20silently%20ignores%20the%20newly%20active%20session%20until%20they%20explicitly%20reset.%20Whether%20this%20is%20intentional%20%22sticky%22%20behaviour%20or%20a%20gap%20worth%20addressing%20with%20a%20comment%20is%20worth%20confirming.%0A%0A&repo=phin-tech%2Froux&pr=214&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22feature%2Fallow-work-trunk-to-work-without-session%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fallow-work-trunk-to-work-without-session%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Flib%2Fcomponents%2FWorktrunkPanel.svelte%3A151-175%0A**Reactive%20%60currentRepo%60%20read%20across%20awaits%20%E2%80%94%20unsnapshot%20race**%0A%0A%60handleCreateNew%60%20reads%20%60currentRepo%60%20reactively%20at%20each%20%60await%60%20point%2C%20but%20the%20new%20%22Change%22%20button%20%28which%20is%20never%20disabled%20while%20%60creatingNew%60%20is%20true%29%20lets%20the%20user%20flip%20%60selectedRepoOverride%20%3D%20null%60%20mid-flight.%20If%20the%20user%20clicks%20Change%20after%20the%20%60createWorktree%60%20call%20resolves%20but%20before%20%60loadWorktrees%60%20runs%3A%20%281%29%20%60createWorktree%60%20ran%20against%20the%20original%20repo%20correctly%2C%20%282%29%20%60currentRepo%60%20is%20now%20%60null%60%20%28no%20session%29%20or%20the%20active%20session's%20repo%2C%20%283%29%20%60loadWorktrees%28currentRepo%29%60%20receives%20%60null%60%20%E2%80%94%20a%20type-unsafe%20call%20%E2%80%94%20or%20loads%20the%20wrong%20repo%2C%20and%20%284%29%20%60clearRepoScopedState%28%29%60%20may%20fire%20and%20set%20%60justCreatedBranch%20%3D%20null%60%20before%20the%20%60justCreatedBranch%20%3D%20branch%60%20assignment%20at%20line%20168%20re-sets%20it%2C%20producing%20a%20stale%20banner%20against%20a%20repo%20that%20no%20longer%20owns%20the%20new%20worktree.%0A%0AAll%20the%20other%20destructive%20handlers%20snapshot%20the%20repo%20first%20%E2%80%94%20%60handleBulkRemove%60%20does%20%60const%20repo%20%3D%20currentRepo%60%20on%20line%20575%20and%20%60handleRemove%60%20does%20the%20same.%20%60handleCreateNew%60%20should%20follow%20the%20same%20pattern%2C%20e.g.%20%60const%20repo%20%3D%20currentRepo%3B%20if%20%28!repo%29%20return%3B%60%20before%20the%20first%20%60await%60%2C%20then%20use%20%60repo%60%20throughout.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Flib%2Fcomponents%2FWorktrunkPanel.svelte%3A222-249%0A**Stale%20repo%20override%20survives%20panel%20close%2Freopen**%0A%0A%60clearRepoScopedState%28%29%60%20resets%20all%20worktree%2Fdiagnostic%20state%20but%20deliberately%20leaves%20%60selectedRepoOverride%60%20untouched.%20When%20the%20panel%20is%20closed%20while%20an%20override%20is%20active%2C%20then%20a%20new%20active%20session%20is%20started%20for%20a%20different%20repo%2C%20re-opening%20the%20panel%20will%20still%20load%20the%20overridden%20repo%20rather%20than%20following%20the%20active%20session.%20The%20%22Change%22%20button%20will%20appear%2C%20so%20the%20user%20can%20recover%2C%20but%20the%20panel%20silently%20ignores%20the%20newly%20active%20session%20until%20they%20explicitly%20reset.%20Whether%20this%20is%20intentional%20%22sticky%22%20behaviour%20or%20a%20gap%20worth%20addressing%20with%20a%20comment%20is%20worth%20confirming.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Fix repo-picker tests to set settings.re..."](https://github.com/phin-tech/roux/commit/4a0240b09c850a6a9fce907a049ce5c5386d0380) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34793937)</sub>

<!-- /greptile_comment -->