### PR TITLE
Add terminal profile env resolution

### DIFF
--- a/crates/roux-cli/src/daemon.rs
+++ b/crates/roux-cli/src/daemon.rs
@@ -525,6 +525,8 @@ async fn handle_session_create_shell(
 
     let pane_id = format!("{id}-main");
     let profile = req.args.get("profile").and_then(|profile| profile.as_str()).map(str::to_string);
+    let profile_data = resolve_spawn_profile_data(&req.args, &settings);
+    let launch_env = parse_launch_env_overrides(&req.args);
     let initial_size = parse_initial_size(&req.args);
     let project_id = req
         .args
@@ -550,6 +552,9 @@ async fn handle_session_create_shell(
             notes: parse_notes_env(&req.args),
             env: parse_pty_env_request(&req.args, identity),
             profile: profile.clone(),
+            profile_data,
+            terminal_defaults: settings.terminal_defaults.clone(),
+            launch_env,
             initial_size,
             role: roux_core::PtyRole::SessionPrimary,
         })
@@ -614,7 +619,10 @@ async fn handle_session_reconnect_shell(
     let _ = host.pty_handle.remove(&primary_pty_id).await;
     let pane_id = format!("{}-main", session.id);
     let initial_size = parse_initial_size(&req.args);
+    let settings = load_daemon_settings();
     let profile = req.args.get("profile").and_then(|profile| profile.as_str()).map(str::to_string);
+    let profile_data = resolve_spawn_profile_data(&req.args, &settings);
+    let launch_env = parse_launch_env_overrides(&req.args);
     let spawn = host
         .pty_handle
         .spawn_shell(PtySpawnRequest {
@@ -627,6 +635,9 @@ async fn handle_session_reconnect_shell(
             notes: parse_notes_env(&req.args),
             env: parse_pty_env_request(&req.args, identity),
             profile,
+            profile_data,
+            terminal_defaults: settings.terminal_defaults.clone(),
+            launch_env,
             initial_size,
             role: roux_core::PtyRole::SessionPrimary,
         })
@@ -1331,6 +1342,7 @@ async fn handle_session_panes_create(
         return Response::err("direction must be horizontal or vertical");
     }
 
+    let settings = load_daemon_settings();
     let profile =
         req.args.get("profile").and_then(|profile| profile.as_str()).unwrap_or("plain-shell");
     let working_dir = req
@@ -1368,6 +1380,10 @@ async fn handle_session_panes_create(
             notes: parse_notes_env(&req.args),
             env: parse_pty_env_request(&req.args, identity),
             profile: Some(profile.to_string()),
+            profile_data: resolve_spawn_profile_data(&req.args, &settings)
+                .or_else(|| roux_core::providers::resolve_profile(profile, &settings)),
+            terminal_defaults: settings.terminal_defaults.clone(),
+            launch_env: parse_launch_env_overrides(&req.args),
             initial_size: parse_initial_size(&req.args),
             role: PtyRole::Secondary,
         })
@@ -1692,6 +1708,7 @@ async fn parse_pty_spawn_request(
         Some("sessionPrimary") | Some("session_primary") => roux_core::PtyRole::SessionPrimary,
         _ => roux_core::PtyRole::Secondary,
     };
+    let settings = load_daemon_settings();
 
     let mut request = PtySpawnRequest {
         id: req.args.get("id").and_then(|id| id.as_str()).map(str::to_string),
@@ -1713,6 +1730,9 @@ async fn parse_pty_spawn_request(
         notes: parse_notes_env(&req.args),
         env: parse_pty_env_request(&req.args, identity),
         profile: req.args.get("profile").and_then(|profile| profile.as_str()).map(str::to_string),
+        profile_data: resolve_spawn_profile_data(&req.args, &settings),
+        terminal_defaults: settings.terminal_defaults.clone(),
+        launch_env: parse_launch_env_overrides(&req.args),
         initial_size: parse_initial_size(&req.args),
         role,
     };
@@ -1738,6 +1758,31 @@ async fn apply_session_spawn_bindings(
         request.worktree_path = Some(session.worktree_path.clone());
     }
     Ok(())
+}
+
+fn resolve_spawn_profile_data(
+    args: &Value,
+    settings: &roux_core::RouxSettings,
+) -> Option<roux_core::SpawnProfile> {
+    if let Some(value) = args.get("profileData").or_else(|| args.get("profile_data")) {
+        if let Ok(profile) = serde_json::from_value::<roux_core::SpawnProfile>(value.clone()) {
+            return Some(profile);
+        }
+    }
+    args.get("profile")
+        .and_then(|profile| profile.as_str())
+        .and_then(|profile| roux_core::providers::resolve_profile(profile, settings))
+}
+
+fn parse_launch_env_overrides(
+    args: &Value,
+) -> Option<std::collections::BTreeMap<String, roux_core::TerminalEnvRule>> {
+    args.get("envOverrides").or_else(|| args.get("env_overrides")).and_then(|value| {
+        serde_json::from_value::<std::collections::BTreeMap<String, roux_core::TerminalEnvRule>>(
+            value.clone(),
+        )
+        .ok()
+    })
 }
 
 fn parse_pty_env_request(args: &Value, identity: &DaemonIdentity) -> PtyEnvRequest {

--- a/crates/roux-cli/src/daemon.rs
+++ b/crates/roux-cli/src/daemon.rs
@@ -525,8 +525,14 @@ async fn handle_session_create_shell(
 
     let pane_id = format!("{id}-main");
     let profile = req.args.get("profile").and_then(|profile| profile.as_str()).map(str::to_string);
-    let profile_data = resolve_spawn_profile_data(&req.args, &settings);
-    let launch_env = parse_launch_env_overrides(&req.args);
+    let profile_data = match resolve_spawn_profile_data(&req.args, &settings) {
+        Ok(profile_data) => profile_data,
+        Err(err) => return Response::err(err),
+    };
+    let launch_env = match parse_launch_env_overrides(&req.args) {
+        Ok(launch_env) => launch_env,
+        Err(err) => return Response::err(err),
+    };
     let initial_size = parse_initial_size(&req.args);
     let project_id = req
         .args
@@ -621,8 +627,14 @@ async fn handle_session_reconnect_shell(
     let initial_size = parse_initial_size(&req.args);
     let settings = load_daemon_settings();
     let profile = req.args.get("profile").and_then(|profile| profile.as_str()).map(str::to_string);
-    let profile_data = resolve_spawn_profile_data(&req.args, &settings);
-    let launch_env = parse_launch_env_overrides(&req.args);
+    let profile_data = match resolve_spawn_profile_data(&req.args, &settings) {
+        Ok(profile_data) => profile_data,
+        Err(err) => return Response::err(err),
+    };
+    let launch_env = match parse_launch_env_overrides(&req.args) {
+        Ok(launch_env) => launch_env,
+        Err(err) => return Response::err(err),
+    };
     let spawn = host
         .pty_handle
         .spawn_shell(PtySpawnRequest {
@@ -1368,6 +1380,17 @@ async fn handle_session_panes_create(
         .map(str::to_string)
         .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
 
+    let profile_data = match resolve_spawn_profile_data(&req.args, &settings) {
+        Ok(profile_data) => {
+            profile_data.or_else(|| roux_core::providers::resolve_profile(profile, &settings))
+        }
+        Err(err) => return Response::err(err),
+    };
+    let launch_env = match parse_launch_env_overrides(&req.args) {
+        Ok(launch_env) => launch_env,
+        Err(err) => return Response::err(err),
+    };
+
     match host
         .pty_handle
         .spawn_shell(PtySpawnRequest {
@@ -1380,10 +1403,9 @@ async fn handle_session_panes_create(
             notes: parse_notes_env(&req.args),
             env: parse_pty_env_request(&req.args, identity),
             profile: Some(profile.to_string()),
-            profile_data: resolve_spawn_profile_data(&req.args, &settings)
-                .or_else(|| roux_core::providers::resolve_profile(profile, &settings)),
+            profile_data,
             terminal_defaults: settings.terminal_defaults.clone(),
-            launch_env: parse_launch_env_overrides(&req.args),
+            launch_env,
             initial_size: parse_initial_size(&req.args),
             role: PtyRole::Secondary,
         })
@@ -1730,9 +1752,9 @@ async fn parse_pty_spawn_request(
         notes: parse_notes_env(&req.args),
         env: parse_pty_env_request(&req.args, identity),
         profile: req.args.get("profile").and_then(|profile| profile.as_str()).map(str::to_string),
-        profile_data: resolve_spawn_profile_data(&req.args, &settings),
+        profile_data: resolve_spawn_profile_data(&req.args, &settings)?,
         terminal_defaults: settings.terminal_defaults.clone(),
-        launch_env: parse_launch_env_overrides(&req.args),
+        launch_env: parse_launch_env_overrides(&req.args)?,
         initial_size: parse_initial_size(&req.args),
         role,
     };
@@ -1763,26 +1785,37 @@ async fn apply_session_spawn_bindings(
 fn resolve_spawn_profile_data(
     args: &Value,
     settings: &roux_core::RouxSettings,
-) -> Option<roux_core::SpawnProfile> {
-    if let Some(value) = args.get("profileData").or_else(|| args.get("profile_data")) {
-        if let Ok(profile) = serde_json::from_value::<roux_core::SpawnProfile>(value.clone()) {
-            return Some(profile);
-        }
+) -> Result<Option<roux_core::SpawnProfile>, String> {
+    if let Some((key, value)) = args
+        .get("profileData")
+        .map(|value| ("profileData", value))
+        .or_else(|| args.get("profile_data").map(|value| ("profile_data", value)))
+    {
+        return serde_json::from_value::<roux_core::SpawnProfile>(value.clone())
+            .map(Some)
+            .map_err(|err| format!("invalid {key}: {err}"));
     }
-    args.get("profile")
+    Ok(args
+        .get("profile")
         .and_then(|profile| profile.as_str())
-        .and_then(|profile| roux_core::providers::resolve_profile(profile, settings))
+        .and_then(|profile| roux_core::providers::resolve_profile(profile, settings)))
 }
 
 fn parse_launch_env_overrides(
     args: &Value,
-) -> Option<std::collections::BTreeMap<String, roux_core::TerminalEnvRule>> {
-    args.get("envOverrides").or_else(|| args.get("env_overrides")).and_then(|value| {
-        serde_json::from_value::<std::collections::BTreeMap<String, roux_core::TerminalEnvRule>>(
-            value.clone(),
-        )
-        .ok()
-    })
+) -> Result<Option<std::collections::BTreeMap<String, roux_core::TerminalEnvRule>>, String> {
+    if let Some((key, value)) = args
+        .get("envOverrides")
+        .map(|value| ("envOverrides", value))
+        .or_else(|| args.get("env_overrides").map(|value| ("env_overrides", value)))
+    {
+        return serde_json::from_value::<
+            std::collections::BTreeMap<String, roux_core::TerminalEnvRule>,
+        >(value.clone())
+        .map(Some)
+        .map_err(|err| format!("invalid {key}: {err}"));
+    }
+    Ok(None)
 }
 
 fn parse_pty_env_request(args: &Value, identity: &DaemonIdentity) -> PtyEnvRequest {

--- a/crates/roux-cli/src/daemon/tests.rs
+++ b/crates/roux-cli/src/daemon/tests.rs
@@ -43,6 +43,33 @@ fn make_watch_config() -> roux_core::CreateWatchConfig {
     }
 }
 
+#[test]
+fn spawn_profile_data_rejects_malformed_inline_payload() {
+    let settings = roux_core::RouxSettings::default();
+    let err = resolve_spawn_profile_data(
+        &serde_json::json!({
+            "profile": "plain-shell",
+            "profileData": { "id": "inline-only" }
+        }),
+        &settings,
+    )
+    .unwrap_err();
+
+    assert!(err.contains("invalid profileData"));
+}
+
+#[test]
+fn launch_env_overrides_reject_malformed_rules() {
+    let err = parse_launch_env_overrides(&serde_json::json!({
+        "envOverrides": {
+            "AWS_PROFILE": { "mode": "bogus" }
+        }
+    }))
+    .unwrap_err();
+
+    assert!(err.contains("invalid envOverrides"));
+}
+
 #[tokio::test]
 async fn daemon_status_is_daemon_only_socket_command() {
     let dir = tempfile::tempdir().unwrap();

--- a/crates/roux-cli/src/daemon/work_items.rs
+++ b/crates/roux-cli/src/daemon/work_items.rs
@@ -1752,6 +1752,8 @@ async fn run_dispatched_profile_with_task_prompt(
                 worktree_path: session.is_worktree.then(|| session.worktree_path.clone()),
                 env: parse_pty_env_request(&env_args, identity),
                 profile: Some(profile_id.to_string()),
+                profile_data: Some(profile.clone()),
+                terminal_defaults: settings.terminal_defaults.clone(),
                 role: roux_core::PtyRole::SessionPrimary,
                 ..PtySpawnRequest::default()
             },

--- a/crates/roux-cli/tests/daemon_terminal_profiles.rs
+++ b/crates/roux-cli/tests/daemon_terminal_profiles.rs
@@ -1,0 +1,245 @@
+#![cfg(unix)]
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use roux_core::{
+    ProfileSource, RouxSettings, SpawnProfile, SplitProfileBehavior, StartupBehavior,
+    TerminalDefaults, TerminalEnvRule, TerminalEnvRuleMode, TerminalEnvRuleSpec,
+};
+use roux_sdk::{CommandRequest, Pty, PtySnapshot, Roux, SocketEndpoint};
+use serde_json::Value;
+
+struct DaemonGuard {
+    child: Child,
+}
+
+impl DaemonGuard {
+    fn new(base_path: &Path) -> Self {
+        let child = Command::new(env!("CARGO_BIN_EXE_roux"))
+            .arg("daemon")
+            .env("ROUX_BASE_PATH", base_path)
+            .env_remove("ROUX_SOCKET")
+            .env_remove("ROUX_DAEMON_BIND")
+            .env_remove("ROUX_DAEMON_TOKEN")
+            .env_remove("ROUX_AUTH_TOKEN")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn roux daemon");
+        Self { child }
+    }
+
+    async fn stop(mut self, client: &Roux) {
+        let _: Value = client.command(CommandRequest::new("daemon-stop")).await.unwrap();
+        let started = Instant::now();
+        while started.elapsed() < Duration::from_secs(3) {
+            if self.child.try_wait().expect("poll daemon child").is_some() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        panic!("daemon-stop was acknowledged but process did not exit");
+    }
+}
+
+impl Drop for DaemonGuard {
+    fn drop(&mut self) {
+        if self.child.try_wait().ok().flatten().is_none() {
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn daemon_process_resolves_terminal_defaults_profiles_and_launch_env() {
+    let dir = tempfile::tempdir().unwrap();
+    let marker = dir.path().join("preflight.log");
+    write_settings(dir.path(), &marker);
+
+    let guard = DaemonGuard::new(dir.path());
+    let client = Roux::builder()
+        .endpoint(SocketEndpoint::Unix(dir.path().join("roux.sock")))
+        .connect()
+        .unwrap();
+    wait_for_daemon(&client, dir.path()).await;
+
+    let mut launch_env = BTreeMap::new();
+    launch_env.insert("SHARED".to_string(), TerminalEnvRule::value("launch"));
+    launch_env.insert("LAUNCH_ONLY".to_string(), TerminalEnvRule::value("launch"));
+    let profile_output = client
+        .spawn_task(sh_command(
+            "printf 'SHARED=%s\nGLOBAL_ONLY=%s\nPROFILE_ONLY=%s\nCOMMAND_VALUE=%s\nUNSET_ME=%s\nLAUNCH_ONLY=%s\n' \"$SHARED\" \"$GLOBAL_ONLY\" \"$PROFILE_ONLY\" \"$COMMAND_VALUE\" \"${UNSET_ME-unset}\" \"$LAUNCH_ONLY\"",
+        ))
+        .id("registered-profile-task")
+        .working_dir(dir.path().to_string_lossy())
+        .profile("prod")
+        .env_overrides(launch_env)
+        .spawn()
+        .await
+        .unwrap();
+    let profile_snapshot =
+        wait_for_pty_exit(&profile_output, "LAUNCH_ONLY=launch", Duration::from_secs(5)).await;
+
+    assert_output_contains(
+        &profile_snapshot.output,
+        &[
+            "SHARED=launch",
+            "GLOBAL_ONLY=global",
+            "PROFILE_ONLY=profile",
+            "COMMAND_VALUE=profile-command",
+            "UNSET_ME=unset",
+            "LAUNCH_ONLY=launch",
+        ],
+    );
+
+    let inline_output = client
+        .spawn_task(sh_command("printf 'SHARED=%s\nINLINE_ONLY=%s\n' \"$SHARED\" \"$INLINE_ONLY\""))
+        .id("inline-profile-task")
+        .working_dir(dir.path().to_string_lossy())
+        .profile_data(inline_profile(&marker))
+        .spawn()
+        .await
+        .unwrap();
+    let inline_snapshot =
+        wait_for_pty_exit(&inline_output, "INLINE_ONLY=inline", Duration::from_secs(5)).await;
+
+    assert_output_contains(&inline_snapshot.output, &["SHARED=inline", "INLINE_ONLY=inline"]);
+
+    let preflight_log = std::fs::read_to_string(&marker).unwrap();
+    assert_output_contains(
+        &preflight_log,
+        &["global-preflight", "profile-preflight", "inline-preflight"],
+    );
+
+    guard.stop(&client).await;
+}
+
+fn write_settings(base_path: &Path, marker: &Path) {
+    let mut settings = RouxSettings::default();
+    settings.shell_binary_path = Some("/bin/sh".to_string());
+    settings.terminal_defaults = TerminalDefaults {
+        env: Some(BTreeMap::from([
+            ("GLOBAL_ONLY".to_string(), TerminalEnvRule::value("global")),
+            ("SHARED".to_string(), TerminalEnvRule::value("global")),
+            ("UNSET_ME".to_string(), TerminalEnvRule::value("global")),
+        ])),
+        before_shell_starts: Some(format!(
+            "printf 'global-preflight\n' >> {}",
+            shell_quote_path(marker)
+        )),
+        split_profile_behavior: SplitProfileBehavior::PlainShell,
+    };
+    settings.spawn_profiles = vec![registered_profile(marker)];
+
+    std::fs::create_dir_all(base_path).unwrap();
+    std::fs::write(
+        base_path.join("settings.json"),
+        serde_json::to_string_pretty(&settings).unwrap(),
+    )
+    .unwrap();
+}
+
+fn registered_profile(marker: &Path) -> SpawnProfile {
+    SpawnProfile {
+        id: "prod".to_string(),
+        name: "Prod".to_string(),
+        setup_command: None,
+        startup_command: None,
+        startup_behavior: Some(StartupBehavior::AutoRun),
+        env: Some(BTreeMap::from([
+            ("PROFILE_ONLY".to_string(), TerminalEnvRule::value("profile")),
+            ("SHARED".to_string(), TerminalEnvRule::value("profile")),
+            ("COMMAND_VALUE".to_string(), TerminalEnvRule::command("printf profile-command")),
+            ("UNSET_ME".to_string(), rule(TerminalEnvRuleMode::Unset)),
+        ])),
+        before_shell_starts: Some(format!(
+            "printf 'profile-preflight\n' >> {}",
+            shell_quote_path(marker)
+        )),
+        cwd_override: None,
+        icon: None,
+        provider: None,
+        source: ProfileSource::User,
+    }
+}
+
+fn inline_profile(marker: &Path) -> SpawnProfile {
+    SpawnProfile {
+        id: "inline-test".to_string(),
+        name: "Inline Test".to_string(),
+        setup_command: None,
+        startup_command: None,
+        startup_behavior: Some(StartupBehavior::AutoRun),
+        env: Some(BTreeMap::from([
+            ("INLINE_ONLY".to_string(), TerminalEnvRule::value("inline")),
+            ("SHARED".to_string(), TerminalEnvRule::value("inline")),
+        ])),
+        before_shell_starts: Some(format!(
+            "printf 'inline-preflight\n' >> {}",
+            shell_quote_path(marker)
+        )),
+        cwd_override: None,
+        icon: None,
+        provider: None,
+        source: ProfileSource::Inline,
+    }
+}
+
+fn rule(mode: TerminalEnvRuleMode) -> TerminalEnvRule {
+    TerminalEnvRule::Structured(TerminalEnvRuleSpec { mode, value: None, command: None })
+}
+
+async fn wait_for_daemon(client: &Roux, base_path: &Path) {
+    let started = Instant::now();
+    while started.elapsed() < Duration::from_secs(5) {
+        match client.status().await {
+            Ok(_) => return,
+            Err(_) => tokio::time::sleep(Duration::from_millis(50)).await,
+        }
+    }
+    let log = std::fs::read_to_string(base_path.join("logs/roux-daemon.log"))
+        .unwrap_or_else(|_| "<missing daemon log>".to_string());
+    panic!("daemon did not become ready; log:\n{log}");
+}
+
+async fn wait_for_pty_exit(pty: &Pty, needle: &str, timeout: Duration) -> PtySnapshot {
+    let started = Instant::now();
+    let mut last: Option<PtySnapshot> = None;
+    while started.elapsed() < timeout {
+        let snapshot = pty.snapshot(65_536).await.unwrap();
+        if !snapshot.record.running && snapshot.output.contains(needle) {
+            return snapshot;
+        }
+        last = Some(snapshot);
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    let output = last.map(|snapshot| snapshot.output).unwrap_or_default();
+    panic!("PTY did not exit with expected output {needle:?}; last output:\n{output}");
+}
+
+fn assert_output_contains(output: &str, needles: &[&str]) {
+    for needle in needles {
+        assert!(
+            output.contains(needle),
+            "expected output to contain {needle:?}; output:\n{output}"
+        );
+    }
+}
+
+fn sh_command(script: &str) -> String {
+    format!("/bin/sh -c {}", shell_quote_str(script))
+}
+
+fn shell_quote_path(path: &Path) -> String {
+    let value = path.to_string_lossy();
+    shell_quote_str(value.as_ref())
+}
+
+fn shell_quote_str(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}

--- a/crates/roux-core/src/models/layout.rs
+++ b/crates/roux-core/src/models/layout.rs
@@ -12,7 +12,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::profile::{ProfileSource, Provider, SpawnProfile, StartupBehavior};
+use super::profile::{ProfileSource, Provider, SpawnProfile, StartupBehavior, TerminalEnvRule};
 
 /// Direction of a split node in a layout. Matches `SplitDirection`
 /// in `src/lib/panes/layout.ts` (`h`/`v`) but spelled out for KDL
@@ -465,12 +465,7 @@ fn parse_leaf_pane(
         }
     };
 
-    Ok(LayoutPaneNode::Leaf {
-        profile_ref,
-        name: attrs.name.clone(),
-        size: attrs.size,
-        cwd: None,
-    })
+    Ok(LayoutPaneNode::Leaf { profile_ref, name: attrs.name.clone(), size: attrs.size, cwd: None })
 }
 
 fn string_value(src: &str, entry: &kdl::KdlEntry, what: &str) -> Result<String, LayoutParseError> {
@@ -508,7 +503,7 @@ fn parse_inline_profile(
     let mut setup_command: Option<String> = None;
     let mut startup_command: Option<String> = None;
     let mut startup_behavior: Option<StartupBehavior> = None;
-    let mut env: Option<std::collections::BTreeMap<String, String>> = None;
+    let mut env: Option<std::collections::BTreeMap<String, TerminalEnvRule>> = None;
 
     for child in body.nodes() {
         match child.name().value() {
@@ -582,7 +577,7 @@ fn parse_inline_profile(
                             ));
                         }
                     };
-                    map.insert(key, value);
+                    map.insert(key, TerminalEnvRule::value(value));
                 }
                 env = Some(map);
             }
@@ -622,6 +617,7 @@ fn parse_inline_profile(
         startup_command,
         startup_behavior,
         env,
+        before_shell_starts: None,
         cwd_override: None,
         icon: None,
         provider: kind,
@@ -667,12 +663,7 @@ mod tests {
         assert_eq!(spec.description, None);
         assert_eq!(spec.source, LayoutSource::User);
         match spec.root {
-            LayoutPaneNode::Leaf {
-                profile_ref,
-                name,
-                size,
-                cwd,
-            } => {
+            LayoutPaneNode::Leaf { profile_ref, name, size, cwd } => {
                 assert_eq!(profile_ref, LayoutProfileRef::Registered { id: "claude".into() });
                 assert_eq!(name, None);
                 assert_eq!(size, None);
@@ -990,5 +981,4 @@ mod tests {
         let spec = parse(src).unwrap();
         assert!(matches!(spec.root, LayoutPaneNode::Leaf { .. }));
     }
-
 }

--- a/crates/roux-core/src/models/mod.rs
+++ b/crates/roux-core/src/models/mod.rs
@@ -38,15 +38,18 @@ pub use notification::{
     ActionKind, Notification, NotificationAction, NotificationEvent, NotificationLevel,
     NotificationRequest, NotificationSource,
 };
-pub use profile::{ProfileSource, Provider, SpawnProfile, StartupBehavior};
+pub use profile::{
+    ProfileSource, Provider, SpawnProfile, StartupBehavior, TerminalEnvRule, TerminalEnvRuleMode,
+    TerminalEnvRuleSpec,
+};
 pub use project::{Project, ProjectUpdate, SessionBlueprint};
 pub use pty::{PtyInfo, PtyRole, PtyStatus};
 pub use session::{map_hook_status, Session, SessionStatus, SessionStatusEvent};
 pub use settings::{
     CursorStyle, ExperimentsConfig, ExternalTool, ExternalToolSurface, ExternalToolWebEmbedder,
     GroupBy, KanbanSettings, KanbanStartupSidebar, LibrarySource, LibrarySourceKind, RouxSettings,
-    SkillSyncMode, StartupTarget, StatusBarPosition, TabPosition, UpdateChannel,
-    WorktreeCleanupMode, WorktreeDefaultBase, WorktreeProvider,
+    SkillSyncMode, SplitProfileBehavior, StartupTarget, StatusBarPosition, TabPosition,
+    TerminalDefaults, UpdateChannel, WorktreeCleanupMode, WorktreeDefaultBase, WorktreeProvider,
 };
 pub use subscription::{BusSubscription, BusSubscriptionEvent};
 pub use task::{KeepOpen, TaskDefinition, TaskGroup};

--- a/crates/roux-core/src/models/profile.rs
+++ b/crates/roux-core/src/models/profile.rs
@@ -39,6 +39,61 @@ pub enum StartupBehavior {
     TypeOnly,
 }
 
+/// Mode for a structured terminal environment rule.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub enum TerminalEnvRuleMode {
+    /// Set the variable to the exact configured value.
+    Value,
+    /// Leave the currently-resolved value alone when one exists.
+    Inherit,
+    /// Remove the variable from the spawned process environment.
+    Unset,
+    /// Run a non-interactive command before spawn and use trimmed stdout.
+    Command,
+}
+
+/// Structured terminal environment rule. `value` is used with `mode:
+/// "value"` and `command` is used with `mode: "command"`. Missing strings
+/// are validated by the runtime resolver so settings can still deserialize
+/// and be edited after a bad value is saved.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct TerminalEnvRuleSpec {
+    pub mode: TerminalEnvRuleMode,
+    #[serde(default)]
+    pub value: Option<String>,
+    #[serde(default)]
+    pub command: Option<String>,
+}
+
+/// Environment rule value. The string variant is the legacy settings shape
+/// and is treated as `mode: "value"`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(untagged)]
+pub enum TerminalEnvRule {
+    LegacyValue(String),
+    Structured(TerminalEnvRuleSpec),
+}
+
+impl TerminalEnvRule {
+    pub fn value(value: impl Into<String>) -> Self {
+        Self::LegacyValue(value.into())
+    }
+
+    pub fn structured(mode: TerminalEnvRuleMode) -> Self {
+        Self::Structured(TerminalEnvRuleSpec { mode, value: None, command: None })
+    }
+
+    pub fn command(command: impl Into<String>) -> Self {
+        Self::Structured(TerminalEnvRuleSpec {
+            mode: TerminalEnvRuleMode::Command,
+            value: None,
+            command: Some(command.into()),
+        })
+    }
+}
+
 /// A named recipe for launching something inside a shell pane. Orthogonal to
 /// pane type: every launched pane is a shell, and a profile is just optional
 /// metadata attached at creation describing how the shell was seeded.
@@ -63,7 +118,9 @@ pub struct SpawnProfile {
     #[serde(default)]
     pub startup_behavior: Option<StartupBehavior>,
     #[serde(default)]
-    pub env: Option<BTreeMap<String, String>>,
+    pub env: Option<BTreeMap<String, TerminalEnvRule>>,
+    #[serde(default)]
+    pub before_shell_starts: Option<String>,
     #[serde(default)]
     pub cwd_override: Option<String>,
     #[serde(default)]
@@ -83,6 +140,7 @@ impl SpawnProfile {
             startup_command: None,
             startup_behavior: None,
             env: None,
+            before_shell_starts: None,
             cwd_override: None,
             icon: None,
             provider: None,
@@ -123,5 +181,15 @@ mod tests {
         assert!(json.contains("\"startupCommand\":null"));
         assert!(json.contains("\"provider\":null"));
         assert!(json.contains("\"env\":null"));
+        assert!(json.contains("\"beforeShellStarts\":null"));
+    }
+
+    #[test]
+    fn env_rule_accepts_legacy_string_and_structured_shapes() {
+        let legacy: TerminalEnvRule = serde_json::from_str(r#""prod""#).unwrap();
+        assert_eq!(legacy, TerminalEnvRule::LegacyValue("prod".to_string()));
+
+        let structured: TerminalEnvRule = serde_json::from_str(r#"{"mode":"unset"}"#).unwrap();
+        assert_eq!(structured, TerminalEnvRule::structured(TerminalEnvRuleMode::Unset));
     }
 }

--- a/crates/roux-core/src/models/settings.rs
+++ b/crates/roux-core/src/models/settings.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
-use super::profile::{ProfileSource, SpawnProfile};
+use super::profile::{ProfileSource, SpawnProfile, TerminalEnvRule};
 
 const DEFAULT_THEME: &str = "deep-blue";
 const DEFAULT_TERMINAL_THEME: &str = "match-gui";
@@ -304,6 +304,40 @@ pub enum StartupTarget {
     None,
 }
 
+/// Profile policy used by the plain Split Horizontal / Split Vertical
+/// commands. Profile-picker commands remain explicit regardless of this
+/// setting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, specta::Type, Default)]
+#[serde(rename_all = "camelCase")]
+pub enum SplitProfileBehavior {
+    #[default]
+    PlainShell,
+    AppDefaultProfile,
+    ActivePaneProfile,
+    AskEveryTime,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase", default)]
+pub struct TerminalDefaults {
+    #[serde(default)]
+    pub env: Option<std::collections::BTreeMap<String, TerminalEnvRule>>,
+    #[serde(default)]
+    pub before_shell_starts: Option<String>,
+    #[serde(default)]
+    pub split_profile_behavior: SplitProfileBehavior,
+}
+
+impl Default for TerminalDefaults {
+    fn default() -> Self {
+        Self {
+            env: None,
+            before_shell_starts: None,
+            split_profile_behavior: SplitProfileBehavior::PlainShell,
+        }
+    }
+}
+
 fn default_agent_profile() -> String {
     "claude".to_string()
 }
@@ -465,6 +499,10 @@ pub struct RouxSettings {
     /// the file says, so users can't forge a `"builtin"` marker.
     #[serde(default)]
     pub spawn_profiles: Vec<SpawnProfile>,
+    /// Environment and preflight rules applied to all newly-spawned terminal
+    /// shells before profile-specific rules.
+    #[serde(default)]
+    pub terminal_defaults: TerminalDefaults,
     /// Default autonomous agent profile used by agent-starting surfaces.
     /// Card-level/profile-specific overrides still win.
     #[serde(default = "default_agent_profile")]
@@ -610,6 +648,7 @@ impl Default for RouxSettings {
             notes_migrated_v1: false,
             update_channel: UpdateChannel::default(),
             spawn_profiles: Vec::new(),
+            terminal_defaults: TerminalDefaults::default(),
             default_agent_profile: default_agent_profile(),
             startup_target: StartupTarget::Restore,
             startup_external_tool_id: None,
@@ -645,6 +684,12 @@ impl RouxSettings {
         for profile in &mut s.spawn_profiles {
             profile.source = ProfileSource::User;
         }
+        s.terminal_defaults.before_shell_starts = s
+            .terminal_defaults
+            .before_shell_starts
+            .as_ref()
+            .map(|cmd| cmd.trim().to_string())
+            .filter(|cmd| !cmd.is_empty());
         s.default_agent_profile = s.default_agent_profile.trim().to_string();
         s.kanban.default_agent_profile = s.kanban.default_agent_profile.trim().to_string();
         if s.default_agent_profile.is_empty() {
@@ -708,13 +753,11 @@ impl RouxSettings {
         s.startup_external_tool_id =
             s.startup_external_tool_id.as_ref().map(|id| id.trim().to_string()).filter(|id| {
                 !id.is_empty()
-                    && s.external_tools.iter().any(|tool| {
-                        tool.id == *id && tool.enabled && !tool.requires_session
-                    })
+                    && s.external_tools
+                        .iter()
+                        .any(|tool| tool.id == *id && tool.enabled && !tool.requires_session)
             });
-        if s.startup_target == StartupTarget::ExternalTool
-            && s.startup_external_tool_id.is_none()
-        {
+        if s.startup_target == StartupTarget::ExternalTool && s.startup_external_tool_id.is_none() {
             s.startup_target = StartupTarget::Restore;
         }
         s.kanban.startup_sidebar = match s.startup_target {
@@ -1130,10 +1173,8 @@ mod tests {
 
     #[test]
     fn empty_global_default_agent_normalizes_to_claude() {
-        let settings = RouxSettings {
-            default_agent_profile: "   ".to_string(),
-            ..RouxSettings::default()
-        };
+        let settings =
+            RouxSettings { default_agent_profile: "   ".to_string(), ..RouxSettings::default() };
 
         let normalized = settings.normalized();
 
@@ -1384,16 +1425,10 @@ mod tests {
         assert!(normalized.external_tools[1].keep_webview_alive);
         assert_eq!(normalized.external_tools[2].id, "terminal-tool");
         assert_eq!(normalized.external_tools[2].command_template, "lazygit");
-        assert_eq!(
-            normalized.external_tools[2].cwd_template,
-            "{{ session.worktree_path }}"
-        );
+        assert_eq!(normalized.external_tools[2].cwd_template, "{{ session.worktree_path }}");
         assert_eq!(normalized.external_tools[2].url_template, None);
         assert_eq!(normalized.external_tools[2].preferred_port, None);
-        assert_eq!(
-            normalized.external_tools[2].web_embedder,
-            ExternalToolWebEmbedder::Webview
-        );
+        assert_eq!(normalized.external_tools[2].web_embedder, ExternalToolWebEmbedder::Webview);
         assert!(!normalized.external_tools[2].keep_webview_alive);
     }
 

--- a/crates/roux-core/src/providers.rs
+++ b/crates/roux-core/src/providers.rs
@@ -577,7 +577,7 @@ mod tests {
     }
 
     #[test]
-    fn initial_prompt_command_preserves_env_and_setup_before_agent() {
+    fn initial_prompt_command_preserves_setup_before_agent() {
         let mut env = std::collections::BTreeMap::new();
         env.insert("FOO".to_string(), TerminalEnvRule::value("bar baz"));
         env.insert("not valid".to_string(), TerminalEnvRule::value("skip"));

--- a/crates/roux-core/src/providers.rs
+++ b/crates/roux-core/src/providers.rs
@@ -419,7 +419,7 @@ mod tests {
     }
 
     #[test]
-    fn startup_input_emits_env_and_setup_before_startup() {
+    fn startup_input_runs_setup_before_startup_without_env_exports() {
         let mut env = std::collections::BTreeMap::new();
         env.insert("FOO".to_string(), TerminalEnvRule::value("bar baz"));
         env.insert("not valid".to_string(), TerminalEnvRule::value("skip"));

--- a/crates/roux-core/src/providers.rs
+++ b/crates/roux-core/src/providers.rs
@@ -36,11 +36,8 @@ pub fn resolve_profile(id: &str, settings: &RouxSettings) -> Option<SpawnProfile
 /// files. Execution runs keep the original profile unchanged.
 pub fn profile_with_planning_constraints(profile: &SpawnProfile) -> SpawnProfile {
     let mut profile = profile.clone();
-    let Some(startup) = profile
-        .startup_command
-        .as_deref()
-        .map(str::trim)
-        .filter(|startup| !startup.is_empty())
+    let Some(startup) =
+        profile.startup_command.as_deref().map(str::trim).filter(|startup| !startup.is_empty())
     else {
         return profile;
     };
@@ -70,6 +67,7 @@ pub fn claude_default_profiles(settings: &RouxSettings) -> Vec<SpawnProfile> {
         startup_command: Some(claude_startup_command(settings)),
         startup_behavior: None,
         env: None,
+        before_shell_starts: None,
         cwd_override: None,
         icon: None,
         provider: Some(Provider::Claude),
@@ -106,6 +104,7 @@ pub fn codex_default_profiles(_settings: &RouxSettings) -> Vec<SpawnProfile> {
         startup_command: Some(shell_quote("codex")),
         startup_behavior: None,
         env: None,
+        before_shell_starts: None,
         cwd_override: None,
         icon: None,
         provider: Some(Provider::Codex),
@@ -114,20 +113,16 @@ pub fn codex_default_profiles(_settings: &RouxSettings) -> Vec<SpawnProfile> {
 }
 
 /// Build the text to type into a freshly-spawned shell to bring `profile` to
-/// life: `cd` override, env exports, setup command, then the startup command
+/// life: `cd` override, setup command, then the startup command
 /// (with `append_system_prompt` folded in per provider). Returns `None` when
 /// the profile has nothing to run (e.g. plain shell), so callers leave the
-/// shell at its prompt. Mirrors the frontend `runProfileInPane` ordering.
+/// shell at its prompt. Profile environment is applied before PTY spawn by
+/// the runtime and is intentionally not exported here.
 pub fn profile_startup_input(
     profile: &SpawnProfile,
     append_system_prompt: Option<&str>,
 ) -> Option<String> {
     let cwd = profile.cwd_override.as_deref().map(str::trim).filter(|s| !s.is_empty());
-    let env: Vec<(&String, &String)> = profile
-        .env
-        .as_ref()
-        .map(|m| m.iter().filter(|(name, _)| is_valid_env_name(name)).collect())
-        .unwrap_or_default();
     let setup = profile.setup_command.as_deref().map(str::trim).filter(|s| !s.is_empty());
     let base_startup = profile.startup_command.as_deref().unwrap_or("");
     let startup = append_agent_system_prompt(
@@ -137,18 +132,13 @@ pub fn profile_startup_input(
     );
     let has_startup = !startup.trim().is_empty();
 
-    if cwd.is_none() && env.is_empty() && setup.is_none() && !has_startup {
+    if cwd.is_none() && setup.is_none() && !has_startup {
         return None;
     }
 
     let mut out = String::new();
     if let Some(cwd) = cwd {
         out.push_str(&format!("cd {}", shell_single_quote(cwd)));
-        out.push(PTY_ENTER);
-    }
-    // env is a BTreeMap, so iteration order is already deterministic (sorted).
-    for (name, value) in env {
-        out.push_str(&format!("export {}={}", name, shell_single_quote(value)));
         out.push(PTY_ENTER);
     }
     if let Some(setup) = setup {
@@ -230,18 +220,9 @@ pub fn profile_startup_command_with_initial_prompt(
     );
     let startup = format!("{startup} {}", shell_single_quote(task));
 
-    let env: Vec<(&String, &String)> = profile
-        .env
-        .as_ref()
-        .map(|m| m.iter().filter(|(name, _)| is_valid_env_name(name)).collect())
-        .unwrap_or_default();
     let setup = profile.setup_command.as_deref().map(str::trim).filter(|s| !s.is_empty());
 
     let mut out = String::new();
-    for (name, value) in env {
-        out.push_str(&format!("export {}={}", name, shell_single_quote(value)));
-        out.push('\n');
-    }
     if let Some(setup) = setup {
         push_shell_command(&mut out, setup);
     }
@@ -290,15 +271,6 @@ fn shell_single_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\\''"))
 }
 
-fn is_valid_env_name(name: &str) -> bool {
-    let mut chars = name.chars();
-    match chars.next() {
-        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
-        _ => return false,
-    }
-    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
-}
-
 fn plain_shell_profile() -> SpawnProfile {
     SpawnProfile {
         id: "plain-shell".into(),
@@ -307,6 +279,7 @@ fn plain_shell_profile() -> SpawnProfile {
         startup_command: None,
         startup_behavior: None,
         env: None,
+        before_shell_starts: None,
         cwd_override: None,
         icon: None,
         provider: None,
@@ -343,6 +316,8 @@ pub fn shell_quote(token: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use crate::TerminalEnvRule;
+
     use super::*;
 
     #[test]
@@ -446,8 +421,8 @@ mod tests {
     #[test]
     fn startup_input_emits_env_and_setup_before_startup() {
         let mut env = std::collections::BTreeMap::new();
-        env.insert("FOO".to_string(), "bar baz".to_string());
-        env.insert("not valid".to_string(), "skip".to_string());
+        env.insert("FOO".to_string(), TerminalEnvRule::value("bar baz"));
+        env.insert("not valid".to_string(), TerminalEnvRule::value("skip"));
         let profile = SpawnProfile {
             id: "custom".into(),
             name: "Custom".into(),
@@ -455,14 +430,14 @@ mod tests {
             startup_command: Some("run".into()),
             startup_behavior: None,
             env: Some(env),
+            before_shell_starts: None,
             cwd_override: None,
             icon: None,
             provider: None,
             source: ProfileSource::User,
         };
         let input = profile_startup_input(&profile, None).unwrap();
-        // Invalid env name dropped; valid one exported (quoted), then setup, then startup.
-        assert_eq!(input, "export FOO='bar baz'\rnpm ci\rrun\r");
+        assert_eq!(input, "npm ci\rrun\r");
     }
 
     #[test]
@@ -474,6 +449,7 @@ mod tests {
             startup_command: Some("claude".into()),
             startup_behavior: Some(StartupBehavior::TypeOnly),
             env: None,
+            before_shell_starts: None,
             cwd_override: None,
             icon: None,
             provider: Some(Provider::Claude),
@@ -510,6 +486,7 @@ mod tests {
             startup_command: Some("claude".into()),
             startup_behavior: Some(StartupBehavior::TypeOnly),
             env: None,
+            before_shell_starts: None,
             cwd_override: None,
             icon: None,
             provider: Some(Provider::Claude),
@@ -530,6 +507,7 @@ mod tests {
             startup_command: Some("run-agent".into()),
             startup_behavior: None,
             env: None,
+            before_shell_starts: None,
             cwd_override: None,
             icon: None,
             provider: None,
@@ -561,8 +539,9 @@ mod tests {
 
     #[test]
     fn planning_constraints_force_claude_plan_permission_mode() {
-        let profile =
-            profile_with_planning_constraints(&claude_default_profiles(&RouxSettings::default())[0]);
+        let profile = profile_with_planning_constraints(
+            &claude_default_profiles(&RouxSettings::default())[0],
+        );
         let command =
             profile_startup_command_with_initial_prompt(&profile, Some("Be terse"), "Plan it")
                 .unwrap();
@@ -600,8 +579,8 @@ mod tests {
     #[test]
     fn initial_prompt_command_preserves_env_and_setup_before_agent() {
         let mut env = std::collections::BTreeMap::new();
-        env.insert("FOO".to_string(), "bar baz".to_string());
-        env.insert("not valid".to_string(), "skip".to_string());
+        env.insert("FOO".to_string(), TerminalEnvRule::value("bar baz"));
+        env.insert("not valid".to_string(), TerminalEnvRule::value("skip"));
         let profile = SpawnProfile {
             id: "custom-claude".into(),
             name: "Custom Claude".into(),
@@ -609,6 +588,7 @@ mod tests {
             startup_command: Some("claude --dangerously-skip-permissions".into()),
             startup_behavior: None,
             env: Some(env),
+            before_shell_starts: None,
             cwd_override: None,
             icon: None,
             provider: Some(Provider::Claude),
@@ -619,7 +599,7 @@ mod tests {
                 .unwrap();
         assert_eq!(
             command,
-            "export FOO='bar baz'\necho setup\nclaude --dangerously-skip-permissions --append-system-prompt 'Be terse' 'Fix it'",
+            "echo setup\nclaude --dangerously-skip-permissions --append-system-prompt 'Be terse' 'Fix it'",
         );
     }
 
@@ -639,6 +619,7 @@ mod tests {
             startup_command: Some("claude".into()),
             startup_behavior: Some(StartupBehavior::TypeOnly),
             env: None,
+            before_shell_starts: None,
             cwd_override: None,
             icon: None,
             provider: Some(Provider::Claude),

--- a/crates/roux-runtime/src/lib.rs
+++ b/crates/roux-runtime/src/lib.rs
@@ -32,6 +32,7 @@ pub mod subscription_persistence;
 pub mod subscription_service;
 pub mod subscription_store;
 pub mod terminal_env;
+pub mod terminal_profile_env;
 pub mod watch_checks;
 pub mod watch_runner;
 pub mod watch_service;

--- a/crates/roux-runtime/src/pty_service.rs
+++ b/crates/roux-runtime/src/pty_service.rs
@@ -6,7 +6,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
-use roux_core::{PtyInfo, PtyRole, PtyStatus};
+use roux_core::{PtyInfo, PtyRole, PtyStatus, SpawnProfile, TerminalDefaults, TerminalEnvRule};
 use tokio::sync::{broadcast, mpsc, oneshot};
 use tokio::task::JoinHandle;
 
@@ -15,6 +15,7 @@ use crate::pty_live::WaitedChild;
 use crate::pty_session::{PtySessionMetadata, PtySessionMetadataInputs};
 use crate::pty_spawn::{self, ShellSpawnPlanInputs, TaskSpawnPlanInputs};
 use crate::terminal_env::{self, NotesEnvInputs};
+use crate::terminal_profile_env::{resolve_terminal_profile_env, TerminalProfileEnvInputs};
 
 pub const PTY_OUTPUT_LIMIT_BYTES: usize = 256 * 1024;
 pub const PTY_OUTPUT_DEFAULT_POLL_BYTES: usize = 64 * 1024;
@@ -46,6 +47,9 @@ pub struct PtySpawnRequest {
     pub notes: Option<NotesEnvInputs>,
     pub env: PtyEnvRequest,
     pub profile: Option<String>,
+    pub profile_data: Option<SpawnProfile>,
+    pub terminal_defaults: TerminalDefaults,
+    pub launch_env: Option<std::collections::BTreeMap<String, TerminalEnvRule>>,
     pub initial_size: Option<(u16, u16)>,
     pub role: PtyRole,
 }
@@ -62,6 +66,9 @@ impl Default for PtySpawnRequest {
             notes: None,
             env: PtyEnvRequest::default(),
             profile: None,
+            profile_data: None,
+            terminal_defaults: TerminalDefaults::default(),
+            launch_env: None,
             initial_size: None,
             role: PtyRole::Secondary,
         }
@@ -598,12 +605,22 @@ fn spawn_pty(
     let working_dir_str = working_dir.to_string_lossy().to_string();
     let shell = resolve_default_shell();
     let roux_env = roux_env_for_request(&request);
+    let terminal_env = resolve_terminal_profile_env(TerminalProfileEnvInputs {
+        base_env: std::env::vars().collect(),
+        terminal_defaults: Some(&request.terminal_defaults),
+        roux_env: &roux_env,
+        profile: request.profile_data.as_ref(),
+        launch_env: request.launch_env.as_ref(),
+        shell: &shell,
+        working_dir: &working_dir,
+    })
+    .map_err(|err| err.to_string())?;
 
-    let spawn_plan = match kind {
+    let mut spawn_plan = match kind {
         PtyKind::Shell => pty_spawn::shell_spawn_plan(ShellSpawnPlanInputs {
             working_dir: &working_dir_str,
             shell: &shell,
-            roux_env: &roux_env,
+            roux_env: &terminal_env.env,
             worktree_path: request.worktree_path.as_deref(),
             initial_size: request.initial_size,
         }),
@@ -611,11 +628,12 @@ fn spawn_pty(
             command: command.as_deref().unwrap_or_default(),
             working_dir: &working_dir_str,
             shell: &shell,
-            roux_env: &roux_env,
+            roux_env: &terminal_env.env,
             worktree_path: request.worktree_path.as_deref(),
             initial_size: request.initial_size,
         }),
     };
+    spawn_plan.command.env_remove = terminal_env.env_remove;
 
     let pty_system = native_pty_system();
     let pair = pty_system
@@ -712,6 +730,9 @@ fn command_builder_from_plan(plan: &pty_spawn::PtyCommandPlan) -> CommandBuilder
     }
     for (key, value) in &plan.env {
         cmd.env(key, value);
+    }
+    for key in &plan.env_remove {
+        cmd.env_remove(key);
     }
     cmd.cwd(&plan.cwd);
     cmd

--- a/crates/roux-runtime/src/pty_spawn.rs
+++ b/crates/roux-runtime/src/pty_spawn.rs
@@ -20,6 +20,7 @@ pub struct PtyCommandPlan {
     pub program: PathBuf,
     pub args: Vec<String>,
     pub env: Vec<(String, String)>,
+    pub env_remove: Vec<String>,
     pub cwd: String,
 }
 
@@ -56,6 +57,7 @@ pub fn shell_spawn_plan(inputs: ShellSpawnPlanInputs<'_>) -> PtySpawnPlan {
         program: PathBuf::from(inputs.shell),
         args: Vec::new(),
         env: inputs.roux_env.to_vec(),
+        env_remove: Vec::new(),
         cwd: inputs.working_dir.to_string(),
     };
 
@@ -69,6 +71,7 @@ pub fn task_spawn_plan(inputs: TaskSpawnPlanInputs<'_>) -> PtySpawnPlan {
         program: PathBuf::from(inputs.shell),
         args: task_command_args(inputs.shell, inputs.command),
         env: inputs.roux_env.to_vec(),
+        env_remove: Vec::new(),
         cwd: inputs.working_dir.to_string(),
     };
 

--- a/crates/roux-runtime/src/terminal_profile_env.rs
+++ b/crates/roux-runtime/src/terminal_profile_env.rs
@@ -57,6 +57,10 @@ pub fn resolve_terminal_profile_env(
 
     apply_env_rules(&mut env, inputs.launch_env, inputs.shell, inputs.working_dir)?;
 
+    for (name, value) in inputs.roux_env {
+        env.set(name, value.clone());
+    }
+
     if let Some(defaults) = inputs.terminal_defaults {
         run_preflight(
             "global beforeShellStarts",
@@ -347,7 +351,10 @@ mod tests {
             ("ROUX_SESSION_ID".to_string(), value("profile-session")),
             ("SHARED".to_string(), value("profile")),
         ]));
-        let launch = BTreeMap::from([("SHARED".to_string(), value("launch"))]);
+        let launch = BTreeMap::from([
+            ("ROUX_SESSION_ID".to_string(), value("launch-session")),
+            ("SHARED".to_string(), value("launch")),
+        ]);
 
         let plan = resolve_terminal_profile_env(TerminalProfileEnvInputs {
             base_env: base_env(),
@@ -365,7 +372,7 @@ mod tests {
             BTreeMap::from([
                 ("GLOBAL".to_string(), "global".to_string()),
                 ("PROFILE".to_string(), "profile".to_string()),
-                ("ROUX_SESSION_ID".to_string(), "profile-session".to_string()),
+                ("ROUX_SESSION_ID".to_string(), "roux-session".to_string()),
                 ("SHARED".to_string(), "launch".to_string()),
             ])
         );

--- a/crates/roux-runtime/src/terminal_profile_env.rs
+++ b/crates/roux-runtime/src/terminal_profile_env.rs
@@ -1,0 +1,455 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use roux_core::{
+    SpawnProfile, TerminalDefaults, TerminalEnvRule, TerminalEnvRuleMode, TerminalEnvRuleSpec,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TerminalProfileEnvPlan {
+    pub env: Vec<(String, String)>,
+    pub env_remove: Vec<String>,
+}
+
+pub struct TerminalProfileEnvInputs<'a> {
+    pub base_env: BTreeMap<String, String>,
+    pub terminal_defaults: Option<&'a TerminalDefaults>,
+    pub roux_env: &'a [(String, String)],
+    pub profile: Option<&'a SpawnProfile>,
+    pub launch_env: Option<&'a BTreeMap<String, TerminalEnvRule>>,
+    pub shell: &'a str,
+    pub working_dir: &'a Path,
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum TerminalProfileEnvError {
+    #[error("terminal env command for {name} is empty")]
+    EmptyEnvCommand { name: String },
+    #[error("terminal env command for {name} failed with status {status}")]
+    EnvCommandFailed { name: String, status: String },
+    #[error("terminal env command for {name} could not run: {error}")]
+    EnvCommandIo { name: String, error: String },
+    #[error("{stage} command failed with status {status}")]
+    PreflightFailed { stage: &'static str, status: String },
+    #[error("{stage} command could not run: {error}")]
+    PreflightIo { stage: &'static str, error: String },
+}
+
+pub fn resolve_terminal_profile_env(
+    inputs: TerminalProfileEnvInputs<'_>,
+) -> Result<TerminalProfileEnvPlan, TerminalProfileEnvError> {
+    let mut env = EnvAccumulator::new(inputs.base_env);
+
+    if let Some(defaults) = inputs.terminal_defaults {
+        apply_env_rules(&mut env, defaults.env.as_ref(), inputs.shell, inputs.working_dir)?;
+    }
+
+    for (name, value) in inputs.roux_env {
+        env.set(name, value.clone());
+    }
+
+    if let Some(profile) = inputs.profile {
+        apply_env_rules(&mut env, profile.env.as_ref(), inputs.shell, inputs.working_dir)?;
+    }
+
+    apply_env_rules(&mut env, inputs.launch_env, inputs.shell, inputs.working_dir)?;
+
+    if let Some(defaults) = inputs.terminal_defaults {
+        run_preflight(
+            "global beforeShellStarts",
+            defaults.before_shell_starts.as_deref(),
+            &env.values,
+            inputs.shell,
+            inputs.working_dir,
+        )?;
+    }
+    if let Some(profile) = inputs.profile {
+        run_preflight(
+            "profile beforeShellStarts",
+            profile.before_shell_starts.as_deref(),
+            &env.values,
+            inputs.shell,
+            inputs.working_dir,
+        )?;
+    }
+
+    Ok(env.into_plan())
+}
+
+fn apply_env_rules(
+    env: &mut EnvAccumulator,
+    rules: Option<&BTreeMap<String, TerminalEnvRule>>,
+    shell: &str,
+    working_dir: &Path,
+) -> Result<(), TerminalProfileEnvError> {
+    let Some(rules) = rules else {
+        return Ok(());
+    };
+    for (name, rule) in rules {
+        if !is_valid_env_name(name) {
+            continue;
+        }
+        apply_env_rule(env, name, rule, shell, working_dir)?;
+    }
+    Ok(())
+}
+
+fn apply_env_rule(
+    env: &mut EnvAccumulator,
+    name: &str,
+    rule: &TerminalEnvRule,
+    shell: &str,
+    working_dir: &Path,
+) -> Result<(), TerminalProfileEnvError> {
+    match rule {
+        TerminalEnvRule::LegacyValue(value) => env.set(name, value.clone()),
+        TerminalEnvRule::Structured(spec) => {
+            apply_structured_rule(env, name, spec, shell, working_dir)?
+        }
+    }
+    Ok(())
+}
+
+fn apply_structured_rule(
+    env: &mut EnvAccumulator,
+    name: &str,
+    spec: &TerminalEnvRuleSpec,
+    shell: &str,
+    working_dir: &Path,
+) -> Result<(), TerminalProfileEnvError> {
+    match spec.mode {
+        TerminalEnvRuleMode::Value => env.set(name, spec.value.clone().unwrap_or_default()),
+        TerminalEnvRuleMode::Inherit => {}
+        TerminalEnvRuleMode::Unset => env.unset(name),
+        TerminalEnvRuleMode::Command => {
+            let command = spec
+                .command
+                .as_deref()
+                .map(str::trim)
+                .filter(|command| !command.is_empty())
+                .ok_or_else(|| TerminalProfileEnvError::EmptyEnvCommand {
+                    name: name.to_string(),
+                })?;
+            let value = run_env_command(name, command, &env.values, shell, working_dir)?;
+            env.set(name, value);
+        }
+    }
+    Ok(())
+}
+
+fn run_env_command(
+    name: &str,
+    command: &str,
+    env: &BTreeMap<String, String>,
+    shell: &str,
+    working_dir: &Path,
+) -> Result<String, TerminalProfileEnvError> {
+    let output = command_with_env(command, env, shell, working_dir)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output()
+        .map_err(|error| TerminalProfileEnvError::EnvCommandIo {
+            name: name.to_string(),
+            error: error.to_string(),
+        })?;
+    if !output.status.success() {
+        return Err(TerminalProfileEnvError::EnvCommandFailed {
+            name: name.to_string(),
+            status: status_label(output.status),
+        });
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn run_preflight(
+    stage: &'static str,
+    command: Option<&str>,
+    env: &BTreeMap<String, String>,
+    shell: &str,
+    working_dir: &Path,
+) -> Result<(), TerminalProfileEnvError> {
+    let Some(command) = command.map(str::trim).filter(|command| !command.is_empty()) else {
+        return Ok(());
+    };
+    let status = command_with_env(command, env, shell, working_dir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map_err(|error| TerminalProfileEnvError::PreflightIo {
+            stage,
+            error: error.to_string(),
+        })?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(TerminalProfileEnvError::PreflightFailed { stage, status: status_label(status) })
+    }
+}
+
+fn command_with_env(
+    command: &str,
+    env: &BTreeMap<String, String>,
+    shell: &str,
+    working_dir: &Path,
+) -> Command {
+    let mut cmd = Command::new(shell);
+    for arg in shell_command_args(shell, command) {
+        cmd.arg(arg);
+    }
+    cmd.current_dir(working_dir);
+    cmd.env_clear();
+    cmd.envs(env);
+    cmd
+}
+
+fn shell_command_args(shell: &str, command: &str) -> Vec<String> {
+    #[cfg(windows)]
+    {
+        let shell_lower = shell.to_ascii_lowercase();
+        if shell_lower.contains("pwsh") {
+            return vec![
+                "-NoLogo".to_string(),
+                "-NoProfile".to_string(),
+                "-Command".to_string(),
+                command.to_string(),
+            ];
+        }
+        if shell_lower.contains("powershell") {
+            return vec![
+                "-NoLogo".to_string(),
+                "-NoProfile".to_string(),
+                "-ExecutionPolicy".to_string(),
+                "Bypass".to_string(),
+                "-Command".to_string(),
+                command.to_string(),
+            ];
+        }
+        vec!["/C".to_string(), command.to_string()]
+    }
+
+    #[cfg(not(windows))]
+    {
+        let _ = shell;
+        vec!["-c".to_string(), command.to_string()]
+    }
+}
+
+fn status_label(status: std::process::ExitStatus) -> String {
+    status.code().map(|code| code.to_string()).unwrap_or_else(|| "signal".to_string())
+}
+
+fn is_valid_env_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+struct EnvAccumulator {
+    values: BTreeMap<String, String>,
+    touched: BTreeSet<String>,
+    removed: BTreeSet<String>,
+}
+
+impl EnvAccumulator {
+    fn new(values: BTreeMap<String, String>) -> Self {
+        Self { values, touched: BTreeSet::new(), removed: BTreeSet::new() }
+    }
+
+    fn set(&mut self, name: &str, value: String) {
+        self.values.insert(name.to_string(), value);
+        self.touched.insert(name.to_string());
+        self.removed.remove(name);
+    }
+
+    fn unset(&mut self, name: &str) {
+        self.values.remove(name);
+        self.touched.remove(name);
+        self.removed.insert(name.to_string());
+    }
+
+    fn into_plan(self) -> TerminalProfileEnvPlan {
+        let env = self
+            .touched
+            .into_iter()
+            .filter_map(|name| self.values.get(&name).map(|value| (name, value.clone())))
+            .collect();
+        TerminalProfileEnvPlan { env, env_remove: self.removed.into_iter().collect() }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use roux_core::{ProfileSource, SplitProfileBehavior, StartupBehavior, TerminalEnvRuleSpec};
+
+    fn base_env() -> BTreeMap<String, String> {
+        BTreeMap::from([
+            ("BASE_ONLY".to_string(), "base".to_string()),
+            ("PATH".to_string(), "/bin".to_string()),
+            ("REMOVE_ME".to_string(), "inherited".to_string()),
+            ("SHARED".to_string(), "base".to_string()),
+        ])
+    }
+
+    fn rule(mode: TerminalEnvRuleMode) -> TerminalEnvRule {
+        TerminalEnvRule::Structured(TerminalEnvRuleSpec { mode, value: None, command: None })
+    }
+
+    fn value(value: &str) -> TerminalEnvRule {
+        TerminalEnvRule::value(value)
+    }
+
+    fn make_profile(env: BTreeMap<String, TerminalEnvRule>) -> SpawnProfile {
+        SpawnProfile {
+            id: "profile".to_string(),
+            name: "Profile".to_string(),
+            setup_command: None,
+            startup_command: None,
+            startup_behavior: Some(StartupBehavior::AutoRun),
+            env: Some(env),
+            before_shell_starts: None,
+            cwd_override: None,
+            icon: None,
+            provider: None,
+            source: ProfileSource::User,
+        }
+    }
+
+    fn defaults(env: BTreeMap<String, TerminalEnvRule>) -> TerminalDefaults {
+        TerminalDefaults {
+            env: Some(env),
+            before_shell_starts: None,
+            split_profile_behavior: SplitProfileBehavior::PlainShell,
+        }
+    }
+
+    #[test]
+    fn env_precedence_applies_global_roux_profile_and_launch_overrides() {
+        let dir = tempfile::tempdir().unwrap();
+        let defaults = defaults(BTreeMap::from([
+            ("GLOBAL".to_string(), value("global")),
+            ("SHARED".to_string(), value("global")),
+        ]));
+        let profile = make_profile(BTreeMap::from([
+            ("PROFILE".to_string(), value("profile")),
+            ("ROUX_SESSION_ID".to_string(), value("profile-session")),
+            ("SHARED".to_string(), value("profile")),
+        ]));
+        let launch = BTreeMap::from([("SHARED".to_string(), value("launch"))]);
+
+        let plan = resolve_terminal_profile_env(TerminalProfileEnvInputs {
+            base_env: base_env(),
+            terminal_defaults: Some(&defaults),
+            roux_env: &[("ROUX_SESSION_ID".to_string(), "roux-session".to_string())],
+            profile: Some(&profile),
+            launch_env: Some(&launch),
+            shell: "/bin/sh",
+            working_dir: dir.path(),
+        })
+        .unwrap();
+
+        assert_eq!(
+            BTreeMap::<_, _>::from_iter(plan.env),
+            BTreeMap::from([
+                ("GLOBAL".to_string(), "global".to_string()),
+                ("PROFILE".to_string(), "profile".to_string()),
+                ("ROUX_SESSION_ID".to_string(), "profile-session".to_string()),
+                ("SHARED".to_string(), "launch".to_string()),
+            ])
+        );
+    }
+
+    #[test]
+    fn inherit_keeps_resolved_value_and_unset_removes_inherited_value() {
+        let dir = tempfile::tempdir().unwrap();
+        let profile = make_profile(BTreeMap::from([
+            ("BASE_ONLY".to_string(), rule(TerminalEnvRuleMode::Inherit)),
+            ("REMOVE_ME".to_string(), rule(TerminalEnvRuleMode::Unset)),
+        ]));
+
+        let plan = resolve_terminal_profile_env(TerminalProfileEnvInputs {
+            base_env: base_env(),
+            terminal_defaults: None,
+            roux_env: &[],
+            profile: Some(&profile),
+            launch_env: None,
+            shell: "/bin/sh",
+            working_dir: dir.path(),
+        })
+        .unwrap();
+
+        assert!(!plan.env.iter().any(|(name, _)| name == "BASE_ONLY"));
+        assert_eq!(plan.env_remove, vec!["REMOVE_ME".to_string()]);
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn command_mode_captures_trimmed_stdout_without_exposing_value_in_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let profile = make_profile(BTreeMap::from([(
+            "TOKEN".to_string(),
+            TerminalEnvRule::command("printf ' secret-value \\n'"),
+        )]));
+
+        let plan = resolve_terminal_profile_env(TerminalProfileEnvInputs {
+            base_env: base_env(),
+            terminal_defaults: None,
+            roux_env: &[],
+            profile: Some(&profile),
+            launch_env: None,
+            shell: "/bin/sh",
+            working_dir: dir.path(),
+        })
+        .unwrap();
+
+        assert_eq!(plan.env, vec![("TOKEN".to_string(), "secret-value".to_string())]);
+
+        let failing = make_profile(BTreeMap::from([(
+            "TOKEN".to_string(),
+            TerminalEnvRule::command("printf secret-value; exit 7"),
+        )]));
+        let err = resolve_terminal_profile_env(TerminalProfileEnvInputs {
+            base_env: base_env(),
+            terminal_defaults: None,
+            roux_env: &[],
+            profile: Some(&failing),
+            launch_env: None,
+            shell: "/bin/sh",
+            working_dir: dir.path(),
+        })
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("TOKEN"));
+        assert!(!msg.contains("secret-value"));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn preflight_failure_aborts_without_logging_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let defaults = TerminalDefaults {
+            env: None,
+            before_shell_starts: Some("printf sensitive; exit 9".to_string()),
+            split_profile_behavior: SplitProfileBehavior::PlainShell,
+        };
+
+        let err = resolve_terminal_profile_env(TerminalProfileEnvInputs {
+            base_env: base_env(),
+            terminal_defaults: Some(&defaults),
+            roux_env: &[],
+            profile: None,
+            launch_env: None,
+            shell: "/bin/sh",
+            working_dir: dir.path(),
+        })
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("global beforeShellStarts"));
+        assert!(!msg.contains("sensitive"));
+    }
+}

--- a/crates/roux-runtime/src/terminal_profile_env.rs
+++ b/crates/roux-runtime/src/terminal_profile_env.rs
@@ -30,6 +30,8 @@ pub enum TerminalProfileEnvError {
     EnvCommandFailed { name: String, status: String },
     #[error("terminal env command for {name} could not run: {error}")]
     EnvCommandIo { name: String, error: String },
+    #[error("terminal env value for {name} is missing")]
+    MissingEnvValue { name: String },
     #[error("{stage} command failed with status {status}")]
     PreflightFailed { stage: &'static str, status: String },
     #[error("{stage} command could not run: {error}")]
@@ -119,7 +121,12 @@ fn apply_structured_rule(
     working_dir: &Path,
 ) -> Result<(), TerminalProfileEnvError> {
     match spec.mode {
-        TerminalEnvRuleMode::Value => env.set(name, spec.value.clone().unwrap_or_default()),
+        TerminalEnvRuleMode::Value => {
+            let value = spec.value.clone().ok_or_else(|| {
+                TerminalProfileEnvError::MissingEnvValue { name: name.to_string() }
+            })?;
+            env.set(name, value);
+        }
         TerminalEnvRuleMode::Inherit => {}
         TerminalEnvRuleMode::Unset => env.unset(name),
         TerminalEnvRuleMode::Command => {
@@ -385,6 +392,28 @@ mod tests {
 
         assert!(!plan.env.iter().any(|(name, _)| name == "BASE_ONLY"));
         assert_eq!(plan.env_remove, vec!["REMOVE_ME".to_string()]);
+    }
+
+    #[test]
+    fn value_mode_requires_a_value() {
+        let dir = tempfile::tempdir().unwrap();
+        let profile = make_profile(BTreeMap::from([(
+            "MISSING".to_string(),
+            rule(TerminalEnvRuleMode::Value),
+        )]));
+
+        let err = resolve_terminal_profile_env(TerminalProfileEnvInputs {
+            base_env: base_env(),
+            terminal_defaults: None,
+            roux_env: &[],
+            profile: Some(&profile),
+            launch_env: None,
+            shell: "/bin/sh",
+            working_dir: dir.path(),
+        })
+        .unwrap_err();
+
+        assert_eq!(err, TerminalProfileEnvError::MissingEnvValue { name: "MISSING".to_string() });
     }
 
     #[cfg(not(windows))]

--- a/crates/roux-sdk/src/handles.rs
+++ b/crates/roux-sdk/src/handles.rs
@@ -4,6 +4,7 @@ use crate::error::{RouxError, RouxResult};
 use crate::protocol::CommandRequest;
 use crate::types::{PtyAttachFrame, PtyRecord, PtySnapshot};
 use serde_json::Value;
+use std::collections::BTreeMap;
 
 #[derive(Debug, Clone)]
 pub struct Session {
@@ -26,6 +27,8 @@ pub struct SpawnTask {
     pub(crate) session_id: Option<String>,
     pub(crate) pane_id: Option<String>,
     pub(crate) profile: Option<String>,
+    pub(crate) profile_data: Option<roux_core::SpawnProfile>,
+    pub(crate) env_overrides: Option<BTreeMap<String, roux_core::TerminalEnvRule>>,
     pub(crate) initial_size: Option<(u16, u16)>,
 }
 
@@ -37,6 +40,8 @@ pub struct SpawnShell {
     pub(crate) session_id: Option<String>,
     pub(crate) pane_id: Option<String>,
     pub(crate) profile: Option<String>,
+    pub(crate) profile_data: Option<roux_core::SpawnProfile>,
+    pub(crate) env_overrides: Option<BTreeMap<String, roux_core::TerminalEnvRule>>,
     pub(crate) initial_size: Option<(u16, u16)>,
 }
 
@@ -58,6 +63,8 @@ impl Roux {
             session_id: None,
             pane_id: None,
             profile: None,
+            profile_data: None,
+            env_overrides: None,
             initial_size: None,
         }
     }
@@ -70,6 +77,8 @@ impl Roux {
             session_id: None,
             pane_id: None,
             profile: None,
+            profile_data: None,
+            env_overrides: None,
             initial_size: None,
         }
     }
@@ -270,6 +279,19 @@ impl SpawnTask {
         self
     }
 
+    pub fn profile_data(mut self, profile: roux_core::SpawnProfile) -> Self {
+        self.profile_data = Some(profile);
+        self
+    }
+
+    pub fn env_overrides(
+        mut self,
+        env_overrides: BTreeMap<String, roux_core::TerminalEnvRule>,
+    ) -> Self {
+        self.env_overrides = Some(env_overrides);
+        self
+    }
+
     pub fn initial_size(mut self, cols: u16, rows: u16) -> Self {
         self.initial_size = Some((cols, rows));
         self
@@ -298,6 +320,16 @@ impl SpawnTask {
         }
         if let Some(profile) = self.profile {
             args.insert("profile".into(), Value::String(profile));
+        }
+        if let Some(profile_data) =
+            self.profile_data.and_then(|profile| serde_json::to_value(profile).ok())
+        {
+            args.insert("profileData".into(), profile_data);
+        }
+        if let Some(env_overrides) =
+            self.env_overrides.and_then(|env| serde_json::to_value(env).ok())
+        {
+            args.insert("envOverrides".into(), env_overrides);
         }
         if let Some((cols, rows)) = self.initial_size {
             args.insert("initialSize".into(), serde_json::json!([cols, rows]));
@@ -334,6 +366,19 @@ impl SpawnShell {
         self
     }
 
+    pub fn profile_data(mut self, profile: roux_core::SpawnProfile) -> Self {
+        self.profile_data = Some(profile);
+        self
+    }
+
+    pub fn env_overrides(
+        mut self,
+        env_overrides: BTreeMap<String, roux_core::TerminalEnvRule>,
+    ) -> Self {
+        self.env_overrides = Some(env_overrides);
+        self
+    }
+
     pub fn initial_size(mut self, cols: u16, rows: u16) -> Self {
         self.initial_size = Some((cols, rows));
         self
@@ -361,6 +406,16 @@ impl SpawnShell {
         }
         if let Some(profile) = self.profile {
             args.insert("profile".into(), Value::String(profile));
+        }
+        if let Some(profile_data) =
+            self.profile_data.and_then(|profile| serde_json::to_value(profile).ok())
+        {
+            args.insert("profileData".into(), profile_data);
+        }
+        if let Some(env_overrides) =
+            self.env_overrides.and_then(|env| serde_json::to_value(env).ok())
+        {
+            args.insert("envOverrides".into(), env_overrides);
         }
         if let Some((cols, rows)) = self.initial_size {
             args.insert("initialSize".into(), serde_json::json!([cols, rows]));

--- a/crates/roux-sdk/src/lib.rs
+++ b/crates/roux-sdk/src/lib.rs
@@ -406,6 +406,8 @@ mod tests {
                 base: Some("origin/main".to_string()),
                 fetch_first: true,
                 profile: Some("plain-shell".to_string()),
+                profile_data: None,
+                env_overrides: None,
                 initial_size: Some((100, 30)),
                 project_id: Some("project-a".to_string()),
                 blueprint_id: Some("blueprint-a".to_string()),
@@ -465,6 +467,8 @@ mod tests {
             .block_on(client.reconnect_session_shell(ReconnectSessionShell {
                 id: "session-a".to_string(),
                 profile: Some("plain-shell".to_string()),
+                profile_data: None,
+                env_overrides: None,
                 initial_size: Some((120, 40)),
                 notes: Some(NotesEnv {
                     vault_root: "/vault".to_string(),

--- a/crates/roux-sdk/src/requests.rs
+++ b/crates/roux-sdk/src/requests.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use serde_json::Value;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -20,6 +22,8 @@ pub struct CreateSessionShell {
     pub base: Option<String>,
     pub fetch_first: bool,
     pub profile: Option<String>,
+    pub profile_data: Option<roux_core::SpawnProfile>,
+    pub env_overrides: Option<BTreeMap<String, roux_core::TerminalEnvRule>>,
     pub initial_size: Option<(u16, u16)>,
     pub project_id: Option<String>,
     pub blueprint_id: Option<String>,
@@ -30,6 +34,8 @@ pub struct CreateSessionShell {
 pub struct ReconnectSessionShell {
     pub id: String,
     pub profile: Option<String>,
+    pub profile_data: Option<roux_core::SpawnProfile>,
+    pub env_overrides: Option<BTreeMap<String, roux_core::TerminalEnvRule>>,
     pub initial_size: Option<(u16, u16)>,
     pub notes: Option<NotesEnv>,
 }
@@ -60,6 +66,8 @@ impl CreateSessionShell {
             args.insert("fetchFirst".into(), Value::Bool(true));
         }
         insert_optional_string(&mut args, "profile", self.profile);
+        insert_optional_profile(&mut args, "profileData", self.profile_data);
+        insert_optional_env_overrides(&mut args, self.env_overrides);
         insert_initial_size(&mut args, self.initial_size);
         insert_optional_string(&mut args, "projectId", self.project_id);
         insert_optional_string(&mut args, "blueprintId", self.blueprint_id);
@@ -72,6 +80,8 @@ impl ReconnectSessionShell {
     pub(crate) fn into_args(self) -> Value {
         let mut args = serde_json::Map::new();
         insert_optional_string(&mut args, "profile", self.profile);
+        insert_optional_profile(&mut args, "profileData", self.profile_data);
+        insert_optional_env_overrides(&mut args, self.env_overrides);
         insert_initial_size(&mut args, self.initial_size);
         insert_notes_env(&mut args, self.notes);
         Value::Object(args)
@@ -103,6 +113,25 @@ fn insert_optional_string(
 ) {
     if let Some(value) = value {
         args.insert(key.into(), Value::String(value));
+    }
+}
+
+fn insert_optional_profile(
+    args: &mut serde_json::Map<String, Value>,
+    key: &'static str,
+    value: Option<roux_core::SpawnProfile>,
+) {
+    if let Some(value) = value.and_then(|value| serde_json::to_value(value).ok()) {
+        args.insert(key.into(), value);
+    }
+}
+
+fn insert_optional_env_overrides(
+    args: &mut serde_json::Map<String, Value>,
+    value: Option<BTreeMap<String, roux_core::TerminalEnvRule>>,
+) {
+    if let Some(value) = value.and_then(|value| serde_json::to_value(value).ok()) {
+        args.insert("envOverrides".into(), value);
     }
 }
 

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -11,6 +11,7 @@ Roux is a terminal-first workspace for running agent sessions, shells, notes, wa
 - [Kanban Board](kanban.md) — plan card-based agent work, start daemon-owned runs, and resolve blocked decisions.
 - [Project Prompt Templates](project-prompt-templates.md) — Minijinja variables for branch, worktree, model, and sibling-session context.
 - [Layouts](layouts.md) — start sessions from KDL templates and spawn profiles.
+- [Terminal Profiles](terminal-profiles.md) — global terminal defaults, profile env rules, preflight commands, and split profile behavior.
 - [Worktrees](worktrees.md) — manage isolated git checkouts for session work.
 
 ## Context

--- a/docs/features/terminal-profiles.md
+++ b/docs/features/terminal-profiles.md
@@ -1,0 +1,110 @@
+# Terminal Profiles
+
+Terminal profiles describe how Roux should prepare a new shell before any
+interactive setup or startup command is typed into the PTY. Roux owns session
+intent: profile selection, stable environment, and preflight checks. Project
+tools such as `direnv`, `mise`, `asdf`, `nvm`, and shell rc files still own
+project-local environment setup after the shell starts.
+
+## Terminal Defaults
+
+Preferences → Terminal includes defaults applied to every newly spawned PTY:
+
+- Environment rules.
+- A `Before shell starts` command.
+- Plain split behavior for **Split Horizontal** and **Split Vertical**.
+
+Settings apply only to new PTYs. Existing shells are not mutated.
+
+Plain split behavior controls what the plain split commands do:
+
+- `plainShell` — always spawn a plain shell.
+- `appDefaultProfile` — spawn with the configured default agent profile.
+- `activePaneProfile` — reuse the focused pane's profile when available.
+- `askEveryTime` — open the existing split-with-profile picker.
+
+The explicit **Split Horizontal with Profile...** and **Split Vertical with
+Profile...** commands always show the picker, regardless of this setting.
+
+## Environment Rules
+
+Profile and terminal-default `env` values are JSON objects keyed by variable
+name. The editor validates the shape before saving.
+
+Legacy string values still work:
+
+```json
+{
+  "AWS_PROFILE": "prod"
+}
+```
+
+Structured rules support four modes:
+
+```json
+{
+  "AWS_PROFILE": { "mode": "value", "value": "prod" },
+  "PATH": { "mode": "inherit" },
+  "AWS_REGION": { "mode": "unset" },
+  "TOKEN": { "mode": "command", "command": "op read op://Work/token/value" }
+}
+```
+
+Rule behavior:
+
+- `value` sets the variable to the exact configured string.
+- `inherit` leaves the currently resolved value alone if one exists.
+- `unset` removes the variable from the spawned process environment.
+- `command` runs a non-interactive command before spawn and sets the variable
+  from trimmed stdout.
+
+Command-derived values are not logged by default. If a command rule fails,
+shell creation aborts and the error names the variable without printing stdout
+or stderr.
+
+## Preflight Commands
+
+`beforeShellStarts` runs before the PTY is spawned, after environment rules are
+resolved. Use it for readiness checks or authentication steps that need to
+complete before the shell exists.
+
+Example AWS SSO profile preflight:
+
+```sh
+aws sts get-caller-identity --profile prod >/dev/null 2>&1 || aws sso login --profile prod
+```
+
+Terminal-default preflight runs before profile preflight. Both run with the
+final resolved environment.
+
+## Precedence
+
+Environment is resolved in this order:
+
+```text
+daemon base env -> global terminal env -> Roux session env -> profile env -> per-launch overrides
+```
+
+`inherit` means inherit from the resolved environment at that point. It does
+not inspect live exports inside an already-running shell.
+
+## Example AWS SSO Profile
+
+```json
+{
+  "id": "aws-prod",
+  "name": "AWS prod",
+  "source": "user",
+  "env": {
+    "AWS_PROFILE": { "mode": "value", "value": "prod" },
+    "AWS_REGION": { "mode": "value", "value": "us-east-1" }
+  },
+  "beforeShellStarts": "aws sts get-caller-identity --profile prod >/dev/null 2>&1 || aws sso login --profile prod",
+  "startupCommand": "claude",
+  "startupBehavior": "autoRun"
+}
+```
+
+Roux resolves the env and runs the preflight before spawning the PTY. After the
+PTY exists, Roux may type the true shell setup/startup commands. It no longer
+types `export KEY=value` into the frontend terminal for profile env.

--- a/docs/features/terminal-profiles.md
+++ b/docs/features/terminal-profiles.md
@@ -60,7 +60,8 @@ Rule behavior:
 
 Command-derived values are not logged by default. If a command rule fails,
 shell creation aborts and the error names the variable without printing stdout
-or stderr.
+or stderr. Command rules must return promptly; they are not intended for
+interactive authentication.
 
 ## Preflight Commands
 
@@ -75,18 +76,22 @@ aws sts get-caller-identity --profile prod >/dev/null 2>&1 || aws sso login --pr
 ```
 
 Terminal-default preflight runs before profile preflight. Both run with the
-final resolved environment.
+final resolved environment. Preflight commands may perform readiness or
+authentication work, so Roux does not impose a fixed timeout; choose commands
+whose blocking behavior is acceptable for shell creation.
 
 ## Precedence
 
 Environment is resolved in this order:
 
 ```text
-daemon base env -> global terminal env -> Roux session env -> profile env -> per-launch overrides
+daemon base env -> global terminal env -> Roux session env -> profile env -> per-launch overrides -> protected Roux session env
 ```
 
 `inherit` means inherit from the resolved environment at that point. It does
-not inspect live exports inside an already-running shell.
+not inspect live exports inside an already-running shell. Roux-owned session
+variables such as pane and session identifiers are re-applied last so profile
+or launch rules cannot break hook routing.
 
 ## Example AWS SSO Profile
 

--- a/docs/v2/daemon-protocol.md
+++ b/docs/v2/daemon-protocol.md
@@ -111,6 +111,9 @@ Supported `args`:
 - `base`: optional branch start point.
 - `fetchFirst`: run `git fetch origin` before resolving `base`.
 - `profile`: spawn profile id.
+- `profileData`: optional inline spawn profile. When present, it is used for
+  spawn-time env/preflight resolution without requiring a registered profile.
+- `envOverrides`: optional per-launch terminal env rules.
 - `initialSize`: `[cols, rows]`.
 - `projectId`, `blueprintId`.
 - `notesEnv`: notes env snapshot for the primary PTY.
@@ -118,11 +121,15 @@ Supported `args`:
 Returns the created session. If daemon PTY spawn fails after creating a new
 worktree, the daemon attempts to remove the worktree before returning an error.
 
+The daemon applies terminal defaults from settings, Roux session env,
+profile env, and per-launch env overrides before creating the PTY. Profile env
+is not typed into the frontend terminal as `export` commands.
+
 `session-reconnect-shell`
 
 Requires `session_id`. Respawns the primary PTY using the existing session
 record and returns the updated session. Supported `args`: `profile`,
-`initialSize`, `notesEnv`.
+`profileData`, `envOverrides`, `initialSize`, `notesEnv`.
 
 `session-archive`
 
@@ -921,8 +928,32 @@ Starts a daemon-owned shell PTY. Common `args`:
 
 - `id`, `workingDir`, `sessionId`, `paneId`
 - `projectId`, `worktreePath`, `notesEnv`
-- `profile`, `initialSize`
+- `profile`, `profileData`, `envOverrides`, `initialSize`
 - `role`: `sessionPrimary` or `secondary`
+
+`profileData` is an inline `SpawnProfile`. `envOverrides` is a map of terminal
+environment rules. Rules accept either legacy string values or structured
+objects:
+
+```json
+{
+  "AWS_PROFILE": "prod",
+  "AWS_REGION": { "mode": "value", "value": "us-east-1" },
+  "AWS_TOKEN": { "mode": "command", "command": "op read op://Work/aws/token" },
+  "AWS_SESSION_TOKEN": { "mode": "unset" }
+}
+```
+
+The daemon resolves env in this order:
+
+```text
+daemon base env -> global terminal env -> Roux session env -> profile env -> per-launch overrides
+```
+
+If `profileData` is omitted and `profile` is supplied, the daemon resolves the
+profile id from settings and built-ins. Terminal-default `beforeShellStarts`
+runs before profile `beforeShellStarts`; command-mode env stdout is trimmed
+and not logged by default.
 
 Returns a PTY record.
 

--- a/docs/v2/daemon-protocol.md
+++ b/docs/v2/daemon-protocol.md
@@ -947,13 +947,17 @@ objects:
 The daemon resolves env in this order:
 
 ```text
-daemon base env -> global terminal env -> Roux session env -> profile env -> per-launch overrides
+daemon base env -> global terminal env -> Roux session env -> profile env -> per-launch overrides -> protected Roux session env
 ```
 
 If `profileData` is omitted and `profile` is supplied, the daemon resolves the
 profile id from settings and built-ins. Terminal-default `beforeShellStarts`
 runs before profile `beforeShellStarts`; command-mode env stdout is trimmed
-and not logged by default.
+and not logged by default. Command-mode env commands must return promptly and
+are not intended for interactive authentication. Roux-owned session variables
+are re-applied last so profile or launch rules cannot corrupt hook routing.
+Preflight commands may perform authentication work, so the daemon does not
+impose a fixed timeout.
 
 Returns a PTY record.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roux",
-  "version": "0.5.3-pre.9",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roux",
-      "version": "0.5.3-pre.9",
+      "version": "0.5.3",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",
@@ -25,7 +25,8 @@
         "bits-ui": "^2.17.0",
         "codemirror": "^6.0.2",
         "dompurify": "^3.4.1",
-        "marked": "^17.0.6"
+        "marked": "^17.0.6",
+        "svelte-jsoneditor": "^3.12.0"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^5.0.0",
@@ -1155,6 +1156,39 @@
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
     },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.2.0.tgz",
+      "integrity": "sha512-IpR0bER9FY25p+e7BmFH25MZKEwFHTfRAfhOyJubgiDnoJNsSvJ7nigLraHtp4VOG/cy8D7uiV0dLkHOne5Fhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-regular-svg-icons": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-7.2.0.tgz",
+      "integrity": "sha512-iycmlN51EULlQ4D/UU9WZnHiN0CvjJ2TuuCrAh+1MVdzD+4ViKYH2deNAll4XAAYlZa8WAefHR5taSK8hYmSMw==",
+      "license": "(CC-BY-4.0 AND MIT)",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "7.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-7.2.0.tgz",
+      "integrity": "sha512-YTVITFGN0/24PxzXrwqCgnyd7njDuzp5ZvaCx5nq/jg55kUYd94Nj8UTchBdBofi/L0nwRfjGOg0E41d2u9T1w==",
+      "license": "(CC-BY-4.0 AND MIT)",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "7.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@internationalized/date": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.0.tgz",
@@ -1208,6 +1242,39 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsonquerylang/jsonquery": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@jsonquerylang/jsonquery/-/jsonquery-5.1.1.tgz",
+      "integrity": "sha512-Fj4SoA6Ku09EF+t7OEI8QLipA2A+fJCdEOwnDWG84o5jXMRjkcN5NCMH7kFZb5fP62xz914XV5LBOiDdiUXObg==",
+      "license": "ISC",
+      "bin": {
+        "jsonquery": "bin/cli.js"
       }
     },
     "node_modules/@lezer/common": {
@@ -1401,6 +1468,331 @@
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "license": "MIT"
+    },
+    "node_modules/@parcel/watcher": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+      "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.3",
+        "is-glob": "^4.0.3",
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.5.6",
+        "@parcel/watcher-darwin-arm64": "2.5.6",
+        "@parcel/watcher-darwin-x64": "2.5.6",
+        "@parcel/watcher-freebsd-x64": "2.5.6",
+        "@parcel/watcher-linux-arm-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm-musl": "2.5.6",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm64-musl": "2.5.6",
+        "@parcel/watcher-linux-x64-glibc": "2.5.6",
+        "@parcel/watcher-linux-x64-musl": "2.5.6",
+        "@parcel/watcher-win32-arm64": "2.5.6",
+        "@parcel/watcher-win32-ia32": "2.5.6",
+        "@parcel/watcher-win32-x64": "2.5.6"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+      "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+      "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+      "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+      "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+      "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+      "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+      "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+      "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+      "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+      "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+      "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+      "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@replit/codemirror-indentation-markers": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@replit/codemirror-indentation-markers/-/codemirror-indentation-markers-6.5.3.tgz",
+      "integrity": "sha512-hL5Sfvw3C1vgg7GolLe/uxX5T3tmgOA3ZzqlMv47zjU1ON51pzNWiVbS22oh6crYhtVhv8b3gdXwoYp++2ilHw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
     },
     "node_modules/@replit/codemirror-vim": {
       "version": "6.3.0",
@@ -1764,6 +2156,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@sphinxxxx/color-conversion": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@sphinxxxx/color-conversion/-/color-conversion-2.2.2.tgz",
+      "integrity": "sha512-XExJS3cLqgrmNBIP3bBw6+1oQ1ksGjFh0+oClDKFYpCCqx/hlqwWO5KO/S63fzUo67SxI9dMrF0y5T/Ey7h8Zw==",
+      "license": "ISC"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -2654,6 +3052,22 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -2789,6 +3203,17 @@
         "@codemirror/view": "^6.0.0"
       }
     },
+    "node_modules/codemirror-wrapped-line-indent": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/codemirror-wrapped-line-indent/-/codemirror-wrapped-line-indent-1.0.9.tgz",
+      "integrity": "sha512-oc976hHLt35u6Ojbhub+IWOxEpapZSqYieLEdGhsgFZ4rtYQtdb5KjxzgjCCyVe3t0yk+a6hmaIOEsjU/tZRxQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@codemirror/language": "^6.9.0",
+        "@codemirror/state": "^6.2.1",
+        "@codemirror/view": "^6.17.1"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -2878,7 +3303,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -2889,6 +3314,15 @@
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.4.tgz",
       "integrity": "sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==",
       "license": "MIT"
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
     },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
@@ -3018,6 +3452,28 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -3071,11 +3527,46 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/immutable": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.6.tgz",
+      "integrity": "sha512-q1swsS8K7L8usSHuOqF2TAoCCkonYz0SG38wLAggaa4Wml70zixIvt2ql4coQ2C2B3hTjltJry4r6bULwgAXLQ==",
+      "license": "MIT"
+    },
+    "node_modules/immutable-json-patch": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/immutable-json-patch/-/immutable-json-patch-6.0.2.tgz",
+      "integrity": "sha512-KwCA5DXJiyldda8SPha1zB+6+vbEi5/jRRcYii/6yFXlyu9ZjiSH/wPq8Ri2Hk8iGjjTMcHW3Z21S4MOpl7sOw==",
+      "license": "ISC"
+    },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
       "license": "MIT"
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
@@ -3101,6 +3592,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jmespath": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/js-tokens": {
@@ -3149,6 +3649,54 @@
         "canvas": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jsep": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/json-source-map/-/json-source-map-0.6.1.tgz",
+      "integrity": "sha512-1QoztHPsMQqhDq0hlXY5ZqcEdUzxQEIxgFkKl4WUp2pgShObl+9ovi4kRh2TfvAfxAoHOJ9vIMEqk3k4iex7tg==",
+      "license": "MIT"
+    },
+    "node_modules/jsonpath-plus": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.4.0.tgz",
+      "integrity": "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/jsonrepair": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/jsonrepair/-/jsonrepair-3.14.0.tgz",
+      "integrity": "sha512-tWPGKMZf/8UPim+fcW2EfcQ/d/7aKUrP6IECz9G3Tu6Q5dX0orSleqJ9z6sSw7qrQkjF8/Edo4DvsWBZ8H+HNg==",
+      "license": "ISC",
+      "bin": {
+        "jsonrepair": "bin/cli.js"
       }
     },
     "node_modules/kleur": {
@@ -3428,6 +3976,12 @@
       "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
       "license": "MIT"
     },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "11.2.7",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
@@ -3475,6 +4029,12 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
+      "license": "MIT"
+    },
     "node_modules/mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -3510,6 +4070,19 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/natural-compare-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
+      "license": "MIT"
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/obug": {
       "version": "2.1.1",
@@ -3553,7 +4126,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3641,7 +4214,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3729,6 +4301,54 @@
         "node": ">=6"
       }
     },
+    "node_modules/sass": {
+      "version": "1.100.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.100.0.tgz",
+      "integrity": "sha512-B5j0rYMlinhhOo9tjQebMVVn0TfyXAF+wB3b2ggZUuJ/is/Y+7+JGjirAMxHZ9Z3hIP98NPfamlAkBHa1lAaXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^5.0.0",
+        "immutable": "^5.1.5",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher": "^2.4.1"
+      }
+    },
+    "node_modules/sass/node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/sass/node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -3753,7 +4373,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -3815,6 +4434,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/svelte-awesome": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/svelte-awesome/-/svelte-awesome-3.3.5.tgz",
+      "integrity": "sha512-RIi+OI6CEn+fTdYy7UOgImEUWvdQSwP9SiMC44UKyFO+8+gjj+NgTG67hI8j2rTHQVvCP820Uj+4UoZG8CCUfA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "svelte": ">= 3.43.1 < 6"
+      }
+    },
     "node_modules/svelte-check": {
       "version": "4.4.6",
       "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.4.6.tgz",
@@ -3837,6 +4465,64 @@
       "peerDependencies": {
         "svelte": "^4.0.0 || ^5.0.0-next.0",
         "typescript": ">=5.0.0"
+      }
+    },
+    "node_modules/svelte-floating-ui": {
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/svelte-floating-ui/-/svelte-floating-ui-1.5.8.tgz",
+      "integrity": "sha512-dVvJhZ2bT+kQDHlE4Lep8t+sgEc0XD96fXLzAi2DDI2bsaegBbClxXVNMma0C2WsG+n9GJSYx292dTvA8CYRtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.5.0",
+        "@floating-ui/dom": "^1.5.3"
+      }
+    },
+    "node_modules/svelte-jsoneditor": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/svelte-jsoneditor/-/svelte-jsoneditor-3.12.0.tgz",
+      "integrity": "sha512-BUWsAmmDbQTs4AAMvVGA09X1aP8l1kr7dDdzbLVPX8895Ov52PVoAlAsCXERPh+GIan+qZTEBqwSqbM3VRMBaw==",
+      "license": "ISC",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.18.1",
+        "@codemirror/commands": "^6.7.1",
+        "@codemirror/lang-json": "^6.0.1",
+        "@codemirror/language": "^6.10.3",
+        "@codemirror/lint": "^6.8.2",
+        "@codemirror/search": "^6.5.6",
+        "@codemirror/state": "^6.4.1",
+        "@codemirror/view": "^6.34.1",
+        "@fortawesome/free-regular-svg-icons": "^6.6.0 || ^7.0.1",
+        "@fortawesome/free-solid-svg-icons": "^6.6.0 || ^7.0.1",
+        "@jsonquerylang/jsonquery": "^3.1.1 || ^4.0.0 || ^5.0.0",
+        "@lezer/highlight": "^1.2.1",
+        "@replit/codemirror-indentation-markers": "^6.5.3",
+        "ajv": "^8.17.1",
+        "codemirror-wrapped-line-indent": "^1.0.8",
+        "diff-sequences": "^29.6.3",
+        "immutable-json-patch": "^6.0.1",
+        "jmespath": "^0.16.0",
+        "json-source-map": "^0.6.1",
+        "jsonpath-plus": "^10.3.0",
+        "jsonrepair": "^3.0.0",
+        "lodash-es": "^4.17.23",
+        "memoize-one": "^6.0.0",
+        "natural-compare-lite": "^1.4.0",
+        "sass": "^1.80.4",
+        "svelte-awesome": "^3.3.5",
+        "svelte-select": "^5.8.3",
+        "vanilla-picker": "^2.12.3"
+      },
+      "peerDependencies": {
+        "svelte": "^5.0.0"
+      }
+    },
+    "node_modules/svelte-select": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/svelte-select/-/svelte-select-5.8.3.tgz",
+      "integrity": "sha512-nQsvflWmTCOZjssdrNptzfD1Ok45hHVMTL5IHay5DINk7dfu5Er+8KsVJnZMJdSircqtR0YlT4YkCFlxOUhVPA==",
+      "license": "ISC",
+      "dependencies": {
+        "svelte-floating-ui": "1.5.8"
       }
     },
     "node_modules/svelte-toolbelt": {
@@ -4011,6 +4697,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
+      }
+    },
+    "node_modules/vanilla-picker": {
+      "version": "2.12.3",
+      "resolved": "https://registry.npmjs.org/vanilla-picker/-/vanilla-picker-2.12.3.tgz",
+      "integrity": "sha512-qVkT1E7yMbUsB2mmJNFmaXMWE2hF8ffqzMMwe9zdAikd8u2VfnsVY2HQcOUi2F38bgbxzlJBEdS1UUhOXdF9GQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@sphinxxxx/color-conversion": "^2.2.2"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "bits-ui": "^2.17.0",
     "codemirror": "^6.0.2",
     "dompurify": "^3.4.1",
-    "marked": "^17.0.6"
+    "marked": "^17.0.6",
+    "svelte-jsoneditor": "^3.12.0"
   }
 }

--- a/src-tauri/src/commands/daemon.rs
+++ b/src-tauri/src/commands/daemon.rs
@@ -146,6 +146,8 @@ pub(crate) async fn daemon_pty_spawn_shell(
             session_id,
             pane_id,
             profile,
+            None,
+            None,
             initial_size,
         )
         .await
@@ -165,7 +167,17 @@ pub(crate) async fn daemon_pty_spawn_task(
 ) -> Result<PtyRecord, String> {
     let client = required_daemon_client_ref(&state)?;
     client
-        .spawn_daemon_pty_task(command, id, working_dir, session_id, pane_id, profile, initial_size)
+        .spawn_daemon_pty_task(
+            command,
+            id,
+            working_dir,
+            session_id,
+            pane_id,
+            profile,
+            None,
+            None,
+            initial_size,
+        )
         .await
         .map_err(Into::into)
 }

--- a/src-tauri/src/commands/external_tools.rs
+++ b/src-tauri/src/commands/external_tools.rs
@@ -151,6 +151,8 @@ async fn launch_terminal_tool(
             session_id,
             None,
             None,
+            None,
+            None,
             initial_size,
         )
         .await

--- a/src-tauri/src/commands/sessions.rs
+++ b/src-tauri/src/commands/sessions.rs
@@ -4,6 +4,7 @@ use crate::state::{
     required_daemon_client, required_daemon_client_ref, AppState, DaemonPtyAttachTask,
 };
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use tauri::Manager;
 
@@ -19,6 +20,10 @@ pub(crate) struct CreateShellOpts {
     /// the PTY env so agents wake up under the right profile.
     #[serde(default)]
     pub profile: Option<String>,
+    #[serde(default)]
+    pub profile_data: Option<roux_core::SpawnProfile>,
+    #[serde(default)]
+    pub env_overrides: Option<BTreeMap<String, roux_core::TerminalEnvRule>>,
     #[serde(default)]
     pub initial_size: Option<(u16, u16)>,
     /// Git starting point for a new worktree's branch (e.g. "main",
@@ -39,6 +44,17 @@ pub(crate) struct CreateShellOpts {
     /// blueprint row when the live session is up.
     #[serde(default)]
     pub blueprint_id: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SpawnPtyOpts {
+    #[serde(default)]
+    pub profile_data: Option<roux_core::SpawnProfile>,
+    #[serde(default)]
+    pub env_overrides: Option<BTreeMap<String, roux_core::TerminalEnvRule>>,
+    #[serde(default)]
+    pub initial_size: Option<(u16, u16)>,
 }
 
 pub(crate) fn abort_daemon_attach_task(state: &AppState, id: &str) -> Result<(), String> {
@@ -142,10 +158,11 @@ pub(crate) async fn spawn_shell(
     session_id: Option<String>,
     pane_id: Option<String>,
     profile: Option<String>,
-    initial_size: Option<(u16, u16)>,
+    opts: Option<SpawnPtyOpts>,
     state: tauri::State<'_, AppState>,
     _app: tauri::AppHandle,
 ) -> Result<(), String> {
+    let opts = opts.unwrap_or_default();
     let client = required_daemon_client(&state)?;
     client
         .spawn_daemon_pty_shell(
@@ -154,7 +171,9 @@ pub(crate) async fn spawn_shell(
             session_id,
             pane_id,
             profile,
-            initial_size,
+            opts.profile_data,
+            opts.env_overrides,
+            opts.initial_size,
         )
         .await?;
     Ok(())
@@ -169,10 +188,11 @@ pub(crate) async fn spawn_task(
     session_id: Option<String>,
     pane_id: Option<String>,
     profile: Option<String>,
-    initial_size: Option<(u16, u16)>,
+    opts: Option<SpawnPtyOpts>,
     state: tauri::State<'_, AppState>,
     _app: tauri::AppHandle,
 ) -> Result<(), String> {
+    let opts = opts.unwrap_or_default();
     // See spawn_shell above: project/worktree env is deferred for the
     // secondary-pane path until this command goes async.
     let context = crate::automation_hooks::HookContext {
@@ -199,7 +219,9 @@ pub(crate) async fn spawn_task(
             session_id.clone(),
             pane_id,
             profile,
-            initial_size,
+            opts.profile_data,
+            opts.env_overrides,
+            opts.initial_size,
         )
         .await?;
     let scope = session_id.as_ref().map(|_| "session".to_string());
@@ -497,6 +519,8 @@ pub(crate) async fn create_session_shell(
             base: daemon_base,
             fetch_first: daemon_fetch_first,
             profile: opts.profile,
+            profile_data: opts.profile_data,
+            env_overrides: opts.env_overrides,
             initial_size,
             project_id: opts.project_id,
             blueprint_id: opts.blueprint_id,
@@ -515,6 +539,8 @@ pub(crate) async fn create_session_shell(
 pub(crate) async fn reconnect_session_shell(
     id: String,
     profile: Option<String>,
+    profile_data: Option<roux_core::SpawnProfile>,
+    env_overrides: Option<BTreeMap<String, roux_core::TerminalEnvRule>>,
     initial_size: Option<(u16, u16)>,
     state: tauri::State<'_, AppState>,
     _app: tauri::AppHandle,
@@ -541,6 +567,8 @@ pub(crate) async fn reconnect_session_shell(
         .reconnect_session_shell(crate::daemon_client::DaemonReconnectSessionShellRequest {
             id,
             profile,
+            profile_data,
+            env_overrides,
             initial_size,
             notes: Some(notes),
         })

--- a/src-tauri/src/daemon_client.rs
+++ b/src-tauri/src/daemon_client.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::Duration;
@@ -73,6 +74,8 @@ pub(crate) struct DaemonCreateSessionShellRequest {
     pub(crate) base: Option<String>,
     pub(crate) fetch_first: bool,
     pub(crate) profile: Option<String>,
+    pub(crate) profile_data: Option<roux_core::SpawnProfile>,
+    pub(crate) env_overrides: Option<BTreeMap<String, roux_core::TerminalEnvRule>>,
     pub(crate) initial_size: Option<(u16, u16)>,
     pub(crate) project_id: Option<String>,
     pub(crate) blueprint_id: Option<String>,
@@ -83,6 +86,8 @@ pub(crate) struct DaemonCreateSessionShellRequest {
 pub(crate) struct DaemonReconnectSessionShellRequest {
     pub(crate) id: String,
     pub(crate) profile: Option<String>,
+    pub(crate) profile_data: Option<roux_core::SpawnProfile>,
+    pub(crate) env_overrides: Option<BTreeMap<String, roux_core::TerminalEnvRule>>,
     pub(crate) initial_size: Option<(u16, u16)>,
     pub(crate) notes: Option<NotesEnvInputs>,
 }
@@ -698,6 +703,8 @@ impl DaemonClient {
                 base: request.base,
                 fetch_first: request.fetch_first,
                 profile: request.profile,
+                profile_data: request.profile_data,
+                env_overrides: request.env_overrides,
                 initial_size: request.initial_size,
                 project_id: request.project_id,
                 blueprint_id: request.blueprint_id,
@@ -715,6 +722,8 @@ impl DaemonClient {
             .reconnect_session_shell(roux_sdk::ReconnectSessionShell {
                 id: request.id,
                 profile: request.profile,
+                profile_data: request.profile_data,
+                env_overrides: request.env_overrides,
                 initial_size: request.initial_size,
                 notes: request.notes.map(sdk_notes_env),
             })
@@ -865,6 +874,8 @@ impl DaemonClient {
         session_id: Option<String>,
         pane_id: Option<String>,
         profile: Option<String>,
+        profile_data: Option<roux_core::SpawnProfile>,
+        env_overrides: Option<BTreeMap<String, roux_core::TerminalEnvRule>>,
         initial_size: Option<(u16, u16)>,
     ) -> DaemonClientResult<PtyRecord> {
         let mut spawn = self.sdk.spawn_shell();
@@ -883,6 +894,12 @@ impl DaemonClient {
         if let Some(profile) = profile {
             spawn = spawn.profile(profile);
         }
+        if let Some(profile_data) = profile_data {
+            spawn = spawn.profile_data(profile_data);
+        }
+        if let Some(env_overrides) = env_overrides {
+            spawn = spawn.env_overrides(env_overrides);
+        }
         if let Some((cols, rows)) = initial_size {
             spawn = spawn.initial_size(cols, rows);
         }
@@ -897,6 +914,8 @@ impl DaemonClient {
         session_id: Option<String>,
         pane_id: Option<String>,
         profile: Option<String>,
+        profile_data: Option<roux_core::SpawnProfile>,
+        env_overrides: Option<BTreeMap<String, roux_core::TerminalEnvRule>>,
         initial_size: Option<(u16, u16)>,
     ) -> DaemonClientResult<PtyRecord> {
         let mut spawn = self.sdk.spawn_task(command);
@@ -914,6 +933,12 @@ impl DaemonClient {
         }
         if let Some(profile) = profile {
             spawn = spawn.profile(profile);
+        }
+        if let Some(profile_data) = profile_data {
+            spawn = spawn.profile_data(profile_data);
+        }
+        if let Some(env_overrides) = env_overrides {
+            spawn = spawn.env_overrides(env_overrides);
         }
         if let Some((cols, rows)) = initial_size {
             spawn = spawn.initial_size(cols, rows);

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -70,6 +70,9 @@ fn command_builder_from_plan(plan: &pty_spawn::PtyCommandPlan) -> CommandBuilder
     for (key, value) in &plan.env {
         cmd.env(key, value);
     }
+    for key in &plan.env_remove {
+        cmd.env_remove(key);
+    }
     cmd.cwd(&plan.cwd);
     cmd
 }

--- a/src-tauri/src/socket.rs
+++ b/src-tauri/src/socket.rs
@@ -475,7 +475,9 @@ async fn handle_session_poll(req: Request, app: &tauri::AppHandle) -> Response {
 async fn handle_session_rename(req: Request, app: &tauri::AppHandle) -> Response {
     let session_id = match req.session_id.as_deref() {
         Some(id) => id.to_string(),
-        None => return Response::err("session_id required (set $ROUX_SESSION_ID or pass --session)"),
+        None => {
+            return Response::err("session_id required (set $ROUX_SESSION_ID or pass --session)")
+        }
     };
     let raw = match req.args.get("name").and_then(|n| n.as_str()) {
         Some(n) => n.to_string(),
@@ -483,11 +485,11 @@ async fn handle_session_rename(req: Request, app: &tauri::AppHandle) -> Response
     };
     // Empty / whitespace-only name clears the override (matches the
     // GUI's clearSessionNameOverride path).
-    let name_override =
-        if raw.trim().is_empty() { None } else { Some(raw.trim().to_string()) };
+    let name_override = if raw.trim().is_empty() { None } else { Some(raw.trim().to_string()) };
 
     let state: tauri::State<AppState> = app.state();
-    if let Err(e) = state.runtime.session_handle.set_name_override(&session_id, name_override.clone()).await
+    if let Err(e) =
+        state.runtime.session_handle.set_name_override(&session_id, name_override.clone()).await
     {
         return Response::err(format!("{}", e));
     }
@@ -508,14 +510,11 @@ async fn handle_session_kill(req: Request, app: &tauri::AppHandle) -> Response {
     let session_id = match req.session_id.as_deref() {
         Some(id) => id.to_string(),
         None => {
-            return Response::err(
-                "session_id required (set $ROUX_SESSION_ID or pass --session)",
-            )
+            return Response::err("session_id required (set $ROUX_SESSION_ID or pass --session)")
         }
     };
     let state: tauri::State<AppState> = app.state();
-    if let Err(e) =
-        crate::commands::sessions::archive_session_with_hooks(&state, &session_id).await
+    if let Err(e) = crate::commands::sessions::archive_session_with_hooks(&state, &session_id).await
     {
         return Response::err(e);
     }
@@ -854,8 +853,7 @@ async fn handle_session_create(req: Request, app: &tauri::AppHandle) -> Response
     let working_dir = req.args.get("working_dir").and_then(|d| d.as_str()).map(|s| s.to_string());
     let worktree_branch =
         req.args.get("worktree_branch").and_then(|d| d.as_str()).map(|s| s.to_string());
-    let start_point =
-        req.args.get("start_point").and_then(|d| d.as_str()).map(|s| s.to_string());
+    let start_point = req.args.get("start_point").and_then(|d| d.as_str()).map(|s| s.to_string());
     let prompt = req.args.get("prompt").and_then(|d| d.as_str()).map(|s| s.to_string());
     let profile = req.args.get("profile").and_then(|p| p.as_str()).unwrap_or("claude").to_string();
     let flags: Vec<String> = req
@@ -893,11 +891,7 @@ async fn handle_session_create(req: Request, app: &tauri::AppHandle) -> Response
     // origin ref so it resolves to an up-to-date commit.
     let target = if let Some(branch) = worktree_branch.as_deref() {
         let fetch_first = start_point.as_deref().is_some_and(|sp| sp.starts_with("origin/"));
-        SessionTarget::NewWorktree {
-            branch,
-            start_point: start_point.as_deref(),
-            fetch_first,
-        }
+        SessionTarget::NewWorktree { branch, start_point: start_point.as_deref(), fetch_first }
     } else {
         match &working_dir {
             Some(dir) if dir != &repo_path => SessionTarget::ExistingWorktree { path: dir },
@@ -1322,15 +1316,14 @@ async fn prepare_send(
     let session_id = req.session_id.as_deref().ok_or_else(|| "session_id required".to_string())?;
 
     let pane_type = req.args.get("pane_type").and_then(|v| v.as_str());
-    let pty_id =
-        resolve_send_pty_id(
-            pane_handle,
-            session_handle,
-            session_id,
-            req.pane_id.as_deref(),
-            pane_type,
-        )
-        .await?;
+    let pty_id = resolve_send_pty_id(
+        pane_handle,
+        session_handle,
+        session_id,
+        req.pane_id.as_deref(),
+        pane_type,
+    )
+    .await?;
 
     let cr = req.args.get("enter").and_then(|v| v.as_bool()).unwrap_or(true);
     let data = format_send_data(&text, cr).into_bytes();
@@ -1339,11 +1332,11 @@ async fn prepare_send(
 
 async fn handle_send(req: Request, app: &tauri::AppHandle) -> Response {
     let state: tauri::State<AppState> = app.state();
-    let (pty_id, bytes) = match prepare_send(&state.runtime.pane_handle, &state.runtime.session_handle, &req).await
-    {
-        Ok(pair) => pair,
-        Err(e) => return Response::err(e),
-    };
+    let (pty_id, bytes) =
+        match prepare_send(&state.runtime.pane_handle, &state.runtime.session_handle, &req).await {
+            Ok(pair) => pair,
+            Err(e) => return Response::err(e),
+        };
     if let Err(e) = state.pty_manager.write(&pty_id, &bytes) {
         return Response::err(format!("Failed to write to session: {}", e));
     }
@@ -1479,20 +1472,21 @@ async fn handle_alias_set(req: Request, app: &tauri::AppHandle) -> Response {
     };
     // Caller may target a specific session via args.session_id; otherwise
     // default to the calling session's id.
-    let session_id = args_str(&req, "session_id")
-        .map(String::from)
-        .or_else(|| req.session_id.clone());
+    let session_id =
+        args_str(&req, "session_id").map(String::from).or_else(|| req.session_id.clone());
     let session_id = match session_id {
         Some(s) => s,
-        None => return Response::err("session_id required (call from a session, or pass args.session_id)"),
+        None => {
+            return Response::err(
+                "session_id required (call from a session, or pass args.session_id)",
+            )
+        }
     };
     let project_id = args_str(&req, "project_id").map(String::from);
     let force = args_bool(&req, "force").unwrap_or(false);
     // `args.pane_id` overrides `req.pane_id` (both are optional). Without
     // either, the binding stays at session-level for Phase-1 compat.
-    let pane_id = args_str(&req, "pane_id")
-        .map(String::from)
-        .or_else(|| req.pane_id.clone());
+    let pane_id = args_str(&req, "pane_id").map(String::from).or_else(|| req.pane_id.clone());
 
     let state: tauri::State<AppState> = app.state();
     let bind_req = roux_lib::aliases::BindRequest {
@@ -1541,9 +1535,7 @@ async fn handle_alias_claim(req: Request, app: &tauri::AppHandle) -> Response {
     // Claim picks up the calling pane via `req.pane_id` (set by the CLI
     // from `$ROUX_PANE_ID`). `args.pane_id` lets the caller target a
     // specific pane explicitly, useful from MCP / programmatic clients.
-    let pane_id = args_str(&req, "pane_id")
-        .map(String::from)
-        .or_else(|| req.pane_id.clone());
+    let pane_id = args_str(&req, "pane_id").map(String::from).or_else(|| req.pane_id.clone());
 
     let state: tauri::State<AppState> = app.state();
     let bind_req = roux_lib::aliases::BindRequest {
@@ -1595,8 +1587,7 @@ async fn handle_alias_get(req: Request, app: &tauri::AppHandle) -> Response {
             0 => Response::err(format!("alias '{canonical}' not found")),
             1 => Response::success(serde_json::to_value(&matches[0]).unwrap_or_default()),
             _ => {
-                let projects: Vec<_> =
-                    matches.iter().map(|a| a.project_id.clone()).collect();
+                let projects: Vec<_> = matches.iter().map(|a| a.project_id.clone()).collect();
                 Response::err(format!(
                     "alias '{canonical}' is ambiguous across projects {projects:?}; pass project_id"
                 ))
@@ -1608,12 +1599,15 @@ async fn handle_alias_get(req: Request, app: &tauri::AppHandle) -> Response {
 }
 
 async fn handle_alias_whoami(req: Request, app: &tauri::AppHandle) -> Response {
-    let session_id = args_str(&req, "session_id")
-        .map(String::from)
-        .or_else(|| req.session_id.clone());
+    let session_id =
+        args_str(&req, "session_id").map(String::from).or_else(|| req.session_id.clone());
     let session_id = match session_id {
         Some(s) => s,
-        None => return Response::err("session_id required (call from a session, or pass args.session_id)"),
+        None => {
+            return Response::err(
+                "session_id required (call from a session, or pass args.session_id)",
+            )
+        }
     };
     let state: tauri::State<AppState> = app.state();
     let aliases = state.alias_manager.whoami(&session_id);
@@ -1629,13 +1623,12 @@ async fn handle_alias_add_member(req: Request, app: &tauri::AppHandle) -> Respon
         },
         None => return Response::err("alias required"),
     };
-    let pane_id = match args_str(&req, "pane_id").map(str::to_string).or_else(|| req.pane_id.clone()) {
+    let pane_id = match args_str(&req, "pane_id")
+        .map(str::to_string)
+        .or_else(|| req.pane_id.clone())
+    {
         Some(p) => p,
-        None => {
-            return Response::err(
-                "pane_id required (call from a pane, or pass args.pane_id)",
-            )
-        }
+        None => return Response::err("pane_id required (call from a pane, or pass args.pane_id)"),
     };
     let project_id = args_str(&req, "project_id").map(str::to_string);
     let state: tauri::State<AppState> = app.state();
@@ -1654,10 +1647,11 @@ async fn handle_alias_remove_member(req: Request, app: &tauri::AppHandle) -> Res
         },
         None => return Response::err("alias required"),
     };
-    let pane_id = match args_str(&req, "pane_id").map(str::to_string).or_else(|| req.pane_id.clone()) {
-        Some(p) => p,
-        None => return Response::err("pane_id required"),
-    };
+    let pane_id =
+        match args_str(&req, "pane_id").map(str::to_string).or_else(|| req.pane_id.clone()) {
+            Some(p) => p,
+            None => return Response::err("pane_id required"),
+        };
     let project_id = args_str(&req, "project_id").map(str::to_string);
     let state: tauri::State<AppState> = app.state();
     match state.alias_manager.remove_member(&alias, project_id.as_deref(), &pane_id, Some(app)) {
@@ -1689,12 +1683,7 @@ async fn handle_alias_mode(req: Request, app: &tauri::AppHandle) -> Response {
     };
     let project_id = args_str(&req, "project_id").map(str::to_string);
     let state: tauri::State<AppState> = app.state();
-    match state.alias_manager.set_consumption_mode(
-        &alias,
-        project_id.as_deref(),
-        mode,
-        Some(app),
-    ) {
+    match state.alias_manager.set_consumption_mode(&alias, project_id.as_deref(), mode, Some(app)) {
         Ok(a) => Response::success(serde_json::to_value(a).unwrap_or_default()),
         Err(e) => Response::err(e.to_string()),
     }
@@ -1714,9 +1703,7 @@ fn parse_event_kind(s: &str) -> Result<roux_core::EventKind, String> {
         "question" => Ok(EventKind::Question),
         "fyi" => Ok(EventKind::Fyi),
         "signal" => Ok(EventKind::Signal),
-        other => Err(format!(
-            "invalid kind: {other}; expected task|result|question|fyi|signal"
-        )),
+        other => Err(format!("invalid kind: {other}; expected task|result|question|fyi|signal")),
     }
 }
 
@@ -1886,8 +1873,7 @@ async fn handle_mailbox_peek(req: Request, app: &tauri::AppHandle) -> Response {
     };
     let unread_only = args_bool(&req, "unread").unwrap_or(false);
     let filter = mailbox_project_filter(args_str(&req, "project_id"), args_bool(&req, "global"));
-    let mut events =
-        state.mailbox_manager.list_for_recipient(&alias, unread_only, filter);
+    let mut events = state.mailbox_manager.list_for_recipient(&alias, unread_only, filter);
     if let Some(limit) = req.args.get("limit").and_then(|v| v.as_u64()) {
         events.truncate(limit as usize);
     }
@@ -1902,8 +1888,7 @@ async fn handle_mailbox_read(req: Request, app: &tauri::AppHandle) -> Response {
     };
     let with_ack = args_bool(&req, "ack").unwrap_or(false);
     let filter = mailbox_project_filter(args_str(&req, "project_id"), args_bool(&req, "global"));
-    let mut events =
-        state.mailbox_manager.list_for_recipient(&alias, true, filter);
+    let mut events = state.mailbox_manager.list_for_recipient(&alias, true, filter);
     if let Some(limit) = req.args.get("limit").and_then(|v| v.as_u64()) {
         events.truncate(limit as usize);
     }
@@ -2014,9 +1999,7 @@ async fn handle_mailbox_reply(req: Request, app: &tauri::AppHandle) -> Response 
     let recipient = match original.from.as_deref() {
         Some(r) => r.to_string(),
         None => {
-            return Response::err(
-                "cannot reply: original event has no `from` (anonymous sender)",
-            );
+            return Response::err("cannot reply: original event has no `from` (anonymous sender)");
         }
     };
     let canonical_to = roux_core::validate_alias_name(&recipient).ok().unwrap_or(recipient);
@@ -2038,10 +2021,8 @@ async fn handle_mailbox_reply(req: Request, app: &tauri::AppHandle) -> Response 
         None => roux_core::EventKind::Result,
     };
 
-    let mut builder = EventBuilder::new(body)
-        .to(canonical_to.clone())
-        .kind(kind)
-        .correlation_id(correlation_id);
+    let mut builder =
+        EventBuilder::new(body).to(canonical_to.clone()).kind(kind).correlation_id(correlation_id);
     if let Some(f) = from {
         builder = builder.from(f);
     }
@@ -2072,9 +2053,7 @@ async fn handle_mailbox_sent(req: Request, app: &tauri::AppHandle) -> Response {
         None => match default_from(&state, &req) {
             Some(s) => s,
             None => {
-                return Response::err(
-                    "sender required (call from a session, or pass args.sender)",
-                );
+                return Response::err("sender required (call from a session, or pass args.sender)");
             }
         },
     };
@@ -2182,10 +2161,10 @@ fn resolve_subscriber_alias(req: &Request, app: &tauri::AppHandle) -> Result<Str
     })?;
     let held = state.alias_manager.find_for_pane(pane_id);
     match held.len() {
-        0 => Err(
-            "no --alias given and the calling pane holds no alias; pass --alias <name>"
-                .to_string(),
-        ),
+        0 => {
+            Err("no --alias given and the calling pane holds no alias; pass --alias <name>"
+                .to_string())
+        }
         1 => Ok(held[0].alias.clone()),
         _ => {
             let names: Vec<_> = held.iter().map(|a| a.alias.as_str()).collect();
@@ -2330,8 +2309,7 @@ pub(crate) async fn watch_stream_loop<R, W>(
     // (b) `Posted` arm + `TopicDelivered` arm for the same subscribed
     //     event (both broadcast on every post — the watcher must
     //     deliver only once).
-    let mut forwarded_ids: std::collections::HashSet<String> =
-        std::collections::HashSet::new();
+    let mut forwarded_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
 
     if send_backlog {
         let backlog = mailbox.list_for_recipient(alias, true, project_filter);
@@ -2759,8 +2737,9 @@ mod tests {
             crate::session_service::spawn_with_path(vec![], dir.path().join("sessions.json"));
         panes.upsert(pane_record("sid-1-main", "sid-1")).await.unwrap();
 
-        let pty_id =
-            resolve_send_pty_id(&panes, &sessions, "sid-1", Some("sid-1-main"), None).await.unwrap();
+        let pty_id = resolve_send_pty_id(&panes, &sessions, "sid-1", Some("sid-1-main"), None)
+            .await
+            .unwrap();
         assert_eq!(pty_id, "sid-1");
     }
 
@@ -2792,8 +2771,9 @@ mod tests {
             dir.path().join("sessions.json"),
         );
 
-        let err =
-            resolve_send_pty_id(&panes, &sessions, "sid-2", Some("sid-1-main"), None).await.unwrap_err();
+        let err = resolve_send_pty_id(&panes, &sessions, "sid-2", Some("sid-1-main"), None)
+            .await
+            .unwrap_err();
         assert!(err.contains("pane not found"), "got: {}", err);
     }
 
@@ -2813,8 +2793,9 @@ mod tests {
         panes.upsert(pane_record("sid-A-main", "sid-A")).await.unwrap();
         panes.upsert(pane_record("sid-B-main", "sid-B")).await.unwrap();
 
-        let err =
-            resolve_send_pty_id(&panes, &sessions, "sid-B", Some("sid-A-main"), None).await.unwrap_err();
+        let err = resolve_send_pty_id(&panes, &sessions, "sid-B", Some("sid-A-main"), None)
+            .await
+            .unwrap_err();
         assert!(err.contains("does not belong to session"), "got: {}", err);
     }
 
@@ -2825,7 +2806,8 @@ mod tests {
         let (sessions, _sjoin) =
             crate::session_service::spawn_with_path(vec![], dir.path().join("sessions.json"));
 
-        let err = resolve_send_pty_id(&panes, &sessions, "missing-sid", None, None).await.unwrap_err();
+        let err =
+            resolve_send_pty_id(&panes, &sessions, "missing-sid", None, None).await.unwrap_err();
         assert!(err.contains("session not found"), "got: {}", err);
     }
 
@@ -2870,15 +2852,15 @@ mod tests {
         assert_eq!(pty_id, "pty-shell-a");
 
         // Asking for a type with no match errors cleanly.
-        let err =
-            resolve_send_pty_id(&panes, &sessions, "sid-1", None, Some("command")).await.unwrap_err();
+        let err = resolve_send_pty_id(&panes, &sessions, "sid-1", None, Some("command"))
+            .await
+            .unwrap_err();
         assert!(err.contains("no 'command' pane found"), "got: {}", err);
     }
 
     #[test]
     fn request_session_kill_deserializes() {
-        let json =
-            r#"{"command": "session-kill", "session_id": "sid-1"}"#;
+        let json = r#"{"command": "session-kill", "session_id": "sid-1"}"#;
         let req: Request = serde_json::from_str(json).unwrap();
         assert_eq!(req.command, "session-kill");
         assert_eq!(req.session_id.as_deref(), Some("sid-1"));
@@ -3181,6 +3163,7 @@ mod tests {
             startup_command: None,
             startup_behavior: None,
             env: None,
+            before_shell_starts: None,
             cwd_override: None,
             icon: None,
             provider: None,
@@ -3199,6 +3182,7 @@ mod tests {
             startup_command: None,
             startup_behavior: None,
             env: None,
+            before_shell_starts: None,
             cwd_override: None,
             icon: None,
             provider: None,
@@ -3520,10 +3504,8 @@ mod tests {
         let (server_read, server_write) = tokio::io::split(server_side);
         let buf_reader = BufReader::new(server_read);
         tokio::spawn(async move {
-            watch_stream_loop(
-                &mailbox, alias, filter, ack, send_backlog, buf_reader, server_write,
-            )
-            .await;
+            watch_stream_loop(&mailbox, alias, filter, ack, send_backlog, buf_reader, server_write)
+                .await;
         });
         client_side
     }
@@ -3593,12 +3575,7 @@ mod tests {
         let (_dir, mgr, subs) = watch_test_managers();
         // Post BEFORE starting the watcher → the event lives in backlog.
         let event = mgr
-            .post(
-                roux_core::EventBuilder::new("queued")
-                    .to("auditor")
-                    .from("builder"),
-                None,
-            )
+            .post(roux_core::EventBuilder::new("queued").to("auditor").from("builder"), None)
             .unwrap();
 
         let mut client = spawn_watch_for_test(mgr, subs, "auditor", false, true);
@@ -3611,16 +3588,16 @@ mod tests {
     #[tokio::test]
     async fn watch_no_backlog_skips_existing_events() {
         let (_dir, mgr, subs) = watch_test_managers();
-        mgr.post(
-            roux_core::EventBuilder::new("queued")
-                .to("auditor")
-                .from("builder"),
-            None,
-        )
-        .unwrap();
+        mgr.post(roux_core::EventBuilder::new("queued").to("auditor").from("builder"), None)
+            .unwrap();
 
-        let mut client =
-            spawn_watch_for_test(mgr.clone(), subs, "auditor", false, /* send_backlog */ false);
+        let mut client = spawn_watch_for_test(
+            mgr.clone(),
+            subs,
+            "auditor",
+            false,
+            /* send_backlog */ false,
+        );
 
         let frames = read_frames(&mut client, 1, std::time::Duration::from_millis(150)).await;
         // Only `ready` — no event (queued was unread but backlog suppressed).
@@ -3635,20 +3612,10 @@ mod tests {
         tokio::time::sleep(std::time::Duration::from_millis(20)).await;
 
         // Post one to a different alias, one to auditor.
-        mgr.post(
-            roux_core::EventBuilder::new("not for you")
-                .to("reviewer")
-                .from("builder"),
-            None,
-        )
-        .unwrap();
+        mgr.post(roux_core::EventBuilder::new("not for you").to("reviewer").from("builder"), None)
+            .unwrap();
         let mine = mgr
-            .post(
-                roux_core::EventBuilder::new("for you")
-                    .to("auditor")
-                    .from("builder"),
-                None,
-            )
+            .post(roux_core::EventBuilder::new("for you").to("auditor").from("builder"), None)
             .unwrap();
 
         let frames = read_frames(&mut client, 3, std::time::Duration::from_millis(500)).await;
@@ -3702,12 +3669,7 @@ mod tests {
 
         // Post first so the event is unread → goes into the backlog.
         let event = mgr
-            .post(
-                roux_core::EventBuilder::new("queued")
-                    .to("auditor")
-                    .from("builder"),
-                None,
-            )
+            .post(roux_core::EventBuilder::new("queued").to("auditor").from("builder"), None)
             .unwrap();
 
         // The watcher's broadcast subscribe happens inside the spawn,
@@ -3744,21 +3706,13 @@ mod tests {
 
         // Project-scoped event must NOT propagate to a global watcher.
         mgr.post(
-            roux_core::EventBuilder::new("p1")
-                .to("auditor")
-                .from("builder")
-                .project_id("p1"),
+            roux_core::EventBuilder::new("p1").to("auditor").from("builder").project_id("p1"),
             None,
         )
         .unwrap();
         // Global event MUST propagate.
         let global = mgr
-            .post(
-                roux_core::EventBuilder::new("g")
-                    .to("auditor")
-                    .from("builder"),
-                None,
-            )
+            .post(roux_core::EventBuilder::new("g").to("auditor").from("builder"), None)
             .unwrap();
 
         let frames = read_frames(&mut client, 3, std::time::Duration::from_millis(300)).await;
@@ -3778,12 +3732,7 @@ mod tests {
     async fn watch_with_ack_marks_event_read_and_acked() {
         let (_dir, mgr, subs) = watch_test_managers();
         let event = mgr
-            .post(
-                roux_core::EventBuilder::new("queued")
-                    .to("auditor")
-                    .from("builder"),
-                None,
-            )
+            .post(roux_core::EventBuilder::new("queued").to("auditor").from("builder"), None)
             .unwrap();
 
         let mut client =
@@ -3810,12 +3759,7 @@ mod tests {
     async fn forward_event_does_not_ack_when_write_fails() {
         let (_dir, mgr, _subs) = watch_test_managers();
         let event = mgr
-            .post(
-                roux_core::EventBuilder::new("queued")
-                    .to("auditor")
-                    .from("builder"),
-                None,
-            )
+            .post(roux_core::EventBuilder::new("queued").to("auditor").from("builder"), None)
             .unwrap();
 
         // tokio::io::sink() with a custom Empty wouldn't fail — instead

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -900,10 +900,6 @@
             const direction = cmd.direction === "vertical" ? "v" : "h";
             const profileId = cmd.profileId ?? "plain-shell";
 
-            const ptyId = crypto.randomUUID();
-            const paneId = crypto.randomUUID();
-            await spawnShell(ptyId, workingDir, sessionId, paneId);
-
             // Bare shell marker — no profile startup commands. Any other id
             // is backend-validated, so the registry lookup should succeed;
             // throw if it doesn't so the CLI caller sees the failure.
@@ -914,6 +910,16 @@
                 throw new Error(`profile '${profileId}' not found in registry`);
               }
             }
+
+            const ptyId = crypto.randomUUID();
+            const paneId = crypto.randomUUID();
+            await spawnShell(
+              ptyId,
+              workingDir,
+              sessionId,
+              paneId,
+              profile ? profile.id : null,
+            );
 
             const newPaneId = splitPane(sessionId, direction, {
               id: paneId,

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -64,8 +64,8 @@ export const commands = {
 	cmdReadAutomationHookLog: (path: string) => typedError<string, string>(__TAURI_INVOKE("cmd_read_automation_hook_log", { path })),
 	writeToSession: (id: string, data: string) => typedError<null, string>(__TAURI_INVOKE("write_to_session", { id, data })),
 	resizeSession: (id: string, cols: number, rows: number) => typedError<null, string>(__TAURI_INVOKE("resize_session", { id, cols, rows })),
-	spawnShell: (id: string, workingDir: string, sessionId: string | null, paneId: string | null, profile: string | null, initialSize: [number, number] | null) => typedError<null, string>(__TAURI_INVOKE("spawn_shell", { id, workingDir, sessionId, paneId, profile, initialSize })),
-	spawnTask: (id: string, command: string, workingDir: string, sessionId: string | null, paneId: string | null, profile: string | null, initialSize: [number, number] | null) => typedError<null, string>(__TAURI_INVOKE("spawn_task", { id, command, workingDir, sessionId, paneId, profile, initialSize })),
+	spawnShell: (id: string, workingDir: string, sessionId: string | null, paneId: string | null, profile: string | null, opts: SpawnPtyOpts | null) => typedError<null, string>(__TAURI_INVOKE("spawn_shell", { id, workingDir, sessionId, paneId, profile, opts })),
+	spawnTask: (id: string, command: string, workingDir: string, sessionId: string | null, paneId: string | null, profile: string | null, opts: SpawnPtyOpts | null) => typedError<null, string>(__TAURI_INVOKE("spawn_task", { id, command, workingDir, sessionId, paneId, profile, opts })),
 	/**
 	 *  Archive a session (soft-delete). The frontend command name is retained
 	 *  for backward-compat, but the record is kept on disk and shown in the
@@ -158,6 +158,8 @@ export const commands = {
 	 *  blueprint row when the live session is up.
 	 */
 	blueprintId?: string | null,
+	profileData?: SpawnProfile | null,
+	envOverrides?: { [key in string]: TerminalEnvRule } | null,
 } | null) => typedError<Session, string>(__TAURI_INVOKE("create_session_shell", { repoPath, name, worktreePath, branch, opts })),
 	/**
 	 *  Respawns a plain shell in the session's primary PTY. The frontend
@@ -165,7 +167,7 @@ export const commands = {
 	 *  this call returns, so agents come back up the same way they were
 	 *  originally launched via `create_session_shell`.
 	 */
-	reconnectSessionShell: (id: string, profile: string | null, initialSize: [number, number] | null) => typedError<Session, string>(__TAURI_INVOKE("reconnect_session_shell", { id, profile, initialSize })),
+	reconnectSessionShell: (id: string, profile: string | null, initialSize: [number, number] | null, profileData: SpawnProfile | null, envOverrides: { [key in string]: TerminalEnvRule } | null) => typedError<Session, string>(__TAURI_INVOKE("reconnect_session_shell", { id, profile, initialSize, profileData, envOverrides })),
 	/**
 	 *  Active sessions only — archived rows are excluded. The history view
 	 *  uses `list_archived_sessions` for those.
@@ -1055,6 +1057,7 @@ export type RouxSettings = {
 	 *  `"match-gui"` so a future schema addition cannot brick old clients.
 	 */
 	terminalTheme?: string,
+	terminalDefaults?: TerminalDefaults,
 	defaultModel: string | null,
 	claudeBinaryPath?: string | null,
 	/**
@@ -1352,6 +1355,13 @@ export type SetupStatus = {
 export type SkillSyncMode = "off" | "copy" | "symlink";
 
 /**
+ *  Profile policy used by the plain Split Horizontal / Split Vertical
+ *  commands. Profile-picker commands remain explicit regardless of this
+ *  setting.
+ */
+export type SplitProfileBehavior = "plainShell" | "appDefaultProfile" | "activePaneProfile" | "askEveryTime";
+
+/**
  *  A named recipe for launching something inside a shell pane. Orthogonal to
  *  pane type: every launched pane is a shell, and a profile is just optional
  *  metadata attached at creation describing how the shell was seeded.
@@ -1367,11 +1377,18 @@ export type SpawnProfile = {
 	setupCommand?: string | null,
 	startupCommand?: string | null,
 	startupBehavior?: StartupBehavior | null,
-	env?: { [key in string]: string } | null,
+	env?: { [key in string]: TerminalEnvRule } | null,
+	beforeShellStarts?: string | null,
 	cwdOverride?: string | null,
 	icon?: string | null,
 	provider?: Provider | null,
 	source: ProfileSource,
+};
+
+export type SpawnPtyOpts = {
+	profileData?: SpawnProfile | null,
+	envOverrides?: { [key in string]: TerminalEnvRule } | null,
+	initialSize?: [number, number] | null,
 };
 
 /**
@@ -1383,6 +1400,35 @@ export type StartupBehavior = "autoRun" | "typeOnly";
 export type StatusBarPosition = "top" | "bottom";
 
 export type TabPosition = "left" | "right";
+
+export type TerminalDefaults = {
+	env?: { [key in string]: TerminalEnvRule } | null,
+	beforeShellStarts?: string | null,
+	splitProfileBehavior?: SplitProfileBehavior,
+};
+
+/**
+ *  Environment rule value. The string variant is the legacy settings shape
+ *  and is treated as `mode: "value"`.
+ */
+export type TerminalEnvRule = string | TerminalEnvRuleSpec;
+
+/**
+ *  Mode for a structured terminal environment rule.
+ */
+export type TerminalEnvRuleMode = "value" | "inherit" | "unset" | "command";
+
+/**
+ *  Structured terminal environment rule. `value` is used with `mode:
+ *  "value"` and `command` is used with `mode: "command"`. Missing strings
+ *  are validated by the runtime resolver so settings can still deserialize
+ *  and be edited after a bad value is saved.
+ */
+export type TerminalEnvRuleSpec = {
+	mode: TerminalEnvRuleMode,
+	value?: string | null,
+	command?: string | null,
+};
 
 export type TaskDefinition = {
 	id: string,

--- a/src/lib/commands/panes.ts
+++ b/src/lib/commands/panes.ts
@@ -32,6 +32,7 @@ import { openCustomProfileEditor } from "$lib/stores/customProfileModal";
 import { log, logError } from "$lib/logging";
 import { settings } from "$lib/stores/settings";
 import { openCommandPaletteWithCommand } from "$lib/stores/commandSurface";
+import { resolveAppDefaultSplitProfile } from "$lib/panes/splitProfileBehavior";
 
 async function spawnPlainShellPane(direction: "h" | "v"): Promise<void> {
   const session = queries.activeSession();
@@ -70,7 +71,10 @@ async function splitWithConfiguredBehavior(direction: "h" | "v"): Promise<void> 
 
   let profile: SpawnProfile | null = null;
   if (behavior === "appDefaultProfile") {
-    profile = get(profileRegistry).get(get(settings).defaultAgentProfile ?? "claude") ?? null;
+    profile = resolveAppDefaultSplitProfile(
+      get(profileRegistry),
+      get(settings).defaultAgentProfile,
+    );
   } else if (behavior === "activePaneProfile") {
     profile = resolveProfileRef(queries.focusedPane()?.spawnProfileRef);
   }

--- a/src/lib/commands/panes.ts
+++ b/src/lib/commands/panes.ts
@@ -19,6 +19,8 @@ import { resolveMultiLineEditorSeed } from "$lib/panes/multiLineEditorSeed";
 import { getTerminalController } from "$lib/panes/terminalRuntime";
 import {
   profileList,
+  profileRegistry,
+  resolveProfileRef,
   type SpawnProfile,
   type SpawnProfileRef,
 } from "$lib/panes/profiles";
@@ -28,6 +30,57 @@ import { spawnShell, spawnTask, listDocs, notificationsPush, listSessionPtys, ki
 import { attachPtyToPane } from "$lib/panes/attach";
 import { openCustomProfileEditor } from "$lib/stores/customProfileModal";
 import { log, logError } from "$lib/logging";
+import { settings } from "$lib/stores/settings";
+import { openCommandPaletteWithCommand } from "$lib/stores/commandSurface";
+
+async function spawnPlainShellPane(direction: "h" | "v"): Promise<void> {
+  const session = queries.activeSession();
+  if (!session) return;
+  const ptyId = crypto.randomUUID();
+  const paneId = crypto.randomUUID();
+  log(`Split ${direction}: pane=${paneId} pty=${ptyId} cwd=${session.worktreePath}`);
+  try {
+    await spawnShell(ptyId, session.worktreePath, session.id, paneId, null);
+  } catch (e) {
+    logError(`Failed to spawn shell for ${direction} split`, e);
+    return;
+  }
+  const activeId = queries.activeSessionId();
+  if (!activeId) return;
+  const newPaneId = splitPane(activeId, direction, { id: paneId, type: "shell", ptyId });
+  if (newPaneId) {
+    const { connectPaneTerminal } = await import("$lib/panes/terminals");
+    await connectPaneTerminal(newPaneId, (payload) => {
+      log(`Shell pane ${newPaneId} exited (code=${payload.code})`);
+      updateInstance(newPaneId, {
+        terminalState: { kind: "dead", ptyId, exitCode: payload.code ?? null },
+      });
+    });
+  }
+}
+
+async function splitWithConfiguredBehavior(direction: "h" | "v"): Promise<void> {
+  const behavior = get(settings).terminalDefaults?.splitProfileBehavior ?? "plainShell";
+  if (behavior === "askEveryTime") {
+    openCommandPaletteWithCommand(
+      direction === "h" ? "pane.split-horizontal-with-profile" : "pane.split-vertical-with-profile",
+    );
+    return;
+  }
+
+  let profile: SpawnProfile | null = null;
+  if (behavior === "appDefaultProfile") {
+    profile = get(profileRegistry).get(get(settings).defaultAgentProfile ?? "claude") ?? null;
+  } else if (behavior === "activePaneProfile") {
+    profile = resolveProfileRef(queries.focusedPane()?.spawnProfileRef);
+  }
+
+  if (profile) {
+    await spawnShellPaneWithProfile(direction, profile);
+  } else {
+    await spawnPlainShellPane(direction);
+  }
+}
 
 /**
  * Spawn a new shell pane seeded by a specific profile. Shared by both
@@ -55,6 +108,8 @@ async function spawnShellPaneWithProfile(
       session.id,
       paneId,
       profile.id,
+      null,
+      profile.source === "inline" ? profile : null,
     );
   } catch (e) {
     logError(`Failed to spawn shell for profile "${profile.id}"`, e);
@@ -245,31 +300,7 @@ export function registerPaneCommands() {
     label: "Split Horizontal",
     category: "Panes",
     available: () => queries.canSplitPane(),
-    execute: async () => {
-      const session = queries.activeSession();
-      if (!session) return;
-      const ptyId = crypto.randomUUID();
-      const paneId = crypto.randomUUID();
-      log(`Split horizontal: pane=${paneId} pty=${ptyId} cwd=${session.worktreePath}`);
-      try {
-        await spawnShell(ptyId, session.worktreePath, session.id, paneId, "shell");
-      } catch (e) {
-        logError("Failed to spawn shell for horizontal split", e);
-        return;
-      }
-      const activeId = queries.activeSessionId();
-      if (!activeId) return;
-      const newPaneId = splitPane(activeId, "h", { id: paneId, type: "shell", ptyId });
-      if (newPaneId) {
-        const { connectPaneTerminal } = await import("$lib/panes/terminals");
-        await connectPaneTerminal(newPaneId, (payload) => {
-          log(`Shell pane ${newPaneId} exited (code=${payload.code})`);
-          updateInstance(newPaneId, {
-            terminalState: { kind: "dead", ptyId, exitCode: payload.code ?? null },
-          });
-        });
-      }
-    },
+    execute: () => splitWithConfiguredBehavior("h"),
   });
 
   registry.register({
@@ -277,31 +308,7 @@ export function registerPaneCommands() {
     label: "Split Vertical",
     category: "Panes",
     available: () => queries.canSplitPane(),
-    execute: async () => {
-      const session = queries.activeSession();
-      if (!session) return;
-      const ptyId = crypto.randomUUID();
-      const paneId = crypto.randomUUID();
-      log(`Split vertical: pane=${paneId} pty=${ptyId} cwd=${session.worktreePath}`);
-      try {
-        await spawnShell(ptyId, session.worktreePath, session.id, paneId, "shell");
-      } catch (e) {
-        logError("Failed to spawn shell for vertical split", e);
-        return;
-      }
-      const activeId = queries.activeSessionId();
-      if (!activeId) return;
-      const newPaneId = splitPane(activeId, "v", { id: paneId, type: "shell", ptyId });
-      if (newPaneId) {
-        const { connectPaneTerminal } = await import("$lib/panes/terminals");
-        await connectPaneTerminal(newPaneId, (payload) => {
-          log(`Shell pane ${newPaneId} exited (code=${payload.code})`);
-          updateInstance(newPaneId, {
-            terminalState: { kind: "dead", ptyId, exitCode: payload.code ?? null },
-          });
-        });
-      }
-    },
+    execute: () => splitWithConfiguredBehavior("v"),
   });
 
   registry.register({

--- a/src/lib/components/NewSessionDialog.svelte
+++ b/src/lib/components/NewSessionDialog.svelte
@@ -771,6 +771,7 @@
         {
           initialSize,
           profile: profile.id,
+          profileData: profile.source === "inline" ? profile : null,
           base: defaultBase.base,
           fetchFirst: defaultBase.fetchFirst,
         },

--- a/src/lib/components/NewSessionDialog.svelte
+++ b/src/lib/components/NewSessionDialog.svelte
@@ -712,6 +712,7 @@
           {
             initialSize,
             profile: firstLeafInfo.profileId ?? undefined,
+            profileData: firstLeafInfo.profileData,
             base: defaultBase.base,
             fetchFirst: defaultBase.fetchFirst,
           },

--- a/src/lib/components/settings/SettingsTerminalSection.svelte
+++ b/src/lib/components/settings/SettingsTerminalSection.svelte
@@ -1,11 +1,64 @@
 <script lang="ts">
   import { open } from "@tauri-apps/plugin-dialog";
   import { revealItemInDir } from "@tauri-apps/plugin-opener";
+  import {
+    JSONEditor,
+    Mode,
+    createAjvValidator,
+    type Content,
+    type ContentErrors,
+    type OnChangeStatus,
+  } from "svelte-jsoneditor";
+  import "svelte-jsoneditor/themes/jse-theme-dark.css";
   import { commands } from "$lib/bindings";
-  import type { GpuAcceleration } from "$lib/bindings";
-  import { settings, updateSetting } from "$lib/stores/settings";
+  import type {
+    GpuAcceleration,
+    SplitProfileBehavior,
+    TerminalDefaults,
+    TerminalEnvRule,
+  } from "$lib/bindings";
+  import { settings, updateSetting, updateSettingsDraft } from "$lib/stores/settings";
   import { userTerminalThemes, loadUserTerminalThemes } from "$lib/stores/userTerminalThemes";
   import { getAllTerminalThemeDefinitions } from "$lib/themes";
+
+  type TerminalEnvRules = Record<string, TerminalEnvRule>;
+
+  const DEFAULT_TERMINAL_DEFAULTS: TerminalDefaults = {
+    env: null,
+    beforeShellStarts: null,
+    splitProfileBehavior: "plainShell",
+  };
+
+  const envRuleValidator = createAjvValidator({
+    schema: {
+      type: "object",
+      additionalProperties: {
+        anyOf: [
+          { type: "string" },
+          {
+            type: "object",
+            required: ["mode"],
+            additionalProperties: false,
+            properties: {
+              mode: { enum: ["value", "inherit", "unset", "command"] },
+              value: { type: "string" },
+              command: { type: "string" },
+            },
+            allOf: [
+              {
+                if: { properties: { mode: { const: "value" } }, required: ["mode"] },
+                then: { required: ["value"] },
+              },
+              {
+                if: { properties: { mode: { const: "command" } }, required: ["mode"] },
+                then: { required: ["command"] },
+              },
+            ],
+          },
+        ],
+      },
+    },
+  });
 
   let allTerminalThemes = $derived(getAllTerminalThemeDefinitions($userTerminalThemes));
   let currentTerminalThemeId = $derived($settings.terminalTheme ?? "match-gui");
@@ -15,6 +68,22 @@
   let isMissingUserTheme = $derived(
     !currentDef && currentTerminalThemeId.startsWith("user:"),
   );
+  let terminalDefaults = $derived({
+    ...DEFAULT_TERMINAL_DEFAULTS,
+    ...($settings.terminalDefaults ?? {}),
+  });
+  let envContent = $state<Content>({ json: {} });
+  let envError = $state<string | null>(null);
+  let lastEnvJson = $state("");
+
+  $effect(() => {
+    const serialized = serializeEnv(terminalDefaults.env);
+    if (serialized !== lastEnvJson) {
+      envContent = { json: terminalDefaults.env ?? {} };
+      envError = null;
+      lastEnvJson = serialized;
+    }
+  });
 
   async function browseShellBinary() {
     const selected = await open({
@@ -31,6 +100,72 @@
     } catch (e) {
       console.error("reveal user themes dir failed", e);
     }
+  }
+
+  function updateTerminalDefaults(patch: Partial<TerminalDefaults>): void {
+    updateSettingsDraft((current) => ({
+      ...current,
+      terminalDefaults: {
+        ...DEFAULT_TERMINAL_DEFAULTS,
+        ...(current.terminalDefaults ?? {}),
+        ...patch,
+      },
+    }));
+  }
+
+  function updateBeforeShellStarts(value: string): void {
+    updateTerminalDefaults({ beforeShellStarts: value.trim() ? value : null });
+  }
+
+  function updateSplitProfileBehavior(value: SplitProfileBehavior): void {
+    updateTerminalDefaults({ splitProfileBehavior: value });
+  }
+
+  function handleEnvChange(
+    content: Content,
+    _previousContent: Content,
+    status: OnChangeStatus,
+  ): void {
+    envContent = content;
+    if (status.contentErrors) {
+      envError = describeContentErrors(status.contentErrors);
+      return;
+    }
+
+    let json: unknown;
+    try {
+      json = "json" in content ? content.json : JSON.parse(content.text);
+    } catch (error) {
+      envError = error instanceof Error ? error.message : "Invalid JSON";
+      return;
+    }
+
+    if (!isPlainObject(json)) {
+      envError = "Terminal environment rules must be a JSON object.";
+      return;
+    }
+
+    const env = Object.keys(json).length > 0 ? (json as TerminalEnvRules) : null;
+    envError = null;
+    lastEnvJson = serializeEnv(env);
+    updateTerminalDefaults({ env });
+  }
+
+  function describeContentErrors(errors: ContentErrors): string {
+    if ("parseError" in errors) {
+      return errors.parseError.message;
+    }
+
+    const [first] = errors.validationErrors;
+    return first?.message ?? "Invalid terminal environment rules.";
+  }
+
+  function isPlainObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+  }
+
+  function serializeEnv(env: TerminalDefaults["env"] | undefined): string {
+    return JSON.stringify(env ?? {}, null, 2);
   }
 </script>
 
@@ -141,6 +276,61 @@
   </select>
 </div>
 <div class="mt-3 rounded-xl border border-border-subtle bg-bg-surface/35 p-3">
+  <div class="flex items-start justify-between gap-3">
+    <div>
+      <div class="text-[13px] font-semibold">Terminal defaults</div>
+      <div class="mt-0.5 text-[11px] text-text-muted">Applies to newly spawned shells before profile-specific setup.</div>
+    </div>
+    <select
+      class="bg-bg-deep border border-border rounded px-2 py-1 text-xs text-text-primary outline-none cursor-pointer appearance-none pr-6"
+      value={terminalDefaults.splitProfileBehavior}
+      onchange={(e) => updateSplitProfileBehavior(e.currentTarget.value as SplitProfileBehavior)}
+      title="Plain split behavior"
+    >
+      <option value="plainShell">Plain shell</option>
+      <option value="appDefaultProfile">App default profile</option>
+      <option value="activePaneProfile">Active pane profile</option>
+      <option value="askEveryTime">Ask every time</option>
+    </select>
+  </div>
+
+  <div class="mt-3 flex flex-col gap-1.5">
+    <label for="terminal-before-shell-starts" class="text-[11px] font-semibold uppercase tracking-wider text-text-muted">
+      Before shell starts
+    </label>
+    <textarea
+      id="terminal-before-shell-starts"
+      class="min-h-16 rounded-md border border-border bg-bg-deep px-3 py-2 font-mono text-xs text-text-primary outline-none focus:border-accent-dim"
+      value={terminalDefaults.beforeShellStarts ?? ""}
+      oninput={(e) => updateBeforeShellStarts(e.currentTarget.value)}
+      spellcheck="false"
+      placeholder="aws sts get-caller-identity --profile prod >/dev/null 2>&1 || aws sso login --profile prod"
+    ></textarea>
+  </div>
+
+  <div class="mt-3 flex flex-col gap-1.5">
+    <div class="flex items-center justify-between gap-3">
+      <label for="terminal-env-rules" class="text-[11px] font-semibold uppercase tracking-wider text-text-muted">
+        Environment
+      </label>
+      {#if envError}
+        <span class="text-[11px] text-red">{envError}</span>
+      {/if}
+    </div>
+    <div id="terminal-env-rules" class="roux-json-editor h-56 overflow-hidden rounded-md border border-border bg-bg-deep">
+      <JSONEditor
+        content={envContent}
+        mode={Mode.text}
+        mainMenuBar={false}
+        navigationBar={false}
+        statusBar={true}
+        validator={envRuleValidator}
+        onChange={handleEnvChange}
+      />
+    </div>
+  </div>
+</div>
+<div class="mt-3 rounded-xl border border-border-subtle bg-bg-surface/35 p-3">
   <div class="flex items-center justify-between">
     <div class="text-[13px] font-semibold">Shell</div>
   </div>
@@ -168,3 +358,16 @@
     </div>
   </div>
 </div>
+
+<style>
+  :global(.roux-json-editor .jse-main) {
+    height: 100%;
+    min-height: 0;
+    background: transparent;
+  }
+
+  :global(.roux-json-editor .jse-menu),
+  :global(.roux-json-editor .jse-status-bar) {
+    border-color: var(--border-subtle);
+  }
+</style>

--- a/src/lib/panes/__tests__/layoutRunner.test.ts
+++ b/src/lib/panes/__tests__/layoutRunner.test.ts
@@ -39,7 +39,7 @@ vi.mock("$lib/panes/actions", () => ({
 
 // ── Imports (after mocks) ───────────────────────────────────────────────────
 
-import { applyLayoutToSession } from "../layoutRunner";
+import { applyLayoutToSession, resolveFirstLeafInfo } from "../layoutRunner";
 import { spawnShell, killPty } from "$lib/tauri";
 import { initTerminal, attachPtyListeners } from "$lib/panes/terminals";
 import { runProfileInPane } from "$lib/panes/profileRunner";
@@ -128,6 +128,33 @@ function layoutSpec(root: LayoutPaneNode, id = "test-layout"): LayoutSpec {
 }
 
 // ── Setup / teardown ────────────────────────────────────────────────────────
+
+describe("resolveFirstLeafInfo", () => {
+  it("returns inline profile data for daemon spawn-time resolution", () => {
+    const inlineProfile = stubProfile("custom-inline", {
+      source: "inline",
+      env: {
+        AWS_PROFILE: { mode: "value", value: "prod" },
+      },
+      beforeShellStarts: "aws sts get-caller-identity --profile prod",
+    });
+    const layout = layoutSpec(inlineLeafNode(inlineProfile));
+
+    expect(resolveFirstLeafInfo(layout)).toEqual({
+      profileId: "custom-inline",
+      profileData: inlineProfile,
+    });
+  });
+
+  it("returns only a profile id for registered first leaves", () => {
+    const layout = layoutSpec(leafNode("claude"));
+
+    expect(resolveFirstLeafInfo(layout)).toEqual({
+      profileId: "claude",
+      profileData: null,
+    });
+  });
+});
 
 describe("applyLayoutToSession", () => {
   beforeEach(() => {

--- a/src/lib/panes/__tests__/profileRunner.test.ts
+++ b/src/lib/panes/__tests__/profileRunner.test.ts
@@ -131,7 +131,7 @@ describe("runProfileInPane", () => {
   });
 
   describe("env", () => {
-    it("emits an export per entry before setup/startup", async () => {
+    it("does not type profile env exports because spawn applies them", async () => {
       await runProfileInPane(
         "pty-1",
         profile({
@@ -139,43 +139,19 @@ describe("runProfileInPane", () => {
           startupCommand: "claude",
         }),
       );
-      // BTreeMap serialization is lexicographic, so BAZ comes first.
-      // We don't hard-assert order in this test because Object iteration
-      // in JS is insertion-ordered; just check both are present and
-      // precede the startup command.
-      const out = writes();
-      const startupIdx = out.indexOf("claude");
-      expect(startupIdx).toBeGreaterThan(-1);
-      expect(out.slice(0, startupIdx)).toEqual(
-        expect.arrayContaining(["export FOO='bar'", "export BAZ='qux'", "\n"]),
-      );
+      expect(writes()).toEqual(["claude", "\n"]);
     });
 
-    it("shell-escapes env values containing single quotes and metacharacters", async () => {
+    it("is a no-op when a profile only has env", async () => {
       await runProfileInPane(
         "pty-1",
         profile({ env: { MSG: "it's; $(whoami)" } }),
       );
-      expect(writes()).toEqual([
-        "export MSG='it'\\''s; $(whoami)'",
-        "\n",
-      ]);
-    });
-
-    it("skips env entries with invalid shell variable names", async () => {
-      // Names must match [A-Za-z_][A-Za-z0-9_]*. `1BAD` and `WITH-DASH`
-      // would silently break the exported line if we didn't filter them.
-      await runProfileInPane(
-        "pty-1",
-        profile({
-          env: { "1BAD": "x", "WITH-DASH": "y", GOOD: "z" },
-        }),
-      );
-      expect(writes()).toEqual(["export GOOD='z'", "\n"]);
+      expect(writes()).toEqual([]);
     });
   });
 
-  it("applies cwdOverride → env → setup → startup in order", async () => {
+  it("applies cwdOverride → setup → startup in order", async () => {
     await runProfileInPane(
       "pty-1",
       profile({
@@ -187,8 +163,6 @@ describe("runProfileInPane", () => {
     );
     expect(writes()).toEqual([
       "cd '/work'",
-      "\n",
-      "export API='https://api'",
       "\n",
       "./seed.sh",
       "\n",

--- a/src/lib/panes/__tests__/splitProfileBehavior.test.ts
+++ b/src/lib/panes/__tests__/splitProfileBehavior.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import type { SpawnProfile } from "../profiles";
+import { resolveAppDefaultSplitProfile } from "../splitProfileBehavior";
+
+function profile(id: string): SpawnProfile {
+  return {
+    id,
+    name: id,
+    source: "builtin",
+  };
+}
+
+describe("resolveAppDefaultSplitProfile", () => {
+  it("uses the configured default profile when it exists", () => {
+    const custom = profile("custom");
+    const registry = new Map<string, SpawnProfile>([
+      ["claude", profile("claude")],
+      ["custom", custom],
+    ]);
+
+    expect(resolveAppDefaultSplitProfile(registry, "custom")).toBe(custom);
+  });
+
+  it("falls back to claude when the configured profile is missing", () => {
+    const claude = profile("claude");
+    const registry = new Map<string, SpawnProfile>([["claude", claude]]);
+
+    expect(resolveAppDefaultSplitProfile(registry, "missing")).toBe(claude);
+  });
+});

--- a/src/lib/panes/layoutRunner.ts
+++ b/src/lib/panes/layoutRunner.ts
@@ -185,7 +185,15 @@ export async function applyLayoutToSession(
   for (const leaf of leaves) {
     if (leaf.isFirst) continue;
     try {
-      await spawnShell(leaf.ptyId, session.worktreePath, session.id, leaf.paneId, leaf.profile.id);
+      await spawnShell(
+        leaf.ptyId,
+        session.worktreePath,
+        session.id,
+        leaf.paneId,
+        leaf.profile.id,
+        null,
+        leaf.profile.source === "inline" ? leaf.profile : null,
+      );
       spawned.push(leaf.ptyId);
     } catch (e) {
       // Step 5: Unwind on failure

--- a/src/lib/panes/layoutRunner.ts
+++ b/src/lib/panes/layoutRunner.ts
@@ -295,6 +295,7 @@ function node(layout: LayoutSpec): LayoutPaneNode {
 
 export interface FirstLeafInfo {
   profileId: string | undefined;
+  profileData: SpawnProfile | null;
 }
 
 export function resolveFirstLeafInfo(layout: LayoutSpec): FirstLeafInfo {
@@ -309,10 +310,13 @@ export function resolveFirstLeafInfo(layout: LayoutSpec): FirstLeafInfo {
 
   const leaf = findFirstLeaf(layout.root);
   if (!leaf || leaf.kind !== "leaf") {
-    return { profileId: undefined };
+    return { profileId: undefined, profileData: null };
   }
 
   const ref = leaf.profile_ref;
   const profileId = ref.kind === "registered" ? ref.id : ref.profile.id;
-  return { profileId };
+  return {
+    profileId,
+    profileData: ref.kind === "inline" ? ref.profile : null,
+  };
 }

--- a/src/lib/panes/profileRunner.ts
+++ b/src/lib/panes/profileRunner.ts
@@ -4,14 +4,6 @@ import type { SpawnProfile } from "./profiles";
 import { appendAgentSystemPrompt } from "./agentPrompt";
 
 /**
- * Valid POSIX-ish shell identifier: must start with a letter or underscore
- * and contain only word characters thereafter. Env entries whose keys don't
- * match are silently dropped — they'd produce a broken `export` line and
- * their use is almost always a typo in the profile editor.
- */
-const VALID_ENV_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
-
-/**
  * Wrap a value in single quotes for safe inclusion in a shell command.
  * Single-quoted strings suppress every form of shell expansion — $, `,
  * \, glob chars, all of it — except for the single quote itself, which
@@ -35,21 +27,21 @@ export interface RunProfileOptions {
 }
 
 /**
- * Type a profile's environment, working-directory override, and setup /
- * startup commands into an existing shell PTY.
+ * Type a profile's working-directory override and setup / startup commands
+ * into an existing shell PTY. Profile environment and preflight commands are
+ * resolved by the daemon/runtime before the shell process starts.
  *
  * Order (each line written as a separate chunk so ordering is explicit and
  * the PTY receives human-looking input):
  *
  *   1. `cd 'escaped/cwdOverride'` (if set and non-empty)
- *   2. `export KEY='escaped value'` for each valid env entry
- *   3. `setupCommand` (always auto-run — the user opted into the profile
+ *   2. `setupCommand` (always auto-run — the user opted into the profile
  *      and is not going to inspect setup mid-stream)
- *   4. `startupCommand`, with trailing `\n` unless `startupBehavior ==
+ *   3. `startupCommand`, with trailing `\n` unless `startupBehavior ==
  *      "typeOnly"`, in which case the command sits at the prompt for
  *      review before the user presses Enter.
  *
- * No-op for profiles that have none of cwdOverride / env / setupCommand /
+ * No-op for profiles that have none of cwdOverride / setupCommand /
  * startupCommand (e.g. the built-in `Plain shell` profile). Safe to call
  * on a just-spawned PTY; the backend's pending-output channel buffers
  * writes until the reader is attached.
@@ -60,9 +52,6 @@ export async function runProfileInPane(
   opts: RunProfileOptions = {},
 ): Promise<void> {
   const cwdOverride = profile.cwdOverride?.trim() ?? "";
-  const envEntries = Object.entries(profile.env ?? {}).filter(
-    ([name]) => VALID_ENV_NAME.test(name),
-  );
   const hasSetup = !!profile.setupCommand && profile.setupCommand.trim().length > 0;
   const baseStartup = profile.startupCommand ?? "";
   const startupCommand = appendAgentSystemPrompt(
@@ -72,7 +61,7 @@ export async function runProfileInPane(
   );
   const hasStartup = startupCommand.trim().length > 0;
 
-  if (!cwdOverride && envEntries.length === 0 && !hasSetup && !hasStartup) {
+  if (!cwdOverride && !hasSetup && !hasStartup) {
     return;
   }
 
@@ -88,11 +77,6 @@ export async function runProfileInPane(
       `runProfileInPane(${ptyId}): cd to override for profile "${profile.id}"`,
     );
     await writeToSession(ptyId, `cd ${shellSingleQuote(cwdOverride)}`);
-    await writeToSession(ptyId, "\n");
-  }
-
-  for (const [name, value] of envEntries) {
-    await writeToSession(ptyId, `export ${name}=${shellSingleQuote(value)}`);
     await writeToSession(ptyId, "\n");
   }
 

--- a/src/lib/panes/restore.ts
+++ b/src/lib/panes/restore.ts
@@ -247,6 +247,8 @@ async function respawnStaleShell(
       session.id,
       descriptor.id,
       profileId,
+      null,
+      descriptor.spawnProfileRef?.kind === "inline" ? descriptor.spawnProfileRef.profile : null,
     );
     return { kind: "ok", ptyId: freshPtyId, profile };
   } catch (e) {

--- a/src/lib/panes/splitProfileBehavior.ts
+++ b/src/lib/panes/splitProfileBehavior.ts
@@ -1,0 +1,9 @@
+import type { SpawnProfile } from "./profiles";
+
+export function resolveAppDefaultSplitProfile(
+  registry: ReadonlyMap<string, SpawnProfile>,
+  defaultProfileId: string | null | undefined,
+): SpawnProfile | null {
+  const configuredId = defaultProfileId?.trim() || "claude";
+  return registry.get(configuredId) ?? registry.get("claude") ?? null;
+}

--- a/src/lib/sessions/__tests__/reconnect.test.ts
+++ b/src/lib/sessions/__tests__/reconnect.test.ts
@@ -127,7 +127,7 @@ describe("reconnectSession — existing behavior preserved", () => {
 
     await reconnectSession(session);
 
-    expect(reconnectSessionShellPty).toHaveBeenCalledWith(session.id, null);
+    expect(reconnectSessionShellPty).toHaveBeenCalledWith(session.id, null, null, null);
   });
 
   it("invokes reconnect with extra flags without error", async () => {
@@ -140,7 +140,7 @@ describe("reconnectSession — existing behavior preserved", () => {
 
     await reconnectSession(session, ["--resume", "abc123"]);
 
-    expect(reconnectSessionShellPty).toHaveBeenCalledWith(session.id, null);
+    expect(reconnectSessionShellPty).toHaveBeenCalledWith(session.id, null, null, null);
   });
 
   it("continues a Claude primary profile with claude --continue", async () => {
@@ -346,21 +346,22 @@ describe("reconnectSession — existing behavior preserved", () => {
     const session = makeSession();
     addSession(session);
     initSession(session.id);
+    const inlineProfile = {
+      id: "custom-inline",
+      name: "Custom Inline",
+      source: "user" as const,
+      provider: null,
+      icon: null,
+      startupCommand: "echo hi",
+      setupCommand: null,
+      startupBehavior: "autoRun" as const,
+      cwdOverride: null,
+      env: {},
+    };
     updateInstance(`${session.id}-main`, {
       spawnProfileRef: {
         kind: "inline",
-        profile: {
-          id: "custom-inline",
-          name: "Custom Inline",
-          source: "user",
-          provider: null,
-          icon: null,
-          startupCommand: "echo hi",
-          setupCommand: null,
-          startupBehavior: "autoRun",
-          cwdOverride: null,
-          env: {},
-        },
+        profile: inlineProfile,
       },
     });
 
@@ -369,6 +370,8 @@ describe("reconnectSession — existing behavior preserved", () => {
     expect(reconnectSessionShellPty).toHaveBeenCalledWith(
       session.id,
       "custom-inline",
+      null,
+      inlineProfile,
     );
   });
 
@@ -482,7 +485,7 @@ describe("reconnectSession — full rehydration", () => {
 
     await reconnectSession(session);
 
-    expect(reconnectSessionShellPty).toHaveBeenCalledWith(session.id, null);
+    expect(reconnectSessionShellPty).toHaveBeenCalledWith(session.id, null, null, null);
     expect(get(sessionLayouts).get(session.id)).toEqual({
       kind: "leaf",
       paneId: `${session.id}-main`,
@@ -500,12 +503,14 @@ describe("reconnectSession — full rehydration", () => {
 
     await reconnectSession(session);
 
-    expect(reconnectSessionShellPty).toHaveBeenCalledWith(session.id, null);
+    expect(reconnectSessionShellPty).toHaveBeenCalledWith(session.id, null, null, null);
     expect(spawnShell).toHaveBeenCalledWith(
       expect.any(String),
       "/repo/a",
       session.id,
       "shell-a",
+      null,
+      null,
       null,
     );
     const tree = get(sessionLayouts).get(session.id);
@@ -531,8 +536,8 @@ describe("reconnectSession — full rehydration", () => {
     await reconnectSession(session);
 
     expect(spawnShell).toHaveBeenCalledTimes(2);
-    expect(spawnShell).toHaveBeenCalledWith(expect.any(String), "/repo/a", session.id, "shell-a", null);
-    expect(spawnShell).toHaveBeenCalledWith(expect.any(String), "/repo/b", session.id, "shell-b", null);
+    expect(spawnShell).toHaveBeenCalledWith(expect.any(String), "/repo/a", session.id, "shell-a", null, null, null);
+    expect(spawnShell).toHaveBeenCalledWith(expect.any(String), "/repo/b", session.id, "shell-b", null, null, null);
 
     const instances = get(paneInstances);
     expect(instances.has("shell-a")).toBe(true);
@@ -830,6 +835,8 @@ describe("reconnectSession — full rehydration", () => {
       session.id,
       "shell-pane",
       "plain-shell",
+      null,
+      null,
     );
   });
 
@@ -946,7 +953,7 @@ describe("retryShellPane", () => {
 
     await retryShellPane(paneId, "sess-1");
 
-    expect(spawnShell).toHaveBeenCalledWith(expect.any(String), "/repo", "sess-1", paneId, null);
+    expect(spawnShell).toHaveBeenCalledWith(expect.any(String), "/repo", "sess-1", paneId, null, null, null);
     const inst = get(paneInstances).get(paneId);
     expect(inst?.restoreError).toBeUndefined();
   });

--- a/src/lib/sessions/reconnect.ts
+++ b/src/lib/sessions/reconnect.ts
@@ -283,6 +283,8 @@ async function rehydratePane(
         sessionId,
         paneId,
         profileId,
+        null,
+        descriptor.spawnProfileRef?.kind === "inline" ? descriptor.spawnProfileRef.profile : null,
       );
       createPane({
         id: paneId,
@@ -348,6 +350,8 @@ async function reconnectPrimaryPaneOnly(
   const updated = await reconnectSessionShellPty(
     session.id,
     profile?.id ?? null,
+    null,
+    instance?.spawnProfileRef?.kind === "inline" ? instance.spawnProfileRef.profile : null,
   );
   const { connectPaneTerminal } = await import("$lib/panes/terminals");
   await connectPaneTerminal(primaryPaneId);
@@ -591,6 +595,8 @@ export async function retryShellPane(paneId: string, sessionId: string): Promise
       sessionId,
       paneId,
       profileId,
+      null,
+      instance.spawnProfileRef?.kind === "inline" ? instance.spawnProfileRef.profile : null,
     );
     updateInstance(paneId, { ptyId, restoreError: undefined });
     const { connectPaneTerminal } = await import("$lib/panes/terminals");

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1,6 +1,6 @@
 import { Channel, invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
-import type { SpawnProfileRef } from "$lib/panes/profiles";
+import type { SpawnProfile, SpawnProfileRef } from "$lib/panes/profiles";
 import type { ProjectPromptTemplateContext } from "$lib/projectPromptTemplates";
 import type {
   ExternalTool,
@@ -33,6 +33,8 @@ export interface CreateSessionShellOpts {
    * PTY env so agents wake up under the right profile.
    */
   profile?: string | null;
+  profileData?: SpawnProfile | null;
+  envOverrides?: SpawnProfile["env"] | null;
   /**
    * Git starting point for a newly-created worktree branch (e.g. "main",
    * "origin/main"). Only used when `branch` is a new branch; ignored for
@@ -199,6 +201,8 @@ export async function createSessionShell(
   const {
     initialSize,
     profile,
+    profileData,
+    envOverrides,
     base,
     fetchFirst,
     projectId,
@@ -211,6 +215,8 @@ export async function createSessionShell(
     branch,
     opts: {
       profile: profile ?? null,
+      profileData: profileData ?? null,
+      envOverrides: envOverrides ?? null,
       initialSize: initialSize ? [initialSize.cols, initialSize.rows] : null,
       base: base ?? null,
       fetchFirst: fetchFirst ?? null,
@@ -242,10 +248,14 @@ export async function reconnectSessionShellPty(
   id: string,
   profile?: string | null,
   initialSize?: InitialPtySize | null,
+  profileData?: SpawnProfile | null,
+  envOverrides?: SpawnProfile["env"] | null,
 ): Promise<Session> {
   return invoke("reconnect_session_shell", {
     id,
     profile: profile ?? null,
+    profileData: profileData ?? null,
+    envOverrides: envOverrides ?? null,
     initialSize: initialSize ? [initialSize.cols, initialSize.rows] : null,
   });
 }
@@ -289,6 +299,8 @@ export async function spawnShell(
   paneId: string | null,
   profile?: string | null,
   initialSize?: InitialPtySize | null,
+  profileData?: SpawnProfile | null,
+  envOverrides?: SpawnProfile["env"] | null,
 ): Promise<void> {
   return invoke("spawn_shell", {
     id,
@@ -296,7 +308,11 @@ export async function spawnShell(
     sessionId,
     paneId,
     profile: profile ?? null,
-    initialSize: initialSize ? [initialSize.cols, initialSize.rows] : null,
+    opts: {
+      profileData: profileData ?? null,
+      envOverrides: envOverrides ?? null,
+      initialSize: initialSize ? [initialSize.cols, initialSize.rows] : null,
+    },
   });
 }
 
@@ -308,6 +324,8 @@ export async function spawnTask(
   paneId: string | null,
   profile?: string | null,
   initialSize?: InitialPtySize | null,
+  profileData?: SpawnProfile | null,
+  envOverrides?: SpawnProfile["env"] | null,
 ): Promise<void> {
   return invoke("spawn_task", {
     id,
@@ -316,7 +334,11 @@ export async function spawnTask(
     sessionId,
     paneId,
     profile: profile ?? null,
-    initialSize: initialSize ? [initialSize.cols, initialSize.rows] : null,
+    opts: {
+      profileData: profileData ?? null,
+      envOverrides: envOverrides ?? null,
+      initialSize: initialSize ? [initialSize.cols, initialSize.rows] : null,
+    },
   });
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -104,6 +104,11 @@ export const DEFAULT_SETTINGS: RouxSettings = {
   worktreeDefaultBase: "currentBranch",
   theme: "deep-blue",
   terminalTheme: "match-gui",
+  terminalDefaults: {
+    env: null,
+    beforeShellStarts: null,
+    splitProfileBehavior: "plainShell",
+  },
   defaultModel: null,
   claudeBinaryPath: null,
   ghBinaryPath: null,


### PR DESCRIPTION
Adds daemon-owned terminal profile environment resolution, terminal defaults, profile preflight support, split profile behavior settings, a JSON settings editor, daemon integration coverage, and docs. Verification: cargo test -p roux-cli --test daemon_terminal_profiles -- --nocapture; cargo test -p roux-runtime terminal_profile_env; cargo test -p roux-sdk; cd src-tauri && cargo check; npm run check; npm run test -- src/lib/panes/__tests__/layoutRunner.test.ts; npm run test -- src/lib/panes/__tests__/profileRunner.test.ts.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves terminal profile environment resolution from the frontend shell into the daemon, adds structured env rules with value/inherit/unset/command modes, introduces a `before_shell_starts` preflight hook, and wires up a configurable plain-split profile behavior with a JSON settings editor. Previously-reported issues (ROUX_* session-var overwrite, stale test names, no-timeout documentation) are all addressed in this revision.

- **`terminal_profile_env.rs`** implements `resolve_terminal_profile_env` with an `EnvAccumulator` that applies global defaults → roux session env → profile env → launch overrides → roux session env (re-applied to prevent profile overwrite), then runs global and profile preflight commands with the resolved env.
- **`SpawnProfile` and `TerminalDefaults`** gain structured `TerminalEnvRule` types replacing the old `String` map, plus `before_shell_starts` and `SplitProfileBehavior` fields propagated through all spawn request paths (create, reconnect, pane split, task dispatch).
- **Frontend** removes the old `export KEY=value` PTY-typing approach, passes inline profile data to daemon via `profileData`/`envOverrides` named Tauri params, and implements `splitWithConfiguredBehavior` routing through the new `SplitProfileBehavior` enum.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This PR is safe to merge. The env resolution pipeline is correct, the double roux_env application guards session-tracking vars, and all spawn paths thread the new fields consistently.

The core env-resolution logic is well-tested with unit tests covering precedence ordering, inherit/unset semantics, command-mode trimming, and roux_env protection. The integration test exercises the full daemon path end-to-end. Previously-reported concerns are addressed. No functional defects found.

No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/roux-runtime/src/terminal_profile_env.rs | New module implementing daemon-side env resolution with correct precedence (global defaults → roux env × 2 to guard session vars → profile → launch), clean EnvAccumulator, and well-tested edge cases. |
| crates/roux-core/src/models/profile.rs | Adds structured TerminalEnvRule/TerminalEnvRuleSpec types with untagged serde for backward-compat with legacy string values; SpawnProfile gains before_shell_starts field. |
| crates/roux-core/src/models/settings.rs | Adds TerminalDefaults and SplitProfileBehavior to RouxSettings; normalized() trims before_shell_starts; RouxSettings::default() properly initializes terminal_defaults. |
| crates/roux-cli/src/daemon.rs | All spawn handlers (create, reconnect, panes_create, parse_pty_spawn_request) now resolve profile_data/terminal_defaults/launch_env; settings loaded where previously absent. |
| crates/roux-runtime/src/pty_service.rs | Calls resolve_terminal_profile_env before PTY spawn; applies env_remove via CommandBuilder; threads both sets of vars correctly through shell and task paths. |
| crates/roux-sdk/src/handles.rs | Adds profile_data/env_overrides builder methods; serde_json::to_value().ok() silently drops serialization errors (previously flagged, not yet addressed). |
| src/lib/commands/panes.ts | Adds splitWithConfiguredBehavior routing through all four SplitProfileBehavior variants; correctly passes inline profile data for profile-seeded splits. |
| src/lib/components/settings/SettingsTerminalSection.svelte | Adds JSON editor with AJV schema validation for terminal env rules; effect guards prevent feedback loops; split profile behavior selector wired up correctly. |
| src/lib/sessions/reconnect.ts | Inline profile data correctly passed to spawnShell and reconnectSessionShellPty with proper named-parameter ordering. |
| crates/roux-cli/tests/daemon_terminal_profiles.rs | Comprehensive end-to-end integration test covering global defaults, registered profile, inline profile_data, command-mode env resolution, unset, and preflight logging. |
| src/lib/panes/splitProfileBehavior.ts | New utility resolving the app-default split profile with a hardcoded 'claude' fallback when the configured ID is absent; behavior is intentional and tested. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant FE as Frontend
    participant Tauri as Tauri command
    participant Daemon as Daemon handler
    participant PtyService as PtyService
    participant EnvResolver as terminal_profile_env
    participant PTY as PTY process

    FE->>Tauri: spawnShell / spawnTask
    Tauri->>Daemon: PtySpawnRequest
    Daemon->>Daemon: resolve_spawn_profile_data()
    Daemon->>PtyService: spawn_shell(PtySpawnRequest)
    PtyService->>EnvResolver: resolve_terminal_profile_env()
    Note over EnvResolver: 1. Apply terminal_defaults.env
    Note over EnvResolver: 2. Apply roux_env
    Note over EnvResolver: 3. Apply profile.env
    Note over EnvResolver: 4. Apply launch_env
    Note over EnvResolver: 5. Re-apply roux_env
    Note over EnvResolver: 6. Run before_shell_starts preflights
    EnvResolver-->>PtyService: TerminalProfileEnvPlan
    PtyService->>PTY: spawn with env overrides
    FE->>FE: runProfileInPane() cd+setup+startup
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/roux-sdk/src/handles.rs`, line 1608-1617 ([link](https://github.com/phin-tech/roux/blob/db15ffa32c18c4603b6c25fd54c475edaf2a2f53/crates/roux-sdk/src/handles.rs#L1608-L1617)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Silent serialization failure drops profile/env data with no diagnostic**

   `.ok()` on `serde_json::to_value()` discards serialization errors silently. If either the profile or env-overrides map fails to serialize, the key is simply omitted from `args` and the daemon spawns without the expected env configuration. The resulting PTY mismatch would be very hard to diagnose. The same pattern repeats in `requests.rs` (`insert_optional_profile` / `insert_optional_env_overrides`). At minimum, a `debug_assert!` or a `tracing::warn!` would surface this during development; ideally the builder methods should propagate an error.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Froux-sdk%2Fsrc%2Fhandles.rs%0ALine%3A%201608-1617%0A%0AComment%3A%0A**Silent%20serialization%20failure%20drops%20profile%2Fenv%20data%20with%20no%20diagnostic**%0A%0A%60.ok%28%29%60%20on%20%60serde_json%3A%3Ato_value%28%29%60%20discards%20serialization%20errors%20silently.%20If%20either%20the%20profile%20or%20env-overrides%20map%20fails%20to%20serialize%2C%20the%20key%20is%20simply%20omitted%20from%20%60args%60%20and%20the%20daemon%20spawns%20without%20the%20expected%20env%20configuration.%20The%20resulting%20PTY%20mismatch%20would%20be%20very%20hard%20to%20diagnose.%20The%20same%20pattern%20repeats%20in%20%60requests.rs%60%20%28%60insert_optional_profile%60%20%2F%20%60insert_optional_env_overrides%60%29.%20At%20minimum%2C%20a%20%60debug_assert!%60%20or%20a%20%60tracing%3A%3Awarn!%60%20would%20surface%20this%20during%20development%3B%20ideally%20the%20builder%20methods%20should%20propagate%20an%20error.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=phin-tech%2Froux&pr=226&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22feature%2Fsession-commands-and-env-vars%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fsession-commands-and-env-vars%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Froux-sdk%2Fsrc%2Fhandles.rs%0ALine%3A%201608-1617%0A%0AComment%3A%0A**Silent%20serialization%20failure%20drops%20profile%2Fenv%20data%20with%20no%20diagnostic**%0A%0A%60.ok%28%29%60%20on%20%60serde_json%3A%3Ato_value%28%29%60%20discards%20serialization%20errors%20silently.%20If%20either%20the%20profile%20or%20env-overrides%20map%20fails%20to%20serialize%2C%20the%20key%20is%20simply%20omitted%20from%20%60args%60%20and%20the%20daemon%20spawns%20without%20the%20expected%20env%20configuration.%20The%20resulting%20PTY%20mismatch%20would%20be%20very%20hard%20to%20diagnose.%20The%20same%20pattern%20repeats%20in%20%60requests.rs%60%20%28%60insert_optional_profile%60%20%2F%20%60insert_optional_env_overrides%60%29.%20At%20minimum%2C%20a%20%60debug_assert!%60%20or%20a%20%60tracing%3A%3Awarn!%60%20would%20surface%20this%20during%20development%3B%20ideally%20the%20builder%20methods%20should%20propagate%20an%20error.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Protect Roux session env in terminal pro..."](https://github.com/phin-tech/roux/commit/b46e30c7b013c8f2a23313189603c0d5b71bad57) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35351708)</sub>

<!-- /greptile_comment -->