### PR TITLE
[codex] Fix external tool preferences and crash logs

### DIFF
--- a/crates/roux-runtime/src/process_service.rs
+++ b/crates/roux-runtime/src/process_service.rs
@@ -206,6 +206,11 @@ impl ProcessEntry {
         }
 
         let working_dir = resolve_working_dir(working_dir)?;
+        let output = Arc::new(Mutex::new(ProcessOutputBuffer::new(PROCESS_OUTPUT_LIMIT_BYTES)));
+        if let Ok(mut output) = output.lock() {
+            output.append(process_startup_log(&command, &working_dir).as_bytes());
+        }
+
         let mut child = shell_command(&command)
             .current_dir(&working_dir)
             .stdout(Stdio::piped())
@@ -213,7 +218,6 @@ impl ProcessEntry {
             .spawn()
             .map_err(|err| format!("spawn daemon process: {err}"))?;
 
-        let output = Arc::new(Mutex::new(ProcessOutputBuffer::new(PROCESS_OUTPUT_LIMIT_BYTES)));
         let mut reader_threads = Vec::new();
         if let Some(stdout) = child.stdout.take() {
             reader_threads.push(spawn_output_reader(stdout, Arc::clone(&output)));
@@ -304,6 +308,10 @@ impl ProcessEntry {
         }
         self.reader_threads = pending;
     }
+}
+
+fn process_startup_log(command: &str, working_dir: &std::path::Path) -> String {
+    format!("command: {command}\ncwd: {}\n\n", working_dir.to_string_lossy())
 }
 
 struct ProcessOutputBuffer {
@@ -513,7 +521,9 @@ mod tests {
         let snapshot = snapshot.expect("process output and exit should become visible");
         assert_eq!(snapshot.record.id, record.id);
         assert_eq!(snapshot.record.exit_code, Some(0));
-        assert_eq!(snapshot.output, "daemon-runtime");
+        assert!(snapshot.output.contains("command: printf daemon-runtime"));
+        assert!(snapshot.output.contains(&format!("cwd: {}", dir.path().to_string_lossy())));
+        assert!(snapshot.output.ends_with("daemon-runtime"));
 
         handle.shutdown().await;
         join.await.unwrap();

--- a/src/lib/components/ExternalToolWebView.svelte
+++ b/src/lib/components/ExternalToolWebView.svelte
@@ -383,6 +383,8 @@
       outputTruncated = snapshot.record.outputTruncated;
     }
     if (!snapshot.record.running && currentRun.status !== "error") {
+      logs = snapshot.output;
+      outputTruncated = snapshot.record.outputTruncated;
       markExternalToolExited(
         currentRun.id,
         snapshot.record.id,

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -121,6 +121,8 @@
   let externalToolPreviewById = $state<
     Record<string, { loading: boolean; rendered: RenderedExternalTool | null; error: string | null }>
   >({});
+  const externalToolRowKeys = new Map<string, string>();
+  let nextExternalToolRowKey = 0;
   let wasVisible = false;
   onMount(async () => {
     try { appVersion = await getVersion(); } catch { appVersion = "unknown"; }
@@ -221,7 +223,32 @@
     return $settings.externalTools ?? [];
   }
 
+  function externalToolRowKey(id: string): string {
+    let key = externalToolRowKeys.get(id);
+    if (!key) {
+      key = `external-tool-row-${++nextExternalToolRowKey}`;
+      externalToolRowKeys.set(id, key);
+    }
+    return key;
+  }
+
+  function retainExternalToolRowKey(previousId: string, nextId: string): void {
+    if (previousId === nextId) return;
+    const key = externalToolRowKeys.get(previousId);
+    if (!key) return;
+    externalToolRowKeys.delete(previousId);
+    externalToolRowKeys.set(nextId, key);
+  }
+
+  function pruneExternalToolRowKeys(tools: ExternalTool[]): void {
+    const ids = new Set(tools.map((tool) => tool.id));
+    for (const id of externalToolRowKeys.keys()) {
+      if (!ids.has(id)) externalToolRowKeys.delete(id);
+    }
+  }
+
   function updateExternalTools(tools: ExternalTool[]): void {
+    pruneExternalToolRowKeys(tools);
     updateSetting("externalTools", tools);
   }
 
@@ -235,10 +262,11 @@
       }
       nextPatch = { ...patch, id: normalizedId };
     }
-    updateExternalTools(tools.map((tool) => (tool.id === id ? { ...tool, ...nextPatch } : tool)));
-    if (nextPatch.id !== undefined && expandedExternalToolId === id) {
-      expandedExternalToolId = nextPatch.id;
+    if (nextPatch.id !== undefined) {
+      retainExternalToolRowKey(id, nextPatch.id);
+      if (expandedExternalToolId === id) expandedExternalToolId = nextPatch.id;
     }
+    updateExternalTools(tools.map((tool) => (tool.id === id ? { ...tool, ...nextPatch } : tool)));
   }
 
   function preferredPortFromInput(value: string): number | null {
@@ -1455,7 +1483,7 @@
               </div>
 
               <div class="mt-3 flex flex-col gap-2">
-                {#each externalTools() as tool (tool.id)}
+                {#each externalTools() as tool (externalToolRowKey(tool.id))}
                   {@const expanded = expandedExternalToolId === tool.id}
                   {@const preview = externalToolPreviewById[tool.id]}
                   <div class="rounded border border-border-subtle bg-bg-deep/60 p-2">

--- a/src/lib/components/__tests__/ExternalToolWebView.test.ts
+++ b/src/lib/components/__tests__/ExternalToolWebView.test.ts
@@ -242,6 +242,47 @@ describe("ExternalToolWebView", () => {
     unmount();
   });
 
+  it("shows process output when the periodic log refresh sees a crashed process", async () => {
+    tauriMock.probeExternalToolUrl.mockResolvedValue(false);
+    externalToolsMock.readExternalToolProcess.mockResolvedValue({
+      record: {
+        id: "process-1",
+        command: "npx difit",
+        workingDir: "/repo",
+        startedAtMs: 100,
+        running: false,
+        exitCode: 1,
+        retainedOutputBytes: 52,
+        outputTruncated: false,
+      },
+      output: "command: npx difit\ncwd: /repo\n\ncrashed on startup",
+    });
+
+    const initialRun = makeRun();
+    const { rerender, unmount } = render(ExternalToolWebView, { run: initialRun });
+
+    expect(await document.body.textContent).not.toContain("crashed on startup");
+    await waitFor(() =>
+      expect(externalToolsMock.markExternalToolExited).toHaveBeenCalledWith(
+        "difit:session-1",
+        "process-1",
+        1,
+        null,
+      ),
+    );
+    await rerender({
+      run: {
+        ...initialRun,
+        status: "error",
+        error: "Process exited with code 1",
+        logsOpen: true,
+      },
+    });
+    expect(document.body.textContent).toContain("crashed on startup");
+
+    unmount();
+  });
+
   it("ignores stale startup probe failures after a run relaunch", async () => {
     let rejectProbe: (err: Error) => void = () => {};
     tauriMock.probeExternalToolUrl.mockReturnValueOnce(

--- a/src/lib/components/__tests__/SettingsPanel.test.ts
+++ b/src/lib/components/__tests__/SettingsPanel.test.ts
@@ -222,6 +222,20 @@ describe("SettingsPanel external tools", () => {
     expect(ids).not.toContain(" new-id ");
   });
 
+  it("keeps focus while editing an external tool ID", async () => {
+    render(SettingsPanel, { visible: true, onclose: vi.fn() });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Integrations" }));
+    await fireEvent.click(await screen.findByRole("button", { name: "GitHub" }));
+
+    const input = screen.getByDisplayValue("github");
+    input.focus();
+    await fireEvent.input(input, { target: { value: "n" } });
+
+    expect(document.activeElement).toBe(input);
+    expect(get(settings).externalTools?.some((tool) => tool.id === "n")).toBe(true);
+  });
+
   it("clamps preferred ports before saving external web tools", async () => {
     render(SettingsPanel, { visible: true, onclose: vi.fn() });
 

--- a/src/lib/stores/__tests__/externalTools.test.ts
+++ b/src/lib/stores/__tests__/externalTools.test.ts
@@ -497,6 +497,32 @@ describe("externalTools store helpers", () => {
     expect(get(mainViewRoute)).toEqual({ kind: "externalTool", runId: run.id });
   });
 
+  it("keeps a web tool pane open with logs when its process exits", () => {
+    const run = {
+      ...runWithStatus("starting"),
+      id: "difit:global",
+      toolId: "difit",
+      toolName: "Difit",
+      surface: "web" as const,
+      sessionId: null,
+      runtimeId: "process-1",
+      runtimeGeneration: null,
+    };
+    externalToolRuns.set(new Map([[run.id, run]]));
+    openMainView({ kind: "externalTool", runId: run.id });
+
+    markExternalToolExited(run.id, run.runtimeId, 1, run.runtimeGeneration);
+
+    expect(get(externalToolRuns).get(run.id)).toMatchObject({
+      status: "error",
+      error: "Process exited with code 1",
+      logsOpen: true,
+      runtimeId: "process-1",
+    });
+    expect(get(mainViewRoute)).toEqual({ kind: "externalTool", runId: run.id });
+    expect(daemonProcessKill).not.toHaveBeenCalled();
+  });
+
   it("kills the matching web runtime before marking a launched run failed", async () => {
     const run = {
       ...runWithStatus("running"),

--- a/src/lib/stores/externalTools.ts
+++ b/src/lib/stores/externalTools.ts
@@ -167,7 +167,7 @@ export function markExternalToolReady(runId: string): void {
 export function markExternalToolExited(
   runId: string,
   runtimeId: string | null | undefined,
-  _exitCode: number | null,
+  exitCode: number | null,
   generation?: number | null,
 ): void {
   if (!runtimeId) return;
@@ -175,6 +175,10 @@ export function markExternalToolExited(
   if (!run || run.runtimeId !== runtimeId) return;
   if (run.status === "error") return;
   if (generation != null && run.runtimeGeneration !== generation) return;
+  if (run.surface === "web") {
+    setExternalToolRunError(runId, processExitMessage(exitCode), runtimeId, generation);
+    return;
+  }
 
   void killRunRuntime(run);
   removeExternalToolRun(runId);
@@ -348,4 +352,8 @@ async function killLaunchResultRuntime(result: ExternalToolLaunchResult): Promis
 
 function formatError(err: unknown): string {
   return err instanceof Error && err.message ? err.message : String(err);
+}
+
+function processExitMessage(exitCode: number | null): string {
+  return exitCode == null ? "Process exited" : `Process exited with code ${exitCode}`;
 }


### PR DESCRIPTION
## Summary

Fixes the external tools preferences editor and web tool crash diagnostics.

- Keeps external tool rows stable while editing IDs so the focused input no longer unmounts after each character.
- Preserves crashed web tool panes in an error/logs state instead of closing the main view.
- Adds command/cwd startup headers to daemon process output so web external tool logs show exactly what ran and where.
- Ensures exit-code crashes found by periodic log refresh still render the captured output.

## Root Cause

External tool rows were keyed directly by mutable `tool.id`, so changing an ID changed the Svelte key and remounted the row. Web process exits also followed a path that could mark the run errored before copying the final process snapshot into the visible log buffer.

## Validation

- `npm run test` - 97 files passed, 1145 tests passed, 2 skipped
- `npm run check` - 0 errors, 0 warnings
- `cargo test -p roux-runtime process_service` - 3 passed
- `cargo test -p roux-runtime work_item_store::tests::update_clears_nullable_fields_when_json_null_is_present` - 1 passed
- `git diff --check --cached` - passed

## Review Notes

Ran `$roborev-fix`; open job `19` was verified fixed in the current checkout, commented, closed, and audited with `closed=true`.

Note: `src/lib/bindings.ts` has an unrelated unstaged generated diff in the local worktree and is intentionally not included in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * External tool process output now includes startup information (command and working directory).

* **Bug Fixes**
  * Improved detection and display of external tool crashes with proper error state handling.
  * Fixed UI state preservation when editing external tool identifiers.
  * Enhanced log refresh behavior when external tools stop running.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two independent bugs in the external tool subsystem and adds startup diagnostics to daemon process output.

- **External tool row stability**: `SettingsPanel.svelte` now maintains a stable `externalToolRowKeys` Map so the Svelte `{#each}` key for a tool row survives ID edits, preventing input remount and focus loss on each keypress.
- **Web tool crash log preservation**: `markExternalToolExited` now routes web tools to `setExternalToolRunError` (keeping the pane open) instead of removing the run; `refreshLogs` captures the final snapshot output before calling `markExternalToolExited` so periodic-refresh-detected crashes also show their logs; `process_startup_log` prepends command/cwd headers to every daemon process output buffer so the log panel always shows what ran and where.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. All three bug fixes are well-scoped, each backed by a new targeted test, and the changes don't touch pane-tree invariants or daemon protocol contracts.

The logic is sound throughout. The one minor observation is a redundant double-assignment of `logs` in `refreshLogs` when `logsOpen` is already true and the process has exited — both code paths write identical values from the same snapshot, so there is no behavioral difference. The web tool daemon process entry now intentionally persists in the daemon until the user explicitly closes the pane, which is consistent with the new keep-pane-open-for-log-viewing semantics and is cleaned up by `closeExternalToolRun` on explicit close.

No files require special attention. `ExternalToolWebView.svelte` has the minor redundant assignment noted above but it is harmless.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/roux-runtime/src/process_service.rs | Moves output buffer creation before spawn so the startup log (command + cwd) is captured first; adds `process_startup_log` helper; updates tests to expect the header prefix. |
| src/lib/components/ExternalToolWebView.svelte | Captures `logs`/`outputTruncated` from snapshot before calling `markExternalToolExited` in `refreshLogs`, fixing the periodic-refresh crash path. Minor redundancy: logs are assigned twice when the process is exited and `logsOpen` was already true. |
| src/lib/components/SettingsPanel.svelte | Introduces a stable `externalToolRowKeys` Map so Svelte keeps the same DOM key when a tool's ID changes mid-edit, preventing input remount/focus loss. |
| src/lib/stores/externalTools.ts | Web tool exit now calls `setExternalToolRunError` (preserving the pane in error/logs state) instead of removing the run, with `processExitMessage` building the human-readable exit string. |
| src/lib/components/__tests__/ExternalToolWebView.test.ts | Adds a test verifying that crash output is visible after the periodic log refresh detects an exited process and transitions to error state. |
| src/lib/components/__tests__/SettingsPanel.test.ts | Adds a test confirming that typing a character into an external tool ID input keeps focus on the same DOM element after the settings update. |
| src/lib/stores/__tests__/externalTools.test.ts | Adds a test verifying that exiting a web tool's process leaves the pane open in error/logsOpen state with the exit message, rather than closing the main view. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Timer as logTimer (1500ms)
    participant RLogs as refreshLogs()
    participant Store as externalToolRuns store
    participant UI as ExternalToolWebView template

    Timer->>RLogs: tick
    RLogs->>RLogs: capture currentRun snapshot
    RLogs->>Store: readExternalToolProcess(run)
    Store-->>RLogs: "ProcessSnapshot (running=false, exitCode=1)"
    Note over RLogs: NEW: assign logs = snapshot.output<br/>before calling markExternalToolExited
    RLogs->>Store: markExternalToolExited(runId, runtimeId, 1)
    Note over Store: surface==="web" branch:<br/>setExternalToolRunError → status="error", logsOpen=true<br/>(no killRunRuntime, pane preserved)
    Store-->>UI: "run prop updated (status="error", logsOpen=true)"
    UI->>UI: render crash log panel with captured logs
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/lib/components/ExternalToolWebView.svelte`, line 381-388 ([link](https://github.com/phin-tech/roux/blob/1507e5c694226d35dca449f8cc1f754b1971c980/src/lib/components/ExternalToolWebView.svelte#L381-L388)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Redundant double-assignment when `logsOpen` is already true and the process has exited. The first block (`if (currentRun.logsOpen || currentRun.status === "error")`) already assigns `logs` and `outputTruncated` from the same snapshot, so the second block re-assigns identical values. Harmless, but the guard on the second block could skip the re-assignment to make intent clearer.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Flib%2Fcomponents%2FExternalToolWebView.svelte%0ALine%3A%20381-388%0A%0AComment%3A%0ARedundant%20double-assignment%20when%20%60logsOpen%60%20is%20already%20true%20and%20the%20process%20has%20exited.%20The%20first%20block%20%28%60if%20%28currentRun.logsOpen%20%7C%7C%20currentRun.status%20%3D%3D%3D%20%22error%22%29%60%29%20already%20assigns%20%60logs%60%20and%20%60outputTruncated%60%20from%20the%20same%20snapshot%2C%20so%20the%20second%20block%20re-assigns%20identical%20values.%20Harmless%2C%20but%20the%20guard%20on%20the%20second%20block%20could%20skip%20the%20re-assignment%20to%20make%20intent%20clearer.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20%28currentRun.logsOpen%20%7C%7C%20currentRun.status%20%3D%3D%3D%20%22error%22%29%20%7B%0A%20%20%20%20%20%20logs%20%3D%20snapshot.output%3B%0A%20%20%20%20%20%20outputTruncated%20%3D%20snapshot.record.outputTruncated%3B%0A%20%20%20%20%7D%0A%20%20%20%20if%20%28!snapshot.record.running%20%26%26%20currentRun.status%20!%3D%3D%20%22error%22%29%20%7B%0A%20%20%20%20%20%20if%20%28!currentRun.logsOpen%29%20%7B%0A%20%20%20%20%20%20%20%20logs%20%3D%20snapshot.output%3B%0A%20%20%20%20%20%20%20%20outputTruncated%20%3D%20snapshot.record.outputTruncated%3B%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20markExternalToolExited%28%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=phin-tech%2Froux&pr=220&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22codex%2Ffix-external-tool-logs%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Ffix-external-tool-logs%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Flib%2Fcomponents%2FExternalToolWebView.svelte%0ALine%3A%20381-388%0A%0AComment%3A%0ARedundant%20double-assignment%20when%20%60logsOpen%60%20is%20already%20true%20and%20the%20process%20has%20exited.%20The%20first%20block%20%28%60if%20%28currentRun.logsOpen%20%7C%7C%20currentRun.status%20%3D%3D%3D%20%22error%22%29%60%29%20already%20assigns%20%60logs%60%20and%20%60outputTruncated%60%20from%20the%20same%20snapshot%2C%20so%20the%20second%20block%20re-assigns%20identical%20values.%20Harmless%2C%20but%20the%20guard%20on%20the%20second%20block%20could%20skip%20the%20re-assignment%20to%20make%20intent%20clearer.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20%28currentRun.logsOpen%20%7C%7C%20currentRun.status%20%3D%3D%3D%20%22error%22%29%20%7B%0A%20%20%20%20%20%20logs%20%3D%20snapshot.output%3B%0A%20%20%20%20%20%20outputTruncated%20%3D%20snapshot.record.outputTruncated%3B%0A%20%20%20%20%7D%0A%20%20%20%20if%20%28!snapshot.record.running%20%26%26%20currentRun.status%20!%3D%3D%20%22error%22%29%20%7B%0A%20%20%20%20%20%20if%20%28!currentRun.logsOpen%29%20%7B%0A%20%20%20%20%20%20%20%20logs%20%3D%20snapshot.output%3B%0A%20%20%20%20%20%20%20%20outputTruncated%20%3D%20snapshot.record.outputTruncated%3B%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20markExternalToolExited%28%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Flib%2Fcomponents%2FExternalToolWebView.svelte%3A381-388%0ARedundant%20double-assignment%20when%20%60logsOpen%60%20is%20already%20true%20and%20the%20process%20has%20exited.%20The%20first%20block%20%28%60if%20%28currentRun.logsOpen%20%7C%7C%20currentRun.status%20%3D%3D%3D%20%22error%22%29%60%29%20already%20assigns%20%60logs%60%20and%20%60outputTruncated%60%20from%20the%20same%20snapshot%2C%20so%20the%20second%20block%20re-assigns%20identical%20values.%20Harmless%2C%20but%20the%20guard%20on%20the%20second%20block%20could%20skip%20the%20re-assignment%20to%20make%20intent%20clearer.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20%28currentRun.logsOpen%20%7C%7C%20currentRun.status%20%3D%3D%3D%20%22error%22%29%20%7B%0A%20%20%20%20%20%20logs%20%3D%20snapshot.output%3B%0A%20%20%20%20%20%20outputTruncated%20%3D%20snapshot.record.outputTruncated%3B%0A%20%20%20%20%7D%0A%20%20%20%20if%20%28!snapshot.record.running%20%26%26%20currentRun.status%20!%3D%3D%20%22error%22%29%20%7B%0A%20%20%20%20%20%20if%20%28!currentRun.logsOpen%29%20%7B%0A%20%20%20%20%20%20%20%20logs%20%3D%20snapshot.output%3B%0A%20%20%20%20%20%20%20%20outputTruncated%20%3D%20snapshot.record.outputTruncated%3B%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20markExternalToolExited%28%0A%60%60%60%0A%0A&repo=phin-tech%2Froux&pr=220&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22codex%2Ffix-external-tool-logs%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Ffix-external-tool-logs%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Flib%2Fcomponents%2FExternalToolWebView.svelte%3A381-388%0ARedundant%20double-assignment%20when%20%60logsOpen%60%20is%20already%20true%20and%20the%20process%20has%20exited.%20The%20first%20block%20%28%60if%20%28currentRun.logsOpen%20%7C%7C%20currentRun.status%20%3D%3D%3D%20%22error%22%29%60%29%20already%20assigns%20%60logs%60%20and%20%60outputTruncated%60%20from%20the%20same%20snapshot%2C%20so%20the%20second%20block%20re-assigns%20identical%20values.%20Harmless%2C%20but%20the%20guard%20on%20the%20second%20block%20could%20skip%20the%20re-assignment%20to%20make%20intent%20clearer.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20%28currentRun.logsOpen%20%7C%7C%20currentRun.status%20%3D%3D%3D%20%22error%22%29%20%7B%0A%20%20%20%20%20%20logs%20%3D%20snapshot.output%3B%0A%20%20%20%20%20%20outputTruncated%20%3D%20snapshot.record.outputTruncated%3B%0A%20%20%20%20%7D%0A%20%20%20%20if%20%28!snapshot.record.running%20%26%26%20currentRun.status%20!%3D%3D%20%22error%22%29%20%7B%0A%20%20%20%20%20%20if%20%28!currentRun.logsOpen%29%20%7B%0A%20%20%20%20%20%20%20%20logs%20%3D%20snapshot.output%3B%0A%20%20%20%20%20%20%20%20outputTruncated%20%3D%20snapshot.record.outputTruncated%3B%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20markExternalToolExited%28%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Fix external tool preferences and crash ..."](https://github.com/phin-tech/roux/commit/1507e5c694226d35dca449f8cc1f754b1971c980) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35004253)</sub>

<!-- /greptile_comment -->