### PR TITLE
[codex] fix prerelease cli version stamping

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -75,24 +75,15 @@ jobs:
         run: |
           set -euo pipefail
           # release.yml's `task sign` and `task publish` read the version from
-          # src-tauri/tauri.conf.json, not from RELEASE_VERSION, so we must
-          # update the version files before tagging. The tag will point at
-          # this commit; the commit is never pushed to a branch, so it only
-          # exists as the tag target.
+          # src-tauri/tauri.conf.json, and the bundled CLI reports the version
+          # from crates/roux-cli/Cargo.toml. The tag will point at this commit;
+          # the commit is never pushed to a branch, so it only exists as the
+          # tag target.
           VERSION="${TAG#v}"
-          python3 -c "
-          import json
-          with open('src-tauri/tauri.conf.json') as f:
-              d = json.load(f)
-          d['version'] = '${VERSION}'
-          with open('src-tauri/tauri.conf.json', 'w') as f:
-              json.dump(d, f, indent=2)
-          "
-          sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" src-tauri/Cargo.toml
-          sed -i "s/\"version\": \".*\"/\"version\": \"${VERSION}\"/" package.json
+          python3 scripts/stamp-version.py "${VERSION}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add src-tauri/tauri.conf.json src-tauri/Cargo.toml package.json
+          git add package.json package-lock.json Cargo.lock src-tauri/tauri.conf.json src-tauri/Cargo.toml crates/roux-cli/Cargo.toml
           git commit -m "nightly: ${TAG}"
 
       - name: Create and push tag

--- a/.github/workflows/pre-build.yml
+++ b/.github/workflows/pre-build.yml
@@ -117,23 +117,13 @@ jobs:
         run: |
           set -euo pipefail
           # release.yml's `task sign` / `task publish` read the version from
-          # src-tauri/tauri.conf.json, so the tag's commit must already carry
-          # the bumped values. The commit is created here on a detached HEAD
-          # and is never pushed to a branch — only the tag is pushed, so
-          # main is unaffected.
-          sed -i "s/\"version\": \".*\"/\"version\": \"${NEW}\"/" package.json
-          python3 -c "
-          import json
-          with open('src-tauri/tauri.conf.json') as f:
-              d = json.load(f)
-          d['version'] = '${NEW}'
-          with open('src-tauri/tauri.conf.json', 'w') as f:
-              json.dump(d, f, indent=2)
-          "
-          sed -i "s/^version = \".*\"/version = \"${NEW}\"/" src-tauri/Cargo.toml
+          # src-tauri/tauri.conf.json, and the bundled CLI reports the version
+          # from crates/roux-cli/Cargo.toml. The tag's commit must carry both
+          # values so Settings installs the same CLI version as the app.
+          python3 scripts/stamp-version.py "${NEW}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml
+          git add package.json package-lock.json Cargo.lock src-tauri/tauri.conf.json src-tauri/Cargo.toml crates/roux-cli/Cargo.toml
           git commit -m "pre-release: ${TAG}"
 
       - name: Create and push tag

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -469,23 +469,10 @@ tasks:
 
         echo "Bumping version: ${CURRENT} -> ${NEW}"
 
-        # Update package.json
-        sed -i '' "s/\"version\": \".*\"/\"version\": \"${NEW}\"/" package.json
+        # Keep the desktop app and bundled CLI on the same release version.
+        python3 scripts/stamp-version.py "${NEW}"
 
-        # Update tauri.conf.json
-        python3 -c "
-        import json
-        with open('src-tauri/tauri.conf.json') as f:
-            d = json.load(f)
-        d['version'] = '${NEW}'
-        with open('src-tauri/tauri.conf.json', 'w') as f:
-            json.dump(d, f, indent=2)
-        "
-
-        # Update Cargo.toml
-        sed -i '' "s/^version = \".*\"/version = \"${NEW}\"/" src-tauri/Cargo.toml
-
-        git add package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml
+        git add package.json package-lock.json Cargo.lock src-tauri/tauri.conf.json src-tauri/Cargo.toml crates/roux-cli/Cargo.toml
         git commit -m "${COMMIT_PREFIX}: v${NEW}"
         git tag "v${NEW}"
         git push origin main

--- a/scripts/package-cli-release.sh
+++ b/scripts/package-cli-release.sh
@@ -4,10 +4,17 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+MANIFEST_VERSION="$(python3 -c 'import re; print(re.search(r"(?m)^version = \"([^\"]+)\"", open("crates/roux-cli/Cargo.toml").read()).group(1))')"
+
 if [ -n "${ROUX_CLI_VERSION:-}" ]; then
   VERSION="$ROUX_CLI_VERSION"
+  EXPECTED_VERSION="${VERSION#v}"
+  if [ "$MANIFEST_VERSION" != "$EXPECTED_VERSION" ]; then
+    echo "roux-cli Cargo.toml version ${MANIFEST_VERSION} does not match requested CLI release ${VERSION}" >&2
+    exit 1
+  fi
 else
-  VERSION="v$(python3 -c 'import re; print(re.search(r"(?m)^version = \"([^\"]+)\"", open("crates/roux-cli/Cargo.toml").read()).group(1))')"
+  VERSION="v${MANIFEST_VERSION}"
 fi
 
 TARGET="${ROUX_CLI_TARGET:-$(rustc -vV | sed -n 's/^host: //p')}"

--- a/scripts/stamp-version.py
+++ b/scripts/stamp-version.py
@@ -38,7 +38,7 @@ def set_json_version(path: Path, version: str) -> None:
 
 def set_package_lock_version(path: Path, version: str) -> None:
     if not path.exists():
-        return
+        raise FileNotFoundError(f"{path} is required for release version stamping")
 
     data = read_json(path)
     if not isinstance(data, dict):
@@ -55,6 +55,7 @@ def set_cargo_package_version(path: Path, version: str) -> None:
     lines = path.read_text().splitlines()
     in_package = False
     changed = False
+    saw_workspace_inherited_version = False
 
     for i, line in enumerate(lines):
         stripped = line.strip()
@@ -67,8 +68,15 @@ def set_cargo_package_version(path: Path, version: str) -> None:
             lines[i] = f'version = "{version}"'
             changed = True
             break
+        if in_package and stripped == "version.workspace = true":
+            saw_workspace_inherited_version = True
 
     if not changed:
+        if saw_workspace_inherited_version:
+            raise ValueError(
+                f"{path} uses version.workspace = true; stamp-version.py requires a literal "
+                "[package] version so release tags can carry app and CLI versions independently"
+            )
         raise ValueError(f"did not find [package] version in {path}")
 
     path.write_text("\n".join(lines) + "\n")
@@ -76,7 +84,7 @@ def set_cargo_package_version(path: Path, version: str) -> None:
 
 def set_cargo_lock_versions(path: Path, version: str, package_names: set[str]) -> None:
     if not path.exists():
-        return
+        raise FileNotFoundError(f"{path} is required for release version stamping")
 
     lines = path.read_text().splitlines()
     current_package: str | None = None

--- a/scripts/stamp-version.py
+++ b/scripts/stamp-version.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Stamp a Roux release version into every source manifest.
+
+The desktop app and bundled CLI must report the same version. Pre-release and
+nightly workflows create tag-only commits, so this script avoids relying on
+Cargo or npm being installed while still keeping lockfile package metadata in
+sync.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def read_json(path: Path) -> object:
+    with path.open() as f:
+        return json.load(f)
+
+
+def write_json(path: Path, data: object) -> None:
+    with path.open("w") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")
+
+
+def set_json_version(path: Path, version: str) -> None:
+    data = read_json(path)
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} is not a JSON object")
+    data["version"] = version
+    write_json(path, data)
+
+
+def set_package_lock_version(path: Path, version: str) -> None:
+    if not path.exists():
+        return
+
+    data = read_json(path)
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} is not a JSON object")
+
+    data["version"] = version
+    packages = data.get("packages")
+    if isinstance(packages, dict) and isinstance(packages.get(""), dict):
+        packages[""]["version"] = version
+    write_json(path, data)
+
+
+def set_cargo_package_version(path: Path, version: str) -> None:
+    lines = path.read_text().splitlines()
+    in_package = False
+    changed = False
+
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped == "[package]":
+            in_package = True
+            continue
+        if in_package and stripped.startswith("[") and stripped.endswith("]"):
+            break
+        if in_package and line.startswith("version = "):
+            lines[i] = f'version = "{version}"'
+            changed = True
+            break
+
+    if not changed:
+        raise ValueError(f"did not find [package] version in {path}")
+
+    path.write_text("\n".join(lines) + "\n")
+
+
+def set_cargo_lock_versions(path: Path, version: str, package_names: set[str]) -> None:
+    if not path.exists():
+        return
+
+    lines = path.read_text().splitlines()
+    current_package: str | None = None
+    changed: set[str] = set()
+
+    for i, line in enumerate(lines):
+        if line == "[[package]]":
+            current_package = None
+            continue
+        if line.startswith("name = "):
+            current_package = line.split('"', 2)[1]
+            continue
+        if current_package in package_names and line.startswith("version = "):
+            lines[i] = f'version = "{version}"'
+            changed.add(current_package)
+            continue
+
+    missing = package_names - changed
+    if missing:
+        names = ", ".join(sorted(missing))
+        raise ValueError(f"did not find Cargo.lock package version(s): {names}")
+
+    path.write_text("\n".join(lines) + "\n")
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2 or not argv[1]:
+        print("usage: scripts/stamp-version.py VERSION", file=sys.stderr)
+        return 2
+
+    version = argv[1].removeprefix("v")
+
+    set_json_version(ROOT / "package.json", version)
+    set_package_lock_version(ROOT / "package-lock.json", version)
+    set_json_version(ROOT / "src-tauri" / "tauri.conf.json", version)
+    set_cargo_package_version(ROOT / "src-tauri" / "Cargo.toml", version)
+    set_cargo_package_version(ROOT / "crates" / "roux-cli" / "Cargo.toml", version)
+    set_cargo_lock_versions(ROOT / "Cargo.lock", version, {"roux-cli", "roux-desktop"})
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/test_stamp_version.py
+++ b/scripts/test_stamp_version.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("stamp-version.py")
+SPEC = importlib.util.spec_from_file_location("stamp_version", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+stamp_version = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(stamp_version)
+
+
+class StampVersionTests(unittest.TestCase):
+    def test_set_json_version_updates_top_level_version(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "package.json"
+            path.write_text(json.dumps({"name": "roux", "version": "0.1.0"}))
+
+            stamp_version.set_json_version(path, "1.2.3-pre.4")
+
+            self.assertEqual(json.loads(path.read_text())["version"], "1.2.3-pre.4")
+
+    def test_set_json_version_rejects_non_object(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "package.json"
+            path.write_text("[]")
+
+            with self.assertRaisesRegex(ValueError, "not a JSON object"):
+                stamp_version.set_json_version(path, "1.2.3")
+
+    def test_set_package_lock_version_updates_root_package(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "package-lock.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "name": "roux",
+                        "version": "0.1.0",
+                        "packages": {"": {"name": "roux", "version": "0.1.0"}},
+                    }
+                )
+            )
+
+            stamp_version.set_package_lock_version(path, "1.2.3")
+
+            data = json.loads(path.read_text())
+            self.assertEqual(data["version"], "1.2.3")
+            self.assertEqual(data["packages"][""]["version"], "1.2.3")
+
+    def test_set_package_lock_version_requires_existing_lockfile(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "package-lock.json"
+
+            with self.assertRaisesRegex(FileNotFoundError, "package-lock.json"):
+                stamp_version.set_package_lock_version(path, "1.2.3")
+
+    def test_set_cargo_package_version_updates_literal_package_version(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "Cargo.toml"
+            path.write_text('[package]\nname = "roux-cli"\nversion = "0.1.0"\n\n[dependencies]\n')
+
+            stamp_version.set_cargo_package_version(path, "1.2.3")
+
+            self.assertIn('version = "1.2.3"', path.read_text())
+
+    def test_set_cargo_package_version_rejects_workspace_inherited_version(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "Cargo.toml"
+            path.write_text('[package]\nname = "roux-cli"\nversion.workspace = true\n')
+
+            with self.assertRaisesRegex(ValueError, "literal"):
+                stamp_version.set_cargo_package_version(path, "1.2.3")
+
+    def test_set_cargo_lock_versions_updates_named_packages(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "Cargo.lock"
+            path.write_text(
+                '\n'.join(
+                    [
+                        "[[package]]",
+                        'name = "roux-cli"',
+                        'version = "0.1.0"',
+                        "",
+                        "[[package]]",
+                        'name = "tower"',
+                        'version = "0.5.3"',
+                        "",
+                        "[[package]]",
+                        'name = "roux-desktop"',
+                        'version = "0.1.0"',
+                        "",
+                    ]
+                )
+            )
+
+            stamp_version.set_cargo_lock_versions(path, "1.2.3", {"roux-cli", "roux-desktop"})
+
+            lock = path.read_text()
+            self.assertIn('name = "roux-cli"\nversion = "1.2.3"', lock)
+            self.assertIn('name = "roux-desktop"\nversion = "1.2.3"', lock)
+            self.assertIn('name = "tower"\nversion = "0.5.3"', lock)
+
+    def test_set_cargo_lock_versions_requires_existing_lockfile(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "Cargo.lock"
+
+            with self.assertRaisesRegex(FileNotFoundError, "Cargo.lock"):
+                stamp_version.set_cargo_lock_versions(path, "1.2.3", {"roux-cli"})
+
+    def test_set_cargo_lock_versions_rejects_missing_package_entry(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "Cargo.lock"
+            path.write_text('[[package]]\nname = "roux-cli"\nversion = "0.1.0"\n')
+
+            with self.assertRaisesRegex(ValueError, "roux-desktop"):
+                stamp_version.set_cargo_lock_versions(path, "1.2.3", {"roux-cli", "roux-desktop"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Centralize release version stamping in `scripts/stamp-version.py`.
- Stamp pre-release/nightly/local release versions into the desktop app, bundled CLI manifest, npm metadata, and Cargo lock metadata together.
- Add a CLI packaging guard that refuses to build a requested release when `crates/roux-cli/Cargo.toml` still reports a different version.

## Root Cause

Pre-release and nightly tag commits updated the desktop/package version files but skipped `crates/roux-cli/Cargo.toml`. The bundled sidecar CLI therefore compiled with the previous stable crate version, and Settings installed that stale `roux --version` into `~/.local/bin/roux`.

## Validation

- `PYTHONPYCACHEPREFIX=/private/tmp/roux-pycache python3 -m py_compile scripts/stamp-version.py`
- `bash -n scripts/package-cli-release.sh`
- temp-copy stamper assertions for package, Tauri, CLI Cargo, and Cargo.lock versions
- `ROUX_CLI_VERSION=v9.9.9 scripts/package-cli-release.sh` verified the mismatch guard fails before build
- `git diff --check`
- YAML parse check for the edited workflows and Taskfile
- `roborev review --branch --wait` passed with no findings, job 42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored internal version management system to streamline versioning during automated release and nightly build processes.
  * Consolidated version stamping logic for more efficient synchronization across desktop application and bundled components.
  * Enhanced build workflows to improve version consistency tracking throughout the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR centralizes release version stamping into a new `scripts/stamp-version.py` script and adds a version-mismatch guard to `scripts/package-cli-release.sh`. It fixes the root cause of stale bundled CLI versions in pre-release and nightly builds — `crates/roux-cli/Cargo.toml` was previously skipped during tag commits.

- **`scripts/stamp-version.py`**: New script that stamps `package.json`, `package-lock.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, `crates/roux-cli/Cargo.toml`, and `Cargo.lock` atomically from a single version argument; replaces scattered inline `sed`/Python one-liners across three call sites.
- **`scripts/test_stamp_version.py`**: Unit tests covering each stamping function including error paths (missing lockfile, workspace-inherited version, missing Cargo.lock package entry).
- **`scripts/package-cli-release.sh` + workflows**: Adds a pre-build guard that refuses to build a CLI release when the manifest version doesn't match the requested `ROUX_CLI_VERSION`, and updates all three workflow/task call sites to delegate to the centralized script.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — clean consolidation of scattered version-stamping one-liners into a well-tested, cross-platform Python script with explicit error handling for every failure mode.

All five stamping functions handle missing files and malformed inputs with clear exceptions rather than silent skips. The unit tests cover every function's happy path and error path. The CLI mismatch guard in package-cli-release.sh is simple and verified by the author. No logic regressions were found in the workflow or Taskfile changes.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/stamp-version.py | New centralized version stamper; all five functions handle their error cases cleanly, FileNotFoundError raised for missing lockfiles, workspace-inherited version is explicitly rejected with a clear message. |
| scripts/test_stamp_version.py | Unit tests cover all five public functions including happy-path and error-path cases (missing file, wrong JSON shape, workspace-inherited version, missing Cargo.lock entry). |
| scripts/package-cli-release.sh | Adds a pre-flight mismatch guard that exits before cargo build if ROUX_CLI_VERSION doesn't match the Cargo.toml manifest; version extraction refactored cleanly into MANIFEST_VERSION. |
| .github/workflows/nightly.yml | Replaces scattered inline sed/Python one-liners with a single stamp-version.py call and adds crates/roux-cli/Cargo.toml plus lockfiles to the git-add list. |
| .github/workflows/pre-build.yml | Same stamp-version.py consolidation as nightly.yml; git-add list updated to include all stamped files. |
| Taskfile.yml | Replaces macOS-specific sed -i '' one-liners with the cross-platform stamp-version.py call; git-add list updated accordingly. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Release trigger\n(nightly / pre-build / Taskfile bump)"] --> B["python3 scripts/stamp-version.py VERSION"]
    B --> C["set_json_version\npackage.json"]
    B --> D["set_package_lock_version\npackage-lock.json"]
    B --> E["set_json_version\nsrc-tauri/tauri.conf.json"]
    B --> F["set_cargo_package_version\nsrc-tauri/Cargo.toml"]
    B --> G["set_cargo_package_version\ncrates/roux-cli/Cargo.toml"]
    B --> H["set_cargo_lock_versions\nCargo.lock\n{roux-cli, roux-desktop}"]
    C & D & E & F & G & H --> I["git add + git commit\n(tag-only commit)"]
    I --> J["Create & push tag"]
    K["scripts/package-cli-release.sh\nROUX_CLI_VERSION=vX.Y.Z"] --> L{"MANIFEST_VERSION\n== EXPECTED_VERSION?"}
    L -- "No" --> M["exit 1\n(version mismatch guard)"]
    L -- "Yes" --> N["cargo build -p roux-cli"]
    N --> O["tar.gz + sha256 artifact"]
```

<sub>Reviews (2): Last reviewed commit: ["fix stamp version review findings"](https://github.com/phin-tech/roux/commit/07c6eaf239b26ee10c30f862690d95a050009a4e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34798319)</sub>

<!-- /greptile_comment -->