### PR TITLE
[codex] Warn about Homebrew CLI updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4109,6 +4109,7 @@ dependencies = [
  "roux-sdk",
  "roux-worktrunk",
  "schemars 1.2.1",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,6 +28,7 @@ tauri = { version = "2", features = ["tray-icon", "image-png"] }
 tauri-plugin-shell = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+semver = "1"
 sha2 = "0.10"
 uuid = { version = "1", features = ["v4"] }
 portable-pty = "0.9"

--- a/src-tauri/src/commands/setup.rs
+++ b/src-tauri/src/commands/setup.rs
@@ -162,7 +162,6 @@ pub(crate) fn check_setup_needed() -> bool {
         || !svc::is_cli_current()
         || !svc::is_hooks_installed()
         || !svc::is_skill_installed()
-        || !svc::startup_notices().is_empty()
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/setup.rs
+++ b/src-tauri/src/commands/setup.rs
@@ -162,6 +162,7 @@ pub(crate) fn check_setup_needed() -> bool {
         || !svc::is_cli_current()
         || !svc::is_hooks_installed()
         || !svc::is_skill_installed()
+        || !svc::startup_notices().is_empty()
 }
 
 #[tauri::command]
@@ -192,6 +193,7 @@ pub(crate) struct DoctorItem {
 #[derive(serde::Serialize, specta::Type)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct DoctorStatus {
+    notices: Vec<String>,
     items: Vec<DoctorItem>,
 }
 
@@ -225,6 +227,7 @@ pub(crate) fn check_doctor_status() -> DoctorStatus {
         .or_else(|| crate::skill::skill_install_path().map(|p| p.display().to_string()));
 
     DoctorStatus {
+        notices: svc::startup_notices(),
         items: vec![
             DoctorItem {
                 id: "cli".to_string(),

--- a/src-tauri/src/hooks.rs
+++ b/src-tauri/src/hooks.rs
@@ -10,6 +10,12 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::platform;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CliInstallation {
+    pub path: PathBuf,
+    pub version: Option<String>,
+}
+
 #[cfg(not(windows))]
 fn unix_cli_install_path() -> Option<PathBuf> {
     dirs::home_dir().map(|h| h.join(".local").join("bin").join(platform::roux_cli_file_name()))
@@ -29,6 +35,11 @@ fn bundled_cli_source_path() -> Option<PathBuf> {
 
 fn first_existing_path(candidates: impl IntoIterator<Item = Option<PathBuf>>) -> Option<PathBuf> {
     candidates.into_iter().flatten().find(|path| path.is_file())
+}
+
+#[cfg(not(windows))]
+fn first_existing_concrete_path(candidates: impl IntoIterator<Item = PathBuf>) -> Option<PathBuf> {
+    candidates.into_iter().find(|path| path.is_file())
 }
 
 fn find_cli_on_path() -> Option<PathBuf> {
@@ -161,6 +172,53 @@ pub fn cli_is_installed() -> bool {
     let candidates = [unix_cli_install_path(), cargo_cli_install_path()];
 
     first_existing_path(candidates).or_else(find_cli_on_path).is_some()
+}
+
+#[cfg(not(windows))]
+fn homebrew_cli_candidate_paths() -> Vec<PathBuf> {
+    let file_name = platform::roux_cli_file_name();
+    ["/opt/homebrew/bin", "/usr/local/bin", "/home/linuxbrew/.linuxbrew/bin"]
+        .into_iter()
+        .map(|prefix| Path::new(prefix).join(file_name))
+        .collect()
+}
+
+#[cfg(not(windows))]
+pub fn homebrew_cli_installation() -> Option<CliInstallation> {
+    let path = first_existing_concrete_path(homebrew_cli_candidate_paths())?;
+    Some(CliInstallation { version: cli_version_at(&path), path })
+}
+
+#[cfg(windows)]
+pub fn homebrew_cli_installation() -> Option<CliInstallation> {
+    None
+}
+
+fn stale_homebrew_cli_notice_for(
+    installation: CliInstallation,
+    bundled_version: &str,
+) -> Option<String> {
+    if installation.version.as_deref() == Some(bundled_version) {
+        return None;
+    }
+
+    let formula = if bundled_version.contains("-pre")
+        || installation.version.as_deref().is_some_and(|version| version.contains("-pre"))
+    {
+        "phin-tech/tap/roux-pre"
+    } else {
+        "phin-tech/tap/roux"
+    };
+    let installed = installation.version.as_deref().unwrap_or("unknown version");
+
+    Some(format!(
+        "Homebrew roux detected at {} ({installed}). Roux does not upgrade Homebrew formulae from the app; run `brew upgrade {formula}` to update that install.",
+        installation.path.display()
+    ))
+}
+
+pub fn stale_homebrew_cli_notice() -> Option<String> {
+    stale_homebrew_cli_notice_for(homebrew_cli_installation()?, bundled_cli_version())
 }
 
 #[cfg(windows)]
@@ -608,6 +666,21 @@ mod tests {
     fn installs_cli_when_installed_version_unknown() {
         // Present but unrunnable / corrupt → reinstall to be safe.
         assert!(should_install_cli(true, None, "0.5.3"));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn homebrew_notice_points_prereleases_at_prerelease_formula() {
+        let installation = CliInstallation {
+            path: PathBuf::from("/opt/homebrew/bin/roux"),
+            version: Some("0.5.3-pre.1".to_string()),
+        };
+
+        let notice = stale_homebrew_cli_notice_for(installation, "0.5.4-pre.2").unwrap();
+
+        assert!(notice.contains("/opt/homebrew/bin/roux"));
+        assert!(notice.contains("0.5.3-pre.1"));
+        assert!(notice.contains("brew upgrade phin-tech/tap/roux-pre"));
     }
 
     #[cfg(not(windows))]

--- a/src-tauri/src/hooks.rs
+++ b/src-tauri/src/hooks.rs
@@ -17,6 +17,13 @@ pub struct CliInstallation {
 }
 
 #[cfg(not(windows))]
+struct HomebrewPrefix {
+    bin_dir: PathBuf,
+    cellar_dir: PathBuf,
+    opt_dir: PathBuf,
+}
+
+#[cfg(not(windows))]
 fn unix_cli_install_path() -> Option<PathBuf> {
     dirs::home_dir().map(|h| h.join(".local").join("bin").join(platform::roux_cli_file_name()))
 }
@@ -35,11 +42,6 @@ fn bundled_cli_source_path() -> Option<PathBuf> {
 
 fn first_existing_path(candidates: impl IntoIterator<Item = Option<PathBuf>>) -> Option<PathBuf> {
     candidates.into_iter().flatten().find(|path| path.is_file())
-}
-
-#[cfg(not(windows))]
-fn first_existing_concrete_path(candidates: impl IntoIterator<Item = PathBuf>) -> Option<PathBuf> {
-    candidates.into_iter().find(|path| path.is_file())
 }
 
 fn find_cli_on_path() -> Option<PathBuf> {
@@ -175,18 +177,47 @@ pub fn cli_is_installed() -> bool {
 }
 
 #[cfg(not(windows))]
-fn homebrew_cli_candidate_paths() -> Vec<PathBuf> {
-    let file_name = platform::roux_cli_file_name();
-    ["/opt/homebrew/bin", "/usr/local/bin", "/home/linuxbrew/.linuxbrew/bin"]
-        .into_iter()
-        .map(|prefix| Path::new(prefix).join(file_name))
-        .collect()
+fn homebrew_prefixes() -> Vec<HomebrewPrefix> {
+    [
+        HomebrewPrefix {
+            bin_dir: PathBuf::from("/opt/homebrew/bin"),
+            cellar_dir: PathBuf::from("/opt/homebrew/Cellar"),
+            opt_dir: PathBuf::from("/opt/homebrew/opt"),
+        },
+        HomebrewPrefix {
+            bin_dir: PathBuf::from("/usr/local/bin"),
+            cellar_dir: PathBuf::from("/usr/local/Cellar"),
+            opt_dir: PathBuf::from("/usr/local/opt"),
+        },
+        HomebrewPrefix {
+            bin_dir: PathBuf::from("/home/linuxbrew/.linuxbrew/bin"),
+            cellar_dir: PathBuf::from("/home/linuxbrew/.linuxbrew/Cellar"),
+            opt_dir: PathBuf::from("/home/linuxbrew/.linuxbrew/opt"),
+        },
+    ]
+    .into()
+}
+
+#[cfg(not(windows))]
+fn is_homebrew_link(path: &Path, prefix: &HomebrewPrefix) -> bool {
+    let Ok(resolved) = path.canonicalize() else {
+        return false;
+    };
+    let cellar_dir = prefix.cellar_dir.canonicalize().unwrap_or_else(|_| prefix.cellar_dir.clone());
+    let opt_dir = prefix.opt_dir.canonicalize().unwrap_or_else(|_| prefix.opt_dir.clone());
+    resolved.starts_with(cellar_dir) || resolved.starts_with(opt_dir)
 }
 
 #[cfg(not(windows))]
 pub fn homebrew_cli_installation() -> Option<CliInstallation> {
-    let path = first_existing_concrete_path(homebrew_cli_candidate_paths())?;
-    Some(CliInstallation { version: cli_version_at(&path), path })
+    let file_name = platform::roux_cli_file_name();
+    for prefix in homebrew_prefixes() {
+        let path = prefix.bin_dir.join(file_name);
+        if path.is_file() && is_homebrew_link(&path, &prefix) {
+            return Some(CliInstallation { version: cli_version_at(&path), path });
+        }
+    }
+    None
 }
 
 #[cfg(windows)]
@@ -198,21 +229,21 @@ fn stale_homebrew_cli_notice_for(
     installation: CliInstallation,
     bundled_version: &str,
 ) -> Option<String> {
-    if installation.version.as_deref() == Some(bundled_version) {
+    let installed_version = installation.version.as_deref()?;
+    let installed = semver::Version::parse(installed_version).ok()?;
+    let bundled = semver::Version::parse(bundled_version).ok()?;
+    if installed >= bundled {
         return None;
     }
 
-    let formula = if bundled_version.contains("-pre")
-        || installation.version.as_deref().is_some_and(|version| version.contains("-pre"))
-    {
+    let formula = if bundled_version.contains("-pre") || installed_version.contains("-pre") {
         "phin-tech/tap/roux-pre"
     } else {
         "phin-tech/tap/roux"
     };
-    let installed = installation.version.as_deref().unwrap_or("unknown version");
 
     Some(format!(
-        "Homebrew roux detected at {} ({installed}). Roux does not upgrade Homebrew formulae from the app; run `brew upgrade {formula}` to update that install.",
+        "Homebrew roux detected at {} ({installed_version}). Roux does not upgrade Homebrew formulae from the app; run `brew upgrade {formula}` to update that install.",
         installation.path.display()
     ))
 }
@@ -681,6 +712,61 @@ mod tests {
         assert!(notice.contains("/opt/homebrew/bin/roux"));
         assert!(notice.contains("0.5.3-pre.1"));
         assert!(notice.contains("brew upgrade phin-tech/tap/roux-pre"));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn homebrew_notice_skips_unknown_or_current_or_newer_versions() {
+        let path = PathBuf::from("/opt/homebrew/bin/roux");
+
+        assert!(stale_homebrew_cli_notice_for(
+            CliInstallation { path: path.clone(), version: None },
+            "0.5.4"
+        )
+        .is_none());
+        assert!(stale_homebrew_cli_notice_for(
+            CliInstallation { path: path.clone(), version: Some("0.5.4".to_string()) },
+            "0.5.4"
+        )
+        .is_none());
+        assert!(stale_homebrew_cli_notice_for(
+            CliInstallation { path, version: Some("0.5.5".to_string()) },
+            "0.5.4"
+        )
+        .is_none());
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn homebrew_link_detection_requires_cellar_or_opt_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let bin = dir.path().join("bin");
+        let cellar = dir.path().join("Cellar").join("roux").join("0.5.4").join("bin");
+        let opt = dir.path().join("opt").join("roux").join("bin");
+        fs::create_dir_all(&bin).unwrap();
+        fs::create_dir_all(&cellar).unwrap();
+        fs::create_dir_all(&opt).unwrap();
+
+        let prefix = HomebrewPrefix {
+            bin_dir: bin.clone(),
+            cellar_dir: dir.path().join("Cellar").canonicalize().unwrap(),
+            opt_dir: dir.path().join("opt").canonicalize().unwrap(),
+        };
+        let cellar_binary = cellar.join("roux");
+        let opt_binary = opt.join("roux");
+        let manual_binary = bin.join("manual-roux");
+        fs::write(&cellar_binary, b"binary").unwrap();
+        fs::write(&opt_binary, b"binary").unwrap();
+        fs::write(&manual_binary, b"binary").unwrap();
+
+        let linked_from_cellar = bin.join("roux-cellar");
+        let linked_from_opt = bin.join("roux-opt");
+        std::os::unix::fs::symlink(&cellar_binary, &linked_from_cellar).unwrap();
+        std::os::unix::fs::symlink(&opt_binary, &linked_from_opt).unwrap();
+
+        assert!(is_homebrew_link(&linked_from_cellar, &prefix));
+        assert!(is_homebrew_link(&linked_from_opt, &prefix));
+        assert!(!is_homebrew_link(&manual_binary, &prefix));
     }
 
     #[cfg(not(windows))]

--- a/src-tauri/src/services/setup.rs
+++ b/src-tauri/src/services/setup.rs
@@ -151,6 +151,10 @@ pub(crate) fn bundled_cli_version() -> &'static str {
     crate::hooks::bundled_cli_version()
 }
 
+pub(crate) fn startup_notices() -> Vec<String> {
+    crate::hooks::stale_homebrew_cli_notice().into_iter().collect()
+}
+
 pub(crate) fn install_cli() -> anyhow::Result<()> {
     crate::hooks::install_cli().map_err(anyhow::Error::msg)?;
     Ok(())

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -78,7 +78,7 @@
   } from "$lib/stores/sessionPrLookup";
   import { installSessionBranchPoller } from "$lib/stores/sessionBranchPoller";
   import { clearPermissionInfo } from "$lib/panes/agentState";
-  import { listSessions, checkSetupStatus, checkSetupNeeded, onRouxStatusUpdate, onAgentAttentionCleared, onRouxCommand, spawnShell, onWatchUpdate, listWatches, onNotificationEvent, onMailboxEvent, onAliasEvent, onWorkItemEvent, quitApp, submitRouxReply } from "$lib/tauri";
+  import { listSessions, checkSetupStatus, checkSetupNeeded, checkDoctorStatus, onRouxStatusUpdate, onAgentAttentionCleared, onRouxCommand, spawnShell, onWatchUpdate, listWatches, onNotificationEvent, onMailboxEvent, onAliasEvent, onWorkItemEvent, quitApp, submitRouxReply } from "$lib/tauri";
   import { collectPaneTree } from "$lib/panes/query";
   import { profileRegistry } from "$lib/panes/profiles";
   import { runProfileInPane } from "$lib/panes/profileRunner";
@@ -113,11 +113,45 @@
   let showNewSessionDialog = $state(false);
   let showSessionDialog = $derived(showNewSessionDialog || $workItemSessionStart !== null);
   let showSetupPrompt = $state(false);
+  let startupDoctorNotices = $state<string[]>([]);
   let showQuitDialog = $state(false);
+
+  const DISMISSED_STARTUP_DOCTOR_NOTICES_KEY = "roux:dismissed-startup-doctor-notices";
 
   function closeSessionDialog() {
     showNewSessionDialog = false;
     closeWorkItemSessionStart();
+  }
+
+  function dismissedStartupDoctorNotices(): Set<string> {
+    try {
+      const raw = localStorage.getItem(DISMISSED_STARTUP_DOCTOR_NOTICES_KEY);
+      const parsed = raw ? JSON.parse(raw) : [];
+      if (!Array.isArray(parsed)) return new Set();
+      return new Set(parsed.filter((notice): notice is string => typeof notice === "string"));
+    } catch {
+      return new Set();
+    }
+  }
+
+  function dismissStartupDoctorNotices(notices: string[]) {
+    if (notices.length === 0) return;
+    try {
+      const dismissed = dismissedStartupDoctorNotices();
+      for (const notice of notices) dismissed.add(notice);
+      localStorage.setItem(
+        DISMISSED_STARTUP_DOCTOR_NOTICES_KEY,
+        JSON.stringify([...dismissed]),
+      );
+    } catch {
+      // Best-effort: failure only means the startup notice can reappear later.
+    }
+  }
+
+  function handleSetupPromptDone() {
+    dismissStartupDoctorNotices(startupDoctorNotices);
+    startupDoctorNotices = [];
+    showSetupPrompt = false;
   }
 
   /** Returns true if a pane was closed, false if there was nothing to close */
@@ -567,6 +601,18 @@
     if (setupNeeded) {
       log("First-time setup needed");
       showSetupPrompt = true;
+    } else {
+      try {
+        const doctor = await checkDoctorStatus();
+        const dismissed = dismissedStartupDoctorNotices();
+        startupDoctorNotices = (doctor.notices ?? []).filter((notice) => !dismissed.has(notice));
+        if (startupDoctorNotices.length > 0) {
+          log("Startup Doctor notice available");
+          showSetupPrompt = true;
+        }
+      } catch (error) {
+        logError("Failed to check startup Doctor notices", error);
+      }
     }
 
     // Load projects (global, independent of session restore)
@@ -971,5 +1017,5 @@
 <DoctorPanel
   mode="onboarding"
   visible={showSetupPrompt}
-  ondone={() => (showSetupPrompt = false)}
+  ondone={handleSetupPromptDone}
 />

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -457,6 +457,7 @@ export type DoctorItem = {
 };
 
 export type DoctorStatus = {
+	notices: string[],
 	items: DoctorItem[],
 };
 

--- a/src/lib/components/DoctorPanel.svelte
+++ b/src/lib/components/DoctorPanel.svelte
@@ -126,35 +126,46 @@
 </script>
 
 {#snippet rows()}
-  <div class="flex flex-col divide-y divide-hairline">
-    {#if loading}
-      <div class="py-4 text-sm text-text-muted">Checking…</div>
-    {:else if !status}
-      <div class="py-4 text-sm text-red-400">{error || "Failed to load status"}</div>
-    {:else}
-      {#each status.items as item (item.id)}
-        <div class="flex items-center justify-between gap-3 py-3">
-          <div class="min-w-0 flex-1">
-            <div class="text-sm font-medium text-text-primary">{item.label}</div>
-            <div class="flex items-center gap-2 text-xs">
-              <span class={statusColor(item.status)}>{statusLabel(item.status)}</span>
-              {#if item.detail}
-                <span class="truncate text-text-muted" title={item.detail}>— {item.detail}</span>
-              {/if}
-            </div>
+  <div class="flex flex-col gap-3">
+    {#if (status?.notices?.length ?? 0) > 0}
+      <div class="flex flex-col gap-2">
+        {#each status?.notices ?? [] as notice}
+          <div class="rounded border border-amber/30 bg-amber/10 px-3 py-2 text-xs leading-relaxed text-text-primary">
+            {notice}
           </div>
-          {#if item.installable}
-            <button
-              class="ui-btn-ghost shrink-0 rounded-lg px-3 py-1.5 text-xs"
-              onclick={() => handleReinstall(item)}
-              disabled={busy !== null}
-            >
-              {busy === item.id ? "Installing…" : actionLabel(item.status)}
-            </button>
-          {/if}
-        </div>
-      {/each}
+        {/each}
+      </div>
     {/if}
+    <div class="flex flex-col divide-y divide-hairline">
+      {#if loading}
+        <div class="py-4 text-sm text-text-muted">Checking…</div>
+      {:else if !status}
+        <div class="py-4 text-sm text-red-400">{error || "Failed to load status"}</div>
+      {:else}
+        {#each status.items as item (item.id)}
+          <div class="flex items-center justify-between gap-3 py-3">
+            <div class="min-w-0 flex-1">
+              <div class="text-sm font-medium text-text-primary">{item.label}</div>
+              <div class="flex items-center gap-2 text-xs">
+                <span class={statusColor(item.status)}>{statusLabel(item.status)}</span>
+                {#if item.detail}
+                  <span class="truncate text-text-muted" title={item.detail}>— {item.detail}</span>
+                {/if}
+              </div>
+            </div>
+            {#if item.installable}
+              <button
+                class="ui-btn-ghost shrink-0 rounded-lg px-3 py-1.5 text-xs"
+                onclick={() => handleReinstall(item)}
+                disabled={busy !== null}
+              >
+                {busy === item.id ? "Installing…" : actionLabel(item.status)}
+              </button>
+            {/if}
+          </div>
+        {/each}
+      {/if}
+    </div>
     {#if error && !loading}
       <div class="py-2 text-xs text-red-400">{error}</div>
     {/if}

--- a/src/lib/components/__tests__/DoctorPanel.test.ts
+++ b/src/lib/components/__tests__/DoctorPanel.test.ts
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/svelte";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { checkDoctorStatus } = vi.hoisted(() => ({
+  checkDoctorStatus: vi.fn(),
+}));
+
+vi.mock("$lib/tauri", () => ({
+  checkDoctorStatus,
+  installAllMissing: vi.fn().mockResolvedValue(undefined),
+  reinstallCli: vi.fn().mockResolvedValue(undefined),
+  reinstallHooks: vi.fn().mockResolvedValue(undefined),
+  reinstallSkill: vi.fn().mockResolvedValue(undefined),
+}));
+
+import DoctorPanel from "../DoctorPanel.svelte";
+
+describe("DoctorPanel", () => {
+  beforeEach(() => {
+    checkDoctorStatus.mockReset();
+  });
+
+  it("shows startup notices from the backend", async () => {
+    checkDoctorStatus.mockResolvedValue({
+      notices: [
+        "Homebrew roux detected at /opt/homebrew/bin/roux. Run brew upgrade phin-tech/tap/roux-pre to update it.",
+      ],
+      items: [],
+    });
+
+    render(DoctorPanel, { mode: "onboarding", visible: true });
+
+    expect(await screen.findByText(/Homebrew roux detected/)).toBeTruthy();
+    expect(screen.getByText(/brew upgrade phin-tech\/tap\/roux-pre/)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

- Detect a separately installed Homebrew `roux` CLI in common Homebrew prefixes.
- Surface a startup Doctor notice when that Homebrew CLI version differs from the bundled app CLI.
- Explain that Roux does not upgrade Homebrew formulae from inside the app and point users at `brew upgrade phin-tech/tap/roux-pre` or `phin-tech/tap/roux`.
- Render Doctor notices in onboarding/settings and add a focused component test.

## Root cause

The GUI can refresh its app-managed companion CLI at `~/.local/bin/roux`, but it does not update the Homebrew formula. Users with a separate Homebrew install could otherwise assume the app handled that copy too.

## Validation

- `npm run test -- src/lib/components/__tests__/DoctorPanel.test.ts`
- `npm run check`
- `cargo test --manifest-path src-tauri/Cargo.toml hooks::tests::homebrew_notice_points_prereleases_at_prerelease_formula`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Detect when the Homebrew-installed CLI version differs from the bundled version and display notices to users.
  * Display startup notices and warnings in the Doctor panel for improved visibility.

* **Tests**
  * Added test coverage for Doctor panel notice display functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Homebrew CLI version-mismatch detection: on non-Windows systems the app now identifies a Homebrew-managed `roux` binary by checking that its resolved path falls under the Cellar or opt directory, compares its version against the bundled CLI using semver, and surfaces a notice in the Doctor panel when the Homebrew copy is outdated. Dismissed notices are persisted in localStorage so the prompt does not reappear each launch.

- Rust: `homebrew_cli_installation()` uses symlink canonicalization into Cellar/opt to distinguish Homebrew-managed binaries from manual installs; `stale_homebrew_cli_notice_for()` does the version comparison and builds the upgrade message with formula selection.
- Frontend: `App.svelte` fetches `checkDoctorStatus` in the setup-not-needed branch and shows the Doctor panel for any un-dismissed notices; `DoctorPanel.svelte` gains an amber banner section that renders `status.notices`.
- Test coverage added for notice rendering in `DoctorPanel` (Svelte) and formula/version logic in Rust.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the Homebrew detection is additive and read-only, and all changed code paths have tests.

The detection logic is purely observational (read symlinks, compare versions, emit a string), the notice flows through the existing Doctor panel without touching the core setup path, and `check_setup_needed` is deliberately left unchanged. The one formula-heuristic edge case is narrow and the worst outcome is a `brew upgrade` command that does nothing.

The formula-selection branch in `src-tauri/src/hooks.rs` (lines 239-243) is worth a quick look before shipping to a mixed stable/pre-release user base.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src-tauri/src/hooks.rs | Adds Homebrew CLI detection via symlink-to-Cellar/opt check, semver version comparison, and notice generation. Minor: formula selection heuristic uses OR on both version strings which can suggest `roux-pre` to users who only have the stable formula installed. |
| src-tauri/src/commands/setup.rs | Adds `notices` field to `DoctorStatus` populated from `startup_notices()`; `check_setup_needed` is unchanged and does not include Homebrew check, keeping setup flow clean. |
| src-tauri/src/services/setup.rs | Thin wrapper `startup_notices()` collects `stale_homebrew_cli_notice()` into a Vec; no issues. |
| src/App.svelte | Fetches `checkDoctorStatus` in the else-branch of setup, filters against localStorage dismissals, and shows the Doctor panel for un-dismissed notices. Dismissal stores full notice strings keyed by content; logic is correct. |
| src/lib/components/DoctorPanel.svelte | Adds an amber banner section at the top for `status.notices`; layout change is well-scoped and backward-compatible when notices is empty. |
| src/lib/components/__tests__/DoctorPanel.test.ts | New focused test covering notice rendering in `DoctorPanel`; mock setup is clean and the assertion is meaningful. |
| src/lib/bindings.ts | Adds `notices: string[]` to `DoctorStatus` type binding, matching the Rust struct update. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as App.svelte
    participant Tauri as Tauri Backend
    participant FS as Filesystem
    participant LS as localStorage

    App->>Tauri: checkSetupNeeded()
    Tauri-->>App: false (CLI/hooks current)
    App->>Tauri: checkDoctorStatus()
    Tauri->>FS: homebrew_cli_installation() — check Cellar/opt symlinks
    FS-->>Tauri: "CliInstallation { path, version }"
    Tauri->>Tauri: stale_homebrew_cli_notice_for(installation, bundled_version)
    Tauri-->>App: "DoctorStatus { notices: [...], items: [...] }"
    App->>LS: dismissedStartupDoctorNotices()
    LS-->>App: "Set<string>"
    App->>App: filter out dismissed notices
    alt Un-dismissed notices exist
        App->>App: "showSetupPrompt = true"
        App->>App: render DoctorPanel (onboarding mode)
        Note over App: DoctorPanel calls checkDoctorStatus() independently
        App->>LS: dismissStartupDoctorNotices(notices) on done
    end
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc-tauri%2Fsrc%2Fhooks.rs%3A239-243%0A**Formula%20heuristic%20can%20misdirect%20stable-formula%20users**%0A%0AThe%20%60OR%60%20condition%20picks%20%60roux-pre%60%20whenever%20the%20*bundled*%20version%20is%20a%20pre-release%2C%20even%20if%20the%20Homebrew%20install%20has%20the%20stable%20%60phin-tech%2Ftap%2Froux%60%20formula%20%28e.g.%2C%20%60installed%20%3D%20%220.9.0%22%60%2C%20%60bundled%20%3D%20%221.0.0-pre.1%22%60%29.%20A%20user%20who%20ran%20%60brew%20install%20phin-tech%2Ftap%2Froux%60%20and%20then%20installs%20the%20pre-release%20GUI%20gets%20told%20to%20run%20%60brew%20upgrade%20phin-tech%2Ftap%2Froux-pre%60%2C%20which%20would%20fail%20or%20silently%20no-op%20because%20%60roux-pre%60%20was%20never%20installed.%20The%20installed%20version%20string%20is%20the%20more%20reliable%20signal%20for%20which%20formula%20the%20user%20actually%20has%3A%20if%20only%20%60installed_version%60%20contains%20%60%22-pre%22%60%20the%20formula%20should%20be%20%60roux-pre%60%3B%20if%20neither%20does%2C%20%60roux%60%3B%20the%20%60%7C%7C%20bundled_version.contains%28%22-pre%22%29%60%20arm%20is%20the%20ambiguous%20branch%20worth%20revisiting.%0A%0A&repo=phin-tech%2Froux&pr=217&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22fix%2Fhomebrew-compiling%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fhomebrew-compiling%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc-tauri%2Fsrc%2Fhooks.rs%3A239-243%0A**Formula%20heuristic%20can%20misdirect%20stable-formula%20users**%0A%0AThe%20%60OR%60%20condition%20picks%20%60roux-pre%60%20whenever%20the%20*bundled*%20version%20is%20a%20pre-release%2C%20even%20if%20the%20Homebrew%20install%20has%20the%20stable%20%60phin-tech%2Ftap%2Froux%60%20formula%20%28e.g.%2C%20%60installed%20%3D%20%220.9.0%22%60%2C%20%60bundled%20%3D%20%221.0.0-pre.1%22%60%29.%20A%20user%20who%20ran%20%60brew%20install%20phin-tech%2Ftap%2Froux%60%20and%20then%20installs%20the%20pre-release%20GUI%20gets%20told%20to%20run%20%60brew%20upgrade%20phin-tech%2Ftap%2Froux-pre%60%2C%20which%20would%20fail%20or%20silently%20no-op%20because%20%60roux-pre%60%20was%20never%20installed.%20The%20installed%20version%20string%20is%20the%20more%20reliable%20signal%20for%20which%20formula%20the%20user%20actually%20has%3A%20if%20only%20%60installed_version%60%20contains%20%60%22-pre%22%60%20the%20formula%20should%20be%20%60roux-pre%60%3B%20if%20neither%20does%2C%20%60roux%60%3B%20the%20%60%7C%7C%20bundled_version.contains%28%22-pre%22%29%60%20arm%20is%20the%20ambiguous%20branch%20worth%20revisiting.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix: address Homebrew review findings"](https://github.com/phin-tech/roux/commit/94d5711047a8e3ce522b4d112a6428cb9eedaa49) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34805661)</sub>

<!-- /greptile_comment -->