### PR TITLE
ci: cache Rust compilation with sccache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,16 @@ env:
     libgtk-3-dev
     libsoup-3.0-dev
     libjavascriptcoregtk-4.1-dev
+  #
+  # Each Rust compile job (rust-clippy, rust-test, worktrunk-integration)
+  # additionally sets a job-level `env:` enabling sccache:
+  #   RUSTC_WRAPPER: sccache
+  #   SCCACHE_GHA_ENABLED: "true"
+  #   CARGO_INCREMENTAL: "0"      # sccache can't cache incremental builds
+  # Compilation is the bottleneck there (tests run in ~10s; the build is
+  # ~3min); sccache caches compiler output across runs via the Actions
+  # cache. It's scoped per-job so non-Rust jobs (e.g. format's `cargo fmt`)
+  # never reference a wrapper they didn't install.
 
 jobs:
   changes:
@@ -91,6 +101,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true'
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@v4
       - uses: rui314/setup-mold@v1
@@ -102,6 +116,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri -> target
@@ -109,11 +124,18 @@ jobs:
       - name: Clippy
         working-directory: src-tauri
         run: cargo clippy --all-targets -- -D warnings
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats
 
   rust-test:
     runs-on: ubuntu-latest
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true'
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@v4
       - uses: rui314/setup-mold@v1
@@ -124,6 +146,7 @@ jobs:
           version: 1
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@nextest
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri -> target
@@ -131,6 +154,9 @@ jobs:
       - name: Test
         working-directory: src-tauri
         run: cargo nextest run --workspace
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats
 
   # Exhaustive integration tests for the `roux-worktrunk` wrapper that
   # exercise the real `wt` binary against real temp git repositories.
@@ -140,9 +166,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true'
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: . -> target
@@ -155,3 +186,6 @@ jobs:
           git config --global user.name  "Test"
       - name: Run real-wt integration tests
         run: cargo test -p roux-worktrunk --features real-wt-integration --test real_wt
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats


### PR DESCRIPTION
Stacked on #227 (formatting). Base will retarget to `main` once #227 merges.

## Context — why not parallel test sharding

The original ask was to split the Rust tests to run in parallel. I pulled the CI timing first, and the data redirected the work. From the `rust-test` log on a recent `main` run:

- **Compilation: ~3m 06s** — `Finished 'test' profile ... in 3m 06s`
- **Test execution: ~9.8s** — `1395 tests run` across 12 binaries

The tests **already run in parallel** (nextest, 12 binaries, all cores, <10s). The job is ~97% compile, ~5% tests. Sharding test execution across N jobs would make each shard still pay the full ~3min compile and split a 10-second suite — no wall-clock win, N× the runner cost. So the real lever is **compile time**.

## Change

Add **sccache** to the three Rust jobs (`rust-clippy`, `rust-test`, `worktrunk-integration`) to cache compiler output across runs via the GitHub Actions cache backend.

- Job-scoped `env` (`RUSTC_WRAPPER=sccache`, `SCCACHE_GHA_ENABLED=true`, `CARGO_INCREMENTAL=0`) — scoped per-job so non-Rust jobs (e.g. `format`'s `cargo fmt`) never reference a wrapper they didn't install.
- `mozilla-actions/sccache-action@v0.0.10`, set up before any cargo invocation.
- `sccache --show-stats` at the end of each job for hit-rate visibility.

It complements the existing `Swatinem/rust-cache` (registry + dep `target` cache); sccache covers recompiles of the first-party crates that rust-cache strips to keep its cache small.

## Caveats / what to watch

- sccache and rust-cache both consume the repo's 10GB Actions cache quota — possible eviction churn. Watch the `sccache stats` output on the first few runs; if hit-rate is poor we can drop rust-cache's `target` caching in favor of sccache.
- First run after merge is a cold cache (no speedup); the win shows on subsequent runs.
- I could not measure the speedup locally — it only manifests in CI. **The actual improvement should be confirmed from the `sccache stats` + job duration on this PR's CI run** before declaring victory.

## Verification

- `ci.yml` parses as valid YAML; sccache env confirmed scoped to only the 3 Rust jobs.
- Real speedup: **pending CI on this PR** (cold cache first, then warm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `sccache` to the three Rust CI jobs (`rust-clippy`, `rust-test`, `worktrunk-integration`) to cache compiler output across runs via the GitHub Actions cache backend. It correctly addresses the compilation bottleneck (~3m vs ~10s for tests) identified in real CI timing data.

- Adds `mozilla-actions/sccache-action@v0.0.10` to each Rust job, placed before any `cargo` invocation, and scopes `RUSTC_WRAPPER`, `SCCACHE_GHA_ENABLED`, and `CARGO_INCREMENTAL=0` to job-level `env` so the non-Rust `format` job is unaffected.
- Appends `sccache --show-stats` with `if: always()` at the end of each job for cache hit-rate visibility on every run, including failures.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is limited to CI configuration and does not touch application code.

The implementation is correct — sccache is wired in before any cargo invocation, the env vars are scoped to only the three Rust jobs, and the stats step uses `if: always()` for good observability. The only flag is a minor note about the new action being pinned to a mutable version tag instead of a commit SHA, consistent with the rest of the file but worth tracking.

No files require special attention; `.github/workflows/ci.yml` is the only changed file and the changes are straightforward.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Adds sccache to the three Rust jobs (rust-clippy, rust-test, worktrunk-integration) via job-level env vars and mozilla-actions/sccache-action@v0.0.10, placed correctly before any cargo invocation; sccache stats step uses if: always() for debug visibility. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Job starts] --> B[actions/checkout]
    B --> C[rust-toolchain stable]
    C --> D[sccache-action v0.0.10 GHA cache backend]
    D --> E[Swatinem/rust-cache v2 Registry and target dir]
    E --> F{Cache hit?}
    F -->|sccache hit| G[Compiler reads from sccache]
    F -->|cold| H[Compiler writes to sccache]
    G --> I[cargo build or test]
    H --> I
    I --> J[sccache stats - always]
    J --> K[Job ends - cache saved]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fci.yml%3A119-123%0AThe%20%60sccache-action%60%20is%20pinned%20to%20a%20mutable%20version%20tag%20rather%20than%20a%20commit%20SHA.%20If%20the%20tag%20is%20force-pushed%2C%20the%20workflow%20silently%20picks%20up%20new%20code.%20All%20other%20third-party%20actions%20in%20this%20file%20%28%60actions%2Fcheckout%40v4%60%2C%20%60rui314%2Fsetup-mold%40v1%60%2C%20etc.%29%20have%20the%20same%20pattern%2C%20so%20this%20isn't%20a%20regression%20introduced%20here%20%E2%80%94%20but%20adding%20the%20new%20action%20is%20a%20natural%20moment%20to%20consider%20locking%20it.%20GitHub's%20own%20hardening%20guide%20recommends%20SHA-pinning%20for%20third-party%20actions%20to%20prevent%20supply-chain%20substitution.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20uses%3A%20mozilla-actions%2Fsccache-action%40v0.0.10%20%20%23%20TODO%3A%20pin%20to%20a%20commit%20SHA%2C%20e.g.%20%40%3Csha%3E%0A%20%20%20%20%20%20-%20uses%3A%20Swatinem%2Frust-cache%40v2%0A%20%20%20%20%20%20%20%20with%3A%0A%20%20%20%20%20%20%20%20%20%20workspaces%3A%20src-tauri%20-%3E%20target%0A%20%20%20%20%20%20%20%20%20%20key%3A%20clippy%0A%60%60%60%0A%0A&repo=phin-tech%2Froux&pr=228&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22ci%2Fparallel-rust-tests%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ci%2Fparallel-rust-tests%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fci.yml%3A119-123%0AThe%20%60sccache-action%60%20is%20pinned%20to%20a%20mutable%20version%20tag%20rather%20than%20a%20commit%20SHA.%20If%20the%20tag%20is%20force-pushed%2C%20the%20workflow%20silently%20picks%20up%20new%20code.%20All%20other%20third-party%20actions%20in%20this%20file%20%28%60actions%2Fcheckout%40v4%60%2C%20%60rui314%2Fsetup-mold%40v1%60%2C%20etc.%29%20have%20the%20same%20pattern%2C%20so%20this%20isn't%20a%20regression%20introduced%20here%20%E2%80%94%20but%20adding%20the%20new%20action%20is%20a%20natural%20moment%20to%20consider%20locking%20it.%20GitHub's%20own%20hardening%20guide%20recommends%20SHA-pinning%20for%20third-party%20actions%20to%20prevent%20supply-chain%20substitution.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20uses%3A%20mozilla-actions%2Fsccache-action%40v0.0.10%20%20%23%20TODO%3A%20pin%20to%20a%20commit%20SHA%2C%20e.g.%20%40%3Csha%3E%0A%20%20%20%20%20%20-%20uses%3A%20Swatinem%2Frust-cache%40v2%0A%20%20%20%20%20%20%20%20with%3A%0A%20%20%20%20%20%20%20%20%20%20workspaces%3A%20src-tauri%20-%3E%20target%0A%20%20%20%20%20%20%20%20%20%20key%3A%20clippy%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["ci: cache Rust compilation with sccache"](https://github.com/phin-tech/roux/commit/eba75d930fa4a20d4a47d528269a581958c35047) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35371583)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->