### PR TITLE
Add persistent remote daemon CLI config

### DIFF
--- a/crates/roux-cli/src/daemon.rs
+++ b/crates/roux-cli/src/daemon.rs
@@ -2047,20 +2047,12 @@ fn unix_now_ms() -> u64 {
 fn daemon_auth_token(endpoint: &platform::SocketEndpoint) -> Result<Option<String>, String> {
     match endpoint {
         platform::SocketEndpoint::Unix(_) => Ok(None),
-        platform::SocketEndpoint::Tcp(addr) => {
+        platform::SocketEndpoint::Tcp(_) => {
             if let Some(token) = daemon_env_auth_token() {
                 return Ok(Some(token));
             }
 
-            #[cfg(windows)]
-            {
-                Ok(Some(format!("{}-{}", std::process::id(), unix_now_ms())))
-            }
-
-            #[cfg(not(windows))]
-            {
-                Err(format!("TCP daemon bind tcp://{addr} requires ROUX_DAEMON_TOKEN"))
-            }
+            Ok(Some(format!("{}{}", uuid::Uuid::new_v4().simple(), uuid::Uuid::new_v4().simple())))
         }
     }
 }

--- a/crates/roux-cli/src/daemon/server.rs
+++ b/crates/roux-cli/src/daemon/server.rs
@@ -206,7 +206,7 @@ async fn bind_tcp_listener(addr: &str, identity: &DaemonIdentity) -> Result<TcpL
         .to_string();
     write_private_file(
         &platform::socket_addr_file_path(),
-        local_addr.as_bytes(),
+        format!("tcp://{local_addr}").as_bytes(),
         "daemon socket endpoint",
     )?;
     let token = identity.auth_token.as_deref().unwrap_or_default();

--- a/crates/roux-cli/src/daemon/tests.rs
+++ b/crates/roux-cli/src/daemon/tests.rs
@@ -43,6 +43,45 @@ fn make_watch_config() -> roux_core::CreateWatchConfig {
     }
 }
 
+static DAEMON_AUTH_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn with_daemon_auth_env<T>(
+    daemon_token: Option<&str>,
+    auth_token: Option<&str>,
+    f: impl FnOnce() -> T,
+) -> T {
+    let _guard = DAEMON_AUTH_ENV_LOCK.lock().unwrap();
+    let previous_daemon_token = std::env::var_os("ROUX_DAEMON_TOKEN");
+    let previous_auth_token = std::env::var_os("ROUX_AUTH_TOKEN");
+
+    set_env_var("ROUX_DAEMON_TOKEN", daemon_token);
+    set_env_var("ROUX_AUTH_TOKEN", auth_token);
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+
+    restore_env_var("ROUX_DAEMON_TOKEN", previous_daemon_token);
+    restore_env_var("ROUX_AUTH_TOKEN", previous_auth_token);
+
+    match result {
+        Ok(value) => value,
+        Err(panic) => std::panic::resume_unwind(panic),
+    }
+}
+
+fn set_env_var(key: &str, value: Option<&str>) {
+    match value {
+        Some(value) => std::env::set_var(key, value),
+        None => std::env::remove_var(key),
+    }
+}
+
+fn restore_env_var(key: &str, value: Option<std::ffi::OsString>) {
+    match value {
+        Some(value) => std::env::set_var(key, value),
+        None => std::env::remove_var(key),
+    }
+}
+
 #[tokio::test]
 async fn daemon_status_is_daemon_only_socket_command() {
     let dir = tempfile::tempdir().unwrap();
@@ -2973,4 +3012,30 @@ fn request_authorized_requires_identity_token() {
     assert!(!request_authorized(&request(None), &identity));
     assert!(!request_authorized(&request(Some("wrong-token")), &identity));
     assert!(request_authorized(&request(Some("secret-token")), &identity));
+}
+
+#[test]
+fn daemon_auth_token_generates_token_for_tcp_bind_without_env_token() {
+    with_daemon_auth_env(None, None, || {
+        let endpoint = platform::SocketEndpoint::Tcp("100.73.57.24:7777".to_string());
+
+        let token = daemon_auth_token(&endpoint)
+            .expect("tcp bind without env token should generate token")
+            .expect("tcp bind should require an auth token");
+
+        assert!(!token.trim().is_empty());
+    });
+}
+
+#[test]
+fn daemon_auth_token_prefers_env_token_for_tcp_bind() {
+    with_daemon_auth_env(Some("stable-token"), None, || {
+        let endpoint = platform::SocketEndpoint::Tcp("100.73.57.24:7777".to_string());
+
+        let token = daemon_auth_token(&endpoint)
+            .expect("env token should be accepted")
+            .expect("tcp bind should require an auth token");
+
+        assert_eq!(token, "stable-token");
+    });
 }

--- a/crates/roux-cli/src/main.rs
+++ b/crates/roux-cli/src/main.rs
@@ -1378,6 +1378,9 @@ fn print_daemon_lifecycle_line(prefix: &str, status: &Value) {
     println!("{}", parts.join(" "));
 }
 
+const TCP_CONNECT_AUTH_WARNING: &str =
+    "Warning: TCP daemon endpoints require an auth token; pass --auth-token or set ROUX_AUTH_TOKEN.";
+
 fn connect_daemon_socket(socket: &str, auth_token: Option<&str>) -> Result<(), String> {
     let endpoint = parse_daemon_connect_endpoint(socket)?;
     write_private_config_file(&platform::socket_addr_file_path(), &endpoint.display_value())?;
@@ -1385,6 +1388,13 @@ fn connect_daemon_socket(socket: &str, auth_token: Option<&str>) -> Result<(), S
         write_private_config_file(&platform::socket_auth_token_file_path(), auth_token)?;
     } else {
         remove_config_file_if_exists(&platform::socket_auth_token_file_path())?;
+    }
+    if let Some(warning) = daemon_connect_auth_warning(
+        &endpoint,
+        auth_token.is_some(),
+        daemon_connect_env_auth_token_present(),
+    ) {
+        eprintln!("{warning}");
     }
     println!("Connected roux CLI to {}", endpoint.display_value());
     Ok(())
@@ -1406,6 +1416,25 @@ fn parse_daemon_connect_endpoint(socket: &str) -> Result<platform::SocketEndpoin
         return Ok(endpoint);
     }
     Err(format!("invalid daemon socket endpoint: {socket}"))
+}
+
+fn daemon_connect_auth_warning(
+    endpoint: &platform::SocketEndpoint,
+    has_cli_auth_token: bool,
+    has_env_auth_token: bool,
+) -> Option<&'static str> {
+    match endpoint {
+        platform::SocketEndpoint::Tcp(_) if !has_cli_auth_token && !has_env_auth_token => {
+            Some(TCP_CONNECT_AUTH_WARNING)
+        }
+        _ => None,
+    }
+}
+
+fn daemon_connect_env_auth_token_present() -> bool {
+    ["ROUX_DAEMON_TOKEN", "ROUX_AUTH_TOKEN"]
+        .iter()
+        .any(|key| std::env::var(key).ok().map(|value| !value.trim().is_empty()).unwrap_or(false))
 }
 
 fn write_private_config_file(path: &PathBuf, contents: &str) -> Result<(), String> {
@@ -1432,6 +1461,9 @@ fn write_private_config_file(path: &PathBuf, contents: &str) -> Result<(), Strin
                 .map_err(|err| format!("write config file {}: {err}", tmp_path.display()))?;
             file.write_all(contents.as_bytes())
                 .map_err(|err| format!("write config file {}: {err}", tmp_path.display()))?;
+            file.set_permissions(std::fs::Permissions::from_mode(0o600)).map_err(|err| {
+                format!("set permissions on config file {}: {err}", tmp_path.display())
+            })?;
             drop(file);
             std::fs::rename(&tmp_path, path).map_err(|err| {
                 format!("replace config file {} with {}: {err}", path.display(), tmp_path.display())
@@ -1442,9 +1474,6 @@ fn write_private_config_file(path: &PathBuf, contents: &str) -> Result<(), Strin
             let _ = std::fs::remove_file(&tmp_path);
         }
         result?;
-
-        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
-            .map_err(|err| format!("set permissions on config file {}: {err}", path.display()))?;
     }
 
     #[cfg(not(unix))]
@@ -3987,6 +4016,32 @@ mod tests {
             }
             _ => panic!("expected Daemon::Connect"),
         }
+    }
+
+    #[test]
+    fn daemon_connect_warns_when_tcp_endpoint_has_no_auth_token_source() {
+        let endpoint = platform::SocketEndpoint::Tcp("127.0.0.1:7777".to_string());
+
+        assert_eq!(
+            daemon_connect_auth_warning(&endpoint, false, false),
+            Some(TCP_CONNECT_AUTH_WARNING)
+        );
+    }
+
+    #[test]
+    fn daemon_connect_does_not_warn_when_tcp_auth_token_source_exists() {
+        let endpoint = platform::SocketEndpoint::Tcp("127.0.0.1:7777".to_string());
+
+        assert_eq!(daemon_connect_auth_warning(&endpoint, true, false), None);
+        assert_eq!(daemon_connect_auth_warning(&endpoint, false, true), None);
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn daemon_connect_does_not_warn_for_unix_endpoint_without_auth_token() {
+        let endpoint = platform::SocketEndpoint::Unix("/tmp/roux.sock".into());
+
+        assert_eq!(daemon_connect_auth_warning(&endpoint, false, false), None);
     }
 
     #[test]

--- a/crates/roux-cli/src/main.rs
+++ b/crates/roux-cli/src/main.rs
@@ -1413,14 +1413,28 @@ fn write_private_config_file(path: &PathBuf, contents: &str) -> Result<(), Strin
         std::fs::create_dir_all(parent)
             .map_err(|err| format!("create config directory {}: {err}", parent.display()))?;
     }
-    std::fs::write(path, contents)
-        .map_err(|err| format!("write config file {}: {err}", path.display()))?;
-
     #[cfg(unix)]
     {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
         use std::os::unix::fs::PermissionsExt;
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .mode(0o600)
+            .open(path)
+            .map_err(|err| format!("write config file {}: {err}", path.display()))?;
+        file.write_all(contents.as_bytes())
+            .map_err(|err| format!("write config file {}: {err}", path.display()))?;
         std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
             .map_err(|err| format!("set permissions on config file {}: {err}", path.display()))?;
+    }
+
+    #[cfg(not(unix))]
+    {
+        std::fs::write(path, contents)
+            .map_err(|err| format!("write config file {}: {err}", path.display()))?;
     }
 
     Ok(())
@@ -3964,6 +3978,21 @@ mod tests {
         let cli = Cli::try_parse_from(["roux", "daemon", "disconnect"]).unwrap();
 
         assert!(matches!(cli.command, Commands::Daemon { action: Some(DaemonAction::Disconnect) }));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_config_file_is_created_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("roux-socket-token");
+
+        write_private_config_file(&path, "secret-token").unwrap();
+
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+        assert_eq!(std::fs::read_to_string(path).unwrap(), "secret-token");
     }
 
     #[test]

--- a/crates/roux-cli/src/main.rs
+++ b/crates/roux-cli/src/main.rs
@@ -323,6 +323,16 @@ enum DaemonAction {
         #[arg(short, long)]
         follow: bool,
     },
+    /// Persist a daemon socket endpoint for future CLI commands
+    Connect {
+        /// Socket endpoint, e.g. tcp://100.73.57.24:7777
+        socket: String,
+        /// Auth token for TCP daemon endpoints
+        #[arg(long)]
+        auth_token: Option<String>,
+    },
+    /// Clear a persisted daemon socket endpoint
+    Disconnect,
     /// Start a daemon-owned shell command and return its process id
     Run {
         /// Shell command to run inside the daemon
@@ -1368,6 +1378,62 @@ fn print_daemon_lifecycle_line(prefix: &str, status: &Value) {
     println!("{}", parts.join(" "));
 }
 
+fn connect_daemon_socket(socket: &str, auth_token: Option<&str>) -> Result<(), String> {
+    let endpoint = parse_daemon_connect_endpoint(socket)?;
+    write_private_config_file(&platform::socket_addr_file_path(), &endpoint.display_value())?;
+    if let Some(auth_token) = auth_token {
+        write_private_config_file(&platform::socket_auth_token_file_path(), auth_token)?;
+    } else {
+        remove_config_file_if_exists(&platform::socket_auth_token_file_path())?;
+    }
+    println!("Connected roux CLI to {}", endpoint.display_value());
+    Ok(())
+}
+
+fn disconnect_daemon_socket() -> Result<(), String> {
+    remove_config_file_if_exists(&platform::socket_addr_file_path())?;
+    remove_config_file_if_exists(&platform::socket_auth_token_file_path())?;
+    println!("Disconnected roux CLI daemon socket config");
+    Ok(())
+}
+
+fn parse_daemon_connect_endpoint(socket: &str) -> Result<platform::SocketEndpoint, String> {
+    let trimmed = socket.trim();
+    if trimmed.is_empty() {
+        return Err("daemon socket endpoint cannot be empty".to_string());
+    }
+    if let Some(endpoint) = platform::parse_socket_endpoint(trimmed) {
+        return Ok(endpoint);
+    }
+    Err(format!("invalid daemon socket endpoint: {socket}"))
+}
+
+fn write_private_config_file(path: &PathBuf, contents: &str) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|err| format!("create config directory {}: {err}", parent.display()))?;
+    }
+    std::fs::write(path, contents)
+        .map_err(|err| format!("write config file {}: {err}", path.display()))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+            .map_err(|err| format!("set permissions on config file {}: {err}", path.display()))?;
+    }
+
+    Ok(())
+}
+
+fn remove_config_file_if_exists(path: &PathBuf) -> Result<(), String> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(format!("remove config file {}: {err}", path.display())),
+    }
+}
+
 fn show_daemon_logs(lines: usize, follow: bool) -> Result<(), String> {
     let path = platform::log_dir().join("roux-daemon.log");
     if follow {
@@ -2123,6 +2189,18 @@ fn main() {
             }
             Some(DaemonAction::Logs { lines, follow }) => {
                 if let Err(e) = show_daemon_logs(lines, follow) {
+                    eprintln!("Error: {e}");
+                    std::process::exit(1);
+                }
+            }
+            Some(DaemonAction::Connect { socket, auth_token }) => {
+                if let Err(e) = connect_daemon_socket(&socket, auth_token.as_deref()) {
+                    eprintln!("Error: {e}");
+                    std::process::exit(1);
+                }
+            }
+            Some(DaemonAction::Disconnect) => {
+                if let Err(e) = disconnect_daemon_socket() {
                     eprintln!("Error: {e}");
                     std::process::exit(1);
                 }
@@ -3856,6 +3934,36 @@ mod tests {
             }
             _ => panic!("expected Daemon::Logs"),
         }
+    }
+
+    #[test]
+    fn cli_parses_daemon_connect_command() {
+        let cli = Cli::try_parse_from([
+            "roux",
+            "daemon",
+            "connect",
+            "tcp://100.73.57.24:7777",
+            "--auth-token",
+            "secret-token",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Commands::Daemon {
+                action: Some(DaemonAction::Connect { socket, auth_token: Some(auth_token) }),
+            } => {
+                assert_eq!(socket, "tcp://100.73.57.24:7777");
+                assert_eq!(auth_token, "secret-token");
+            }
+            _ => panic!("expected Daemon::Connect"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_daemon_disconnect_command() {
+        let cli = Cli::try_parse_from(["roux", "daemon", "disconnect"]).unwrap();
+
+        assert!(matches!(cli.command, Commands::Daemon { action: Some(DaemonAction::Disconnect) }));
     }
 
     #[test]

--- a/crates/roux-cli/src/main.rs
+++ b/crates/roux-cli/src/main.rs
@@ -1418,15 +1418,31 @@ fn write_private_config_file(path: &PathBuf, contents: &str) -> Result<(), Strin
         use std::io::Write;
         use std::os::unix::fs::OpenOptionsExt;
         use std::os::unix::fs::PermissionsExt;
-        let mut file = std::fs::OpenOptions::new()
-            .create(true)
-            .truncate(true)
-            .write(true)
-            .mode(0o600)
-            .open(path)
-            .map_err(|err| format!("write config file {}: {err}", path.display()))?;
-        file.write_all(contents.as_bytes())
-            .map_err(|err| format!("write config file {}: {err}", path.display()))?;
+
+        let file_name = path.file_name().and_then(|name| name.to_str()).unwrap_or("roux-config");
+        let tmp_path =
+            path.with_file_name(format!(".{file_name}.{}.tmp", uuid::Uuid::new_v4().simple()));
+
+        let result = (|| {
+            let mut file = std::fs::OpenOptions::new()
+                .create_new(true)
+                .write(true)
+                .mode(0o600)
+                .open(&tmp_path)
+                .map_err(|err| format!("write config file {}: {err}", tmp_path.display()))?;
+            file.write_all(contents.as_bytes())
+                .map_err(|err| format!("write config file {}: {err}", tmp_path.display()))?;
+            drop(file);
+            std::fs::rename(&tmp_path, path).map_err(|err| {
+                format!("replace config file {} with {}: {err}", path.display(), tmp_path.display())
+            })?;
+            Ok::<(), String>(())
+        })();
+        if result.is_err() {
+            let _ = std::fs::remove_file(&tmp_path);
+        }
+        result?;
+
         std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
             .map_err(|err| format!("set permissions on config file {}: {err}", path.display()))?;
     }
@@ -3993,6 +4009,23 @@ mod tests {
         let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o600);
         assert_eq!(std::fs::read_to_string(path).unwrap(), "secret-token");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_config_file_replaces_permissive_existing_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("roux-socket-token");
+        std::fs::write(&path, "old-token").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        write_private_config_file(&path, "new-token").unwrap();
+
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+        assert_eq!(std::fs::read_to_string(path).unwrap(), "new-token");
     }
 
     #[test]

--- a/crates/roux-cli/tests/remote_daemon.rs
+++ b/crates/roux-cli/tests/remote_daemon.rs
@@ -1,0 +1,120 @@
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Output, Stdio};
+use std::time::{Duration, Instant};
+
+#[test]
+fn daemon_connect_persists_tcp_endpoint_used_by_normal_cli_commands() {
+    let daemon_dir = tempfile::tempdir().unwrap();
+    let client_dir = tempfile::tempdir().unwrap();
+    let roux = PathBuf::from(env!("CARGO_BIN_EXE_roux"));
+    let mut daemon = DaemonProcess::spawn(&roux, daemon_dir.path());
+
+    let socket = wait_for_file_contents(&daemon_dir.path().join("roux-socket-addr"));
+    let token = wait_for_file_contents(&daemon_dir.path().join("roux-socket-token"));
+
+    let connect = run_roux(
+        &roux,
+        client_dir.path(),
+        &["daemon", "connect", socket.trim(), "--auth-token", token.trim()],
+    );
+    assert_success(&connect, "daemon connect");
+
+    let status = run_roux(&roux, client_dir.path(), &["daemon", "status"]);
+    assert_success(&status, "daemon status");
+    assert!(String::from_utf8_lossy(&status.stdout).contains("\"kind\": \"roux-daemon\""));
+
+    let sessions = run_roux(&roux, client_dir.path(), &["session", "list"]);
+    assert_success(&sessions, "session list");
+    assert!(String::from_utf8_lossy(&sessions.stdout).trim().starts_with('['));
+
+    daemon.stop_with_client_config(client_dir.path());
+}
+
+struct DaemonProcess {
+    roux: PathBuf,
+    child: Option<Child>,
+}
+
+impl DaemonProcess {
+    fn spawn(roux: &Path, daemon_base_path: &Path) -> Self {
+        let child = Command::new(roux)
+            .arg("daemon")
+            .env("ROUX_BASE_PATH", daemon_base_path)
+            .env("ROUX_DAEMON_BIND", "tcp://127.0.0.1:0")
+            .env_remove("ROUX_SOCKET")
+            .env_remove("ROUX_AUTH_TOKEN")
+            .env_remove("ROUX_DAEMON_TOKEN")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn daemon");
+
+        Self { roux: roux.to_path_buf(), child: Some(child) }
+    }
+
+    fn stop_with_client_config(&mut self, client_base_path: &Path) {
+        let _ = run_roux(&self.roux, client_base_path, &["daemon", "stop"]);
+        self.wait_or_kill();
+    }
+
+    fn wait_or_kill(&mut self) {
+        let Some(mut child) = self.child.take() else {
+            return;
+        };
+
+        let started = Instant::now();
+        while started.elapsed() < Duration::from_secs(5) {
+            match child.try_wait() {
+                Ok(Some(_)) => {
+                    let _ = child.wait();
+                    return;
+                }
+                Ok(None) => std::thread::sleep(Duration::from_millis(50)),
+                Err(_) => break,
+            }
+        }
+
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+}
+
+impl Drop for DaemonProcess {
+    fn drop(&mut self) {
+        self.wait_or_kill();
+    }
+}
+
+fn run_roux(roux: &Path, base_path: &Path, args: &[&str]) -> Output {
+    Command::new(roux)
+        .args(args)
+        .env("ROUX_BASE_PATH", base_path)
+        .env_remove("ROUX_SOCKET")
+        .env_remove("ROUX_AUTH_TOKEN")
+        .env_remove("ROUX_DAEMON_TOKEN")
+        .output()
+        .expect("run roux command")
+}
+
+fn assert_success(output: &Output, label: &str) {
+    assert!(
+        output.status.success(),
+        "{label} failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn wait_for_file_contents(path: &Path) -> String {
+    let started = Instant::now();
+    while started.elapsed() < Duration::from_secs(5) {
+        if let Ok(contents) = std::fs::read_to_string(path) {
+            if !contents.trim().is_empty() {
+                return contents;
+            }
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    panic!("timed out waiting for {}", path.display());
+}

--- a/crates/roux-sdk/README.md
+++ b/crates/roux-sdk/README.md
@@ -36,7 +36,9 @@ The default endpoint resolution matches the CLI:
 - `ROUX_SOCKET=tcp://127.0.0.1:7777` uses TCP.
 - `ROUX_SOCKET=unix:///path/to/roux.sock` uses a Unix socket.
 - `ROUX_SOCKET=/path/to/roux.sock` uses a Unix socket on Unix/macOS.
-- Without `ROUX_SOCKET`, Unix/macOS uses `~/.config/roux/roux.sock`.
+- Without `ROUX_SOCKET`, a persisted `roux-socket-addr` endpoint is used when
+  present.
+- Otherwise, Unix/macOS uses `~/.config/roux/roux.sock`.
 - Windows reads the daemon TCP endpoint and token files from `~/.config/roux`.
 
 TCP requests require an auth token. The SDK uses an explicit builder token

--- a/crates/roux-sdk/src/endpoint.rs
+++ b/crates/roux-sdk/src/endpoint.rs
@@ -46,16 +46,44 @@ pub fn resolve_socket_endpoint() -> Option<SocketEndpoint> {
         }
     }
 
-    #[cfg(windows)]
+    if let Some(endpoint) = std::fs::read_to_string(socket_addr_file_path())
+        .ok()
+        .and_then(|value| parse_persisted_socket_endpoint(&value))
     {
-        std::fs::read_to_string(socket_addr_file_path())
-            .ok()
-            .and_then(|value| parse_socket_endpoint(&value))
+        return Some(endpoint);
     }
 
     #[cfg(not(windows))]
     {
         Some(SocketEndpoint::Unix(socket_path()))
+    }
+
+    #[cfg(windows)]
+    {
+        None
+    }
+}
+
+fn parse_persisted_socket_endpoint(raw: &str) -> Option<SocketEndpoint> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if trimmed.starts_with("tcp://") || trimmed.starts_with("unix://") {
+        return parse_socket_endpoint(trimmed);
+    }
+
+    #[cfg(windows)]
+    {
+        Some(SocketEndpoint::Tcp(trimmed.to_string()))
+    }
+    #[cfg(not(windows))]
+    {
+        if PathBuf::from(trimmed).is_absolute() {
+            Some(SocketEndpoint::Unix(PathBuf::from(trimmed)))
+        } else {
+            Some(SocketEndpoint::Tcp(trimmed.to_string()))
+        }
     }
 }
 
@@ -79,7 +107,6 @@ fn socket_path() -> PathBuf {
     roux_core::paths::roux_config_dir().join("roux.sock")
 }
 
-#[cfg(windows)]
 fn socket_addr_file_path() -> PathBuf {
     roux_core::paths::roux_config_dir().join("roux-socket-addr")
 }

--- a/crates/roux-sdk/src/endpoint.rs
+++ b/crates/roux-sdk/src/endpoint.rs
@@ -79,12 +79,27 @@ fn parse_persisted_socket_endpoint(raw: &str) -> Option<SocketEndpoint> {
     }
     #[cfg(not(windows))]
     {
-        if PathBuf::from(trimmed).is_absolute() {
-            Some(SocketEndpoint::Unix(PathBuf::from(trimmed)))
-        } else {
+        let path = PathBuf::from(trimmed);
+        if path.is_absolute() {
+            Some(SocketEndpoint::Unix(path))
+        } else if is_legacy_tcp_addr(trimmed) {
             Some(SocketEndpoint::Tcp(trimmed.to_string()))
+        } else {
+            Some(SocketEndpoint::Unix(path))
         }
     }
+}
+
+#[cfg(not(windows))]
+fn is_legacy_tcp_addr(value: &str) -> bool {
+    let Some((host, port)) = value.rsplit_once(':') else {
+        return false;
+    };
+
+    !host.is_empty()
+        && !port.is_empty()
+        && port.chars().all(|ch| ch.is_ascii_digit())
+        && !host.contains(std::path::MAIN_SEPARATOR)
 }
 
 pub(crate) fn load_socket_auth_token() -> Option<String> {

--- a/crates/roux-sdk/src/lib.rs
+++ b/crates/roux-sdk/src/lib.rs
@@ -35,6 +35,33 @@ mod tests {
     use std::thread;
     use std::time::Duration;
 
+    static ENDPOINT_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_endpoint_env<T>(base_path: &std::path::Path, f: impl FnOnce() -> T) -> T {
+        let _guard = ENDPOINT_ENV_LOCK.lock().unwrap();
+        let previous_base = std::env::var_os("ROUX_BASE_PATH");
+        let previous_socket = std::env::var_os("ROUX_SOCKET");
+
+        std::env::set_var("ROUX_BASE_PATH", base_path);
+        std::env::remove_var("ROUX_SOCKET");
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+
+        match previous_base {
+            Some(value) => std::env::set_var("ROUX_BASE_PATH", value),
+            None => std::env::remove_var("ROUX_BASE_PATH"),
+        }
+        match previous_socket {
+            Some(value) => std::env::set_var("ROUX_SOCKET", value),
+            None => std::env::remove_var("ROUX_SOCKET"),
+        }
+
+        match result {
+            Ok(value) => value,
+            Err(panic) => std::panic::resume_unwind(panic),
+        }
+    }
+
     #[test]
     fn parses_socket_endpoints() {
         assert_eq!(
@@ -50,6 +77,16 @@ mod tests {
             parse_socket_endpoint("/tmp/roux.sock"),
             Some(SocketEndpoint::Unix("/tmp/roux.sock".into()))
         );
+    }
+
+    #[test]
+    fn resolves_persisted_tcp_socket_endpoint_when_env_socket_is_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("roux-socket-addr"), "tcp://100.73.57.24:7777").unwrap();
+
+        let endpoint = with_endpoint_env(dir.path(), resolve_socket_endpoint);
+
+        assert_eq!(endpoint, Some(SocketEndpoint::Tcp("100.73.57.24:7777".to_string())));
     }
 
     #[test]

--- a/crates/roux-sdk/src/lib.rs
+++ b/crates/roux-sdk/src/lib.rs
@@ -89,6 +89,28 @@ mod tests {
         assert_eq!(endpoint, Some(SocketEndpoint::Tcp("100.73.57.24:7777".to_string())));
     }
 
+    #[cfg(not(windows))]
+    #[test]
+    fn resolves_persisted_relative_unix_socket_endpoint_when_env_socket_is_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("roux-socket-addr"), "roux.sock").unwrap();
+
+        let endpoint = with_endpoint_env(dir.path(), resolve_socket_endpoint);
+
+        assert_eq!(endpoint, Some(SocketEndpoint::Unix("roux.sock".into())));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn resolves_legacy_bare_tcp_socket_endpoint_when_env_socket_is_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("roux-socket-addr"), "127.0.0.1:7777").unwrap();
+
+        let endpoint = with_endpoint_env(dir.path(), resolve_socket_endpoint);
+
+        assert_eq!(endpoint, Some(SocketEndpoint::Tcp("127.0.0.1:7777".to_string())));
+    }
+
     #[test]
     fn command_request_serializes_protocol_shape() {
         let request = CommandRequest::new("daemon-status")

--- a/docs/features/cli.md
+++ b/docs/features/cli.md
@@ -251,7 +251,16 @@ roux daemon status
 
 When `roux daemon` owns the endpoint, `roux daemon status` returns the daemon PID, uptime, socket endpoint, log path, loaded session/project/process counts, and daemon capabilities. The daemon also answers headless session, project, PTY, process, worktree, alias, mailbox, and bus commands over the socket.
 
-The default endpoint is the local Unix socket on Unix/macOS. For remote-development experiments, start a TCP daemon with `ROUX_DAEMON_TOKEN=... ROUX_DAEMON_BIND=tcp://127.0.0.1:7777 roux daemon`, then point a client at it with `ROUX_SOCKET=tcp://127.0.0.1:7777 ROUX_AUTH_TOKEN=... roux daemon status`.
+The default endpoint is the local Unix socket on Unix/macOS. For remote-development experiments, start a TCP daemon with `ROUX_DAEMON_BIND=tcp://100.73.57.24:7777 roux daemon`; if no token is supplied, the daemon generates one and writes it to `~/.config/roux/roux-socket-token`.
+
+On the client, persist the endpoint and token once:
+
+```sh
+roux daemon connect tcp://100.73.57.24:7777 --auth-token <token>
+roux daemon status
+```
+
+After `connect`, normal first-class commands such as `roux session list`, `roux daemon ptys`, and `roux work-item runs` use that daemon until `roux daemon disconnect`. `ROUX_SOCKET` and `ROUX_AUTH_TOKEN` still override persisted client config for one-off commands.
 
 The implemented socket protocol is documented in [`../v2/daemon-protocol.md`](../v2/daemon-protocol.md).
 

--- a/docs/v2/daemon-protocol.md
+++ b/docs/v2/daemon-protocol.md
@@ -16,13 +16,15 @@ Requests are JSON objects written to the Roux command endpoint.
   `0` to let the OS choose a local port; `daemon-status.socket` reports the
   actual `tcp://HOST:PORT` endpoint.
 - Clients override discovery with `ROUX_SOCKET=tcp://HOST:PORT` or
-  `ROUX_SOCKET=unix:///path/to/roux.sock`. Plain `ROUX_SOCKET` values remain
+  `ROUX_SOCKET=unix:///path/to/roux.sock`, or persist a default endpoint with
+  `roux daemon connect SOCKET`. Plain `ROUX_SOCKET` values remain
   platform-native: Unix paths on Unix/macOS, TCP addresses on Windows.
 - TCP requests include `auth_token`. Clients load it from `ROUX_DAEMON_TOKEN`,
   `ROUX_AUTH_TOKEN`, or the local token file written by a locally-started TCP
-  daemon. On Unix/macOS, explicit TCP daemon binds require
-  `ROUX_DAEMON_TOKEN`; Windows local TCP binds generate and write a token when
-  one is not supplied.
+  daemon or by `roux daemon connect --auth-token`. TCP daemon binds use
+  `ROUX_DAEMON_TOKEN` / `ROUX_AUTH_TOKEN` when supplied; otherwise the daemon
+  generates a token and writes it to the token file with owner-only
+  permissions.
 - Normal commands return one JSON response and close the connection.
 - `daemon-pty-attach` switches to a line-delimited JSON streaming response.
 


### PR DESCRIPTION
## Summary
- add persistent daemon client config via `roux daemon connect` / `disconnect`
- allow TCP daemon binds to generate auth tokens when none are supplied
- make SDK endpoint resolution honor persisted daemon endpoints
- add local TCP daemon integration coverage and token-file permission regression tests

## Validation
- `cargo test -p roux-cli`
- `cargo test -p roux-sdk`
- `cargo clippy -p roux-cli -p roux-sdk --all-targets -- -D warnings`
- `cargo clippy -p roux-cli --all-targets -- -D warnings`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces persistent remote daemon configuration via two new CLI commands (`roux daemon connect` / `disconnect`), removes the Linux restriction on TCP daemon binds (now auto-generating a secure UUID token instead of requiring `ROUX_DAEMON_TOKEN`), and updates the SDK's `resolve_socket_endpoint` to honour the persisted `roux-socket-addr` file on all platforms rather than Windows-only.

- **New `daemon connect/disconnect` commands** write endpoint and optional auth-token to private config files (`0o600` on Unix via atomic temp-rename), and the SDK's updated `resolve_socket_endpoint` picks them up so all CLI socket commands (which route through `roux_sdk::blocking::send_socket_command`) use the persisted endpoint transparently.
- **Token auto-generation for TCP daemons** replaces the previous Windows-only workaround: the daemon now generates a 64-hex-char UUID-based token for any TCP bind where no env-var token is supplied, writes it to `roux-socket-token` with secure permissions, and prints a warning when `connect` is called without `--auth-token`.
- **Backward-compat shim in `parse_persisted_socket_endpoint`** handles legacy bare `host:port` entries in `roux-socket-addr` (old Windows format), while the server now always writes the `tcp://` prefix.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the connect/disconnect flow, token auto-generation, and SDK endpoint resolution all work correctly and are well-tested.

The core design is sound: CLI socket commands route through the SDK (cli_socket::send_socket_command → roux_sdk::blocking::send_socket_command), so updating the SDK's resolve_socket_endpoint is the right and sufficient fix for endpoint persistence on all platforms. Token auto-generation uses cryptographically random UUIDs (256 bits entropy). The atomic temp-rename write pattern on Unix correctly protects config files. The two noted issues — a redundant set_permissions syscall and the lack of Windows ACL restrictions on the non-Unix write path — are minor and do not affect correctness or security on the primary Unix/macOS targets.

The non-Unix branch of write_private_config_file in crates/roux-cli/src/main.rs warrants a follow-up if Windows is a first-class target for the persisted-token feature.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/roux-cli/src/main.rs | Adds Connect/Disconnect DaemonAction variants and their handlers; write_private_config_file has a redundant set_permissions call and its non-Unix fallback uses plain std::fs::write without permission restrictions for auth token files. |
| crates/roux-sdk/src/endpoint.rs | resolve_socket_endpoint now reads the persisted file for all platforms; parse_persisted_socket_endpoint correctly handles prefixed and legacy bare-address formats with is_legacy_tcp_addr. |
| crates/roux-cli/src/daemon.rs | daemon_auth_token now auto-generates a 64-hex UUID token (256 bits entropy) for TCP binds on all platforms, removing the Linux-only ROUX_DAEMON_TOKEN requirement. |
| crates/roux-cli/src/daemon/server.rs | Single-line change adds tcp:// prefix to socket-addr file, ensuring consistent format across platforms. |
| crates/roux-cli/tests/remote_daemon.rs | New integration test exercises the full connect→status→session-list flow; wait_for_file_contents uses a 5-second polling timeout which could be flaky on slow CI. |
| crates/roux-cli/src/daemon/tests.rs | Adds mutex-guarded env-isolation helper and two unit tests covering token generation and env-var preference for TCP binds. |
| crates/roux-sdk/src/lib.rs | Adds ROUX_BASE_PATH/ROUX_SOCKET env-isolation helpers and three new tests covering persisted TCP, relative Unix socket, and legacy bare-addr resolution. |
| crates/roux-cli/tests/daemon_terminal_profiles.rs | Refactored write_settings to use struct update syntax with ..Default::default(); no logic changes. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant CLI as roux CLI
    participant SDK as roux-sdk
    participant FS as Config Files
    participant Daemon

    Note over User,Daemon: Daemon side (server)
    Daemon->>FS: write roux-socket-addr (tcp://host:port)
    Daemon->>FS: write roux-socket-token (generated UUID token)

    Note over User,Daemon: Client side (connect)
    User->>CLI: roux daemon connect tcp://host:port --auth-token TOKEN
    CLI->>FS: write_private_config_file(roux-socket-addr) [0o600]
    CLI->>FS: write_private_config_file(roux-socket-token) [0o600]
    CLI->>User: Connected roux CLI to tcp://host:port

    Note over User,Daemon: Subsequent commands
    User->>CLI: roux daemon status / session list / ...
    CLI->>SDK: blocking::send_socket_command(request)
    SDK->>FS: read roux-socket-addr
    SDK->>FS: read roux-socket-token
    SDK->>Daemon: TCP connect + auth_token
    Daemon-->>SDK: JSON response
    SDK-->>CLI: parsed response
    CLI-->>User: output

    Note over User,Daemon: Disconnect
    User->>CLI: roux daemon disconnect
    CLI->>FS: remove roux-socket-addr
    CLI->>FS: remove roux-socket-token
    CLI->>User: Disconnected roux CLI daemon socket config
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Froux-cli%2Fsrc%2Fmain.rs%3A1462-1467%0AThe%20%60set_permissions%60%20call%20on%20the%20temp%20file%20is%20redundant.%20The%20%60OpenOptions%3A%3Amode%280o600%29%60%20already%20creates%20the%20file%20with%20the%20correct%20owner-only%20permissions%3B%20the%20subsequent%20%60set_permissions%60%20adds%20no%20protection%20and%20only%20introduces%20an%20extra%20syscall%20that%20can%20fail%20between%20write%20and%20rename.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20file.write_all%28contents.as_bytes%28%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.map_err%28%7Cerr%7C%20format!%28%22write%20config%20file%20%7B%7D%3A%20%7Berr%7D%22%2C%20tmp_path.display%28%29%29%29%3F%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20drop%28file%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Froux-cli%2Fsrc%2Fmain.rs%3A1479-1483%0A**Token%20file%20written%20without%20permission%20restrictions%20on%20non-Unix**%0A%0AOn%20Windows%20%28and%20any%20non-Unix%20target%29%2C%20%60std%3A%3Afs%3A%3Awrite%60%20creates%20the%20file%20with%20whatever%20default%20ACL%20the%20OS%20assigns%20%E2%80%94%20typically%20inheriting%20the%20parent%20directory's%20permissions.%20By%20contrast%2C%20the%20Unix%20branch%20explicitly%20creates%20the%20file%20with%20%60mode%280o600%29%60%20and%20the%20daemon's%20own%20%60write_private_file%60%20may%20apply%20Windows%20ACL%20restrictions.%20If%20the%20config%20directory%20is%20world-readable%2C%20the%20persisted%20auth%20token%20could%20be%20read%20by%20other%20local%20users.%20Consider%20applying%20the%20equivalent%20Windows%20ACL%20%28e.g.%20via%20the%20%60windows%60%20crate%29%20to%20limit%20access%20to%20the%20current%20user's%20SID%2C%20matching%20the%20security%20intent%20of%20the%20Unix%20path.%0A%0A&repo=phin-tech%2Froux&pr=225&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22feature%2Fremote-daemon-cli%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fremote-daemon-cli%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Froux-cli%2Fsrc%2Fmain.rs%3A1462-1467%0AThe%20%60set_permissions%60%20call%20on%20the%20temp%20file%20is%20redundant.%20The%20%60OpenOptions%3A%3Amode%280o600%29%60%20already%20creates%20the%20file%20with%20the%20correct%20owner-only%20permissions%3B%20the%20subsequent%20%60set_permissions%60%20adds%20no%20protection%20and%20only%20introduces%20an%20extra%20syscall%20that%20can%20fail%20between%20write%20and%20rename.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20file.write_all%28contents.as_bytes%28%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.map_err%28%7Cerr%7C%20format!%28%22write%20config%20file%20%7B%7D%3A%20%7Berr%7D%22%2C%20tmp_path.display%28%29%29%29%3F%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20drop%28file%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Froux-cli%2Fsrc%2Fmain.rs%3A1479-1483%0A**Token%20file%20written%20without%20permission%20restrictions%20on%20non-Unix**%0A%0AOn%20Windows%20%28and%20any%20non-Unix%20target%29%2C%20%60std%3A%3Afs%3A%3Awrite%60%20creates%20the%20file%20with%20whatever%20default%20ACL%20the%20OS%20assigns%20%E2%80%94%20typically%20inheriting%20the%20parent%20directory's%20permissions.%20By%20contrast%2C%20the%20Unix%20branch%20explicitly%20creates%20the%20file%20with%20%60mode%280o600%29%60%20and%20the%20daemon's%20own%20%60write_private_file%60%20may%20apply%20Windows%20ACL%20restrictions.%20If%20the%20config%20directory%20is%20world-readable%2C%20the%20persisted%20auth%20token%20could%20be%20read%20by%20other%20local%20users.%20Consider%20applying%20the%20equivalent%20Windows%20ACL%20%28e.g.%20via%20the%20%60windows%60%20crate%29%20to%20limit%20access%20to%20the%20current%20user's%20SID%2C%20matching%20the%20security%20intent%20of%20the%20Unix%20path.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Address daemon connect review findings"](https://github.com/phin-tech/roux/commit/18fb0283be2b7305627e03b1bf8b539d5c62c713) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35350525)</sub>

<!-- /greptile_comment -->