### PR TITLE
Add work item migration status diagnostics

### DIFF
--- a/crates/roux-cli/src/daemon/status.rs
+++ b/crates/roux-cli/src/daemon/status.rs
@@ -151,6 +151,7 @@ pub(super) async fn handle_daemon_status(
         "watchCount": watch_count,
         "processCount": process_count,
         "ptyCount": pty_count,
+        "workItemMigrationStatus": host.work_item_handle.migration_status(),
         "capabilities": capabilities,
     }))
 }

--- a/crates/roux-cli/src/daemon/tests.rs
+++ b/crates/roux-cli/src/daemon/tests.rs
@@ -143,6 +143,10 @@ async fn daemon_status_is_daemon_only_socket_command() {
     assert_eq!(data["socket"], "/tmp/roux.sock");
     assert_eq!(data["logPath"], "/tmp/roux-daemon.log");
     assert_eq!(data["processCount"], 0);
+    assert_eq!(data["workItemMigrationStatus"]["currentVersion"], 7);
+    assert_eq!(data["workItemMigrationStatus"]["targetVersion"], 7);
+    assert_eq!(data["workItemMigrationStatus"]["pendingVersions"], serde_json::json!([]));
+    assert_eq!(data["workItemMigrationStatus"]["storage"], "boardDb");
     assert!(data["capabilities"].as_array().unwrap().contains(&serde_json::json!("daemon-status")));
     assert!(data["capabilities"].as_array().unwrap().contains(&serde_json::json!("daemon-stop")));
     assert!(data["capabilities"]

--- a/crates/roux-core/src/models/mod.rs
+++ b/crates/roux-core/src/models/mod.rs
@@ -59,11 +59,11 @@ pub use user_terminal_themes::{
 };
 pub use watch::*;
 pub use work_item::{
-    decide_work_item_session_attach, ExternalRef, WorkItem, WorkItemDecision,
-    WorkItemDecisionOption, WorkItemDecisionStatus, WorkItemEvent, WorkItemInput,
-    WorkItemInputPresence, WorkItemPlanResult, WorkItemReviewAcceptResult, WorkItemRun,
-    WorkItemRunEvent, WorkItemRunEventKind, WorkItemRunKind, WorkItemRunStatus,
-    WorkItemSessionAttachDecision, WorkItemSessionAttachError, WorkItemSessionAttachInput,
-    WorkItemStartResult, WorkItemStatus,
+    decide_work_item_session_attach, pending_work_item_migrations, ExternalRef, WorkItem,
+    WorkItemDecision, WorkItemDecisionOption, WorkItemDecisionStatus, WorkItemEvent, WorkItemInput,
+    WorkItemInputPresence, WorkItemMigrationStatus, WorkItemMigrationStorage, WorkItemPlanResult,
+    WorkItemReviewAcceptResult, WorkItemRun, WorkItemRunEvent, WorkItemRunEventKind,
+    WorkItemRunKind, WorkItemRunStatus, WorkItemSessionAttachDecision, WorkItemSessionAttachError,
+    WorkItemSessionAttachInput, WorkItemStartResult, WorkItemStatus,
 };
 pub use worktree::{Worktree, WorktrunkMetadata};

--- a/crates/roux-core/src/models/work_item.rs
+++ b/crates/roux-core/src/models/work_item.rs
@@ -47,6 +47,48 @@ impl std::fmt::Display for WorkItemStatus {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub enum WorkItemMigrationStorage {
+    BoardDb,
+    InMemory,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkItemMigrationStatus {
+    pub current_version: i64,
+    pub target_version: i64,
+    pub pending_versions: Vec<i64>,
+    pub storage: WorkItemMigrationStorage,
+    pub error: Option<String>,
+}
+
+impl WorkItemMigrationStatus {
+    pub fn new(
+        current_version: i64,
+        target_version: i64,
+        storage: WorkItemMigrationStorage,
+        error: Option<String>,
+    ) -> Self {
+        WorkItemMigrationStatus {
+            current_version,
+            target_version,
+            pending_versions: pending_work_item_migrations(current_version, target_version),
+            storage,
+            error,
+        }
+    }
+}
+
+pub fn pending_work_item_migrations(current_version: i64, target_version: i64) -> Vec<i64> {
+    if current_version >= target_version {
+        return Vec::new();
+    }
+    let start = current_version.saturating_add(1).max(1);
+    (start..=target_version).collect()
+}
+
 /// Pointer to an item's identity in an external system (e.g. a future
 /// GitHub or Linear adapter). Only `provider` + `external_id` together
 /// form the dedup key; `url` is informational.

--- a/crates/roux-runtime/src/host.rs
+++ b/crates/roux-runtime/src/host.rs
@@ -54,10 +54,7 @@ impl RuntimeHostConfig {
         let work_item_handle = match WorkItemHandle::open(&self.work_item_db_path) {
             Ok(handle) => handle,
             Err(err) => {
-                eprintln!(
-                    "Warning: failed to open board.db at {}: {err}; using in-memory work items for this process.",
-                    self.work_item_db_path.display()
-                );
+                eprintln!("Warning: {err}; using in-memory work items for this process.");
                 WorkItemHandle::in_memory_with_error(Some(err))
             }
         };

--- a/crates/roux-runtime/src/host.rs
+++ b/crates/roux-runtime/src/host.rs
@@ -58,7 +58,7 @@ impl RuntimeHostConfig {
                     "Warning: failed to open board.db at {}: {err}; using in-memory work items for this process.",
                     self.work_item_db_path.display()
                 );
-                WorkItemHandle::in_memory()
+                WorkItemHandle::in_memory_with_error(Some(err))
             }
         };
 

--- a/crates/roux-runtime/src/work_item_service.rs
+++ b/crates/roux-runtime/src/work_item_service.rs
@@ -22,7 +22,9 @@ use roux_core::{
     WorkItemRunEvent, WorkItemRunEventKind, WorkItemRunKind, WorkItemRunStatus, WorkItemStatus,
 };
 
-use crate::work_item_store::WorkItemStore;
+use crate::work_item_store::{
+    WorkItemMigrationStatus, WorkItemMigrationStorage, WorkItemStore, WORK_ITEM_SCHEMA_VERSION,
+};
 
 const BROADCAST_CAPACITY: usize = 256;
 
@@ -34,20 +36,49 @@ fn now_secs() -> u64 {
 pub struct WorkItemHandle {
     inner: Arc<Mutex<WorkItemStore>>,
     broadcast_tx: broadcast::Sender<WorkItemEvent>,
+    migration_status: WorkItemMigrationStatus,
 }
 
 impl WorkItemHandle {
     pub fn open(path: &Path) -> Result<Self, String> {
         let store =
             WorkItemStore::open(path).map_err(|e| format!("failed to open board.db: {e}"))?;
+        let current_version = store
+            .current_schema_version()
+            .map_err(|e| format!("failed to inspect board.db migration status: {e}"))?;
         let (broadcast_tx, _) = broadcast::channel(BROADCAST_CAPACITY);
-        Ok(WorkItemHandle { inner: Arc::new(Mutex::new(store)), broadcast_tx })
+        Ok(WorkItemHandle {
+            inner: Arc::new(Mutex::new(store)),
+            broadcast_tx,
+            migration_status: WorkItemMigrationStatus::new(
+                current_version,
+                WorkItemMigrationStorage::BoardDb,
+                None,
+            ),
+        })
     }
 
     pub fn in_memory() -> Self {
+        Self::in_memory_with_error(None)
+    }
+
+    pub fn in_memory_with_error(error: Option<String>) -> Self {
         let store = WorkItemStore::open_in_memory().expect("in-memory SQLite should always work");
+        let current_version = store.current_schema_version().unwrap_or(WORK_ITEM_SCHEMA_VERSION);
         let (broadcast_tx, _) = broadcast::channel(BROADCAST_CAPACITY);
-        WorkItemHandle { inner: Arc::new(Mutex::new(store)), broadcast_tx }
+        WorkItemHandle {
+            inner: Arc::new(Mutex::new(store)),
+            broadcast_tx,
+            migration_status: WorkItemMigrationStatus::new(
+                current_version,
+                WorkItemMigrationStorage::InMemory,
+                error,
+            ),
+        }
+    }
+
+    pub fn migration_status(&self) -> WorkItemMigrationStatus {
+        self.migration_status.clone()
     }
 
     pub fn subscribe_events(&self) -> broadcast::Receiver<WorkItemEvent> {

--- a/crates/roux-runtime/src/work_item_service.rs
+++ b/crates/roux-runtime/src/work_item_service.rs
@@ -18,13 +18,12 @@ use uuid::Uuid;
 
 use roux_core::{
     Attachment, AttachmentDocument, AttachmentInput, AttachmentTargetKind, WorkItem,
-    WorkItemDecision, WorkItemDecisionOption, WorkItemEvent, WorkItemInput, WorkItemRun,
-    WorkItemRunEvent, WorkItemRunEventKind, WorkItemRunKind, WorkItemRunStatus, WorkItemStatus,
+    WorkItemDecision, WorkItemDecisionOption, WorkItemEvent, WorkItemInput,
+    WorkItemMigrationStatus, WorkItemMigrationStorage, WorkItemRun, WorkItemRunEvent,
+    WorkItemRunEventKind, WorkItemRunKind, WorkItemRunStatus, WorkItemStatus,
 };
 
-use crate::work_item_store::{
-    WorkItemMigrationStatus, WorkItemMigrationStorage, WorkItemStore, WORK_ITEM_SCHEMA_VERSION,
-};
+use crate::work_item_store::{WorkItemStore, WORK_ITEM_SCHEMA_VERSION};
 
 const BROADCAST_CAPACITY: usize = 256;
 
@@ -41,17 +40,18 @@ pub struct WorkItemHandle {
 
 impl WorkItemHandle {
     pub fn open(path: &Path) -> Result<Self, String> {
-        let store =
-            WorkItemStore::open(path).map_err(|e| format!("failed to open board.db: {e}"))?;
-        let current_version = store
-            .current_schema_version()
-            .map_err(|e| format!("failed to inspect board.db migration status: {e}"))?;
+        let store = WorkItemStore::open(path)
+            .map_err(|e| format!("failed to open board.db at {}: {e}", path.display()))?;
+        let current_version = store.current_schema_version().map_err(|e| {
+            format!("failed to inspect board.db migration status at {}: {e}", path.display())
+        })?;
         let (broadcast_tx, _) = broadcast::channel(BROADCAST_CAPACITY);
         Ok(WorkItemHandle {
             inner: Arc::new(Mutex::new(store)),
             broadcast_tx,
             migration_status: WorkItemMigrationStatus::new(
                 current_version,
+                WORK_ITEM_SCHEMA_VERSION,
                 WorkItemMigrationStorage::BoardDb,
                 None,
             ),
@@ -71,6 +71,7 @@ impl WorkItemHandle {
             broadcast_tx,
             migration_status: WorkItemMigrationStatus::new(
                 current_version,
+                WORK_ITEM_SCHEMA_VERSION,
                 WorkItemMigrationStorage::InMemory,
                 error,
             ),
@@ -780,6 +781,18 @@ mod tests {
 
     fn input(title: &str) -> WorkItemInput {
         WorkItemInput { title: title.to_string(), ..Default::default() }
+    }
+
+    #[test]
+    fn open_error_includes_board_db_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = match WorkItemHandle::open(dir.path()) {
+            Ok(_) => panic!("opening a directory as board.db should fail"),
+            Err(err) => err,
+        };
+
+        assert!(err.contains("failed to open board.db at"));
+        assert!(err.contains(&dir.path().display().to_string()));
     }
 
     #[test]

--- a/crates/roux-runtime/src/work_item_store.rs
+++ b/crates/roux-runtime/src/work_item_store.rs
@@ -11,7 +11,6 @@
 use std::path::Path;
 
 use rusqlite::{params, types::Type, Connection, OptionalExtension, Result as SqlResult};
-use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use roux_core::{
@@ -22,50 +21,6 @@ use roux_core::{
 };
 
 pub const WORK_ITEM_SCHEMA_VERSION: i64 = 7;
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub enum WorkItemMigrationStorage {
-    BoardDb,
-    InMemory,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct WorkItemMigrationStatus {
-    pub current_version: i64,
-    pub target_version: i64,
-    pub pending_versions: Vec<i64>,
-    pub storage: WorkItemMigrationStorage,
-    pub error: Option<String>,
-}
-
-impl WorkItemMigrationStatus {
-    pub fn new(
-        current_version: i64,
-        storage: WorkItemMigrationStorage,
-        error: Option<String>,
-    ) -> Self {
-        WorkItemMigrationStatus {
-            current_version,
-            target_version: WORK_ITEM_SCHEMA_VERSION,
-            pending_versions: pending_work_item_migrations(
-                current_version,
-                WORK_ITEM_SCHEMA_VERSION,
-            ),
-            storage,
-            error,
-        }
-    }
-}
-
-pub fn pending_work_item_migrations(current_version: i64, target_version: i64) -> Vec<i64> {
-    if current_version >= target_version {
-        return Vec::new();
-    }
-    let start = current_version.saturating_add(1).max(1);
-    (start..=target_version).collect()
-}
 
 pub struct WorkItemStore {
     conn: Connection,
@@ -1659,9 +1614,9 @@ mod tests {
 
     #[test]
     fn pending_migrations_are_versions_after_current() {
-        assert_eq!(pending_work_item_migrations(4, 7), vec![5, 6, 7]);
-        assert!(pending_work_item_migrations(7, 7).is_empty());
-        assert!(pending_work_item_migrations(8, 7).is_empty());
+        assert_eq!(roux_core::pending_work_item_migrations(4, 7), vec![5, 6, 7]);
+        assert!(roux_core::pending_work_item_migrations(7, 7).is_empty());
+        assert!(roux_core::pending_work_item_migrations(8, 7).is_empty());
     }
 
     #[test]

--- a/crates/roux-runtime/src/work_item_store.rs
+++ b/crates/roux-runtime/src/work_item_store.rs
@@ -11,6 +11,7 @@
 use std::path::Path;
 
 use rusqlite::{params, types::Type, Connection, OptionalExtension, Result as SqlResult};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use roux_core::{
@@ -19,6 +20,52 @@ use roux_core::{
     WorkItemInput, WorkItemRun, WorkItemRunEvent, WorkItemRunEventKind, WorkItemRunKind,
     WorkItemRunStatus, WorkItemStatus,
 };
+
+pub const WORK_ITEM_SCHEMA_VERSION: i64 = 7;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum WorkItemMigrationStorage {
+    BoardDb,
+    InMemory,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkItemMigrationStatus {
+    pub current_version: i64,
+    pub target_version: i64,
+    pub pending_versions: Vec<i64>,
+    pub storage: WorkItemMigrationStorage,
+    pub error: Option<String>,
+}
+
+impl WorkItemMigrationStatus {
+    pub fn new(
+        current_version: i64,
+        storage: WorkItemMigrationStorage,
+        error: Option<String>,
+    ) -> Self {
+        WorkItemMigrationStatus {
+            current_version,
+            target_version: WORK_ITEM_SCHEMA_VERSION,
+            pending_versions: pending_work_item_migrations(
+                current_version,
+                WORK_ITEM_SCHEMA_VERSION,
+            ),
+            storage,
+            error,
+        }
+    }
+}
+
+pub fn pending_work_item_migrations(current_version: i64, target_version: i64) -> Vec<i64> {
+    if current_version >= target_version {
+        return Vec::new();
+    }
+    let start = current_version.saturating_add(1).max(1);
+    (start..=target_version).collect()
+}
 
 pub struct WorkItemStore {
     conn: Connection,
@@ -202,8 +249,12 @@ impl WorkItemStore {
             conn.execute_batch("PRAGMA user_version = 7;")?;
             version = 7;
         }
-        debug_assert!(version >= 7);
+        debug_assert!(version >= WORK_ITEM_SCHEMA_VERSION);
         Ok(WorkItemStore { conn })
+    }
+
+    pub fn current_schema_version(&self) -> SqlResult<i64> {
+        self.conn.query_row("PRAGMA user_version", [], |row| row.get(0))
     }
 
     pub fn list(&self, project_id: Option<&str>) -> SqlResult<Vec<WorkItem>> {
@@ -1604,6 +1655,13 @@ mod tests {
             }),
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn pending_migrations_are_versions_after_current() {
+        assert_eq!(pending_work_item_migrations(4, 7), vec![5, 6, 7]);
+        assert!(pending_work_item_migrations(7, 7).is_empty());
+        assert!(pending_work_item_migrations(8, 7).is_empty());
     }
 
     #[test]

--- a/crates/roux-sdk/src/lib.rs
+++ b/crates/roux-sdk/src/lib.rs
@@ -21,7 +21,10 @@ pub use streams::{
     AliasEventStreamFrame, MailboxEventStreamFrame, SubscriptionEventStreamFrame,
     WatchEventStreamFrame, WorkItemEventStreamFrame,
 };
-pub use types::{DaemonStatus, PtyAttachFrame, PtyKind, PtyRecord, PtySnapshot};
+pub use types::{
+    DaemonStatus, PtyAttachFrame, PtyKind, PtyRecord, PtySnapshot, WorkItemMigrationStatus,
+    WorkItemMigrationStorage,
+};
 
 #[cfg(test)]
 mod tests {

--- a/crates/roux-sdk/src/lib.rs
+++ b/crates/roux-sdk/src/lib.rs
@@ -320,7 +320,7 @@ mod tests {
     #[test]
     fn typed_status_decodes_from_daemon_response() {
         let (client, handle) = tcp_client_with_response(
-            r#"{"ok":true,"data":{"kind":"roux-daemon","pid":42,"socket":"tcp://test","startedAtMs":10,"uptimeMs":20,"sessionCount":1,"projectCount":2,"watchCount":3,"processCount":4,"ptyCount":5,"capabilities":["daemon-status","daemon-pty-list"]}}"#
+            r#"{"ok":true,"data":{"kind":"roux-daemon","pid":42,"socket":"tcp://test","startedAtMs":10,"uptimeMs":20,"sessionCount":1,"projectCount":2,"watchCount":3,"processCount":4,"ptyCount":5,"workItemMigrationStatus":{"currentVersion":7,"targetVersion":7,"pendingVersions":[],"storage":"boardDb","error":null},"capabilities":["daemon-status","daemon-pty-list"]}}"#
                 .to_string(),
         );
         let rt = tokio::runtime::Builder::new_current_thread().build().unwrap();
@@ -330,6 +330,7 @@ mod tests {
         assert_eq!(request["command"], "daemon-status");
         assert_eq!(status.kind, "roux-daemon");
         assert_eq!(status.pty_count, 5);
+        assert_eq!(status.work_item_migration_status.as_ref().unwrap().current_version, 7);
         assert!(status.capabilities.iter().any(|capability| capability == "daemon-pty-list"));
     }
 

--- a/crates/roux-sdk/src/lib.rs
+++ b/crates/roux-sdk/src/lib.rs
@@ -17,14 +17,12 @@ pub use error::{RouxError, RouxResult};
 pub use handles::{LatestOutput, Pty, PtyWrite, Session, SpawnShell, SpawnTask};
 pub use protocol::{CommandRequest, CommandResponse};
 pub use requests::{CreateSessionShell, MailboxPost, NotesEnv, ReconnectSessionShell};
+pub use roux_core::{WorkItemMigrationStatus, WorkItemMigrationStorage};
 pub use streams::{
     AliasEventStreamFrame, MailboxEventStreamFrame, SubscriptionEventStreamFrame,
     WatchEventStreamFrame, WorkItemEventStreamFrame,
 };
-pub use types::{
-    DaemonStatus, PtyAttachFrame, PtyKind, PtyRecord, PtySnapshot, WorkItemMigrationStatus,
-    WorkItemMigrationStorage,
-};
+pub use types::{DaemonStatus, PtyAttachFrame, PtyKind, PtyRecord, PtySnapshot};
 
 #[cfg(test)]
 mod tests {

--- a/crates/roux-sdk/src/types.rs
+++ b/crates/roux-sdk/src/types.rs
@@ -3,6 +3,23 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+pub enum WorkItemMigrationStorage {
+    BoardDb,
+    InMemory,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkItemMigrationStatus {
+    pub current_version: i64,
+    pub target_version: i64,
+    pub pending_versions: Vec<i64>,
+    pub storage: WorkItemMigrationStorage,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct DaemonStatus {
     pub kind: String,
     pub pid: u32,
@@ -19,6 +36,8 @@ pub struct DaemonStatus {
     pub process_count: usize,
     #[serde(default)]
     pub pty_count: usize,
+    #[serde(default)]
+    pub work_item_migration_status: Option<WorkItemMigrationStatus>,
     pub capabilities: Vec<String>,
 }
 

--- a/crates/roux-sdk/src/types.rs
+++ b/crates/roux-sdk/src/types.rs
@@ -1,22 +1,5 @@
-use roux_core::PtyInfo;
+use roux_core::{PtyInfo, WorkItemMigrationStatus};
 use serde::{Deserialize, Serialize};
-
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub enum WorkItemMigrationStorage {
-    BoardDb,
-    InMemory,
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub struct WorkItemMigrationStatus {
-    pub current_version: i64,
-    pub target_version: i64,
-    pub pending_versions: Vec<i64>,
-    pub storage: WorkItemMigrationStorage,
-    pub error: Option<String>,
-}
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -17,7 +17,7 @@ Settings are grouped into categories in a sidebar modal. Changes are persisted a
 - **Notifications** — OS notification master switch, test notification trigger, and Claude/Codex agent notification setup.
 - **Keyboard** — toggles for Option-pane and Command-session hint overlays.
 - **Notes** — experimental multi-scoped vault settings. See below.
-- **Advanced** — app version, updater controls, update channel, logging, and the Doctor panel.
+- **Advanced** — runtime diagnostics, work-item database migration status, app version, updater controls, update channel, logging, and the Doctor panel.
 
 ## Terminal themes
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -33,6 +33,88 @@ Fix the host config manually, then return to **Settings → Agent Integrations**
 
 Latest output is backed by raw PTY replay bytes. Roux always returns the exact bytes as `replay_bytes_base64`; it only includes `text` when those bytes are valid UTF-8. Decode `replay_bytes_base64` if your MCP client needs exact terminal output.
 
+## Work-item DB migration status looks wrong
+
+The Advanced settings panel shows the daemon's live `board.db` migration
+status under **Runtime → Database**. This is read-only diagnostic state. Roux
+migrates the work-item database automatically when the daemon opens it; there
+is no manual migration button.
+
+Normal state:
+
+- **Storage:** `board.db`
+- **Current migration:** same as **Target migration**
+- **Pending:** `None`
+- **Migration error:** absent
+
+Anything else means you should first prove which database and daemon you are
+looking at. Most false alarms are caused by reading the wrong config root or a
+stale daemon.
+
+### Compare UI and daemon status
+
+Run:
+
+```bash
+roux daemon status
+```
+
+Inspect `workItemMigrationStatus`, `pid`, `socket`, and `logPath`. These should
+match the Advanced panel. If they do not, your CLI is talking to a different
+daemon/socket than the desktop app.
+
+For dev runs started by `task dev`, use the same base path as the dev daemon:
+
+```bash
+ROUX_BASE_PATH="$HOME/.config/roux-dev" roux daemon status
+```
+
+### Check the on-disk database version
+
+Default database path:
+
+```text
+~/.config/roux/board.db
+```
+
+Dev database path, when using the default `task dev` environment:
+
+```text
+~/.config/roux-dev/board.db
+```
+
+Check SQLite's schema version:
+
+```bash
+sqlite3 "$HOME/.config/roux/board.db" 'PRAGMA user_version;'
+```
+
+If this differs from the Advanced panel while the panel says **Storage:
+board.db**, you are almost certainly inspecting a different file than the
+daemon opened. Check `ROUX_BASE_PATH`, the daemon socket, and the `logPath`
+from `roux daemon status`.
+
+### Interpret failure states
+
+- **Storage is `In-memory fallback`**: the daemon could not open or migrate
+  the persisted `board.db`. The board is running on temporary in-memory state
+  for this process. Read the **Migration error** row and the daemon log shown
+  in Advanced before changing anything.
+- **Pending is not `None`**: this should not happen after startup in the
+  current implementation, because migrations run during `board.db` open. Treat
+  it as a bug in migration/status plumbing unless you have changed the code
+  locally.
+- **CLI and UI disagree on target/current versions**: you are probably running
+  mixed binaries. Compare the desktop build and the `roux` CLI on your `PATH`,
+  then restart the daemon so it reopens `board.db` with the expected binary.
+
+Do not delete `board.db` as a first debugging step. Copy it aside first if you
+need to test recovery:
+
+```bash
+cp "$HOME/.config/roux/board.db" "$HOME/.config/roux/board.db.backup"
+```
+
 ## Reporting a bug
 
 Please file an issue at [github.com/phin-tech/roux/issues](https://github.com/phin-tech/roux/issues) with:

--- a/docs/v2/daemon-protocol.md
+++ b/docs/v2/daemon-protocol.md
@@ -59,6 +59,12 @@ compatibility.
 should prefer capability checks over hardcoded assumptions while this protocol
 is experimental.
 
+The status payload also includes `workItemMigrationStatus` for the work-item
+board database:
+`{ "currentVersion": 7, "targetVersion": 7, "pendingVersions": [], "storage": "boardDb", "error": null }`.
+When `board.db` cannot be opened, `storage` is `"inMemory"` and `error`
+contains the open/migration failure that forced the runtime fallback.
+
 `daemon-stop` requests graceful daemon shutdown and returns
 `{ "stopping": true, "pid": ..., "socket": "...", "logPath": "..." }` before
 the daemon closes its socket and runtime services. It is used by

--- a/src-tauri/src/daemon_client.rs
+++ b/src-tauri/src/daemon_client.rs
@@ -17,6 +17,7 @@ use roux_runtime::automation_hooks::{
 use roux_runtime::process_service::{ProcessRecord, ProcessSnapshot};
 use roux_runtime::terminal_env::NotesEnvInputs;
 use roux_runtime::work_item_service::WorkItemHandle;
+use roux_runtime::work_item_store::WorkItemMigrationStatus;
 use roux_sdk::{
     AliasEventStreamFrame, MailboxEventStreamFrame, PtyAttachFrame, PtyRecord, PtySnapshot,
     SubscriptionEventStreamFrame, WatchEventStreamFrame, WorkItemEventStreamFrame,
@@ -48,6 +49,8 @@ pub(crate) struct DaemonStatus {
     pub(crate) process_count: usize,
     #[serde(default)]
     pub(crate) pty_count: usize,
+    #[serde(default)]
+    pub(crate) work_item_migration_status: Option<WorkItemMigrationStatus>,
     pub(crate) capabilities: Vec<String>,
 }
 
@@ -1550,6 +1553,7 @@ mod tests {
             watch_count: 0,
             process_count: 0,
             pty_count: 0,
+            work_item_migration_status: None,
             capabilities: vec!["daemon-status".to_string()],
         }
     }

--- a/src-tauri/src/daemon_client.rs
+++ b/src-tauri/src/daemon_client.rs
@@ -9,7 +9,7 @@ use tauri::{AppHandle, Emitter};
 use crate::commands::notes::{NotesRead, NotesSearchQuery, NotesTarget};
 use roux_core::{
     AgentAlias, BusSubscription, CreateWatchConfig, Event, Project, ProjectUpdate, ReadState,
-    Session, SessionExitPayload, SessionExitReason, Watch, Worktree,
+    Session, SessionExitPayload, SessionExitReason, Watch, WorkItemMigrationStatus, Worktree,
 };
 use roux_runtime::automation_hooks::{
     HookListItem, HookLogEntry, HookPreviewItem, HookRunRequest, HookRunSummary,
@@ -17,7 +17,6 @@ use roux_runtime::automation_hooks::{
 use roux_runtime::process_service::{ProcessRecord, ProcessSnapshot};
 use roux_runtime::terminal_env::NotesEnvInputs;
 use roux_runtime::work_item_service::WorkItemHandle;
-use roux_runtime::work_item_store::WorkItemMigrationStatus;
 use roux_sdk::{
     AliasEventStreamFrame, MailboxEventStreamFrame, PtyAttachFrame, PtyRecord, PtySnapshot,
     SubscriptionEventStreamFrame, WatchEventStreamFrame, WorkItemEventStreamFrame,

--- a/src/lib/components/__tests__/SettingsPanel.test.ts
+++ b/src/lib/components/__tests__/SettingsPanel.test.ts
@@ -124,6 +124,13 @@ vi.mock("$lib/tauri", () => ({
       watchCount: 6,
       processCount: 4,
       ptyCount: 5,
+      workItemMigrationStatus: {
+        currentVersion: 7,
+        targetVersion: 7,
+        pendingVersions: [],
+        storage: "boardDb",
+        error: null,
+      },
       capabilities: ["daemon-status", "daemon-pty-list"],
     },
   }),
@@ -672,6 +679,11 @@ describe("SettingsPanel runtime debug", () => {
     expect(await screen.findByText("pid 4242")).toBeDefined();
     expect(await screen.findByText("/tmp/roux.sock")).toBeDefined();
     expect(await screen.findByText(/6 watches/)).toBeDefined();
+    expect(await screen.findByText("Current migration")).toBeDefined();
+    expect(await screen.findByText("Target migration")).toBeDefined();
+    expect((await screen.findAllByText("v7")).length).toBeGreaterThan(1);
+    expect(await screen.findByText("None")).toBeDefined();
+    expect(await screen.findByText("board.db")).toBeDefined();
     expect(getRuntimeStatus).toHaveBeenCalled();
   });
 });

--- a/src/lib/components/settings/SettingsAdvancedSection.svelte
+++ b/src/lib/components/settings/SettingsAdvancedSection.svelte
@@ -3,7 +3,11 @@
   import DoctorPanel from "$lib/components/DoctorPanel.svelte";
   import { getLogPath, setLoggingEnabled } from "$lib/logging";
   import { settings, updateSetting } from "$lib/stores/settings";
-  import { getRuntimeStatus, type RuntimeStatus } from "$lib/tauri";
+  import {
+    getRuntimeStatus,
+    type RuntimeStatus,
+    type WorkItemMigrationStorage,
+  } from "$lib/tauri";
 
   let runtimeStatus = $state<RuntimeStatus | null>(null);
   let runtimeStatusError = $state<string | null>(null);
@@ -51,6 +55,19 @@
     if (hours > 0) return `${hours}h ${minutes}m`;
     if (minutes > 0) return `${minutes}m ${seconds}s`;
     return `${seconds}s`;
+  }
+
+  function migrationStorageLabel(storage: WorkItemMigrationStorage): string {
+    return storage === "boardDb" ? "board.db" : "In-memory fallback";
+  }
+
+  function formatMigrationVersion(version: number): string {
+    return Number.isFinite(version) ? `v${version}` : String(version);
+  }
+
+  function formatPendingMigrations(versions: number[]): string {
+    if (versions.length === 0) return "None";
+    return versions.map(formatMigrationVersion).join(", ");
   }
 </script>
 
@@ -134,6 +151,34 @@
           {runtimeStatus.daemon.processCount ?? 0} processes,
           {runtimeStatus.daemon.ptyCount ?? 0} PTYs
         </div>
+
+        {#if runtimeStatus.daemon.workItemMigrationStatus}
+          {@const migration = runtimeStatus.daemon.workItemMigrationStatus}
+          <div class="text-text-muted">Database</div>
+          <div class="text-text-secondary">
+            {migrationStorageLabel(migration.storage)}
+          </div>
+
+          <div class="text-text-muted">Current migration</div>
+          <div class="font-mono text-text-secondary">
+            {formatMigrationVersion(migration.currentVersion)}
+          </div>
+
+          <div class="text-text-muted">Target migration</div>
+          <div class="font-mono text-text-secondary">
+            {formatMigrationVersion(migration.targetVersion)}
+          </div>
+
+          <div class="text-text-muted">Pending</div>
+          <div class="font-mono text-text-secondary">
+            {formatPendingMigrations(migration.pendingVersions)}
+          </div>
+
+          {#if migration.error}
+            <div class="text-text-muted">Migration error</div>
+            <div class="break-all text-amber">{migration.error}</div>
+          {/if}
+        {/if}
       {:else if runtimeStatus.local}
         <div class="text-text-muted">State</div>
         <div class="text-text-secondary">

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -68,7 +68,18 @@ export interface DaemonStatus {
   watchCount?: number;
   processCount?: number;
   ptyCount?: number;
+  workItemMigrationStatus?: WorkItemMigrationStatus | null;
   capabilities: string[];
+}
+
+export type WorkItemMigrationStorage = "boardDb" | "inMemory";
+
+export interface WorkItemMigrationStatus {
+  currentVersion: number;
+  targetVersion: number;
+  pendingVersions: number[];
+  storage: WorkItemMigrationStorage;
+  error?: string | null;
 }
 
 export interface RuntimeCounts {


### PR DESCRIPTION
## Summary
- Add read-only work-item board database migration status to daemon/runtime status.
- Surface current/target/pending migration state in Advanced settings.
- Document daemon protocol and troubleshooting steps for out-of-sync status.

## Verification
- cargo test -p roux-runtime work_item_store::tests
- cargo test -p roux-cli daemon_status_is_daemon_only_socket_command
- cargo test -p roux-sdk typed_status_decodes_from_daemon_response
- cargo test --manifest-path src-tauri/Cargo.toml daemon_client::tests::event_bridge_reconnects_after_eof_and_error
- npm run test -- SettingsPanel.test.ts --run
- npm run check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds read-only work-item board database migration diagnostics to the daemon status payload and surfaces them in the Advanced settings panel. The canonical types live in `roux-core` and are shared across `roux-runtime`, `roux-sdk`, and the Tauri client, avoiding duplication.

- **New types & helper** (`roux-core`): `WorkItemMigrationStatus`, `WorkItemMigrationStorage`, and `pending_work_item_migrations` are defined once and re-exported everywhere they're needed.
- **Status capture** (`roux-runtime`): `WorkItemHandle` now snapshots the migration state at open time and exposes it via `migration_status()`; the in-memory fallback stores the board.db open error so the UI is self-contained for triage.
- **UI surface** (`SettingsAdvancedSection.svelte`, `tauri.ts`): A new Database sub-section renders migration fields when the optional `workItemMigrationStatus` field is present, guarded for backward compatibility with older daemons.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are additive, read-only diagnostics with no mutations to existing state or data paths.

The migration status is captured once at open time (after migrations have already run), shared via a single canonical type in roux-core, and surfaced behind an optional field that older daemons simply omit. Error strings include the board.db path, the UI guards against a missing field, and the changes are covered by new tests across all three crates and the frontend.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/roux-core/src/models/work_item.rs | Adds WorkItemMigrationStatus, WorkItemMigrationStorage types and pending_work_item_migrations helper; edge cases handled via saturating_add/max(1). |
| crates/roux-runtime/src/work_item_service.rs | Captures migration status at open time (post-migration), exposes it via migration_status(); in_memory_with_error correctly includes the board.db path in the stored error string. |
| crates/roux-runtime/src/host.rs | Switches fallback to in_memory_with_error(Some(err)) so the error (including path) propagates into migration status. |
| src/lib/components/settings/SettingsAdvancedSection.svelte | Adds a Database section under Runtime diagnostics, guarded by the optional migration status field. |
| src/lib/tauri.ts | Adds WorkItemMigrationStorage union type and WorkItemMigrationStatus interface matching the Rust serialisation. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Host as RuntimeHostConfig
    participant Handle as WorkItemHandle
    participant Store as WorkItemStore
    participant CLI as roux daemon status
    participant UI as SettingsAdvancedSection

    Host->>Handle: open(work_item_db_path)
    alt board.db opens successfully
        Handle->>Store: open(path) + configure_and_migrate
        Store-->>Handle: Ok(store)
        Handle->>Store: current_schema_version()
        Handle->>Handle: "migration_status = new(current, target, BoardDb, None)"
        Handle-->>Host: Ok(WorkItemHandle)
    else open or version-query fails
        Handle-->>Host: Err(err_with_path)
        Host->>Handle: in_memory_with_error(Some(err))
        Handle->>Store: open_in_memory() + configure_and_migrate
        Handle->>Handle: "migration_status = new(current, target, InMemory, Some(err))"
        Handle-->>Host: WorkItemHandle (in-memory fallback)
    end
    CLI->>Handle: migration_status()
    Handle-->>CLI: WorkItemMigrationStatus clone
    CLI-->>UI: JSON workItemMigrationStatus
    UI-->>UI: Render Database section
```

<sub>Reviews (2): Last reviewed commit: ["Fix migration status review findings"](https://github.com/phin-tech/roux/commit/e5436363b09e9c19d188f7d777e7bc6c457d415f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35592006)</sub>

<!-- /greptile_comment -->