### PR TITLE
[codex] introduce reusable main view workflow

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -113,7 +113,8 @@
   import {
     commandBlockedByMainView,
     eventTargetIsEditable,
-    eventTargetIsInsideMainView,
+    eventTargetIsMainViewKeyboardOwner,
+    mainViewTargetShouldBypassAppKeymap,
   } from "$lib/mainView/keyGate";
 
   let showNewSessionDialog = $state(false);
@@ -365,17 +366,14 @@
     const mainRoute = get(mainViewRoute);
     if (mainRoute) {
       const target = e.target;
-      const mainViewOwnsKeyboard =
-        eventTargetIsInsideMainView(target) ||
-        target === document.body ||
-        target === document.documentElement;
-      if (mainViewOwnsKeyboard) {
+      if (eventTargetIsMainViewKeyboardOwner(target)) {
         if (e.key === "Escape" && !eventTargetIsEditable(target)) {
           e.preventDefault();
           closeMainView();
           keymapExitTree();
+          return;
         }
-        return;
+        if (mainViewTargetShouldBypassAppKeymap(target)) return;
       }
     }
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -50,7 +50,7 @@
   } from "$lib/stores/subscriptions";
   import { initPtyInventoryPolling } from "$lib/stores/ptyInventory";
   import { initSessionWithProfile, splitPane, closeSessionPanes } from "$lib/panes/actions";
-  import { hasSplitPanes } from "$lib/panes/layout";
+  import { findSessionForPane, hasSplitPanes } from "$lib/panes/layout";
   import { setLogicalFocus, focusedPaneId } from "$lib/panes/focus";
   import { getTerminalController } from "$lib/panes/terminalRuntime";
   import { initPersistence, flushPaneState, loadPaneState } from "$lib/panes/persistence";
@@ -109,6 +109,12 @@
     closeWorkItemSessionStart,
     workItemSessionStart,
   } from "$lib/stores/ui";
+  import { closeMainView, mainViewRoute } from "$lib/stores/mainView";
+  import {
+    commandBlockedByMainView,
+    eventTargetIsEditable,
+    eventTargetIsInsideMainView,
+  } from "$lib/mainView/keyGate";
 
   let showNewSessionDialog = $state(false);
   let showSessionDialog = $derived(showNewSessionDialog || $workItemSessionStart !== null);
@@ -175,6 +181,7 @@
 
     const cmd = registry.get(commandId);
     if (!cmd) return;
+    if (get(mainViewRoute) && commandBlockedByMainView(cmd)) return;
 
     if (cmd.id === "session.new") {
       showNewSessionDialog = true;
@@ -238,6 +245,7 @@
   function isCommandAvailable(commandId: string): boolean {
     const cmd = registry.get(commandId);
     if (!cmd) return false;
+    if (get(mainViewRoute) && commandBlockedByMainView(cmd)) return false;
     return !cmd.available || cmd.available();
   }
 
@@ -267,6 +275,10 @@
     if (!surface.leaderPromptCommandId) return;
     const cmd = registry.get(surface.leaderPromptCommandId);
     if (!cmd?.onInput) return;
+    if (get(mainViewRoute) && commandBlockedByMainView(cmd)) {
+      closeCommandSurface();
+      return;
+    }
     const value = surface.leaderPromptValue;
     closeCommandSurface();
     void cmd.onInput(value);
@@ -350,6 +362,23 @@
       return;
     }
 
+    const mainRoute = get(mainViewRoute);
+    if (mainRoute) {
+      const target = e.target;
+      const mainViewOwnsKeyboard =
+        eventTargetIsInsideMainView(target) ||
+        target === document.body ||
+        target === document.documentElement;
+      if (mainViewOwnsKeyboard) {
+        if (e.key === "Escape" && !eventTargetIsEditable(target)) {
+          e.preventDefault();
+          closeMainView();
+          keymapExitTree();
+        }
+        return;
+      }
+    }
+
     // Keymap dispatch.
     const km = get(keymapState);
     const resolution = resolveKey(e, km, isCommandAvailable);
@@ -415,6 +444,29 @@
       });
     }
     prevSurfaceOpen = open;
+  });
+
+  let mainViewWasOpen = $state(false);
+  let paneFocusBeforeMainView = $state<string | null>(null);
+  $effect(() => {
+    const open = $mainViewRoute !== null;
+    if (open && !mainViewWasOpen) {
+      paneFocusBeforeMainView = get(focusedPaneId);
+      setLogicalFocus(null);
+    }
+    if (!open && mainViewWasOpen) {
+      const restorePaneId = paneFocusBeforeMainView;
+      paneFocusBeforeMainView = null;
+      queueMicrotask(() => {
+        const active = document.activeElement as HTMLElement | null;
+        if (active && active !== document.body && active.tagName !== "HTML") return;
+        if (!restorePaneId || get(focusedPaneId) !== null) return;
+        const activeSession = get(sessionState).activeSessionId;
+        if (!activeSession || findSessionForPane(restorePaneId) !== activeSession) return;
+        if (getTerminalController(restorePaneId)) setLogicalFocus(restorePaneId);
+      });
+    }
+    mainViewWasOpen = open;
   });
 
   $effect(() => {

--- a/src/lib/commands/__tests__/ui.test.ts
+++ b/src/lib/commands/__tests__/ui.test.ts
@@ -40,8 +40,13 @@ vi.mock("$lib/stores/userTerminalThemes", () => ({
   loadUserTerminalThemes: vi.fn(),
 }));
 
+vi.mock("$lib/stores/mainView", () => ({
+  toggleMainView: vi.fn(),
+}));
+
 import { registry } from "../registry";
 import { registerUiCommands } from "../ui";
+import { toggleMainView } from "$lib/stores/mainView";
 import {
   closePrStatusDetails,
   prStatusDetailsOpen,
@@ -49,9 +54,22 @@ import {
 
 describe("ui commands", () => {
   beforeEach(() => {
+    registry.unregister("ui.toggle-board");
     registry.unregister("ui.toggle-pr-status-details");
     queryMock.activeSession = null;
+    vi.clearAllMocks();
     closePrStatusDetails();
+  });
+
+  it("registers a board main-view toggle command", () => {
+    registerUiCommands();
+
+    const command = registry.get("ui.toggle-board");
+    expect(command?.label).toBe("Toggle Board Main View");
+    expect(command?.category).toBe("App");
+
+    command?.execute?.();
+    expect(toggleMainView).toHaveBeenCalledWith({ kind: "board" });
   });
 
   it("registers a bindable PR status details toggle command", () => {

--- a/src/lib/commands/ui.ts
+++ b/src/lib/commands/ui.ts
@@ -11,10 +11,10 @@ import {
   pinnedSidebar,
   pinSidebar,
   PINNABLE_SIDEBARS,
-  toggleBoardFullscreen,
   toggleSidebar,
   unpinSidebar,
 } from "$lib/stores/ui";
+import { toggleMainView } from "$lib/stores/mainView";
 import {
   setRailSide,
   toggleRailSide,
@@ -140,9 +140,9 @@ export function registerUiCommands() {
 
   registry.register({
     id: "ui.toggle-board",
-    label: "Toggle Board (Fullscreen)",
+    label: "Toggle Board Main View",
     category: "App",
-    execute: () => toggleBoardFullscreen(),
+    execute: () => toggleMainView({ kind: "board" }),
   });
 
   registry.register({

--- a/src/lib/components/BoardMainView.svelte
+++ b/src/lib/components/BoardMainView.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { derived } from "svelte/store";
-  import X from "@lucide/svelte/icons/x";
   import {
     itemsByColumn,
     WORK_ITEM_COLUMNS,
@@ -18,11 +17,11 @@
   import { sessionList } from "$lib/stores/sessions";
   import type { SessionStatus } from "$lib/types";
   import {
-    closeBoardFullscreen,
     openNewWorkItemEditor,
     openWorkItemEditor,
     openWorkItemSessionStart,
   } from "$lib/stores/ui";
+  import { closeMainView } from "$lib/stores/mainView";
   import { openSessionById } from "$lib/panes/openSession";
   import { formatWorkItemStartError } from "$lib/board/startErrors";
   import {
@@ -168,8 +167,8 @@
       console.error(`Session ${sessionId} is no longer running`);
       return;
     }
-    // Reveal the terminal we just focused — the board overlay covers it.
-    closeBoardFullscreen();
+    // Reveal the terminal we just focused — the main view covers it.
+    closeMainView();
   }
 
   function handleDragOver(event: DragEvent, col: WorkItemStatus) {
@@ -193,32 +192,9 @@
     await handleMove(payload.itemId, col);
   }
 
-  function handleKeydown(event: KeyboardEvent) {
-    if (event.key === "Escape") {
-      event.preventDefault();
-      closeBoardFullscreen();
-    }
-  }
 </script>
 
-<svelte:window onkeydown={handleKeydown} />
-
-<div class="absolute inset-0 z-30 flex flex-col bg-bg-deep">
-  <div
-    class="flex h-9 shrink-0 items-center justify-between border-b border-hairline bg-bg-surface/30 px-3"
-  >
-    <span class="text-sm font-semibold tracking-tight text-text-primary">Board</span>
-    <button
-      type="button"
-      class="flex h-6 w-6 items-center justify-center rounded text-text-muted transition-colors hover:bg-surface-2 hover:text-text"
-      onclick={closeBoardFullscreen}
-      aria-label="Close board"
-      title="Close board (Esc)"
-    >
-      <X size={14} />
-    </button>
-  </div>
-
+<div class="flex h-full min-h-0 flex-col bg-bg-deep">
   <div class="flex min-h-0 flex-1 flex-row gap-3 overflow-x-auto p-4">
     {#each WORK_ITEM_COLUMNS as col (col)}
       {@const items = $itemsByColumn.get(col) ?? []}

--- a/src/lib/components/BoardPanel.svelte
+++ b/src/lib/components/BoardPanel.svelte
@@ -16,9 +16,9 @@
   } from "$lib/stores/workItems";
   import { sessionList } from "$lib/stores/sessions";
   import type { SessionStatus } from "$lib/types";
-  import Maximize2 from "@lucide/svelte/icons/maximize-2";
+  import PanelTopOpen from "@lucide/svelte/icons/panel-top-open";
+  import { openMainView } from "$lib/stores/mainView";
   import {
-    openBoardFullscreen,
     openNewWorkItemEditor,
     openWorkItemEditor,
     openWorkItemSessionStart,
@@ -181,11 +181,11 @@
       <button
         type="button"
         class="flex h-6 w-6 items-center justify-center rounded text-text-muted transition-colors hover:bg-surface-2 hover:text-text"
-        onclick={openBoardFullscreen}
-        aria-label="Open board fullscreen"
-        title="Open board fullscreen"
+        onclick={() => openMainView({ kind: "board" })}
+        aria-label="Open board in main view"
+        title="Open board in main view"
       >
-        <Maximize2 size={14} />
+        <PanelTopOpen size={14} />
       </button>
       {#if onTogglePin}
         <PinButton {pinned} ontoggle={onTogglePin} />

--- a/src/lib/components/CommandPalette.svelte
+++ b/src/lib/components/CommandPalette.svelte
@@ -2,6 +2,8 @@
   import { fade, scale } from "svelte/transition";
   import { Command } from "bits-ui";
   import { registry, type Command as Cmd, type CommandItem as CmdItem } from "$lib/commands/registry";
+  import { mainViewRoute } from "$lib/stores/mainView";
+  import { commandBlockedByMainView } from "$lib/mainView/keyGate";
   import { formatShortcut } from "$lib/platform";
   import { shortcutFor, keymapState } from "$lib/keymap/store";
   import Bot from "@lucide/svelte/icons/bot";
@@ -46,7 +48,10 @@
 
   let availableCommands = $derived.by(() => {
     if (inDrillStep) return [];
-    const cmds = registry.getAvailable();
+    const mainViewOpen = $mainViewRoute !== null;
+    const cmds = registry.getAvailable().filter((cmd) =>
+      !mainViewOpen || !commandBlockedByMainView(cmd),
+    );
     const groups = new Map<string, Cmd[]>();
     for (const cmd of cmds) {
       if (!groups.has(cmd.category)) groups.set(cmd.category, []);
@@ -63,7 +68,7 @@
       stepStack = [];
       if (initialCommandId) {
         const cmd = registry.get(initialCommandId);
-        if (cmd?.getItems) {
+        if (cmd?.getItems && !($mainViewRoute !== null && commandBlockedByMainView(cmd))) {
           // Auto-drill into the command's picker. Run async so the effect
           // completes synchronously; the drill happens on next tick.
           void Promise.resolve(cmd.getItems()).then((items) => {
@@ -80,6 +85,8 @@
   });
 
   async function handleCommandSelect(cmd: Cmd) {
+    if ($mainViewRoute !== null && commandBlockedByMainView(cmd)) return;
+
     if (cmd.getItems) {
       const items = await cmd.getItems();
       stepStack = [...stepStack, { label: cmd.label, items, sourceCmd: cmd }];
@@ -151,6 +158,7 @@
     if (!inDrillStep || !inputValue.trim()) return;
     const cmd = currentStep?.sourceCmd;
     if (!cmd?.onInput) return;
+    if ($mainViewRoute !== null && commandBlockedByMainView(cmd)) return;
     const text = inputValue.trim();
     stepStack = [];
     inputValue = "";

--- a/src/lib/components/Layout.svelte
+++ b/src/lib/components/Layout.svelte
@@ -3,12 +3,12 @@
   import SidebarDock from "./SidebarDock.svelte";
   import SplitPane from "./SplitPane.svelte";
   import StatusBar from "./StatusBar.svelte";
-  import BoardFullscreen from "./BoardFullscreen.svelte";
+  import MainViewHost from "./MainViewHost.svelte";
   import { activeSessionId, sessionList } from "$lib/stores/sessions";
   import { sessionLayouts } from "$lib/panes/layout";
   import { settings } from "$lib/stores/settings";
   import { sidebarLayout } from "$lib/stores/sidebarLayout";
-  import { boardFullscreen } from "$lib/stores/ui";
+  import { mainViewRoute } from "$lib/stores/mainView";
   import { openNewProjectDialog } from "$lib/stores/newProjectDialog";
   import type { Snippet } from "svelte";
 
@@ -97,8 +97,8 @@
           {/if}
         {/each}
       {/if}
-        {#if $boardFullscreen}
-          <BoardFullscreen />
+        {#if $mainViewRoute}
+          <MainViewHost />
         {/if}
       </div>
 

--- a/src/lib/components/LibraryWindow.svelte
+++ b/src/lib/components/LibraryWindow.svelte
@@ -18,6 +18,7 @@
     openLibraryEdit,
     openLibraryNew,
   } from "$lib/stores/libraryWindow";
+  import { eventTargetIsEditable } from "$lib/keymap/editableTarget";
   import LibraryItemEditor from "./LibraryItemEditor.svelte";
 
   let items = $state<LibraryItem[]>([]);
@@ -122,7 +123,7 @@
   function handleKeydown(e: KeyboardEvent) {
     if (!visible) return;
     if (e.key === "Escape") {
-      if (isEditableTarget(e.target)) return;
+      if (eventTargetIsEditable(e.target)) return;
       e.preventDefault();
       closeSafely();
       return;
@@ -130,11 +131,6 @@
     if (e.key === "Tab") {
       trapFocus(e);
     }
-  }
-
-  function isEditableTarget(target: EventTarget | null): boolean {
-    if (!(target instanceof HTMLElement)) return false;
-    return Boolean(target.closest("input, textarea, select, [contenteditable='true'], .cm-editor"));
   }
 
   function focusableElements(): HTMLElement[] {

--- a/src/lib/components/MainViewHost.svelte
+++ b/src/lib/components/MainViewHost.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+  import { mainViewRoute, closeMainView } from "$lib/stores/mainView";
+  import { sessionDisplayName, sessionList } from "$lib/stores/sessions";
+  import BoardMainView from "./BoardMainView.svelte";
+  import MainViewShell from "./MainViewShell.svelte";
+  import SessionDetailView from "./SessionDetailView.svelte";
+
+  let route = $derived($mainViewRoute);
+  let session = $derived(
+    route?.kind === "sessionDetail"
+      ? ($sessionList.find((s) => s.id === route.sessionId) ?? null)
+      : null,
+  );
+  let title = $derived.by(() => {
+    if (!route) return "";
+    switch (route.kind) {
+      case "board":
+        return "Board";
+      case "sessionDetail":
+        return session ? sessionDisplayName(session) : "Session Details";
+    }
+  });
+  let subtitle = $derived.by(() => {
+    if (!route) return null;
+    switch (route.kind) {
+      case "board":
+        return null;
+      case "sessionDetail":
+        if (!session) return "Session no longer available";
+        return [session.status, session.branch, session.worktreePath]
+          .filter((part) => part && part.trim())
+          .join(" · ");
+    }
+  });
+  let closeLabel = $derived.by(() => {
+    if (!route) return "Close View";
+    switch (route.kind) {
+      case "board":
+        return "Close Board";
+      case "sessionDetail":
+        return "Close Session Details";
+    }
+  });
+</script>
+
+{#if route}
+  <MainViewShell {title} {subtitle} {closeLabel} onclose={closeMainView}>
+    {#if route.kind === "board"}
+      <BoardMainView />
+    {:else if route.kind === "sessionDetail"}
+      <SessionDetailView sessionId={route.sessionId} />
+    {/if}
+  </MainViewShell>
+{/if}

--- a/src/lib/components/MainViewShell.svelte
+++ b/src/lib/components/MainViewShell.svelte
@@ -33,7 +33,7 @@
     </div>
     <button
       type="button"
-      class="flex h-6 w-6 shrink-0 items-center justify-center rounded text-text-muted transition-colors hover:bg-surface-2 hover:text-text focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50"
+      class="flex h-6 w-6 shrink-0 items-center justify-center rounded text-text-muted transition-colors hover:bg-bg-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50"
       onclick={onclose}
       aria-label={closeLabel}
       title={`${closeLabel} (Esc)`}

--- a/src/lib/components/MainViewShell.svelte
+++ b/src/lib/components/MainViewShell.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+  import X from "@lucide/svelte/icons/x";
+  import type { Snippet } from "svelte";
+
+  interface Props {
+    title: string;
+    subtitle?: string | null;
+    closeLabel: string;
+    onclose: () => void;
+    children?: Snippet;
+  }
+
+  let { title, subtitle = null, closeLabel, onclose, children }: Props = $props();
+  let root = $state<HTMLDivElement | null>(null);
+
+  $effect(() => {
+    root?.focus();
+  });
+</script>
+
+<div
+  bind:this={root}
+  class="absolute inset-0 z-30 flex min-h-0 flex-col bg-bg-deep"
+  data-main-view-root
+  tabindex="-1"
+>
+  <div class="flex h-9 shrink-0 items-center justify-between gap-3 border-b border-hairline bg-bg-surface/30 px-3">
+    <div class="flex min-w-0 items-baseline gap-2">
+      <span class="truncate text-sm font-semibold tracking-tight text-text-primary">{title}</span>
+      {#if subtitle}
+        <span class="truncate text-[11px] text-text-muted">{subtitle}</span>
+      {/if}
+    </div>
+    <button
+      type="button"
+      class="flex h-6 w-6 shrink-0 items-center justify-center rounded text-text-muted transition-colors hover:bg-surface-2 hover:text-text focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50"
+      onclick={onclose}
+      aria-label={closeLabel}
+      title={`${closeLabel} (Esc)`}
+    >
+      <X size={14} />
+    </button>
+  </div>
+
+  <div class="min-h-0 flex-1 overflow-hidden">
+    {@render children?.()}
+  </div>
+</div>

--- a/src/lib/components/SessionDetailView.svelte
+++ b/src/lib/components/SessionDetailView.svelte
@@ -56,6 +56,8 @@
   $effect(() => {
     const currentSession = session;
     const targetId = sessionId;
+    documentOpenGeneration += 1;
+    documentLoadingId = null;
     selectedDocument = null;
     if (!currentSession) {
       documents = [];

--- a/src/lib/components/SessionDetailView.svelte
+++ b/src/lib/components/SessionDetailView.svelte
@@ -57,16 +57,19 @@
   $effect(() => {
     const currentSession = session;
     const targetId = currentSession ? sessionId : null;
-    if (documentTargetId !== targetId) {
-      documentTargetId = targetId;
-      documentOpenGeneration += 1;
-      documentLoadingId = null;
-      selectedDocument = null;
-    }
+    if (documentTargetId === targetId) return;
+
+    documentTargetId = targetId;
+    documentOpenGeneration += 1;
+    documentLoadingId = null;
+    selectedDocument = null;
+
     if (!currentSession) {
       documents = [];
+      documentsLoading = false;
       return;
     }
+
     void refreshDocuments(sessionId);
   });
 
@@ -229,7 +232,7 @@
             {#if session.status === "disconnected"}
               <button
                 type="button"
-                class="inline-flex h-8 items-center gap-1.5 rounded border border-accent-dim/30 bg-accent-dim/15 px-3 text-xs font-semibold text-accent transition-colors hover:bg-accent-dim/24 disabled:cursor-wait disabled:opacity-60"
+                class="inline-flex h-8 items-center gap-1.5 rounded border border-accent-dim/30 bg-accent-dim/15 px-3 text-xs font-semibold text-accent transition-colors hover:bg-accent-dim/24 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50 disabled:cursor-wait disabled:opacity-60"
                 onclick={handleContinue}
                 disabled={reconnecting}
                 aria-label="Continue session"

--- a/src/lib/components/SessionDetailView.svelte
+++ b/src/lib/components/SessionDetailView.svelte
@@ -167,7 +167,7 @@
   }
 
   function formatEpochSeconds(epoch: number | null | undefined): string | null {
-    if (!epoch) return null;
+    if (epoch == null) return null;
     return new Date(epoch * 1000).toLocaleString();
   }
 

--- a/src/lib/components/SessionDetailView.svelte
+++ b/src/lib/components/SessionDetailView.svelte
@@ -34,6 +34,7 @@
   let reconnecting = $state(false);
   let refreshGeneration = 0;
   let documentOpenGeneration = 0;
+  let documentTargetId: string | null = null;
 
   let session = $derived($sessionList.find((s) => s.id === sessionId) ?? null);
   let displayName = $derived(session ? sessionDisplayName(session) : "");
@@ -55,15 +56,18 @@
 
   $effect(() => {
     const currentSession = session;
-    const targetId = sessionId;
-    documentOpenGeneration += 1;
-    documentLoadingId = null;
-    selectedDocument = null;
+    const targetId = currentSession ? sessionId : null;
+    if (documentTargetId !== targetId) {
+      documentTargetId = targetId;
+      documentOpenGeneration += 1;
+      documentLoadingId = null;
+      selectedDocument = null;
+    }
     if (!currentSession) {
       documents = [];
       return;
     }
-    void refreshDocuments(targetId);
+    void refreshDocuments(sessionId);
   });
 
   function metadataRows(s: Session): Array<[string, string | null]> {

--- a/src/lib/components/SessionDetailView.svelte
+++ b/src/lib/components/SessionDetailView.svelte
@@ -33,6 +33,7 @@
   let documentError = $state<string | null>(null);
   let reconnecting = $state(false);
   let refreshGeneration = 0;
+  let documentOpenGeneration = 0;
 
   let session = $derived($sessionList.find((s) => s.id === sessionId) ?? null);
   let displayName = $derived(session ? sessionDisplayName(session) : "");
@@ -98,14 +99,20 @@
   }
 
   async function openDocument(attachment: Attachment): Promise<void> {
+    const generation = ++documentOpenGeneration;
     documentLoadingId = attachment.id;
     documentError = null;
     try {
-      selectedDocument = await getDocument(attachment.documentId);
+      const next = await getDocument(attachment.documentId);
+      if (generation !== documentOpenGeneration) return;
+      selectedDocument = next;
     } catch (err) {
+      if (generation !== documentOpenGeneration) return;
       documentError = formatError(err, "Failed to read attachment.");
     } finally {
-      documentLoadingId = null;
+      if (generation === documentOpenGeneration) {
+        documentLoadingId = null;
+      }
     }
   }
 

--- a/src/lib/components/SessionDetailView.svelte
+++ b/src/lib/components/SessionDetailView.svelte
@@ -1,0 +1,347 @@
+<script lang="ts">
+  import Pencil from "@lucide/svelte/icons/pencil";
+  import RefreshCw from "@lucide/svelte/icons/refresh-cw";
+  import Terminal from "@lucide/svelte/icons/terminal";
+  import RotateCcw from "@lucide/svelte/icons/rotate-ccw";
+  import {
+    renameSession,
+    sessionDisplayName,
+    sessionList,
+    setActiveSession,
+  } from "$lib/stores/sessions";
+  import { projects } from "$lib/stores/projects";
+  import { closeMainView } from "$lib/stores/mainView";
+  import { continueSession } from "$lib/sessions/reconnect";
+  import { collectLeafIds, sessionLayouts } from "$lib/panes/layout";
+  import { paneInstances, type PaneInstance } from "$lib/panes/instances";
+  import { getDocument, listDocuments } from "$lib/stores/workItems";
+  import type { Attachment, AttachmentDocument } from "$lib/types/workItems";
+  import type { Session } from "$lib/types";
+
+  interface Props {
+    sessionId: string;
+  }
+
+  let { sessionId }: Props = $props();
+
+  let editingName = $state(false);
+  let nameDraft = $state("");
+  let documents = $state<Attachment[]>([]);
+  let selectedDocument = $state<AttachmentDocument | null>(null);
+  let documentsLoading = $state(false);
+  let documentLoadingId = $state<string | null>(null);
+  let documentError = $state<string | null>(null);
+  let reconnecting = $state(false);
+  let refreshGeneration = 0;
+
+  let session = $derived($sessionList.find((s) => s.id === sessionId) ?? null);
+  let displayName = $derived(session ? sessionDisplayName(session) : "");
+  let project = $derived(
+    session?.projectId ? ($projects.find((p) => p.id === session.projectId) ?? null) : null,
+  );
+  let paneRows = $derived.by(() => {
+    const layout = $sessionLayouts.get(sessionId);
+    if (!layout) return [];
+    return collectLeafIds(layout).map((paneId) => ({
+      paneId,
+      pane: $paneInstances.get(paneId) ?? null,
+    }));
+  });
+
+  $effect(() => {
+    if (!editingName) nameDraft = displayName;
+  });
+
+  $effect(() => {
+    const currentSession = session;
+    const targetId = sessionId;
+    selectedDocument = null;
+    if (!currentSession) {
+      documents = [];
+      return;
+    }
+    void refreshDocuments(targetId);
+  });
+
+  function metadataRows(s: Session): Array<[string, string | null]> {
+    return [
+      ["Status", s.status],
+      ["Project", project?.name ?? s.projectId ?? null],
+      ["Repository", s.repoRoot],
+      ["Worktree", s.worktreePath],
+      ["Branch", s.branch || null],
+      ["Model", s.model],
+      ["Cost", s.cost == null ? null : `$${s.cost.toFixed(2)}`],
+      ["Created", formatEpochSeconds(s.createdAt)],
+      ["Primary PTY", s.primaryPtyId ?? null],
+      ["Pinned PR", s.pinnedPrUrl ?? null],
+    ];
+  }
+
+  async function refreshDocuments(targetId = sessionId): Promise<void> {
+    const generation = ++refreshGeneration;
+    documentsLoading = true;
+    documentError = null;
+    try {
+      const next = await listDocuments("session", targetId);
+      if (generation !== refreshGeneration || targetId !== sessionId) return;
+      documents = next;
+    } catch (err) {
+      if (generation !== refreshGeneration || targetId !== sessionId) return;
+      documentError = formatError(err, "Failed to load attachments.");
+      documents = [];
+    } finally {
+      if (generation === refreshGeneration && targetId === sessionId) {
+        documentsLoading = false;
+      }
+    }
+  }
+
+  async function openDocument(attachment: Attachment): Promise<void> {
+    documentLoadingId = attachment.id;
+    documentError = null;
+    try {
+      selectedDocument = await getDocument(attachment.documentId);
+    } catch (err) {
+      documentError = formatError(err, "Failed to read attachment.");
+    } finally {
+      documentLoadingId = null;
+    }
+  }
+
+  function startRename(): void {
+    nameDraft = displayName;
+    editingName = true;
+  }
+
+  function cancelRename(): void {
+    nameDraft = displayName;
+    editingName = false;
+  }
+
+  function commitRename(): void {
+    if (!session) return;
+    const trimmed = nameDraft.trim();
+    editingName = false;
+    if (!trimmed || trimmed === displayName) return;
+    renameSession(session.id, trimmed);
+  }
+
+  function openTerminal(): void {
+    if (!session) return;
+    setActiveSession(session.id);
+    closeMainView();
+  }
+
+  async function handleContinue(): Promise<void> {
+    if (!session || reconnecting) return;
+    reconnecting = true;
+    try {
+      await continueSession(session);
+    } finally {
+      reconnecting = false;
+    }
+  }
+
+  function paneName(paneId: string, pane: PaneInstance | null): string {
+    return pane?.name?.trim() || pane?.docPath?.split(/[\\/]+/).pop() || paneId;
+  }
+
+  function profileLabel(pane: PaneInstance | null): string {
+    const ref = pane?.spawnProfileRef;
+    if (!ref) return "plain";
+    return ref.kind === "registered" ? ref.id : (ref.profile.name || "custom");
+  }
+
+  function formatEpochSeconds(epoch: number | null | undefined): string | null {
+    if (!epoch) return null;
+    return new Date(epoch * 1000).toLocaleString();
+  }
+
+  function formatBytes(bytes: number): string {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+
+  function formatError(err: unknown, fallback: string): string {
+    return err instanceof Error && err.message ? err.message : fallback;
+  }
+</script>
+
+{#if !session}
+  <div class="flex h-full items-center justify-center text-sm text-text-muted">
+    Session no longer available
+  </div>
+{:else}
+  <div class="app-scrollbar h-full overflow-y-auto bg-bg-deep">
+    <div class="mx-auto flex w-full max-w-6xl flex-col gap-5 p-5">
+      <section class="border-b border-hairline pb-4">
+        <div class="flex flex-wrap items-start justify-between gap-3">
+          <div class="min-w-0 flex-1">
+            {#if editingName}
+              <input
+                class="h-9 max-w-xl border border-accent-dim/40 bg-bg-base px-2.5 text-base font-semibold text-text-primary outline-none focus:border-accent"
+                bind:value={nameDraft}
+                aria-label="Session name"
+                onblur={commitRename}
+                onkeydown={(e) => {
+                  if (e.key === "Enter") {
+                    e.stopPropagation();
+                    commitRename();
+                  }
+                  if (e.key === "Escape") {
+                    e.stopPropagation();
+                    cancelRename();
+                  }
+                }}
+              />
+            {:else}
+              <div class="flex min-w-0 items-center gap-2">
+                <h2 class="truncate text-base font-semibold text-text-primary">{displayName}</h2>
+                <button
+                  type="button"
+                  class="flex h-7 w-7 items-center justify-center rounded text-text-muted transition-colors hover:bg-bg-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50"
+                  aria-label="Rename session"
+                  title="Rename session"
+                  onclick={startRename}
+                >
+                  <Pencil size={13} />
+                </button>
+              </div>
+            {/if}
+            <div class="mt-1 truncate font-mono text-[11px] text-text-muted">{session.id}</div>
+          </div>
+          <div class="flex shrink-0 items-center gap-2">
+            {#if session.status === "disconnected"}
+              <button
+                type="button"
+                class="inline-flex h-8 items-center gap-1.5 rounded border border-accent-dim/30 bg-accent-dim/15 px-3 text-xs font-semibold text-accent transition-colors hover:bg-accent-dim/24 disabled:cursor-wait disabled:opacity-60"
+                onclick={handleContinue}
+                disabled={reconnecting}
+                aria-label="Continue session"
+              >
+                <RotateCcw size={13} />
+                <span>{reconnecting ? "Continuing..." : "Continue session"}</span>
+              </button>
+            {/if}
+            <button
+              type="button"
+              class="inline-flex h-8 items-center gap-1.5 rounded border border-accent-dim/30 bg-accent-dim/15 px-3 text-xs font-semibold text-accent transition-colors hover:bg-accent-dim/24 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50"
+              onclick={openTerminal}
+              aria-label="Open terminal"
+            >
+              <Terminal size={13} />
+              <span>Open terminal</span>
+            </button>
+          </div>
+        </div>
+      </section>
+
+      <div class="grid gap-5 xl:grid-cols-[minmax(0,1.1fr)_minmax(320px,0.9fr)]">
+        <div class="flex min-w-0 flex-col gap-5">
+          <section>
+            <h3 class="mb-2 text-xs font-semibold uppercase tracking-wide text-text-muted">Session</h3>
+            <dl class="grid gap-px overflow-hidden rounded border border-border-subtle bg-border-subtle sm:grid-cols-[160px_minmax(0,1fr)]">
+              {#each metadataRows(session) as [label, value] (label)}
+                <dt class="bg-bg-surface px-3 py-2 text-xs text-text-muted">{label}</dt>
+                <dd class="min-w-0 bg-bg-base px-3 py-2 font-mono text-xs text-text-primary">
+                  {#if value}
+                    <span class="break-all">{value}</span>
+                  {:else}
+                    <span class="text-text-muted">-</span>
+                  {/if}
+                </dd>
+              {/each}
+            </dl>
+          </section>
+
+          <section>
+            <h3 class="mb-2 text-xs font-semibold uppercase tracking-wide text-text-muted">Panes</h3>
+            {#if paneRows.length === 0}
+              <div class="rounded border border-border-subtle bg-bg-base px-3 py-3 text-xs text-text-muted">
+                No pane layout is registered for this session.
+              </div>
+            {:else}
+              <div class="overflow-hidden rounded border border-border-subtle">
+                {#each paneRows as row (row.paneId)}
+                  <div class="grid gap-px border-b border-border-subtle bg-border-subtle last:border-b-0 sm:grid-cols-[minmax(0,1fr)_100px_120px_160px]">
+                    <div class="min-w-0 bg-bg-base px-3 py-2">
+                      <div class="truncate text-xs font-medium text-text-primary">{paneName(row.paneId, row.pane)}</div>
+                      <div class="truncate font-mono text-[10px] text-text-muted">{row.paneId}</div>
+                    </div>
+                    <div class="bg-bg-base px-3 py-2 text-xs text-text-secondary">{row.pane?.type ?? "missing"}</div>
+                    <div class="bg-bg-base px-3 py-2 font-mono text-xs text-text-secondary">{profileLabel(row.pane)}</div>
+                    <div class="min-w-0 bg-bg-base px-3 py-2 font-mono text-xs text-text-secondary">
+                      <span class="block truncate">{row.pane?.ptyId || "-"}</span>
+                    </div>
+                  </div>
+                {/each}
+              </div>
+            {/if}
+          </section>
+        </div>
+
+        <section class="min-w-0">
+          <div class="mb-2 flex items-center justify-between gap-2">
+            <h3 class="text-xs font-semibold uppercase tracking-wide text-text-muted">Attachments</h3>
+            <button
+              type="button"
+              class="flex h-7 w-7 items-center justify-center rounded text-text-muted transition-colors hover:bg-bg-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50"
+              aria-label="Refresh attachments"
+              title="Refresh attachments"
+              onclick={() => refreshDocuments()}
+            >
+              <RefreshCw size={13} />
+            </button>
+          </div>
+          <div class="grid min-h-[360px] overflow-hidden rounded border border-border-subtle bg-bg-base md:grid-cols-[220px_minmax(0,1fr)] xl:grid-cols-1 2xl:grid-cols-[220px_minmax(0,1fr)]">
+            <div class="min-h-0 border-b border-border-subtle md:border-b-0 md:border-r xl:border-b xl:border-r-0 2xl:border-b-0 2xl:border-r">
+              {#if documentsLoading}
+                <div class="px-3 py-3 text-xs text-text-muted">Loading attachments...</div>
+              {:else if documents.length === 0}
+                <div class="px-3 py-3 text-xs text-text-muted">No attachments.</div>
+              {:else}
+                <div class="app-scrollbar max-h-72 overflow-y-auto">
+                  {#each documents as attachment (attachment.id)}
+                    <button
+                      type="button"
+                      class="flex w-full flex-col items-start gap-1 border-b border-border-subtle bg-transparent px-3 py-2 text-left last:border-b-0 hover:bg-bg-hover focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-accent-dim/50"
+                      class:bg-bg-active={selectedDocument?.attachment.id === attachment.id}
+                      onclick={() => openDocument(attachment)}
+                      aria-label={attachment.title || attachment.documentId}
+                    >
+                      <span class="line-clamp-2 text-xs font-medium text-text-primary">
+                        {attachment.title || attachment.documentId}
+                      </span>
+                      <span class="font-mono text-[10px] text-text-muted">
+                        {formatBytes(attachment.byteLen)}
+                      </span>
+                    </button>
+                  {/each}
+                </div>
+              {/if}
+            </div>
+
+            <div class="app-scrollbar min-h-0 overflow-y-auto p-3">
+              {#if documentError}
+                <div class="rounded border border-red/30 bg-red/10 px-3 py-2 text-xs text-red" role="alert">{documentError}</div>
+              {:else if documentLoadingId}
+                <div class="text-xs text-text-muted">Loading attachment...</div>
+              {:else if selectedDocument}
+                <div class="mb-2 text-xs font-semibold text-text-primary">
+                  {selectedDocument.attachment.title || selectedDocument.attachment.documentId}
+                </div>
+                <pre class="max-h-[520px] whitespace-pre-wrap break-words rounded border border-border-subtle bg-bg-deep p-3 font-mono text-xs leading-5 text-text-primary">{selectedDocument.content}</pre>
+              {:else}
+                <div class="flex h-full min-h-44 items-center justify-center text-center text-xs text-text-muted">
+                  Select an attachment to read it.
+                </div>
+              {/if}
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  </div>
+{/if}

--- a/src/lib/components/SessionTabs.svelte
+++ b/src/lib/components/SessionTabs.svelte
@@ -35,7 +35,9 @@
     openNewProjectDialog,
     openEditProjectDialog,
   } from "$lib/stores/newProjectDialog";
+  import { openMainView } from "$lib/stores/mainView";
 
+  import Info from "@lucide/svelte/icons/info";
   import PinButton from "./PinButton.svelte";
   import CollapseSidebarButton from "./CollapseSidebarButton.svelte";
   import SidebarPanelHeader from "./SidebarPanelHeader.svelte";
@@ -295,6 +297,14 @@
   function handleContextMenu(e: MouseEvent, session: Session) {
     resetMenus();
     contextMenu = { x: e.clientX, y: e.clientY, session };
+  }
+
+  function handleOpenSessionDetails() {
+    if (!contextMenu) return;
+    const id = contextMenu.session.id;
+    setActiveSession(id);
+    openMainView({ kind: "sessionDetail", sessionId: id });
+    closeContextMenu();
   }
 
   function handleGroupHeaderContextMenu(e: MouseEvent, key: string) {
@@ -779,6 +789,13 @@
         </div>
       {/if}
     {:else if !worktreeInput}
+      <button
+        class="flex w-full cursor-pointer items-center gap-2 bg-transparent px-3 py-2 text-left text-xs text-text-secondary hover:bg-bg-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50 focus-visible:ring-offset-1 focus-visible:ring-offset-bg-base"
+        onclick={handleOpenSessionDetails}
+      >
+        <Info size={12} class="text-text-secondary" />
+        Session Details
+      </button>
       <button
         class="flex w-full cursor-pointer items-center gap-2 bg-transparent px-3 py-2 text-left text-xs text-text-secondary hover:bg-bg-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50 focus-visible:ring-offset-1 focus-visible:ring-offset-bg-base"
         onclick={showProjectMenu}

--- a/src/lib/components/__tests__/BoardMainView.test.ts
+++ b/src/lib/components/__tests__/BoardMainView.test.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/svelte";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import BoardFullscreen from "../BoardFullscreen.svelte";
+import BoardMainView from "../BoardMainView.svelte";
 import {
   itemsByColumn,
   acceptWorkItemReview,
@@ -12,11 +12,8 @@ import {
   runsByItem,
 } from "$lib/stores/workItems";
 import { deleteWorkItemWithMode } from "$lib/workItems/deleteFlow";
-import {
-  closeBoardFullscreen,
-  openNewWorkItemEditor,
-  openWorkItemSessionStart,
-} from "$lib/stores/ui";
+import { openNewWorkItemEditor, openWorkItemSessionStart } from "$lib/stores/ui";
+import { closeMainView } from "$lib/stores/mainView";
 import { openSessionById } from "$lib/panes/openSession";
 import { WORK_ITEM_DRAG_MIME } from "$lib/board/drag";
 import type { WorkItem } from "$lib/bindings";
@@ -41,7 +38,7 @@ if (typeof Element !== "undefined" && !Element.prototype.animate) {
 }
 
 // itemsByColumn is replaced with a plain writable so the test can drive the
-// columns directly; moveWorkItem / closeBoardFullscreen become spies.
+// columns directly; moveWorkItem / closeMainView become spies.
 vi.mock("$lib/stores/workItems", async () => {
   const { writable } = await import("svelte/store");
   return {
@@ -75,10 +72,13 @@ vi.mock("$lib/stores/sessions", async () => {
 });
 
 vi.mock("$lib/stores/ui", () => ({
-  closeBoardFullscreen: vi.fn(),
   openNewWorkItemEditor: vi.fn(),
   openWorkItemEditor: vi.fn(),
   openWorkItemSessionStart: vi.fn(),
+}));
+
+vi.mock("$lib/stores/mainView", () => ({
+  closeMainView: vi.fn(),
 }));
 
 vi.mock("$lib/panes/openSession", () => ({
@@ -165,7 +165,7 @@ function dragData(payload: { itemId: string; fromStatus: string }): DataTransfer
   } as unknown as DataTransfer;
 }
 
-describe("BoardFullscreen", () => {
+describe("BoardMainView", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     seedColumns([]);
@@ -176,7 +176,7 @@ describe("BoardFullscreen", () => {
   });
 
   it("renders one section per column with labels", () => {
-    render(BoardFullscreen);
+    render(BoardMainView);
     expect(screen.getAllByTestId("board-column")).toHaveLength(5);
     expect(screen.getByText("To Do")).toBeTruthy();
     expect(screen.getByText("Ready")).toBeTruthy();
@@ -187,7 +187,7 @@ describe("BoardFullscreen", () => {
 
   it("moves a card to the dropped-on column", async () => {
     seedColumns([workItem({ id: "wi-1", status: "todo" })]);
-    render(BoardFullscreen);
+    render(BoardMainView);
 
     const doneColumn = document.querySelector('[data-column="done"]')!;
     await fireEvent.drop(doneColumn, {
@@ -199,7 +199,7 @@ describe("BoardFullscreen", () => {
 
   it("ignores a drop onto the card's current column", async () => {
     seedColumns([workItem({ id: "wi-1", status: "todo" })]);
-    render(BoardFullscreen);
+    render(BoardMainView);
 
     const todoColumn = document.querySelector('[data-column="todo"]')!;
     await fireEvent.drop(todoColumn, {
@@ -209,17 +209,11 @@ describe("BoardFullscreen", () => {
     expect(moveWorkItem).not.toHaveBeenCalled();
   });
 
-  it("closes via the header button", async () => {
-    render(BoardFullscreen);
-    await fireEvent.click(screen.getByLabelText("Close board"));
-    expect(closeBoardFullscreen).toHaveBeenCalled();
-  });
-
   it("Start delegates to daemon start without issuing a second move", async () => {
     seedColumns([
       workItem({ id: "wi-1", status: "todo", projectId: "proj-1", sessionId: null }),
     ].map((item) => ({ ...item, agentProfile: "claude" } as WorkItem)));
-    render(BoardFullscreen);
+    render(BoardMainView);
 
     await fireEvent.click(screen.getByLabelText("Start work item"));
 
@@ -234,7 +228,7 @@ describe("BoardFullscreen", () => {
     seedColumns([
       workItem({ id: "wi-1", status: "todo", projectId: "proj-1", sessionId: null }),
     ].map((item) => ({ ...item, agentProfile: "claude" } as WorkItem)));
-    render(BoardFullscreen);
+    render(BoardMainView);
 
     await fireEvent.click(screen.getByLabelText("Start work item"));
 
@@ -250,7 +244,7 @@ describe("BoardFullscreen", () => {
   it("opens the session prompt when Start is clicked on an unprojected card", async () => {
     const item = workItem({ id: "wi-1", title: "Wire task start", projectId: null, sessionId: null });
     seedColumns([item]);
-    render(BoardFullscreen);
+    render(BoardMainView);
 
     expect(screen.getByText("Configure")).toBeTruthy();
     await fireEvent.click(screen.getByLabelText("Start work item"));
@@ -292,7 +286,7 @@ describe("BoardFullscreen", () => {
       notification({ id: "n-impl", sessionId: "impl-sess-1" }),
       notification({ id: "n-other", sessionId: "other-sess" }),
     ]);
-    render(BoardFullscreen);
+    render(BoardMainView);
 
     const badge = screen.getByLabelText("Open session with unread activity");
     expect(badge.textContent).toBe("2");
@@ -301,12 +295,12 @@ describe("BoardFullscreen", () => {
     await fireEvent.click(badge);
 
     expect(openSessionById).toHaveBeenCalledWith("plan-sess-1");
-    await vi.waitFor(() => expect(closeBoardFullscreen).toHaveBeenCalled());
+    await vi.waitFor(() => expect(closeMainView).toHaveBeenCalled());
   });
 
   it("does not delete from the right-click menu when the delete dialog is canceled", async () => {
     seedColumns([workItem({ id: "wi-delete", title: "Keep me" })]);
-    render(BoardFullscreen);
+    render(BoardMainView);
 
     await fireEvent.contextMenu(screen.getByTestId("work-item-card"), {
       clientX: 64,
@@ -322,14 +316,14 @@ describe("BoardFullscreen", () => {
     seedColumns([
       workItem({ id: "wi-1", status: "doing", sessionId: "sess-1" }),
     ]);
-    render(BoardFullscreen);
+    render(BoardMainView);
 
     // Session-bound cards show Open terminal, not Start.
     expect(screen.queryByLabelText("Start work item")).toBeNull();
     await fireEvent.click(screen.getByLabelText("Open terminal"));
 
     expect(openSessionById).toHaveBeenCalledWith("sess-1");
-    await vi.waitFor(() => expect(closeBoardFullscreen).toHaveBeenCalled());
+    await vi.waitFor(() => expect(closeMainView).toHaveBeenCalled());
   });
 
   it("accepts review from the card actions menu without directly moving the card", async () => {
@@ -341,7 +335,7 @@ describe("BoardFullscreen", () => {
         sessionId: "sess-1",
       }),
     ]);
-    render(BoardFullscreen);
+    render(BoardMainView);
 
     await fireEvent.contextMenu(screen.getByTestId("work-item-card"));
     await fireEvent.click(screen.getByText("Accept done"));
@@ -375,13 +369,13 @@ describe("BoardFullscreen", () => {
         ],
       ]),
     );
-    render(BoardFullscreen);
+    render(BoardMainView);
 
     expect(screen.queryByLabelText("Start work item")).toBeNull();
     await fireEvent.click(screen.getByLabelText("Open planning terminal"));
 
     expect(openSessionById).toHaveBeenCalledWith("plan-sess-1");
-    await vi.waitFor(() => expect(closeBoardFullscreen).toHaveBeenCalled());
+    await vi.waitFor(() => expect(closeMainView).toHaveBeenCalled());
   });
 
   it("routes pending question attention to the planning session without rendering the question body", async () => {
@@ -430,13 +424,13 @@ describe("BoardFullscreen", () => {
         ],
       ]),
     );
-    render(BoardFullscreen);
+    render(BoardMainView);
 
     expect(screen.queryByText("What should the report include?")).toBeNull();
     await fireEvent.click(screen.getByLabelText("Open session with pending question"));
 
     expect(openSessionById).toHaveBeenCalledWith("plan-sess-1");
-    await vi.waitFor(() => expect(closeBoardFullscreen).toHaveBeenCalled());
+    await vi.waitFor(() => expect(closeMainView).toHaveBeenCalled());
   });
 
   it("replans an active planning run from the card actions menu", async () => {
@@ -464,7 +458,7 @@ describe("BoardFullscreen", () => {
         ],
       ]),
     );
-    render(BoardFullscreen);
+    render(BoardMainView);
 
     await fireEvent.contextMenu(screen.getByTestId("work-item-card"));
     await fireEvent.click(screen.getByText("Retry planning"));
@@ -473,7 +467,7 @@ describe("BoardFullscreen", () => {
   });
 
   it("opens the new card editor for the selected column", async () => {
-    render(BoardFullscreen);
+    render(BoardMainView);
 
     // The Review column's add button (4 columns → 4 add buttons).
     const reviewColumn = document.querySelector('[data-column="review"]')!;

--- a/src/lib/components/__tests__/BoardPanel.test.ts
+++ b/src/lib/components/__tests__/BoardPanel.test.ts
@@ -12,6 +12,7 @@ import {
 } from "$lib/stores/workItems";
 import { deleteWorkItemWithMode } from "$lib/workItems/deleteFlow";
 import { openWorkItemSessionStart } from "$lib/stores/ui";
+import { openMainView } from "$lib/stores/mainView";
 import type { WorkItem } from "$lib/bindings";
 
 // jsdom lacks the Web Animations API that Svelte's transition:fade/scale use.
@@ -63,10 +64,13 @@ vi.mock("$lib/stores/sessions", async () => {
 });
 
 vi.mock("$lib/stores/ui", () => ({
-  openBoardFullscreen: vi.fn(),
   openNewWorkItemEditor: vi.fn(),
   openWorkItemEditor: vi.fn(),
   openWorkItemSessionStart: vi.fn(),
+}));
+
+vi.mock("$lib/stores/mainView", () => ({
+  openMainView: vi.fn(),
 }));
 
 vi.mock("$lib/panes/openSession", () => ({
@@ -126,6 +130,14 @@ describe("BoardPanel", () => {
 
     expect(startWorkItem).toHaveBeenCalledWith("wi-1");
     expect(moveWorkItem).not.toHaveBeenCalled();
+  });
+
+  it("opens the board in the main view from the header", async () => {
+    render(BoardPanel, { visible: true, onclose: vi.fn() });
+
+    await fireEvent.click(screen.getByLabelText("Open board in main view"));
+
+    expect(openMainView).toHaveBeenCalledWith({ kind: "board" });
   });
 
   it("shows an inline error when Start dispatch fails", async () => {

--- a/src/lib/components/__tests__/SessionDetailView.test.ts
+++ b/src/lib/components/__tests__/SessionDetailView.test.ts
@@ -258,6 +258,9 @@ describe("SessionDetailView", () => {
         session.id === "session-1" ? { ...session, status: "generating" } : session,
       ),
     }));
+    await tick();
+
+    expect(listDocuments).toHaveBeenCalledTimes(1);
 
     resolveDocument?.({ attachment, content: "Still current content" });
     await new Promise((resolve) => setTimeout(resolve, 0));

--- a/src/lib/components/__tests__/SessionDetailView.test.ts
+++ b/src/lib/components/__tests__/SessionDetailView.test.ts
@@ -225,6 +225,39 @@ describe("SessionDetailView", () => {
     expect(screen.getByText("Select an attachment to read it.")).toBeTruthy();
   });
 
+  it("keeps pending attachment reads alive across same-session metadata updates", async () => {
+    const attachment = makeAttachment({
+      title: "Live session note",
+    });
+    let resolveDocument:
+      | ((value: { attachment: Attachment; content: string }) => void)
+      | undefined;
+
+    sessionState.set({ sessions: [makeSession()], activeSessionId: "session-1" });
+    vi.mocked(listDocuments).mockResolvedValue([attachment]);
+    vi.mocked(getDocument).mockImplementation(() => {
+      return new Promise((resolve) => {
+        resolveDocument = resolve;
+      });
+    });
+
+    render(SessionDetailView, { sessionId: "session-1" });
+
+    await fireEvent.click(await screen.findByRole("button", { name: "Live session note" }));
+    sessionState.update((state) => ({
+      ...state,
+      sessions: state.sessions.map((session) =>
+        session.id === "session-1" ? { ...session, status: "generating" } : session,
+      ),
+    }));
+
+    resolveDocument?.({ attachment, content: "Still current content" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await tick();
+
+    expect(screen.getByText("Still current content")).toBeTruthy();
+  });
+
   it("renames the session inline", async () => {
     sessionState.set({ sessions: [makeSession()], activeSessionId: "session-1" });
     render(SessionDetailView, { sessionId: "session-1" });

--- a/src/lib/components/__tests__/SessionDetailView.test.ts
+++ b/src/lib/components/__tests__/SessionDetailView.test.ts
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/svelte";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { tick } from "svelte";
 import { get } from "svelte/store";
 import SessionDetailView from "../SessionDetailView.svelte";
 import { sessionState } from "$lib/stores/sessions";
@@ -127,6 +128,49 @@ describe("SessionDetailView", () => {
 
     expect(getDocument).toHaveBeenCalledWith("session-1.doc-1");
     expect(await screen.findByText("These are the attached notes.")).toBeTruthy();
+  });
+
+  it("ignores stale attachment reads when a later selection resolves first", async () => {
+    const first = makeAttachment({
+      id: "doc-1",
+      documentId: "session-1.doc-1",
+      title: "First note",
+    });
+    const second = makeAttachment({
+      id: "doc-2",
+      documentId: "session-1.doc-2",
+      title: "Second note",
+    });
+    let resolveFirst:
+      | ((value: { attachment: Attachment; content: string }) => void)
+      | undefined;
+    let resolveSecond:
+      | ((value: { attachment: Attachment; content: string }) => void)
+      | undefined;
+
+    sessionState.set({ sessions: [makeSession()], activeSessionId: "session-1" });
+    vi.mocked(listDocuments).mockResolvedValue([first, second]);
+    vi.mocked(getDocument).mockImplementation((documentId) => {
+      return new Promise((resolve) => {
+        if (documentId === first.documentId) resolveFirst = resolve;
+        if (documentId === second.documentId) resolveSecond = resolve;
+      });
+    });
+
+    render(SessionDetailView, { sessionId: "session-1" });
+
+    await fireEvent.click(await screen.findByRole("button", { name: "First note" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Second note" }));
+
+    resolveSecond?.({ attachment: second, content: "Second content" });
+    await tick();
+    expect(await screen.findByText("Second content")).toBeTruthy();
+
+    resolveFirst?.({ attachment: first, content: "First stale content" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await tick();
+    expect(screen.queryByText("First stale content")).toBeNull();
+    expect(screen.getByText("Second content")).toBeTruthy();
   });
 
   it("renames the session inline", async () => {

--- a/src/lib/components/__tests__/SessionDetailView.test.ts
+++ b/src/lib/components/__tests__/SessionDetailView.test.ts
@@ -1,0 +1,169 @@
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { get } from "svelte/store";
+import SessionDetailView from "../SessionDetailView.svelte";
+import { sessionState } from "$lib/stores/sessions";
+import { projects } from "$lib/stores/projects";
+import { sessionLayouts } from "$lib/panes/layout";
+import { paneInstances, type PaneInstance } from "$lib/panes/instances";
+import { closeMainView } from "$lib/stores/mainView";
+import { continueSession } from "$lib/sessions/reconnect";
+import { getDocument, listDocuments } from "$lib/stores/workItems";
+import type { Attachment } from "$lib/types/workItems";
+import type { Session } from "$lib/types";
+
+vi.mock("$lib/stores/workItems", () => ({
+  listDocuments: vi.fn().mockResolvedValue([]),
+  getDocument: vi.fn(),
+}));
+
+vi.mock("$lib/stores/mainView", () => ({
+  closeMainView: vi.fn(),
+}));
+
+vi.mock("$lib/sessions/reconnect", () => ({
+  continueSession: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock("$lib/tauri", () => ({
+  setSessionNameOverride: vi.fn().mockResolvedValue(undefined),
+}));
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "session-1",
+    name: "main",
+    repoRoot: "/repo",
+    worktreePath: "/repo/.worktrees/feature",
+    branch: "feature/main-view",
+    isWorktree: true,
+    status: "idle",
+    model: "claude-sonnet",
+    cost: 1.25,
+    createdAt: 1_700_000_000,
+    projectId: "project-1",
+    isGitRepo: true,
+    nameOverride: null,
+    primaryPtyId: "pty-primary",
+    archived: false,
+    endedAt: null,
+    pinnedPrUrl: "https://github.com/acme/repo/pull/123",
+    ...overrides,
+  };
+}
+
+function makePane(overrides: Partial<PaneInstance> = {}): PaneInstance {
+  return {
+    id: "pane-1",
+    type: "shell",
+    ptyId: "pty-primary",
+    unlisteners: [],
+    name: "main shell",
+    spawnProfileRef: { kind: "registered", id: "claude" },
+    sessionId: "session-1",
+    ...overrides,
+  };
+}
+
+function makeAttachment(overrides: Partial<Attachment> = {}): Attachment {
+  return {
+    id: "doc-1",
+    documentId: "session-1.doc-1",
+    targetKind: "session",
+    targetId: "session-1",
+    title: "Implementation notes",
+    contentKind: "text",
+    mimeType: "text/markdown",
+    sourcePath: null,
+    byteLen: 42,
+    sha256: "abc",
+    createdAt: 1_700_000_100,
+    updatedAt: 1_700_000_100,
+    ...overrides,
+  };
+}
+
+describe("SessionDetailView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionState.set({ sessions: [], activeSessionId: null });
+    projects.set([]);
+    sessionLayouts.set(new Map());
+    paneInstances.set(new Map());
+    vi.mocked(listDocuments).mockResolvedValue([]);
+  });
+
+  it("renders live session metadata and read-only pane summary", async () => {
+    sessionState.set({ sessions: [makeSession()], activeSessionId: "session-1" });
+    projects.set([{ id: "project-1", name: "Main Project", repoRoots: ["/repo"] }]);
+    sessionLayouts.set(new Map([
+      ["session-1", { kind: "leaf", paneId: "pane-1" }],
+    ]));
+    paneInstances.set(new Map([["pane-1", makePane()]]));
+
+    render(SessionDetailView, { sessionId: "session-1" });
+
+    expect(await screen.findByText("Main Project")).toBeTruthy();
+    expect(screen.getByText("/repo/.worktrees/feature")).toBeTruthy();
+    expect(screen.getAllByText("feature/main-view").length).toBeGreaterThan(0);
+    expect(screen.getByText("main shell")).toBeTruthy();
+    expect(screen.getByText("shell")).toBeTruthy();
+    expect(screen.getByText("claude")).toBeTruthy();
+    expect(listDocuments).toHaveBeenCalledWith("session", "session-1");
+  });
+
+  it("opens an attached document inline", async () => {
+    const attachment = makeAttachment();
+    sessionState.set({ sessions: [makeSession()], activeSessionId: "session-1" });
+    vi.mocked(listDocuments).mockResolvedValue([attachment]);
+    vi.mocked(getDocument).mockResolvedValue({
+      attachment,
+      content: "These are the attached notes.",
+    });
+
+    render(SessionDetailView, { sessionId: "session-1" });
+
+    await fireEvent.click(await screen.findByRole("button", { name: "Implementation notes" }));
+
+    expect(getDocument).toHaveBeenCalledWith("session-1.doc-1");
+    expect(await screen.findByText("These are the attached notes.")).toBeTruthy();
+  });
+
+  it("renames the session inline", async () => {
+    sessionState.set({ sessions: [makeSession()], activeSessionId: "session-1" });
+    render(SessionDetailView, { sessionId: "session-1" });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Rename session" }));
+    const input = screen.getByLabelText("Session name");
+    await fireEvent.input(input, { target: { value: "Renamed Session" } });
+    await fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(screen.getByText("Renamed Session")).toBeTruthy();
+  });
+
+  it("focuses the session and closes the main view when opening the terminal", async () => {
+    sessionState.set({ sessions: [makeSession()], activeSessionId: null });
+    render(SessionDetailView, { sessionId: "session-1" });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Open terminal" }));
+
+    expect(get(sessionState).activeSessionId).toBe("session-1");
+    expect(closeMainView).toHaveBeenCalled();
+  });
+
+  it("continues a disconnected session from the detail view", async () => {
+    const session = makeSession({ status: "disconnected" });
+    sessionState.set({ sessions: [session], activeSessionId: "session-1" });
+    render(SessionDetailView, { sessionId: "session-1" });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Continue session" }));
+
+    expect(continueSession).toHaveBeenCalledWith(session);
+  });
+
+  it("shows an empty state when the session no longer exists", () => {
+    render(SessionDetailView, { sessionId: "missing-session" });
+
+    expect(screen.getByText("Session no longer available")).toBeTruthy();
+  });
+});

--- a/src/lib/components/__tests__/SessionDetailView.test.ts
+++ b/src/lib/components/__tests__/SessionDetailView.test.ts
@@ -173,6 +173,58 @@ describe("SessionDetailView", () => {
     expect(screen.getByText("Second content")).toBeTruthy();
   });
 
+  it("ignores pending attachment reads after the session detail route changes", async () => {
+    const firstAttachment = makeAttachment({
+      id: "doc-1",
+      documentId: "session-1.doc-1",
+      targetId: "session-1",
+      title: "First session note",
+    });
+    const secondAttachment = makeAttachment({
+      id: "doc-2",
+      documentId: "session-2.doc-2",
+      targetId: "session-2",
+      title: "Second session note",
+    });
+    let resolveFirst:
+      | ((value: { attachment: Attachment; content: string }) => void)
+      | undefined;
+
+    sessionState.set({
+      sessions: [
+        makeSession(),
+        makeSession({
+          id: "session-2",
+          name: "second",
+          primaryPtyId: "pty-second",
+        }),
+      ],
+      activeSessionId: "session-1",
+    });
+    vi.mocked(listDocuments).mockImplementation((_, targetId) => {
+      if (targetId === "session-1") return Promise.resolve([firstAttachment]);
+      return Promise.resolve([secondAttachment]);
+    });
+    vi.mocked(getDocument).mockImplementation((documentId) => {
+      return new Promise((resolve) => {
+        if (documentId === firstAttachment.documentId) resolveFirst = resolve;
+      });
+    });
+
+    const view = render(SessionDetailView, { sessionId: "session-1" });
+
+    await fireEvent.click(await screen.findByRole("button", { name: "First session note" }));
+    await view.rerender({ sessionId: "session-2" });
+    expect(await screen.findByRole("button", { name: "Second session note" })).toBeTruthy();
+
+    resolveFirst?.({ attachment: firstAttachment, content: "First session stale content" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await tick();
+
+    expect(screen.queryByText("First session stale content")).toBeNull();
+    expect(screen.getByText("Select an attachment to read it.")).toBeTruthy();
+  });
+
   it("renames the session inline", async () => {
     sessionState.set({ sessions: [makeSession()], activeSessionId: "session-1" });
     render(SessionDetailView, { sessionId: "session-1" });

--- a/src/lib/components/__tests__/SessionDetailView.test.ts
+++ b/src/lib/components/__tests__/SessionDetailView.test.ts
@@ -113,6 +113,14 @@ describe("SessionDetailView", () => {
     expect(listDocuments).toHaveBeenCalledWith("session", "session-1");
   });
 
+  it("renders a Unix epoch createdAt value instead of treating it as missing", async () => {
+    sessionState.set({ sessions: [makeSession({ createdAt: 0 })], activeSessionId: "session-1" });
+
+    render(SessionDetailView, { sessionId: "session-1" });
+
+    expect(await screen.findByText(new Date(0).toLocaleString())).toBeTruthy();
+  });
+
   it("opens an attached document inline", async () => {
     const attachment = makeAttachment();
     sessionState.set({ sessions: [makeSession()], activeSessionId: "session-1" });

--- a/src/lib/components/__tests__/SessionTabs.test.ts
+++ b/src/lib/components/__tests__/SessionTabs.test.ts
@@ -1,0 +1,94 @@
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { get } from "svelte/store";
+import SessionTabs from "../SessionTabs.svelte";
+import { sessionState } from "$lib/stores/sessions";
+import { projects } from "$lib/stores/projects";
+import { openMainView } from "$lib/stores/mainView";
+import type { Session } from "$lib/types";
+
+vi.mock("$lib/stores/mainView", () => ({
+  openMainView: vi.fn(),
+}));
+
+vi.mock("$lib/stores/tasks", () => ({
+  refreshTasks: vi.fn(),
+  initTaskOverrides: vi.fn(),
+}));
+
+vi.mock("$lib/tauri", () => ({
+  createSessionShell: vi.fn(),
+  openInEditor: vi.fn(),
+  refreshSessionGitStatus: vi.fn().mockResolvedValue(true),
+  setSessionProject: vi.fn().mockResolvedValue(undefined),
+  listArchivedSessions: vi.fn().mockResolvedValue([]),
+  listSessions: vi.fn().mockResolvedValue([]),
+  openPathInFinder: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("$lib/sessions/close", () => ({
+  closeSession: vi.fn(),
+}));
+
+vi.mock("$lib/sessions/reconnect", () => ({
+  continueSession: vi.fn(),
+}));
+
+vi.mock("$lib/sessions/spawnBlueprint", () => ({
+  spawnBlueprintForProject: vi.fn(),
+}));
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "session-1",
+    name: "feature-a",
+    repoRoot: "/repo",
+    worktreePath: "/repo/.worktrees/feature-a",
+    branch: "feature-a",
+    isWorktree: true,
+    status: "idle",
+    model: null,
+    cost: null,
+    createdAt: 1,
+    projectId: null,
+    isGitRepo: true,
+    nameOverride: null,
+    primaryPtyId: "pty-1",
+    archived: false,
+    endedAt: null,
+    ...overrides,
+  };
+}
+
+describe("SessionTabs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    projects.set([]);
+    sessionState.set({
+      sessions: [
+        makeSession(),
+        makeSession({
+          id: "session-2",
+          name: "feature-b",
+          worktreePath: "/repo/.worktrees/feature-b",
+          branch: "feature-b",
+          primaryPtyId: "pty-2",
+        }),
+      ],
+      activeSessionId: "session-2",
+    });
+  });
+
+  it("opens session details from the session context menu", async () => {
+    render(SessionTabs, { onNewSession: vi.fn() });
+
+    await fireEvent.contextMenu(screen.getByText("feature-a"));
+    await fireEvent.click(screen.getByText("Session Details"));
+
+    expect(openMainView).toHaveBeenCalledWith({
+      kind: "sessionDetail",
+      sessionId: "session-1",
+    });
+    expect(get(sessionState).activeSessionId).toBe("session-1");
+  });
+});

--- a/src/lib/keymap/editableTarget.ts
+++ b/src/lib/keymap/editableTarget.ts
@@ -1,0 +1,19 @@
+export function eventTargetIsEditable(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+
+  if (target.closest("input, textarea, select, .cm-editor")) return true;
+
+  for (let current: Element | null = target; current; current = current.parentElement) {
+    if (!(current instanceof HTMLElement)) continue;
+    if (current.isContentEditable) return true;
+
+    const value = current.getAttribute("contenteditable");
+    if (value == null) continue;
+
+    const normalized = value.trim().toLowerCase();
+    if (normalized === "false") return false;
+    if (normalized === "" || normalized === "true" || normalized === "plaintext-only") return true;
+  }
+
+  return false;
+}

--- a/src/lib/mainView/__tests__/keyGate.test.ts
+++ b/src/lib/mainView/__tests__/keyGate.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  commandBlockedByMainView,
+  eventTargetIsEditable,
+  eventTargetIsInsideMainView,
+} from "../keyGate";
+import type { Command } from "$lib/commands/registry";
+
+function command(overrides: Partial<Command>): Command {
+  return {
+    id: "app.test",
+    label: "Test",
+    category: "App",
+    ...overrides,
+  };
+}
+
+describe("main-view key gate", () => {
+  it("blocks pane commands by category or id prefix", () => {
+    expect(commandBlockedByMainView(command({ id: "pane.split-right", category: "Panes" }))).toBe(true);
+    expect(commandBlockedByMainView(command({ id: "pane.open-doc", category: "Documents" }))).toBe(true);
+    expect(commandBlockedByMainView(command({ id: "session.next", category: "Sessions" }))).toBe(false);
+    expect(commandBlockedByMainView(command({ id: "ui.toggle-board", category: "App" }))).toBe(false);
+  });
+
+  it("detects editable targets that should own Escape", () => {
+    const input = document.createElement("input");
+    const textarea = document.createElement("textarea");
+    const editable = document.createElement("div");
+    editable.setAttribute("contenteditable", "true");
+    const button = document.createElement("button");
+
+    expect(eventTargetIsEditable(input)).toBe(true);
+    expect(eventTargetIsEditable(textarea)).toBe(true);
+    expect(eventTargetIsEditable(editable)).toBe(true);
+    expect(eventTargetIsEditable(button)).toBe(false);
+  });
+
+  it("detects focus inside the main-view root", () => {
+    const root = document.createElement("div");
+    root.dataset.mainViewRoot = "";
+    const child = document.createElement("button");
+    root.appendChild(child);
+
+    expect(eventTargetIsInsideMainView(child)).toBe(true);
+    expect(eventTargetIsInsideMainView(document.createElement("button"))).toBe(false);
+  });
+});

--- a/src/lib/mainView/__tests__/keyGate.test.ts
+++ b/src/lib/mainView/__tests__/keyGate.test.ts
@@ -28,13 +28,32 @@ describe("main-view key gate", () => {
   it("detects editable targets that should own Escape", () => {
     const input = document.createElement("input");
     const textarea = document.createElement("textarea");
+    const select = document.createElement("select");
     const editable = document.createElement("div");
     editable.setAttribute("contenteditable", "true");
+    const emptyEditable = document.createElement("div");
+    emptyEditable.setAttribute("contenteditable", "");
+    const plaintextEditable = document.createElement("div");
+    plaintextEditable.setAttribute("contenteditable", "plaintext-only");
+    const inheritedEditable = document.createElement("div");
+    inheritedEditable.setAttribute("contenteditable", "true");
+    const inheritedChild = document.createElement("span");
+    inheritedEditable.appendChild(inheritedChild);
+    const disabledEditable = document.createElement("div");
+    disabledEditable.setAttribute("contenteditable", "false");
+    const codeMirror = document.createElement("div");
+    codeMirror.className = "cm-editor";
     const button = document.createElement("button");
 
     expect(eventTargetIsEditable(input)).toBe(true);
     expect(eventTargetIsEditable(textarea)).toBe(true);
+    expect(eventTargetIsEditable(select)).toBe(true);
     expect(eventTargetIsEditable(editable)).toBe(true);
+    expect(eventTargetIsEditable(emptyEditable)).toBe(true);
+    expect(eventTargetIsEditable(plaintextEditable)).toBe(true);
+    expect(eventTargetIsEditable(inheritedChild)).toBe(true);
+    expect(eventTargetIsEditable(disabledEditable)).toBe(false);
+    expect(eventTargetIsEditable(codeMirror)).toBe(true);
     expect(eventTargetIsEditable(button)).toBe(false);
   });
 

--- a/src/lib/mainView/__tests__/keyGate.test.ts
+++ b/src/lib/mainView/__tests__/keyGate.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   commandBlockedByMainView,
   eventTargetIsEditable,
+  eventTargetIsMainViewKeyboardOwner,
   eventTargetIsInsideMainView,
+  mainViewTargetShouldBypassAppKeymap,
 } from "../keyGate";
 import type { Command } from "$lib/commands/registry";
 
@@ -44,5 +46,17 @@ describe("main-view key gate", () => {
 
     expect(eventTargetIsInsideMainView(child)).toBe(true);
     expect(eventTargetIsInsideMainView(document.createElement("button"))).toBe(false);
+  });
+
+  it("lets non-editable main-view focus continue to app shortcut handling", () => {
+    const root = document.createElement("div");
+    root.dataset.mainViewRoot = "";
+    const button = document.createElement("button");
+    const input = document.createElement("input");
+    root.append(button, input);
+
+    expect(eventTargetIsMainViewKeyboardOwner(button)).toBe(true);
+    expect(mainViewTargetShouldBypassAppKeymap(button)).toBe(false);
+    expect(mainViewTargetShouldBypassAppKeymap(input)).toBe(true);
   });
 });

--- a/src/lib/mainView/keyGate.ts
+++ b/src/lib/mainView/keyGate.ts
@@ -1,4 +1,7 @@
 import type { Command } from "$lib/commands/registry";
+import { eventTargetIsEditable } from "$lib/keymap/editableTarget";
+
+export { eventTargetIsEditable };
 
 export function commandBlockedByMainView(command: Command | undefined): boolean {
   if (!command) return false;
@@ -19,10 +22,4 @@ export function eventTargetIsMainViewKeyboardOwner(target: EventTarget | null): 
 
 export function mainViewTargetShouldBypassAppKeymap(target: EventTarget | null): boolean {
   return eventTargetIsMainViewKeyboardOwner(target) && eventTargetIsEditable(target);
-}
-
-export function eventTargetIsEditable(target: EventTarget | null): boolean {
-  if (!(target instanceof Element)) return false;
-  const editable = target.closest("input, textarea, select, [contenteditable='true']");
-  return editable !== null;
 }

--- a/src/lib/mainView/keyGate.ts
+++ b/src/lib/mainView/keyGate.ts
@@ -9,6 +9,18 @@ export function eventTargetIsInsideMainView(target: EventTarget | null): boolean
   return target instanceof Element && target.closest("[data-main-view-root]") !== null;
 }
 
+export function eventTargetIsMainViewKeyboardOwner(target: EventTarget | null): boolean {
+  return (
+    eventTargetIsInsideMainView(target) ||
+    target === document.body ||
+    target === document.documentElement
+  );
+}
+
+export function mainViewTargetShouldBypassAppKeymap(target: EventTarget | null): boolean {
+  return eventTargetIsMainViewKeyboardOwner(target) && eventTargetIsEditable(target);
+}
+
 export function eventTargetIsEditable(target: EventTarget | null): boolean {
   if (!(target instanceof Element)) return false;
   const editable = target.closest("input, textarea, select, [contenteditable='true']");

--- a/src/lib/mainView/keyGate.ts
+++ b/src/lib/mainView/keyGate.ts
@@ -1,0 +1,16 @@
+import type { Command } from "$lib/commands/registry";
+
+export function commandBlockedByMainView(command: Command | undefined): boolean {
+  if (!command) return false;
+  return command.id.startsWith("pane.") || command.category === "Panes";
+}
+
+export function eventTargetIsInsideMainView(target: EventTarget | null): boolean {
+  return target instanceof Element && target.closest("[data-main-view-root]") !== null;
+}
+
+export function eventTargetIsEditable(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+  const editable = target.closest("input, textarea, select, [contenteditable='true']");
+  return editable !== null;
+}

--- a/src/lib/stores/__tests__/mainView.test.ts
+++ b/src/lib/stores/__tests__/mainView.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, afterEach } from "vitest";
+import { get } from "svelte/store";
+import {
+  closeMainView,
+  mainViewActive,
+  mainViewRoute,
+  openMainView,
+  toggleMainView,
+} from "../mainView";
+
+describe("mainViewRoute", () => {
+  afterEach(() => {
+    closeMainView();
+  });
+
+  it("starts closed", () => {
+    expect(get(mainViewRoute)).toBeNull();
+    expect(get(mainViewActive)).toBe(false);
+  });
+
+  it("opens, replaces, and closes routes", () => {
+    openMainView({ kind: "board" });
+    expect(get(mainViewRoute)).toEqual({ kind: "board" });
+    expect(get(mainViewActive)).toBe(true);
+
+    openMainView({ kind: "sessionDetail", sessionId: "session-1" });
+    expect(get(mainViewRoute)).toEqual({
+      kind: "sessionDetail",
+      sessionId: "session-1",
+    });
+
+    closeMainView();
+    expect(get(mainViewRoute)).toBeNull();
+    expect(get(mainViewActive)).toBe(false);
+  });
+
+  it("toggles only the matching route", () => {
+    toggleMainView({ kind: "board" });
+    expect(get(mainViewRoute)).toEqual({ kind: "board" });
+
+    toggleMainView({ kind: "sessionDetail", sessionId: "session-1" });
+    expect(get(mainViewRoute)).toEqual({
+      kind: "sessionDetail",
+      sessionId: "session-1",
+    });
+
+    toggleMainView({ kind: "sessionDetail", sessionId: "session-2" });
+    expect(get(mainViewRoute)).toEqual({
+      kind: "sessionDetail",
+      sessionId: "session-2",
+    });
+
+    toggleMainView({ kind: "sessionDetail", sessionId: "session-2" });
+    expect(get(mainViewRoute)).toBeNull();
+  });
+});

--- a/src/lib/stores/__tests__/ui.test.ts
+++ b/src/lib/stores/__tests__/ui.test.ts
@@ -4,8 +4,6 @@ import {
   activeSidebar,
   armPaneHints,
   armSessionHints,
-  boardFullscreen,
-  closeBoardFullscreen,
   editingWorkItemId,
   newWorkItemEditor,
   openNewWorkItemEditor,
@@ -16,14 +14,12 @@ import {
   hidePaneHints,
   hideSessionHints,
   isPinned,
-  openBoardFullscreen,
   openSidebar,
   pinnedSidebar,
   pinSidebar,
   PINNABLE_SIDEBARS,
   showPaneHints,
   showSessionHints,
-  toggleBoardFullscreen,
   toggleSidebar,
   unpinSidebar,
 } from "../ui";
@@ -294,42 +290,6 @@ describe("showPaneHints", () => {
     hideSessionHints();
     expect(get(showSessionHints)).toBe(false);
     expect(get(showPaneHints)).toBe(true);
-  });
-});
-
-describe("boardFullscreen", () => {
-  afterEach(() => {
-    closeBoardFullscreen();
-  });
-
-  it("starts closed", () => {
-    expect(get(boardFullscreen)).toBe(false);
-  });
-
-  it("opens, closes, and toggles", () => {
-    openBoardFullscreen();
-    expect(get(boardFullscreen)).toBe(true);
-    openBoardFullscreen();
-    expect(get(boardFullscreen)).toBe(true);
-
-    closeBoardFullscreen();
-    expect(get(boardFullscreen)).toBe(false);
-
-    toggleBoardFullscreen();
-    expect(get(boardFullscreen)).toBe(true);
-    toggleBoardFullscreen();
-    expect(get(boardFullscreen)).toBe(false);
-  });
-
-  it("is independent of the sidebar slots", () => {
-    pinSidebar("sessions");
-    openBoardFullscreen();
-    expect(get(boardFullscreen)).toBe(true);
-    expect(get(pinnedSidebar)).toBe("sessions");
-
-    closeBoardFullscreen();
-    expect(get(pinnedSidebar)).toBe("sessions");
-    unpinSidebar();
   });
 });
 

--- a/src/lib/stores/mainView.ts
+++ b/src/lib/stores/mainView.ts
@@ -1,0 +1,34 @@
+import { derived, get, writable } from "svelte/store";
+
+export type MainViewRoute =
+  | { kind: "board" }
+  | { kind: "sessionDetail"; sessionId: string };
+
+export const mainViewRoute = writable<MainViewRoute | null>(null);
+export const mainViewActive = derived(mainViewRoute, ($route) => $route !== null);
+
+export function openMainView(route: MainViewRoute): void {
+  mainViewRoute.set(route);
+}
+
+export function closeMainView(): void {
+  mainViewRoute.set(null);
+}
+
+export function toggleMainView(route: MainViewRoute): void {
+  const current = get(mainViewRoute);
+  if (current && routesEqual(current, route)) {
+    closeMainView();
+    return;
+  }
+  openMainView(route);
+}
+
+function routesEqual(a: MainViewRoute, b: MainViewRoute): boolean {
+  if (a.kind !== b.kind) return false;
+  if (a.kind === "board" && b.kind === "board") return true;
+  if (a.kind === "sessionDetail" && b.kind === "sessionDetail") {
+    return a.sessionId === b.sessionId;
+  }
+  return false;
+}

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -133,7 +133,6 @@ export type StartupSidebarPreference = "restore" | "sessions" | "kanban" | "none
 
 export function applyStartupSidebarPreference(preference: StartupSidebarPreference): void {
   if (preference === "restore") return;
-  boardFullscreen.set(false);
   if (preference === "none") {
     sidebarState.set({ pinned: null, active: null });
     clearNotesOverrideIfLeaving(null);
@@ -192,26 +191,6 @@ export function openNotesForSession(sessionId: string): void {
   showSidebar();
   notesOverrideSessionId.set(sessionId);
   sidebarState.update((s) => ({ ...s, active: "notes" }));
-}
-
-/**
- * The board has two surfaces: the lightweight dock panel (a pinnable
- * `SidebarId`) and a roomy full-screen view that overlays the main content
- * area. This flag drives the full-screen view only; it is independent of the
- * sidebar pinned/active slots so opening one never disturbs the other.
- */
-export const boardFullscreen = writable(false);
-
-export function openBoardFullscreen(): void {
-  boardFullscreen.set(true);
-}
-
-export function closeBoardFullscreen(): void {
-  boardFullscreen.set(false);
-}
-
-export function toggleBoardFullscreen(): void {
-  boardFullscreen.update((v) => !v);
 }
 
 /**


### PR DESCRIPTION
## Summary

Introduces a reusable app-level main-view workflow that replaces the old board fullscreen flag with typed main-view routes and shared chrome.

## Changes

- Added `mainViewRoute` state plus reusable `MainViewHost` and `MainViewShell` components.
- Migrated the Board fullscreen surface to `BoardMainView` under the new main-view workflow.
- Added a read-only Session Detail main view with metadata, pane summary, inline rename, terminal/continue actions, and attachment reading.
- Added Session Details to the session context menu.
- Gated keyboard handling so pane commands are blocked while a main view is active, while allowed app shortcuts still work.
- Guarded session-detail attachment reads against stale async responses across selection changes and session route changes.

## Impact

This makes full-window app surfaces reusable without turning them into panes or floating overlays. The sidebar and status bar remain visible, panes stay mounted underneath, and main views can be opened explicitly from implementing items.

## Validation

- `npm run check` PASS
- `npm run test` PASS (`1109 passed`, `2 skipped`)
- `npm run build` PASS
- roborev review job `53` PASS: no issues found


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Main view system for full-screen board and session detail displays
  * Session detail view with metadata, pane information, and attachment browsing
  * Session Details context menu option for quick access
  * Improved keyboard navigation with focus preservation

* **Refactor**
  * Replaced board fullscreen toggle with main view routing system

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the board-specific `boardFullscreen` flag with a typed `mainViewRoute` store that supports multiple named surfaces (`board`, `sessionDetail`). A shared `MainViewShell` chrome (title bar + close) and a `MainViewHost` router wrap all main-view content, and a new keyboard gate (`keyGate.ts`) blocks pane commands while any view is open.

- **New `mainViewRoute` store** – `openMainView`, `closeMainView`, and `toggleMainView` replace the old `boardFullscreen` helpers; `routesEqual` ensures toggle only closes the exact matching route.
- **`SessionDetailView`** – new read-only panel showing session metadata, pane summary, inline rename, terminal/continue actions, and document attachment browsing; stale async reads are guarded by generation counters and a `documentTargetId` identity check that prevents re-fetching on heartbeat-level metadata updates.
- **Keyboard gating** – `commandBlockedByMainView` blocks `pane.*`-prefixed and `\"Panes\"`-category commands while a view is active; `eventTargetIsEditable` is extracted to a shared utility and upgraded to handle `contenteditable=\"\"`, `contenteditable=\"plaintext-only\"`, and inherited editability.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are confined to UI routing and keyboard gating, with no pane-tree, PTY, or daemon-protocol modifications.

The stale-async guard in SessionDetailView (generation counters + documentTargetId identity check) is correct and directly tested. The keyboard gate correctly allows session/app shortcuts while blocking pane-split commands. The store migration from boardFullscreen to mainViewRoute is clean and backward-safe. Tests pass across all new surfaces. The only open item is a focus UX gap when switching route kinds inside an already-mounted shell, which does not break any core functionality.

src/lib/components/MainViewShell.svelte — the $effect focus call fires on mount only; route-kind switches leave focus on document.body until the user clicks.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/stores/mainView.ts | New store: typed MainViewRoute discriminated union, clean open/close/toggle helpers, routesEqual correctly narrows both sides of the union for TypeScript |
| src/lib/mainView/keyGate.ts | Blocks pane.* / Panes-category commands; correctly treats document.body and document.documentElement as main-view keyboard owners; re-exports eventTargetIsEditable cleanly |
| src/lib/keymap/editableTarget.ts | Extracted utility; correctly handles contenteditable="", "plaintext-only", and inherited editability via isContentEditable; contenteditable="false" islands are honored |
| src/lib/components/MainViewShell.svelte | Shared chrome with correct tabindex=-1 focus container; $effect focuses on mount but does not re-focus when the route switches kinds while the shell stays mounted |
| src/lib/components/MainViewHost.svelte | Clean route dispatcher; subtitle correctly filters falsy parts; session lookup guards against missing sessions |
| src/lib/components/SessionDetailView.svelte | Stale read protection via generation counters + documentTargetId identity guard; $effect guard correctly prevents re-fetching on metadata heartbeats; well-tested |
| src/App.svelte | Keyboard gating and focus capture/restore added; the known edge case (session switched before view opens misses pane-focus restoration) is tracked in existing review threads |
| src/lib/stores/ui.ts | boardFullscreen helpers cleanly removed; applyStartupSidebarPreference no longer needs to reset the new store since mainViewRoute initialises to null and is not persisted |
| src/lib/components/SessionTabs.svelte | Session Details added to context menu; handleOpenSessionDetails correctly captures session id before closing the menu |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant SessionTabs
    participant mainViewRoute
    participant App
    participant MainViewHost
    participant MainViewShell
    participant SessionDetailView

    User->>SessionTabs: right-click session → Session Details
    SessionTabs->>mainViewRoute: "openMainView({kind:"sessionDetail", sessionId})"
    mainViewRoute-->>App: $mainViewRoute reactive update
    App->>App: capture paneFocusBeforeMainView, setLogicalFocus(null)
    mainViewRoute-->>MainViewHost: route changes → renders SessionDetailView
    MainViewHost->>MainViewShell: mount (title, onclose)
    MainViewShell->>MainViewShell: $effect → root.focus()
    MainViewShell->>SessionDetailView: render
    SessionDetailView->>SessionDetailView: $effect → refreshDocuments(sessionId)

    User->>SessionDetailView: click Open terminal
    SessionDetailView->>mainViewRoute: closeMainView()
    mainViewRoute-->>App: "$mainViewRoute = null"
    App->>App: queueMicrotask → restore pane focus (guarded by session/pane ownership checks)

    User->>App: press Escape (focus on body or main-view root)
    App->>App: eventTargetIsMainViewKeyboardOwner → true, !editable → closeMainView()
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/App.svelte`, line 80-101 ([link](https://github.com/phin-tech/roux/blob/92a5807b17342ab4ccf47235cf5bd1f3f865378d/src/App.svelte#L80-L101)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Focus not restored after opening terminal for a non-active session**

   `paneFocusBeforeMainView` is captured when the main view opens (from `get(focusedPaneId)` at that moment). When the user opens Session Detail via context menu for a session that is *not* the currently-active one, `handleOpenSessionDetails` calls `setActiveSession(id)` before `openMainView`. The pane-focus capture still picks up a pane from the old session. When "Open terminal" is clicked and the main view closes, the microtask checks `findSessionForPane(restorePaneId) !== activeSession` — the pane belongs to the previous session, so the condition fails and no focus is restored. The user ends up with no pane focus after closing the view.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2FApp.svelte%0ALine%3A%2080-101%0A%0AComment%3A%0A**Focus%20not%20restored%20after%20opening%20terminal%20for%20a%20non-active%20session**%0A%0A%60paneFocusBeforeMainView%60%20is%20captured%20when%20the%20main%20view%20opens%20%28from%20%60get%28focusedPaneId%29%60%20at%20that%20moment%29.%20When%20the%20user%20opens%20Session%20Detail%20via%20context%20menu%20for%20a%20session%20that%20is%20*not*%20the%20currently-active%20one%2C%20%60handleOpenSessionDetails%60%20calls%20%60setActiveSession%28id%29%60%20before%20%60openMainView%60.%20The%20pane-focus%20capture%20still%20picks%20up%20a%20pane%20from%20the%20old%20session.%20When%20%22Open%20terminal%22%20is%20clicked%20and%20the%20main%20view%20closes%2C%20the%20microtask%20checks%20%60findSessionForPane%28restorePaneId%29%20!%3D%3D%20activeSession%60%20%E2%80%94%20the%20pane%20belongs%20to%20the%20previous%20session%2C%20so%20the%20condition%20fails%20and%20no%20focus%20is%20restored.%20The%20user%20ends%20up%20with%20no%20pane%20focus%20after%20closing%20the%20view.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=phin-tech%2Froux&pr=218&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22feature%2Ffull-window-mode%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Ffull-window-mode%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2FApp.svelte%0ALine%3A%2080-101%0A%0AComment%3A%0A**Focus%20not%20restored%20after%20opening%20terminal%20for%20a%20non-active%20session**%0A%0A%60paneFocusBeforeMainView%60%20is%20captured%20when%20the%20main%20view%20opens%20%28from%20%60get%28focusedPaneId%29%60%20at%20that%20moment%29.%20When%20the%20user%20opens%20Session%20Detail%20via%20context%20menu%20for%20a%20session%20that%20is%20*not*%20the%20currently-active%20one%2C%20%60handleOpenSessionDetails%60%20calls%20%60setActiveSession%28id%29%60%20before%20%60openMainView%60.%20The%20pane-focus%20capture%20still%20picks%20up%20a%20pane%20from%20the%20old%20session.%20When%20%22Open%20terminal%22%20is%20clicked%20and%20the%20main%20view%20closes%2C%20the%20microtask%20checks%20%60findSessionForPane%28restorePaneId%29%20!%3D%3D%20activeSession%60%20%E2%80%94%20the%20pane%20belongs%20to%20the%20previous%20session%2C%20so%20the%20condition%20fails%20and%20no%20focus%20is%20restored.%20The%20user%20ends%20up%20with%20no%20pane%20focus%20after%20closing%20the%20view.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Flib%2Fcomponents%2FMainViewShell.svelte%3A16-18%0A**Focus%20not%20re-established%20on%20same-shell%20route%20switch**%0A%0A%60%24effect%28%28%29%20%3D%3E%20%7B%20root%3F.focus%28%29%3B%20%7D%29%60%20depends%20on%20%60root%60%2C%20which%20is%20set%20once%20via%20%60bind%3Athis%60%20when%20the%20shell%20mounts.%20When%20a%20route%20switch%20happens%20while%20the%20shell%20is%20already%20visible%20%E2%80%94%20e.g.%20the%20user%20right-clicks%20a%20session%20while%20Board%20is%20showing%2C%20which%20calls%20%60openMainView%28%7B%20kind%3A%20%22sessionDetail%22%2C%20%E2%80%A6%20%7D%29%60%20%E2%80%94%20%60MainViewHost%60%20keeps%20%60MainViewShell%60%20mounted%20and%20swaps%20the%20child%20content.%20%60root%60%20never%20changes%2C%20so%20the%20effect%20does%20not%20re-fire.%20The%20Board%20child%20unmounts%2C%20focus%20moves%20to%20%60document.body%60%2C%20and%20the%20incoming%20Session%20Detail%20view%20mounts%20without%20programmatic%20focus.%20Keyboard%20interaction%20in%20the%20new%20view%20%28rename%20field%2C%20attachment%20list%2C%20etc.%29%20requires%20the%20user%20to%20click%20first.%0A%0AThe%20simplest%20fix%20is%20to%20accept%20a%20%60routeKey%60%20prop%20in%20%60MainViewShell%60%20%28e.g.%20a%20string%20that%20changes%20on%20every%20route%20kind%20swap%29%20and%20read%20it%20inside%20the%20effect%20so%20a%20route%20change%20re-triggers%20focus.%0A%0A&repo=phin-tech%2Froux&pr=218&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22feature%2Ffull-window-mode%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Ffull-window-mode%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Flib%2Fcomponents%2FMainViewShell.svelte%3A16-18%0A**Focus%20not%20re-established%20on%20same-shell%20route%20switch**%0A%0A%60%24effect%28%28%29%20%3D%3E%20%7B%20root%3F.focus%28%29%3B%20%7D%29%60%20depends%20on%20%60root%60%2C%20which%20is%20set%20once%20via%20%60bind%3Athis%60%20when%20the%20shell%20mounts.%20When%20a%20route%20switch%20happens%20while%20the%20shell%20is%20already%20visible%20%E2%80%94%20e.g.%20the%20user%20right-clicks%20a%20session%20while%20Board%20is%20showing%2C%20which%20calls%20%60openMainView%28%7B%20kind%3A%20%22sessionDetail%22%2C%20%E2%80%A6%20%7D%29%60%20%E2%80%94%20%60MainViewHost%60%20keeps%20%60MainViewShell%60%20mounted%20and%20swaps%20the%20child%20content.%20%60root%60%20never%20changes%2C%20so%20the%20effect%20does%20not%20re-fire.%20The%20Board%20child%20unmounts%2C%20focus%20moves%20to%20%60document.body%60%2C%20and%20the%20incoming%20Session%20Detail%20view%20mounts%20without%20programmatic%20focus.%20Keyboard%20interaction%20in%20the%20new%20view%20%28rename%20field%2C%20attachment%20list%2C%20etc.%29%20requires%20the%20user%20to%20click%20first.%0A%0AThe%20simplest%20fix%20is%20to%20accept%20a%20%60routeKey%60%20prop%20in%20%60MainViewShell%60%20%28e.g.%20a%20string%20that%20changes%20on%20every%20route%20kind%20swap%29%20and%20read%20it%20inside%20the%20effect%20so%20a%20route%20change%20re-triggers%20focus.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["fix: address PR review bot findings"](https://github.com/phin-tech/roux/commit/d553e485623c0da88ecb393a2c34232321e324c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34815713)</sub>

<!-- /greptile_comment -->