### PR TITLE
Improve external tool webview handling

### DIFF
--- a/crates/roux-core/src/models/settings.rs
+++ b/crates/roux-core/src/models/settings.rs
@@ -1200,12 +1200,25 @@ mod tests {
                     web_embedder: ExternalToolWebEmbedder::Webview,
                     keep_webview_alive: true,
                 },
+                super::ExternalTool {
+                    id: "terminal-tool".to_string(),
+                    name: "Terminal Tool".to_string(),
+                    enabled: true,
+                    surface: ExternalToolSurface::Terminal,
+                    command_template: " lazygit ".to_string(),
+                    cwd_template: " {{ session.worktree_path }} ".to_string(),
+                    requires_session: true,
+                    url_template: Some(" http://127.0.0.1:{{ port }} ".to_string()),
+                    preferred_port: Some(4966),
+                    web_embedder: ExternalToolWebEmbedder::Iframe,
+                    keep_webview_alive: true,
+                },
             ],
             ..RouxSettings::default()
         };
 
         let normalized = settings.normalized();
-        assert_eq!(normalized.external_tools.len(), 2);
+        assert_eq!(normalized.external_tools.len(), 3);
         assert_eq!(normalized.external_tools[0].id, "my-tool");
         assert_eq!(normalized.external_tools[0].name, "My Tool");
         assert_eq!(normalized.external_tools[0].command_template, "serve --port {{ port }}");
@@ -1224,6 +1237,19 @@ mod tests {
             Some("https://github.com")
         );
         assert!(normalized.external_tools[1].keep_webview_alive);
+        assert_eq!(normalized.external_tools[2].id, "terminal-tool");
+        assert_eq!(normalized.external_tools[2].command_template, "lazygit");
+        assert_eq!(
+            normalized.external_tools[2].cwd_template,
+            "{{ session.worktree_path }}"
+        );
+        assert_eq!(normalized.external_tools[2].url_template, None);
+        assert_eq!(normalized.external_tools[2].preferred_port, None);
+        assert_eq!(
+            normalized.external_tools[2].web_embedder,
+            ExternalToolWebEmbedder::Webview
+        );
+        assert!(!normalized.external_tools[2].keep_webview_alive);
     }
 
     #[test]

--- a/crates/roux-core/src/models/settings.rs
+++ b/crates/roux-core/src/models/settings.rs
@@ -140,6 +140,8 @@ pub struct ExternalTool {
     pub preferred_port: Option<u16>,
     #[serde(default)]
     pub web_embedder: ExternalToolWebEmbedder,
+    #[serde(default)]
+    pub keep_webview_alive: bool,
 }
 
 fn default_external_tools() -> Vec<ExternalTool> {
@@ -155,6 +157,7 @@ fn default_external_tools() -> Vec<ExternalTool> {
             url_template: None,
             preferred_port: None,
             web_embedder: ExternalToolWebEmbedder::Webview,
+            keep_webview_alive: false,
         },
         ExternalTool {
             id: "difit".to_string(),
@@ -168,6 +171,7 @@ fn default_external_tools() -> Vec<ExternalTool> {
             url_template: Some("http://127.0.0.1:{{ port }}".to_string()),
             preferred_port: Some(4966),
             web_embedder: ExternalToolWebEmbedder::Iframe,
+            keep_webview_alive: false,
         },
         ExternalTool {
             id: "github".to_string(),
@@ -180,6 +184,7 @@ fn default_external_tools() -> Vec<ExternalTool> {
             url_template: Some("https://github.com".to_string()),
             preferred_port: None,
             web_embedder: ExternalToolWebEmbedder::Webview,
+            keep_webview_alive: false,
         },
     ]
 }
@@ -684,6 +689,12 @@ fn normalize_external_tools(tools: &[ExternalTool]) -> Vec<ExternalTool> {
             next.url_template = None;
             next.preferred_port = None;
             next.web_embedder = ExternalToolWebEmbedder::Webview;
+            next.keep_webview_alive = false;
+        }
+        if next.surface == ExternalToolSurface::Web
+            && next.web_embedder != ExternalToolWebEmbedder::Webview
+        {
+            next.keep_webview_alive = false;
         }
         cleaned.push(next);
     }
@@ -1104,6 +1115,7 @@ mod tests {
         assert_eq!(difit.preferred_port, Some(4966));
         assert_eq!(difit.url_template.as_deref(), Some("http://127.0.0.1:{{ port }}"));
         assert_eq!(difit.web_embedder, ExternalToolWebEmbedder::Iframe);
+        assert!(!difit.keep_webview_alive);
 
         let github = &settings.external_tools[2];
         assert_eq!(github.name, "GitHub");
@@ -1114,6 +1126,7 @@ mod tests {
         assert_eq!(github.url_template.as_deref(), Some("https://github.com"));
         assert_eq!(github.preferred_port, None);
         assert_eq!(github.web_embedder, ExternalToolWebEmbedder::Webview);
+        assert!(!github.keep_webview_alive);
     }
 
     #[test]
@@ -1159,6 +1172,7 @@ mod tests {
                     url_template: Some(" http://127.0.0.1:{{ port }} ".to_string()),
                     preferred_port: Some(0),
                     web_embedder: ExternalToolWebEmbedder::Iframe,
+                    keep_webview_alive: true,
                 },
                 super::ExternalTool {
                     id: "blank-command".to_string(),
@@ -1171,6 +1185,7 @@ mod tests {
                     url_template: Some(" https://github.com ".to_string()),
                     preferred_port: None,
                     web_embedder: ExternalToolWebEmbedder::Webview,
+                    keep_webview_alive: true,
                 },
                 super::ExternalTool {
                     id: "blank-terminal".to_string(),
@@ -1183,6 +1198,7 @@ mod tests {
                     url_template: None,
                     preferred_port: None,
                     web_embedder: ExternalToolWebEmbedder::Webview,
+                    keep_webview_alive: true,
                 },
             ],
             ..RouxSettings::default()
@@ -1200,12 +1216,14 @@ mod tests {
         );
         assert_eq!(normalized.external_tools[0].preferred_port, None);
         assert_eq!(normalized.external_tools[0].web_embedder, ExternalToolWebEmbedder::Iframe);
+        assert!(!normalized.external_tools[0].keep_webview_alive);
         assert_eq!(normalized.external_tools[1].id, "blank-command");
         assert_eq!(normalized.external_tools[1].command_template, "");
         assert_eq!(
             normalized.external_tools[1].url_template.as_deref(),
             Some("https://github.com")
         );
+        assert!(normalized.external_tools[1].keep_webview_alive);
     }
 
     #[test]

--- a/src-tauri/src/commands/external_tools.rs
+++ b/src-tauri/src/commands/external_tools.rs
@@ -296,6 +296,7 @@ mod tests {
             url_template: url_template.map(str::to_string),
             preferred_port: None,
             web_embedder: ExternalToolWebEmbedder::Webview,
+            keep_webview_alive: false,
         }
     }
 

--- a/src-tauri/src/services/external_tools.rs
+++ b/src-tauri/src/services/external_tools.rs
@@ -198,6 +198,7 @@ mod tests {
             url_template: Some("http://127.0.0.1:{{ port }}/{{ session.worktree_name }}".into()),
             preferred_port: Some(4966),
             web_embedder: ExternalToolWebEmbedder::Iframe,
+            keep_webview_alive: false,
         };
 
         let rendered = render_external_tool(&tool, Some(&session()), Some(4999)).unwrap();
@@ -220,6 +221,7 @@ mod tests {
             url_template: None,
             preferred_port: None,
             web_embedder: ExternalToolWebEmbedder::Webview,
+            keep_webview_alive: false,
         };
 
         let err = render_external_tool(&tool, None, None).unwrap_err();
@@ -239,6 +241,7 @@ mod tests {
             url_template: None,
             preferred_port: Some(4966),
             web_embedder: ExternalToolWebEmbedder::Iframe,
+            keep_webview_alive: false,
         };
 
         let err = render_external_tool(&tool, None, Some(4966)).unwrap_err();
@@ -258,6 +261,7 @@ mod tests {
             url_template: Some("   ".to_string()),
             preferred_port: Some(4966),
             web_embedder: ExternalToolWebEmbedder::Iframe,
+            keep_webview_alive: false,
         };
 
         let err = render_external_tool(&tool, None, Some(4966)).unwrap_err();

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -491,6 +491,7 @@ export type ExternalTool = {
 	urlTemplate?: string | null,
 	preferredPort?: number | null,
 	webEmbedder?: ExternalToolWebEmbedder,
+	keepWebviewAlive?: boolean,
 };
 
 export type ExternalToolSurface = "terminal" | "web";

--- a/src/lib/components/ExternalToolWebView.svelte
+++ b/src/lib/components/ExternalToolWebView.svelte
@@ -19,8 +19,15 @@
   import type { UnlistenFn } from "@tauri-apps/api/event";
   import { LogicalPosition, LogicalSize } from "@tauri-apps/api/dpi";
   import { getCurrentWindow } from "@tauri-apps/api/window";
+  import type { BackgroundThrottlingPolicy } from "@tauri-apps/api/window";
   import { probeExternalToolUrl } from "$lib/tauri";
   import { commandSurface } from "$lib/stores/commandSurface";
+  import {
+    closeNativeWebview,
+    closeRetainedExternalToolWebview,
+    retainExternalToolWebview,
+    takeRetainedExternalToolWebview,
+  } from "$lib/externalTools/nativeWebviews";
   import type { ExternalToolRun } from "$lib/stores/externalTools";
   import {
     failExternalToolRun,
@@ -51,6 +58,8 @@
     webEmbedder: ExternalToolRun["webEmbedder"];
     launchedAtMs: number;
   }
+
+  const KEEP_ACTIVE_BACKGROUND_THROTTLING = "disabled" as BackgroundThrottlingPolicy;
 
   let { run }: Props = $props();
   let host = $state<HTMLDivElement | null>(null);
@@ -110,7 +119,7 @@
     schedulePositionWebview();
   });
 
-  $effect(() => registerExternalToolViewCloser(run.id, closeWebview));
+  $effect(() => registerExternalToolViewCloser(run.id, () => closeWebview()));
 
   $effect(() => {
     run.logsOpen;
@@ -135,21 +144,32 @@
   });
 
   $effect(() => {
-    const key = `${run.id}:${run.runtimeId ?? ""}:${run.rendered?.url ?? ""}:${run.launchedAtMs}:${run.webEmbedder}:${run.status}`;
-    if (key === pollKey) return;
+    const key = `${run.id}:${run.runtimeId ?? ""}:${run.rendered?.url ?? ""}:${run.launchedAtMs}:${run.webEmbedder}`;
+    if (key === pollKey) {
+      ensureReadyWebview(key);
+      return;
+    }
     pollKey = key;
-    closeWebview();
+    closeWebview({ closeRetained: false });
     if (run.status === "launching" || run.status === "starting") {
       const snapshot = pollingSnapshot(key);
       if (snapshot) startPolling(snapshot);
     } else if (run.status === "ready" && run.webEmbedder === "webview") {
       clearPoll();
-      const snapshot = pollingSnapshot(key);
-      if (snapshot) void createWebview(snapshot);
+      ensureReadyWebview(key);
     } else {
       clearPoll();
     }
   });
+
+  function ensureReadyWebview(key: string): void {
+    if (run.status !== "ready" || run.webEmbedder !== "webview" || webview || creatingWebviewKey) {
+      return;
+    }
+    const snapshot = pollingSnapshot(key);
+    if (snapshot) void createWebview(snapshot);
+  }
+
   function startPolling(snapshot: PollSnapshot): void {
     clearPoll();
     const startedPollingAt = Date.now();
@@ -217,6 +237,23 @@
       if (creatingWebviewKey === snapshot.key) creatingWebviewKey = null;
       return;
     }
+    const retained = snapshot.run.keepWebviewAlive
+      ? takeRetainedExternalToolWebview(snapshot.runId, nativeWebviewCacheKey(snapshot))
+      : null;
+    if (retained) {
+      webview = retained.webview;
+      webviewLabel = retained.label;
+      const hiddenForPalette = $commandSurface.open && $commandSurface.mode === "palette";
+      webviewHiddenForPalette = hiddenForPalette;
+      if (!hiddenForPalette) {
+        await retained.webview.show();
+      }
+      await syncAfterLayout();
+      void focusNativeWebview(retained.webview);
+      markExternalToolReady(snapshot.runId);
+      if (creatingWebviewKey === snapshot.key) creatingWebviewKey = null;
+      return;
+    }
     const label = nativeWebviewLabel(snapshot);
     webviewLabel = label;
     const next = new Webview(getCurrentWindow(), label, {
@@ -226,6 +263,9 @@
       width: bounds.width,
       height: bounds.height,
       focus: true,
+      backgroundThrottling: snapshot.run.keepWebviewAlive
+        ? KEEP_ACTIVE_BACKGROUND_THROTTLING
+        : undefined,
     });
     webview = next;
     try {
@@ -271,6 +311,12 @@
 
   function pollIsCurrent(snapshot: PollSnapshot): boolean {
     return !destroyed && pollKey === snapshot.key;
+  }
+
+  function nativeWebviewCacheKey(
+    snapshot: Pick<PollSnapshot, "runId" | "runtimeId" | "url" | "launchedAtMs">,
+  ): string {
+    return `${snapshot.runId}:${snapshot.runtimeId ?? ""}:${snapshot.url}:${snapshot.launchedAtMs}`;
   }
 
   async function waitForWebviewCreated(next: Webview): Promise<void> {
@@ -414,13 +460,14 @@
     }
   }
 
-  function closeWebview(): void {
+  function closeWebview({ closeRetained = true }: { closeRetained?: boolean } = {}): void {
     const current = webview;
     const label = webviewLabel ?? current?.label ?? null;
     webview = null;
     webviewLabel = null;
     creatingWebviewKey = null;
     webviewHiddenForPalette = false;
+    if (closeRetained) closeRetainedExternalToolWebview(run.id);
     closeNativeWebview(current);
     if (label) {
       void Webview.getByLabel(label)
@@ -429,14 +476,6 @@
         })
         .catch(() => {});
     }
-  }
-
-  function closeNativeWebview(current: Webview | null): void {
-    if (!current) return;
-    void current.hide().catch(() => {});
-    void current.setSize(new LogicalSize(1, 1)).catch(() => {});
-    void current.setPosition(new LogicalPosition(-32000, -32000)).catch(() => {});
-    void current.close().catch(() => {});
   }
 
   async function refreshLogs(): Promise<void> {
@@ -490,6 +529,36 @@
     cleanupWindowResize = null;
     cleanupWindowScale?.();
     cleanupWindowScale = null;
+    retainOrCloseWebview();
+  }
+
+  function retainOrCloseWebview(): void {
+    const current = webview;
+    if (
+      current &&
+      run.keepWebviewAlive &&
+      run.status === "ready" &&
+      run.webEmbedder === "webview" &&
+      run.rendered?.url
+    ) {
+      const label = webviewLabel ?? current.label;
+      webview = null;
+      webviewLabel = null;
+      creatingWebviewKey = null;
+      webviewHiddenForPalette = false;
+      retainExternalToolWebview({
+        runId: run.id,
+        key: nativeWebviewCacheKey({
+          runId: run.id,
+          runtimeId: run.runtimeId,
+          url: run.rendered.url,
+          launchedAtMs: run.launchedAtMs,
+        }),
+        label,
+        webview: current,
+      });
+      return;
+    }
     closeWebview();
   }
 

--- a/src/lib/components/ExternalToolWebView.svelte
+++ b/src/lib/components/ExternalToolWebView.svelte
@@ -241,17 +241,38 @@
       ? takeRetainedExternalToolWebview(snapshot.runId, nativeWebviewCacheKey(snapshot))
       : null;
     if (retained) {
-      webview = retained.webview;
+      const current = retained.webview;
+      webview = current;
       webviewLabel = retained.label;
       const hiddenForPalette = $commandSurface.open && $commandSurface.mode === "palette";
       webviewHiddenForPalette = hiddenForPalette;
-      if (!hiddenForPalette) {
-        await retained.webview.show();
+      try {
+        if (!hiddenForPalette) {
+          await current.show();
+        }
+        if (!webviewSnapshotIsCurrent(snapshot)) {
+          discardCurrentWebview(current);
+          return;
+        }
+        await syncAfterLayout();
+        if (!webviewSnapshotIsCurrent(snapshot)) {
+          discardCurrentWebview(current);
+          return;
+        }
+        void focusNativeWebview(current);
+        markExternalToolReady(snapshot.runId);
+      } catch (err) {
+        discardCurrentWebview(current);
+        if (webviewSnapshotIsCurrent(snapshot)) {
+          await failExternalToolRun(
+            snapshot.runId,
+            snapshot.runtimeId,
+            `Failed to open ${snapshot.url}: ${formatError(err)}`,
+          );
+        }
+      } finally {
+        if (creatingWebviewKey === snapshot.key) creatingWebviewKey = null;
       }
-      await syncAfterLayout();
-      void focusNativeWebview(retained.webview);
-      markExternalToolReady(snapshot.runId);
-      if (creatingWebviewKey === snapshot.key) creatingWebviewKey = null;
       return;
     }
     const label = nativeWebviewLabel(snapshot);
@@ -270,21 +291,23 @@
     webview = next;
     try {
       await waitForWebviewCreated(next);
-      if (!pollIsCurrent(snapshot)) {
-        if (webview === next) webview = null;
-        closeNativeWebview(next);
+      if (!webviewSnapshotIsCurrent(snapshot)) {
+        discardCurrentWebview(next);
         return;
       }
       await syncWebviewPaletteVisibility(
         $commandSurface.open && $commandSurface.mode === "palette",
       );
       await syncAfterLayout();
+      if (!webviewSnapshotIsCurrent(snapshot)) {
+        discardCurrentWebview(next);
+        return;
+      }
       void focusNativeWebview(next);
       markExternalToolReady(snapshot.runId);
     } catch (err) {
-      if (webview === next) webview = null;
-      closeNativeWebview(next);
-      if (pollIsCurrent(snapshot)) {
+      discardCurrentWebview(next);
+      if (webviewSnapshotIsCurrent(snapshot)) {
         await failExternalToolRun(
           snapshot.runId,
           snapshot.runtimeId,
@@ -311,6 +334,18 @@
 
   function pollIsCurrent(snapshot: PollSnapshot): boolean {
     return !destroyed && pollKey === snapshot.key;
+  }
+
+  function webviewSnapshotIsCurrent(snapshot: PollSnapshot): boolean {
+    return (
+      pollIsCurrent(snapshot) &&
+      run.id === snapshot.runId &&
+      run.runtimeId === snapshot.runtimeId &&
+      run.rendered?.url === snapshot.url &&
+      run.webEmbedder === snapshot.webEmbedder &&
+      run.launchedAtMs === snapshot.launchedAtMs &&
+      run.status !== "error"
+    );
   }
 
   function nativeWebviewCacheKey(
@@ -476,6 +511,15 @@
         })
         .catch(() => {});
     }
+  }
+
+  function discardCurrentWebview(current: Webview): void {
+    if (webview === current) {
+      webview = null;
+      webviewLabel = null;
+      webviewHiddenForPalette = false;
+    }
+    closeNativeWebview(current);
   }
 
   async function refreshLogs(): Promise<void> {

--- a/src/lib/components/ExternalToolWebView.svelte
+++ b/src/lib/components/ExternalToolWebView.svelte
@@ -54,6 +54,7 @@
 
   let { run }: Props = $props();
   let host = $state<HTMLDivElement | null>(null);
+  let iframe = $state<HTMLIFrameElement | null>(null);
   let logs = $state("");
   let outputTruncated = $state(false);
   let webview: Webview | null = null;
@@ -114,6 +115,12 @@
   $effect(() => {
     run.logsOpen;
     void refreshLogs();
+  });
+
+  $effect(() => {
+    if (run.status !== "ready" || run.webEmbedder !== "iframe" || !run.rendered?.url) return;
+    const frame = requestAnimationFrame(() => iframe?.focus());
+    return () => cancelAnimationFrame(frame);
   });
 
   $effect(() => {
@@ -228,11 +235,12 @@
         closeNativeWebview(next);
         return;
       }
-      markExternalToolReady(snapshot.runId);
       await syncWebviewPaletteVisibility(
         $commandSurface.open && $commandSurface.mode === "palette",
       );
       await syncAfterLayout();
+      void focusNativeWebview(next);
+      markExternalToolReady(snapshot.runId);
     } catch (err) {
       if (webview === next) webview = null;
       closeNativeWebview(next);
@@ -391,8 +399,18 @@
       await current.show();
       webviewHiddenForPalette = false;
       await syncAfterLayout();
+      void focusNativeWebview(current);
     } catch {
       // Palette visibility is best-effort; the native child webview may close mid-sync.
+    }
+  }
+
+  async function focusNativeWebview(current: Webview): Promise<void> {
+    if (current !== webview || webviewHiddenForPalette) return;
+    try {
+      await current.setFocus();
+    } catch {
+      // Focus is best-effort; some platforms can reject if the child webview is closing.
     }
   }
 
@@ -511,6 +529,7 @@
     {/if}
     {#if run.status === "ready" && run.rendered?.url && run.webEmbedder === "iframe"}
       <iframe
+        bind:this={iframe}
         src={run.rendered.url}
         title={run.toolName}
         class="h-full w-full border-0 bg-bg-deep"

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -290,6 +290,7 @@
       urlTemplate: surface === "web" ? "http://127.0.0.1:{{ port }}" : null,
       preferredPort: surface === "web" ? 4966 : null,
       webEmbedder: "webview",
+      keepWebviewAlive: false,
     };
     updateExternalTools([...externalTools(), tool]);
     expandedExternalToolId = id;
@@ -1566,13 +1567,27 @@
                                 <button
                                   type="button"
                                   class="px-2 py-1 text-[11px] transition-colors {tool.webEmbedder === option.value ? 'bg-bg-active text-text-primary' : 'text-text-muted hover:bg-bg-hover hover:text-text-secondary'}"
-                                  onclick={() => updateExternalTool(tool.id, { webEmbedder: option.value as ExternalToolWebEmbedder })}
+                                  onclick={() => updateExternalTool(tool.id, {
+                                    webEmbedder: option.value as ExternalToolWebEmbedder,
+                                    keepWebviewAlive: option.value === "webview" ? (tool.keepWebviewAlive ?? false) : false,
+                                  })}
                                 >
                                   {option.label}
                                 </button>
                               {/each}
                             </div>
                           </div>
+                          {#if tool.webEmbedder === "webview"}
+                            <label class="flex items-center gap-2 text-[11px] text-text-secondary">
+                              <input
+                                type="checkbox"
+                                class="h-3 w-3 accent-accent"
+                                checked={tool.keepWebviewAlive === true}
+                                onchange={(e) => updateExternalTool(tool.id, { keepWebviewAlive: e.currentTarget.checked })}
+                              />
+                              Keep webview active
+                            </label>
+                          {/if}
                           <div class="grid gap-2 md:grid-cols-[1fr_120px]">
                             <label class="grid gap-1 text-[11px] text-text-muted">
                               <span>URL template</span>

--- a/src/lib/components/__tests__/ExternalToolMainView.test.ts
+++ b/src/lib/components/__tests__/ExternalToolMainView.test.ts
@@ -65,6 +65,7 @@ function makeWebErrorRun(): ExternalToolRun {
     toolName: "Difit",
     surface: "web",
     webEmbedder: "webview",
+    keepWebviewAlive: false,
     sessionId: null,
     runtimeId: "process-1",
     runtimeGeneration: null,

--- a/src/lib/components/__tests__/ExternalToolWebView.test.ts
+++ b/src/lib/components/__tests__/ExternalToolWebView.test.ts
@@ -20,6 +20,7 @@ const webviewMock = vi.hoisted(() => {
     setSize = vi.fn().mockResolvedValue(undefined);
     hide = vi.fn().mockResolvedValue(undefined);
     show = vi.fn().mockResolvedValue(undefined);
+    setFocus = vi.fn().mockResolvedValue(undefined);
     close = vi.fn().mockResolvedValue(undefined);
     once = vi.fn((event: string, handler: () => void) => {
       if (event === "tauri://created") queueMicrotask(handler);
@@ -179,9 +180,25 @@ describe("ExternalToolWebView", () => {
 
     expect(webview.setPosition).toHaveBeenCalled();
     expect(webview.setSize).toHaveBeenCalled();
+    expect(webview.setFocus).toHaveBeenCalled();
     expect(externalToolsMock.markExternalToolReady).toHaveBeenCalledWith("difit:session-1");
 
     unmount();
+  });
+
+  it("focuses iframe web tools when they are ready", async () => {
+    const focus = vi.spyOn(HTMLIFrameElement.prototype, "focus").mockImplementation(() => {});
+    const { unmount } = render(ExternalToolWebView, {
+      run: { ...makeRun(), status: "ready", webEmbedder: "iframe" },
+    });
+
+    try {
+      flushAnimationFrames();
+      await waitFor(() => expect(focus).toHaveBeenCalled());
+    } finally {
+      unmount();
+      focus.mockRestore();
+    }
   });
 
   it("recreates a ready native webview when the component remounts", async () => {

--- a/src/lib/components/__tests__/ExternalToolWebView.test.ts
+++ b/src/lib/components/__tests__/ExternalToolWebView.test.ts
@@ -6,6 +6,7 @@ import {
   openCommandPalette,
   resetCommandSurface,
 } from "$lib/stores/commandSurface";
+import { closeRetainedExternalToolWebview } from "$lib/externalTools/nativeWebviews";
 
 const webviewMock = vi.hoisted(() => {
   class MockWebview {
@@ -74,6 +75,9 @@ vi.mock("@tauri-apps/api/webview", () => ({
 }));
 
 vi.mock("@tauri-apps/api/window", () => ({
+  BackgroundThrottlingPolicy: {
+    Disabled: "disabled",
+  },
   getCurrentWindow: vi.fn(() => ({
     label: "main",
     onResized: windowMock.onResized,
@@ -116,13 +120,16 @@ function flushAnimationFrames(): void {
   for (const callback of callbacks) callback(0);
 }
 
-function makeRun(): ExternalToolRun {
+function makeRun(
+  overrides: Partial<ExternalToolRun> & { keepWebviewAlive?: boolean } = {},
+): ExternalToolRun {
   return {
     id: "difit:session-1",
     toolId: "difit",
     toolName: "Difit",
     surface: "web",
     webEmbedder: "webview",
+    keepWebviewAlive: false,
     sessionId: "session-1",
     runtimeId: "process-1",
     runtimeGeneration: null,
@@ -136,7 +143,8 @@ function makeRun(): ExternalToolRun {
     error: null,
     logsOpen: false,
     launchedAtMs: 100,
-  };
+    ...overrides,
+  } as ExternalToolRun;
 }
 
 describe("ExternalToolWebView", () => {
@@ -167,6 +175,7 @@ describe("ExternalToolWebView", () => {
   });
 
   afterEach(() => {
+    closeRetainedExternalToolWebview("difit:session-1");
     resetCommandSurface();
     vi.unstubAllGlobals();
     vi.clearAllMocks();
@@ -225,6 +234,43 @@ describe("ExternalToolWebView", () => {
     expect(tauriMock.probeExternalToolUrl).not.toHaveBeenCalled();
 
     finishClose();
+    second.unmount();
+  });
+
+  it("does not recreate the native webview when startup marks the same run ready", async () => {
+    const initialRun = makeRun({ status: "starting" });
+    const { rerender, unmount } = render(ExternalToolWebView, { run: initialRun });
+
+    await waitFor(() => expect(webviewMock.MockWebview.instances).toHaveLength(1));
+    const webview = webviewMock.MockWebview.instances[0];
+
+    await rerender({ run: { ...initialRun, status: "ready" } });
+
+    expect(webviewMock.MockWebview.instances).toHaveLength(1);
+    expect(webview.close).not.toHaveBeenCalled();
+
+    unmount();
+  });
+
+  it("keeps active native webviews hidden across main-view remounts", async () => {
+    const readyRun = makeRun({ status: "ready", keepWebviewAlive: true });
+
+    const first = render(ExternalToolWebView, { run: readyRun });
+    await waitFor(() => expect(webviewMock.MockWebview.instances).toHaveLength(1));
+    const retained = webviewMock.MockWebview.instances[0];
+    expect(retained.options).toMatchObject({ backgroundThrottling: "disabled" });
+
+    first.unmount();
+    expect(retained.hide).toHaveBeenCalled();
+    expect(retained.close).not.toHaveBeenCalled();
+
+    const second = render(ExternalToolWebView, { run: readyRun });
+    await waitFor(() => expect(retained.show).toHaveBeenCalled());
+
+    expect(webviewMock.MockWebview.instances).toHaveLength(1);
+    expect(retained.setPosition).toHaveBeenCalled();
+    expect(retained.setSize).toHaveBeenCalled();
+
     second.unmount();
   });
 

--- a/src/lib/components/__tests__/ExternalToolWebView.test.ts
+++ b/src/lib/components/__tests__/ExternalToolWebView.test.ts
@@ -274,6 +274,58 @@ describe("ExternalToolWebView", () => {
     second.unmount();
   });
 
+  it("reports retained native webview reuse failures", async () => {
+    const readyRun = makeRun({ status: "ready", keepWebviewAlive: true });
+
+    const first = render(ExternalToolWebView, { run: readyRun });
+    await waitFor(() => expect(webviewMock.MockWebview.instances).toHaveLength(1));
+    const retained = webviewMock.MockWebview.instances[0];
+    first.unmount();
+
+    retained.show.mockRejectedValueOnce(new Error("webview gone"));
+    const second = render(ExternalToolWebView, { run: readyRun });
+
+    await waitFor(() =>
+      expect(externalToolsMock.failExternalToolRun).toHaveBeenCalledWith(
+        "difit:session-1",
+        "process-1",
+        "Failed to open http://127.0.0.1:4966: webview gone",
+      ),
+    );
+    expect(retained.close).toHaveBeenCalled();
+
+    second.unmount();
+  });
+
+  it("does not mark stale retained native webviews ready", async () => {
+    const readyRun = makeRun({ status: "ready", keepWebviewAlive: true });
+
+    const first = render(ExternalToolWebView, { run: readyRun });
+    await waitFor(() => expect(webviewMock.MockWebview.instances).toHaveLength(1));
+    const retained = webviewMock.MockWebview.instances[0];
+    first.unmount();
+    externalToolsMock.markExternalToolReady.mockClear();
+    retained.close.mockClear();
+
+    let finishShow: () => void = () => {};
+    retained.show.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        finishShow = resolve;
+      }),
+    );
+    const second = render(ExternalToolWebView, { run: readyRun });
+    await waitFor(() => expect(retained.show).toHaveBeenCalled());
+
+    await second.rerender({ run: { ...readyRun, status: "error", error: "failed" } });
+    finishShow();
+
+    await waitFor(() => expect(retained.close).toHaveBeenCalled());
+    await Promise.resolve();
+    expect(externalToolsMock.markExternalToolReady).not.toHaveBeenCalled();
+
+    second.unmount();
+  });
+
   it("registers a closer that closes the child webview", async () => {
     const closeView = { current: null as (() => void) | null };
     const unregister = vi.fn();

--- a/src/lib/components/__tests__/SettingsPanel.test.ts
+++ b/src/lib/components/__tests__/SettingsPanel.test.ts
@@ -254,6 +254,21 @@ describe("SettingsPanel external tools", () => {
     await fireEvent.input(input, { target: { value: "" } });
     expect(get(settings).externalTools?.find((tool) => tool.id === "difit")?.preferredPort).toBeNull();
   });
+
+  it("toggles keep-active mode for native webview tools", async () => {
+    render(SettingsPanel, { visible: true, onclose: vi.fn() });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Integrations" }));
+    await fireEvent.click(await screen.findByRole("button", { name: "GitHub" }));
+
+    const checkbox = screen.getByLabelText("Keep webview active") as HTMLInputElement;
+    expect(checkbox.checked).toBe(false);
+
+    await fireEvent.click(checkbox);
+
+    expect(get(settings).externalTools?.find((tool) => tool.id === "github")?.keepWebviewAlive)
+      .toBe(true);
+  });
 });
 
 describe("SettingsPanel agent notification setup", () => {

--- a/src/lib/externalTools/nativeWebviews.ts
+++ b/src/lib/externalTools/nativeWebviews.ts
@@ -1,0 +1,50 @@
+import { LogicalPosition, LogicalSize } from "@tauri-apps/api/dpi";
+import type { Webview } from "@tauri-apps/api/webview";
+
+export interface RetainedExternalToolWebview {
+  runId: string;
+  key: string;
+  label: string;
+  webview: Webview;
+}
+
+const retainedWebviews = new Map<string, RetainedExternalToolWebview>();
+
+export function retainExternalToolWebview(entry: RetainedExternalToolWebview): void {
+  closeRetainedExternalToolWebview(entry.runId);
+  retainedWebviews.set(entry.runId, entry);
+  hideNativeWebview(entry.webview);
+}
+
+export function takeRetainedExternalToolWebview(
+  runId: string,
+  key: string,
+): RetainedExternalToolWebview | null {
+  const retained = retainedWebviews.get(runId);
+  if (!retained) return null;
+  if (retained.key !== key) {
+    closeRetainedExternalToolWebview(runId);
+    return null;
+  }
+  retainedWebviews.delete(runId);
+  return retained;
+}
+
+export function closeRetainedExternalToolWebview(runId: string): void {
+  const retained = retainedWebviews.get(runId);
+  if (!retained) return;
+  retainedWebviews.delete(runId);
+  closeNativeWebview(retained.webview);
+}
+
+export function closeNativeWebview(current: Webview | null): void {
+  if (!current) return;
+  hideNativeWebview(current);
+  void current.close().catch(() => {});
+}
+
+function hideNativeWebview(current: Webview): void {
+  void current.hide().catch(() => {});
+  void current.setSize(new LogicalSize(1, 1)).catch(() => {});
+  void current.setPosition(new LogicalPosition(-32000, -32000)).catch(() => {});
+}

--- a/src/lib/stores/__tests__/externalTools.test.ts
+++ b/src/lib/stores/__tests__/externalTools.test.ts
@@ -53,6 +53,7 @@ function runWithStatus(status: ExternalToolRunStatus): ExternalToolRun {
     toolName: "Lazygit",
     surface: "terminal",
     webEmbedder: "webview",
+    keepWebviewAlive: false,
     sessionId: "session-1",
     runtimeId: "pty-1",
     runtimeGeneration: 1,
@@ -76,6 +77,7 @@ function webTool(): ExternalTool {
     urlTemplate: "http://127.0.0.1:4966",
     preferredPort: 4966,
     webEmbedder: "webview",
+    keepWebviewAlive: false,
   };
 }
 
@@ -91,6 +93,7 @@ function terminalTool(): ExternalTool {
     urlTemplate: null,
     preferredPort: null,
     webEmbedder: "webview",
+    keepWebviewAlive: false,
   };
 }
 

--- a/src/lib/stores/externalTools.ts
+++ b/src/lib/stores/externalTools.ts
@@ -12,6 +12,7 @@ import {
 import { activeSession, sessionList } from "$lib/stores/sessions";
 import { settings } from "$lib/stores/settings";
 import { closeMainView, mainViewRoute, openMainView } from "$lib/stores/mainView";
+import { closeRetainedExternalToolWebview } from "$lib/externalTools/nativeWebviews";
 
 export type ExternalToolRunStatus =
   | "launching"
@@ -26,6 +27,7 @@ export interface ExternalToolRun {
   toolName: string;
   surface: ExternalToolSurface;
   webEmbedder: ExternalToolWebEmbedder;
+  keepWebviewAlive: boolean;
   sessionId: string | null;
   runtimeId: string | null;
   runtimeGeneration: number | null;
@@ -98,6 +100,7 @@ export async function restartExternalToolRun(runId: string): Promise<void> {
 function markExternalToolRelaunching(runId: string): number {
   const relaunchToken = ++nextExternalToolRelaunchCleanupToken;
   closeExternalToolView(runId);
+  closeRetainedExternalToolWebview(runId);
   cancelExternalToolLaunch(runId);
   externalToolRelaunchCleanupTokens.set(runId, relaunchToken);
   updateRun(runId, (run) => ({
@@ -139,6 +142,7 @@ export function registerExternalToolViewCloser(runId: string, closeView: () => v
 
 function removeExternalToolRun(runId: string): void {
   closeExternalToolView(runId);
+  closeRetainedExternalToolWebview(runId);
   cancelExternalToolLaunch(runId);
   externalToolRelaunchCleanupTokens.delete(runId);
   externalToolRuns.update((runs) => {
@@ -239,6 +243,7 @@ async function launchRun(
     toolName: tool.name,
     surface,
     webEmbedder: externalToolWebEmbedder(tool),
+    keepWebviewAlive: externalToolKeepsWebviewAlive(tool),
     sessionId,
     runtimeId: null,
     runtimeGeneration: null,
@@ -261,6 +266,7 @@ async function launchRun(
       ...run,
       surface: result.surface,
       webEmbedder: externalToolWebEmbedder(tool),
+      keepWebviewAlive: externalToolKeepsWebviewAlive(tool),
       runtimeId: result.runtimeId,
       runtimeGeneration: result.runtimeGeneration ?? null,
       rendered: result.rendered,
@@ -299,6 +305,14 @@ function resolveBoundSessionId(tool: ExternalTool): string | null {
 function externalToolWebEmbedder(tool: ExternalTool): ExternalToolWebEmbedder {
   if ((tool.surface ?? "terminal") !== "web") return "webview";
   return tool.webEmbedder ?? "webview";
+}
+
+function externalToolKeepsWebviewAlive(tool: ExternalTool): boolean {
+  return (
+    (tool.surface ?? "terminal") === "web" &&
+    externalToolWebEmbedder(tool) === "webview" &&
+    tool.keepWebviewAlive === true
+  );
 }
 
 function findTool(toolId: string): ExternalTool {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -143,6 +143,7 @@ export const DEFAULT_SETTINGS: RouxSettings = {
       urlTemplate: null,
       preferredPort: null,
       webEmbedder: "webview",
+      keepWebviewAlive: false,
     },
     {
       id: "difit",
@@ -155,6 +156,7 @@ export const DEFAULT_SETTINGS: RouxSettings = {
       urlTemplate: "http://127.0.0.1:{{ port }}",
       preferredPort: 4966,
       webEmbedder: "iframe",
+      keepWebviewAlive: false,
     },
     {
       id: "github",
@@ -167,6 +169,7 @@ export const DEFAULT_SETTINGS: RouxSettings = {
       urlTemplate: "https://github.com",
       preferredPort: null,
       webEmbedder: "webview",
+      keepWebviewAlive: false,
     },
   ],
   kanban: {


### PR DESCRIPTION
## Summary
- focus native external webviews once they are ready so newly opened web tools are immediately usable
- add a keep-active setting for native external webviews and retain them across main-view remounts
- normalize the setting for terminal and iframe tools, and cover the lifecycle/settings behavior with tests

## Verification
- npm run test -- externalTools.test.ts ExternalToolMainView.test.ts ExternalToolWebView.test.ts SettingsPanel.test.ts
- npm run check
- cargo test -p roux-core external_tools
- env CI=1 cargo test -p roux-desktop external_tools

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves the external-tool webview experience with three coordinated changes: newly opened web tools (both native webview and iframe) receive immediate focus when they become ready; a new `keepWebviewAlive` setting lets native webviews survive main-view remounts by parking them off-screen rather than closing them; and removing `status` from the poll key prevents an unnecessary webview teardown/recreate when a launching run transitions to ready.

- **Retain/restore lifecycle** (`nativeWebviews.ts`, `ExternalToolWebView.svelte`): on component unmount a keep-alive webview is hidden, stored in a module-level map keyed by `runId`, and restored on the next mount via `takeRetainedExternalToolWebview`; staleness is detected by a composite key (`runId:runtimeId:url:launchedAtMs`).
- **Settings plumbing** (`settings.rs`, `bindings.ts`, `externalTools.ts`, `SettingsPanel.svelte`): `keep_webview_alive` is added to `ExternalTool` with `serde(default)` for backward compatibility; normalization forces it to `false` for Terminal-surface and Web+iframe tools; the UI checkbox is conditionally shown only for native-webview web tools.
- **Test coverage** (`ExternalToolWebView.test.ts`, `ExternalToolMainView.test.ts`, `externalTools.test.ts`, `SettingsPanel.test.ts`): new tests cover the retain/restore cycle, reuse-failure error reporting, stale-snapshot protection, focus-on-ready for both embedder types, and the no-recreate-on-ready transition.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with one fix: `discardCurrentWebview` can close a just-retained webview when the component unmounts during an async re-show, causing a user-visible error on the next open of the same keep-alive tool.

The retain/restore machinery, settings normalization, and cleanup paths are all well-structured and backed by thorough tests. The single issue — `discardCurrentWebview` calling `closeNativeWebview` unconditionally even when ownership was already transferred to the retain map — is a systematic failure of the new keep-alive feature when the user navigates away quickly during a re-show. The fix is a one-line guard and the rest of the PR is solid.

src/lib/components/ExternalToolWebView.svelte — specifically the `discardCurrentWebview` function at line 516.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/components/ExternalToolWebView.svelte | Core of the PR: adds retain/restore lifecycle, focus-on-ready for both iframe and native webview, and removes `status` from the poll key so the webview isn't recreated when the same run transitions to ready. Contains a defect in `discardCurrentWebview` that can close a just-retained webview. |
| src/lib/externalTools/nativeWebviews.ts | New module providing module-level singleton map for retained webviews; `retainExternalToolWebview`, `takeRetainedExternalToolWebview`, `closeRetainedExternalToolWebview` added with correct key-mismatch eviction. `closeNativeWebview` extracted here from the component. |
| src/lib/stores/externalTools.ts | Adds `keepWebviewAlive` to `ExternalToolRun`, `externalToolKeepsWebviewAlive` helper, and correctly calls `closeRetainedExternalToolWebview` in both `markExternalToolRelaunching` and `removeExternalToolRun`. |
| crates/roux-core/src/models/settings.rs | Adds `keep_webview_alive` field with `serde(default)` for backward compatibility; normalization correctly forces `false` for Terminal surface and for Web+non-Webview embedder; tests cover all three normalization branches. |
| src/lib/components/SettingsPanel.svelte | Adds 'Keep webview active' checkbox, only visible when `webEmbedder === 'webview'`; resets `keepWebviewAlive` to false when switching to iframe, preserves it when switching back. |
| src/lib/components/__tests__/ExternalToolWebView.test.ts | Adds comprehensive tests for retain/restore cycle, error reporting on retain-reuse failure, stale-snapshot protection, and focus-on-ready for both iframe and native webview paths. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User
    participant SV as ExternalToolWebView
    participant NW as nativeWebviews.ts
    participant TV as Tauri Webview

    Note over U,TV: First open (keepWebviewAlive: true)
    U->>SV: mount
    SV->>TV: new Webview(...)
    TV-->>SV: tauri://created
    SV->>TV: setPosition / setSize
    SV->>TV: setFocus()
    SV->>SV: markExternalToolReady

    Note over U,TV: User navigates away
    U->>SV: unmount → cleanup()
    SV->>SV: retainOrCloseWebview()
    SV->>NW: retainExternalToolWebview(runId, key, webview)
    NW->>TV: hide() + move off-screen

    Note over U,TV: User navigates back
    U->>SV: mount
    SV->>NW: takeRetainedExternalToolWebview(runId, key)
    NW-->>SV: retained entry (or null if key mismatch)
    SV->>TV: show()
    SV->>TV: setPosition / setSize
    SV->>TV: setFocus()
    SV->>SV: markExternalToolReady

    Note over U,TV: Relaunch / remove
    SV->>NW: closeRetainedExternalToolWebview(runId)
    NW->>TV: close()
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Flib%2Fcomponents%2FExternalToolWebView.svelte%3A516-523%0A**%60discardCurrentWebview%60%20closes%20retained%20webviews%20it%20no%20longer%20owns**%0A%0AWhen%20a%20component%20unmounts%20while%20re-showing%20a%20retained%20webview%20%28e.g.%2C%20the%20user%20opens%20a%20keep-alive%20tool%20and%20immediately%20closes%20it%20before%20%60show%28%29%60%20%2F%20%60syncAfterLayout%28%29%60%20resolve%29%2C%20the%20lifecycle%20runs%20as%20follows%3A%0A%0A1.%20%60cleanup%28%29%60%20fires%20synchronously%20%E2%86%92%20%60retainOrCloseWebview%28%29%60%20retains%20the%20webview%2C%20sets%20%60webview%20%3D%20null%60.%0A2.%20The%20suspended%20async%20%60createWebview%60%20continuation%20resumes%2C%20%60webviewSnapshotIsCurrent%60%20returns%20%60false%60%20%28destroyed%29%2C%20and%20%60discardCurrentWebview%28current%29%60%20is%20called.%0A3.%20%60webview%20%3D%3D%3D%20current%60%20is%20%60false%60%20%28null%20vs%20current%29%2C%20so%20the%20state%20block%20is%20skipped%20%E2%80%94%20but%20%60closeNativeWebview%28current%29%60%20is%20called%20unconditionally%2C%20closing%20the%20handle%20that%20was%20just%20stored%20in%20%60retainedWebviews%60.%0A%0AThe%20map%20entry%20now%20points%20to%20a%20closed%20native%20webview.%20On%20the%20next%20open%2C%20%60takeRetainedExternalToolWebview%60%20returns%20the%20stale%20entry%2C%20%60show%28%29%60%20throws%2C%20and%20%60failExternalToolRun%60%20fires%20%E2%80%94%20the%20user%20sees%20an%20error%20before%20the%20tool%20recovers%20on%20a%20third%20attempt.%0A%0AThe%20fix%20is%20to%20skip%20%60closeNativeWebview%60%20when%20%60webview%20!%3D%3D%20current%60%2C%20since%20in%20that%20case%20ownership%20has%20already%20been%20transferred%20%28either%20retained%20or%20closed%20by%20%60closeWebview%60%29%3A%0A%0A%60%60%60ts%0Afunction%20discardCurrentWebview%28current%3A%20Webview%29%3A%20void%20%7B%0A%20%20if%20%28webview%20!%3D%3D%20current%29%20return%3B%20%2F%2F%20already%20retained%20or%20closed%20elsewhere%0A%20%20webview%20%3D%20null%3B%0A%20%20webviewLabel%20%3D%20null%3B%0A%20%20webviewHiddenForPalette%20%3D%20false%3B%0A%20%20closeNativeWebview%28current%29%3B%0A%7D%0A%60%60%60%0A%0A&repo=phin-tech%2Froux&pr=222&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22feature%2Fexternal-tools-rough-edges%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fexternal-tools-rough-edges%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Flib%2Fcomponents%2FExternalToolWebView.svelte%3A516-523%0A**%60discardCurrentWebview%60%20closes%20retained%20webviews%20it%20no%20longer%20owns**%0A%0AWhen%20a%20component%20unmounts%20while%20re-showing%20a%20retained%20webview%20%28e.g.%2C%20the%20user%20opens%20a%20keep-alive%20tool%20and%20immediately%20closes%20it%20before%20%60show%28%29%60%20%2F%20%60syncAfterLayout%28%29%60%20resolve%29%2C%20the%20lifecycle%20runs%20as%20follows%3A%0A%0A1.%20%60cleanup%28%29%60%20fires%20synchronously%20%E2%86%92%20%60retainOrCloseWebview%28%29%60%20retains%20the%20webview%2C%20sets%20%60webview%20%3D%20null%60.%0A2.%20The%20suspended%20async%20%60createWebview%60%20continuation%20resumes%2C%20%60webviewSnapshotIsCurrent%60%20returns%20%60false%60%20%28destroyed%29%2C%20and%20%60discardCurrentWebview%28current%29%60%20is%20called.%0A3.%20%60webview%20%3D%3D%3D%20current%60%20is%20%60false%60%20%28null%20vs%20current%29%2C%20so%20the%20state%20block%20is%20skipped%20%E2%80%94%20but%20%60closeNativeWebview%28current%29%60%20is%20called%20unconditionally%2C%20closing%20the%20handle%20that%20was%20just%20stored%20in%20%60retainedWebviews%60.%0A%0AThe%20map%20entry%20now%20points%20to%20a%20closed%20native%20webview.%20On%20the%20next%20open%2C%20%60takeRetainedExternalToolWebview%60%20returns%20the%20stale%20entry%2C%20%60show%28%29%60%20throws%2C%20and%20%60failExternalToolRun%60%20fires%20%E2%80%94%20the%20user%20sees%20an%20error%20before%20the%20tool%20recovers%20on%20a%20third%20attempt.%0A%0AThe%20fix%20is%20to%20skip%20%60closeNativeWebview%60%20when%20%60webview%20!%3D%3D%20current%60%2C%20since%20in%20that%20case%20ownership%20has%20already%20been%20transferred%20%28either%20retained%20or%20closed%20by%20%60closeWebview%60%29%3A%0A%0A%60%60%60ts%0Afunction%20discardCurrentWebview%28current%3A%20Webview%29%3A%20void%20%7B%0A%20%20if%20%28webview%20!%3D%3D%20current%29%20return%3B%20%2F%2F%20already%20retained%20or%20closed%20elsewhere%0A%20%20webview%20%3D%20null%3B%0A%20%20webviewLabel%20%3D%20null%3B%0A%20%20webviewHiddenForPalette%20%3D%20false%3B%0A%20%20closeNativeWebview%28current%29%3B%0A%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Fix retained external webview reuse"](https://github.com/phin-tech/roux/commit/1841fe8381707380014b8afe008b2cbf3d47d5ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35112833)</sub>

<!-- /greptile_comment -->