### PR TITLE
[codex] Fix daemon and MCP ghost processes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4068,6 +4068,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "uuid",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/roux-cli/Cargo.toml
+++ b/crates/roux-cli/Cargo.toml
@@ -32,5 +32,12 @@ uuid = { version = "1", features = ["v4"] }
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_System_Diagnostics_ToolHelp",
+    "Win32_System_Threading",
+] }
+
 [dev-dependencies]
 tempfile = "3"

--- a/crates/roux-cli/src/daemon.rs
+++ b/crates/roux-cli/src/daemon.rs
@@ -141,7 +141,7 @@ pub async fn run() -> Result<(), String> {
     wait_for_shutdown_signal(shutdown_rx).await?;
     log.write("Shutdown signal received");
 
-    socket_server.shutdown();
+    let owner_guard = socket_server.shutdown();
     log.write("Socket server stopped");
     host.process_handle.shutdown().await;
     host.pty_handle.shutdown().await;
@@ -159,6 +159,7 @@ pub async fn run() -> Result<(), String> {
         }
     }
 
+    drop(owner_guard);
     log.write("Shutdown complete");
     Ok(())
 }

--- a/crates/roux-cli/src/daemon.rs
+++ b/crates/roux-cli/src/daemon.rs
@@ -48,7 +48,7 @@ use projects::{
     handle_project_update,
 };
 use protocol::{Request, Response};
-use server::start_socket_server;
+use server::{acquire_daemon_owner, start_socket_server};
 use status::{handle_daemon_status, handle_daemon_stop};
 use watches::{
     handle_watch_cleanup_orphans, handle_watch_create, handle_watch_find_or_create,
@@ -69,6 +69,9 @@ const DEFAULT_LATEST_OUTPUT_BYTES: usize = 8 * 1024;
 const MAX_LATEST_OUTPUT_BYTES: usize = 64 * 1024;
 
 pub async fn run() -> Result<(), String> {
+    let endpoint = platform::daemon_bind_endpoint();
+    let owner_guard =
+        acquire_daemon_owner(&platform::daemon_owner_lock_path(), &endpoint.display_value())?;
     paths::migrate_legacy_config_dir();
     let log = DaemonLog::init();
 
@@ -125,14 +128,18 @@ pub async fn run() -> Result<(), String> {
 
     let watch_runner = WatchRunner::new(host.watch_handle.clone(), daemon_hook_manager());
     watch_runner.start_all().await;
-    let endpoint = platform::daemon_bind_endpoint();
     let auth_token = daemon_auth_token(&endpoint)?;
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
     let identity =
         DaemonIdentity::new(endpoint, log.path().clone(), auth_token).with_shutdown(shutdown_tx);
-    let socket_server =
-        start_socket_server(host.clone(), watch_runner.clone(), identity.clone(), log.clone())
-            .await?;
+    let socket_server = start_socket_server(
+        host.clone(),
+        watch_runner.clone(),
+        identity.clone(),
+        log.clone(),
+        owner_guard,
+    )
+    .await?;
     log.write(&format!(
         "Started on {}; press Ctrl-C to stop",
         socket_server.endpoint.display_value()

--- a/crates/roux-cli/src/daemon/identity.rs
+++ b/crates/roux-cli/src/daemon/identity.rs
@@ -15,7 +15,6 @@ pub(super) struct DaemonIdentity {
     pub(super) started_at_ms: u64,
     pub(super) socket: PathBuf,
     pub(super) log_path: PathBuf,
-    pub(super) owner_lock_path: PathBuf,
     #[cfg_attr(not(windows), allow(dead_code))]
     pub(super) auth_token: Option<String>,
     pub(super) endpoint: platform::SocketEndpoint,
@@ -42,7 +41,6 @@ impl DaemonIdentity {
             started_at_ms: unix_now_ms(),
             socket: endpoint_path(&endpoint),
             log_path,
-            owner_lock_path: platform::daemon_owner_lock_path(),
             auth_token,
             endpoint,
             alias_manager: AliasManager::load_from(paths::roux_config_dir().join("aliases.json")),
@@ -73,7 +71,6 @@ impl DaemonIdentity {
             started_at_ms: 1_000,
             socket: socket.clone(),
             log_path: PathBuf::from("/tmp/roux-daemon.log"),
-            owner_lock_path: platform::daemon_owner_lock_path(),
             auth_token: None,
             endpoint: platform::SocketEndpoint::Unix(socket),
             alias_manager: AliasManager::in_memory(),
@@ -93,7 +90,6 @@ impl DaemonIdentity {
             started_at_ms: 1_000,
             socket: endpoint_path(&endpoint),
             log_path: PathBuf::from("/tmp/roux-daemon.log"),
-            owner_lock_path: platform::daemon_owner_lock_path(),
             auth_token,
             endpoint,
             alias_manager: AliasManager::in_memory(),
@@ -114,7 +110,6 @@ impl DaemonIdentity {
             started_at_ms: 1_000,
             socket: socket.clone(),
             log_path: PathBuf::from("/tmp/roux-daemon.log"),
-            owner_lock_path: platform::daemon_owner_lock_path(),
             auth_token: None,
             endpoint: platform::SocketEndpoint::Unix(socket),
             alias_manager: AliasManager::load_from(alias_path),
@@ -138,7 +133,6 @@ impl DaemonIdentity {
             started_at_ms: 1_000,
             socket: socket.clone(),
             log_path: PathBuf::from("/tmp/roux-daemon.log"),
-            owner_lock_path: platform::daemon_owner_lock_path(),
             auth_token: None,
             endpoint: platform::SocketEndpoint::Unix(socket),
             alias_manager: AliasManager::load_from(alias_path),
@@ -150,12 +144,6 @@ impl DaemonIdentity {
             .with_subscriptions(subscription_manager),
             shutdown_tx: None,
         }
-    }
-
-    #[cfg(test)]
-    pub(super) fn with_owner_lock_path(mut self, owner_lock_path: PathBuf) -> Self {
-        self.owner_lock_path = owner_lock_path;
-        self
     }
 }
 

--- a/crates/roux-cli/src/daemon/identity.rs
+++ b/crates/roux-cli/src/daemon/identity.rs
@@ -15,6 +15,7 @@ pub(super) struct DaemonIdentity {
     pub(super) started_at_ms: u64,
     pub(super) socket: PathBuf,
     pub(super) log_path: PathBuf,
+    pub(super) owner_lock_path: PathBuf,
     #[cfg_attr(not(windows), allow(dead_code))]
     pub(super) auth_token: Option<String>,
     pub(super) endpoint: platform::SocketEndpoint,
@@ -41,6 +42,7 @@ impl DaemonIdentity {
             started_at_ms: unix_now_ms(),
             socket: endpoint_path(&endpoint),
             log_path,
+            owner_lock_path: platform::daemon_owner_lock_path(),
             auth_token,
             endpoint,
             alias_manager: AliasManager::load_from(paths::roux_config_dir().join("aliases.json")),
@@ -71,6 +73,7 @@ impl DaemonIdentity {
             started_at_ms: 1_000,
             socket: socket.clone(),
             log_path: PathBuf::from("/tmp/roux-daemon.log"),
+            owner_lock_path: platform::daemon_owner_lock_path(),
             auth_token: None,
             endpoint: platform::SocketEndpoint::Unix(socket),
             alias_manager: AliasManager::in_memory(),
@@ -90,6 +93,7 @@ impl DaemonIdentity {
             started_at_ms: 1_000,
             socket: endpoint_path(&endpoint),
             log_path: PathBuf::from("/tmp/roux-daemon.log"),
+            owner_lock_path: platform::daemon_owner_lock_path(),
             auth_token,
             endpoint,
             alias_manager: AliasManager::in_memory(),
@@ -110,6 +114,7 @@ impl DaemonIdentity {
             started_at_ms: 1_000,
             socket: socket.clone(),
             log_path: PathBuf::from("/tmp/roux-daemon.log"),
+            owner_lock_path: platform::daemon_owner_lock_path(),
             auth_token: None,
             endpoint: platform::SocketEndpoint::Unix(socket),
             alias_manager: AliasManager::load_from(alias_path),
@@ -133,6 +138,7 @@ impl DaemonIdentity {
             started_at_ms: 1_000,
             socket: socket.clone(),
             log_path: PathBuf::from("/tmp/roux-daemon.log"),
+            owner_lock_path: platform::daemon_owner_lock_path(),
             auth_token: None,
             endpoint: platform::SocketEndpoint::Unix(socket),
             alias_manager: AliasManager::load_from(alias_path),
@@ -144,6 +150,12 @@ impl DaemonIdentity {
             .with_subscriptions(subscription_manager),
             shutdown_tx: None,
         }
+    }
+
+    #[cfg(test)]
+    pub(super) fn with_owner_lock_path(mut self, owner_lock_path: PathBuf) -> Self {
+        self.owner_lock_path = owner_lock_path;
+        self
     }
 }
 

--- a/crates/roux-cli/src/daemon/server.rs
+++ b/crates/roux-cli/src/daemon/server.rs
@@ -22,6 +22,7 @@ use super::work_items::handle_work_item_events_stream;
 pub(super) struct SocketServerHandle {
     join: tokio::task::JoinHandle<()>,
     cleanup: SocketCleanup,
+    _owner_guard: Option<SocketOwnerGuard>,
     pub(super) endpoint: platform::SocketEndpoint,
 }
 
@@ -29,6 +30,22 @@ impl SocketServerHandle {
     pub(super) fn shutdown(self) {
         self.join.abort();
         self.cleanup.remove();
+    }
+}
+
+#[cfg(not(windows))]
+struct SocketOwnerGuard {
+    _file: std::fs::File,
+    path: PathBuf,
+}
+
+#[cfg(windows)]
+struct SocketOwnerGuard;
+
+#[cfg(not(windows))]
+impl Drop for SocketOwnerGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
     }
 }
 
@@ -54,6 +71,7 @@ pub(super) async fn start_socket_server(
         platform::SocketEndpoint::Unix(path) => {
             #[cfg(not(windows))]
             {
+                let owner_guard = acquire_unix_socket_owner(&path)?;
                 let listener = bind_unix_listener(&path)?;
                 log.write(&format!("Socket server listening on {}", path.display()));
                 let cleanup_paths = vec![path.clone()];
@@ -89,6 +107,7 @@ pub(super) async fn start_socket_server(
                 Ok(SocketServerHandle {
                     join,
                     cleanup: SocketCleanup { paths: cleanup_paths },
+                    _owner_guard: Some(owner_guard),
                     endpoint,
                 })
             }
@@ -144,10 +163,46 @@ pub(super) async fn start_socket_server(
             Ok(SocketServerHandle {
                 join,
                 cleanup: SocketCleanup { paths: cleanup_paths },
+                _owner_guard: None,
                 endpoint,
             })
         }
     }
+}
+
+#[cfg(not(windows))]
+fn acquire_unix_socket_owner(path: &Path) -> Result<SocketOwnerGuard, String> {
+    use std::os::fd::AsRawFd;
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|err| format!("create socket directory {}: {err}", parent.display()))?;
+    }
+
+    let lock_path = unix_socket_lock_path(path);
+    let file =
+        std::fs::OpenOptions::new().create(true).read(true).write(true).open(&lock_path).map_err(
+            |err| format!("open daemon socket owner lock {}: {err}", lock_path.display()),
+        )?;
+    let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+    if result == -1 {
+        let err = std::io::Error::last_os_error();
+        if err.kind() == std::io::ErrorKind::WouldBlock {
+            return Err(format!("Roux daemon already running for socket {}", path.display()));
+        }
+        return Err(format!("lock daemon socket owner {}: {err}", lock_path.display()));
+    }
+
+    Ok(SocketOwnerGuard { _file: file, path: lock_path })
+}
+
+#[cfg(not(windows))]
+fn unix_socket_lock_path(path: &Path) -> PathBuf {
+    let mut lock_path = path.to_path_buf();
+    let mut file_name = path.file_name().map(std::ffi::OsString::from).unwrap_or_default();
+    file_name.push(".lock");
+    lock_path.set_file_name(file_name);
+    lock_path
 }
 
 #[cfg(not(windows))]

--- a/crates/roux-cli/src/daemon/server.rs
+++ b/crates/roux-cli/src/daemon/server.rs
@@ -174,8 +174,9 @@ pub(super) fn acquire_daemon_owner(
     use std::os::fd::AsRawFd;
 
     if let Some(parent) = lock_path.parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|err| format!("create socket directory {}: {err}", parent.display()))?;
+        std::fs::create_dir_all(parent).map_err(|err| {
+            format!("create daemon owner lock directory {}: {err}", parent.display())
+        })?;
     }
 
     let file =
@@ -186,7 +187,7 @@ pub(super) fn acquire_daemon_owner(
     if result == -1 {
         let err = std::io::Error::last_os_error();
         if err.kind() == std::io::ErrorKind::WouldBlock {
-            return Err(format!("Roux daemon already running for {endpoint}"));
+            return Err(daemon_already_running_message(endpoint));
         }
         return Err(format!("lock daemon socket owner {}: {err}", lock_path.display()));
     }
@@ -202,8 +203,9 @@ pub(super) fn acquire_daemon_owner(
     use std::os::windows::fs::OpenOptionsExt;
 
     if let Some(parent) = lock_path.parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|err| format!("create socket directory {}: {err}", parent.display()))?;
+        std::fs::create_dir_all(parent).map_err(|err| {
+            format!("create daemon owner lock directory {}: {err}", parent.display())
+        })?;
     }
 
     let file = std::fs::OpenOptions::new()
@@ -214,12 +216,16 @@ pub(super) fn acquire_daemon_owner(
         .open(lock_path)
         .map_err(|err| match err.kind() {
             std::io::ErrorKind::PermissionDenied | std::io::ErrorKind::WouldBlock => {
-                format!("Roux daemon already running for {endpoint}")
+                daemon_already_running_message(endpoint)
             }
             _ => format!("open daemon socket owner lock {}: {err}", lock_path.display()),
         })?;
 
     Ok(SocketOwnerGuard { _file: file })
+}
+
+fn daemon_already_running_message(attempted_endpoint: &str) -> String {
+    format!("Roux daemon already running; attempted endpoint: {attempted_endpoint}")
 }
 
 #[cfg(not(windows))]
@@ -456,14 +462,14 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let lock_path = dir.path().join("roux-daemon.lock");
 
-        let first = acquire_daemon_owner(&lock_path, "test endpoint").unwrap();
+        let first = acquire_daemon_owner(&lock_path, "unix:///tmp/roux.sock").unwrap();
         assert!(lock_path.exists());
 
-        let second = match acquire_daemon_owner(&lock_path, "test endpoint") {
+        let second = match acquire_daemon_owner(&lock_path, "tcp://127.0.0.1:0") {
             Ok(_) => panic!("second owner should fail while first guard is held"),
             Err(err) => err,
         };
-        assert!(second.contains("already running"));
+        assert_eq!(second, "Roux daemon already running; attempted endpoint: tcp://127.0.0.1:0");
 
         drop(first);
         assert!(lock_path.exists(), "flock path should remain as a reusable inode");

--- a/crates/roux-cli/src/daemon/server.rs
+++ b/crates/roux-cli/src/daemon/server.rs
@@ -62,13 +62,12 @@ pub(super) async fn start_socket_server(
     watch_runner: WatchRunner,
     mut identity: DaemonIdentity,
     log: DaemonLog,
+    owner_guard: SocketOwnerGuard,
 ) -> Result<SocketServerHandle, String> {
     match identity.endpoint.clone() {
         platform::SocketEndpoint::Unix(path) => {
             #[cfg(not(windows))]
             {
-                let owner_guard =
-                    acquire_daemon_owner(&identity.owner_lock_path, &identity.endpoint_display())?;
                 let listener = bind_unix_listener(&path)?;
                 log.write(&format!("Socket server listening on {}", path.display()));
                 let cleanup_paths = vec![path.clone()];
@@ -118,8 +117,6 @@ pub(super) async fn start_socket_server(
             }
         }
         platform::SocketEndpoint::Tcp(addr) => {
-            let owner_guard =
-                acquire_daemon_owner(&identity.owner_lock_path, &identity.endpoint_display())?;
             let listener = bind_tcp_listener(&addr, &identity).await?;
             let local_addr = listener
                 .local_addr()
@@ -170,7 +167,10 @@ pub(super) async fn start_socket_server(
 }
 
 #[cfg(not(windows))]
-fn acquire_daemon_owner(lock_path: &Path, endpoint: &str) -> Result<SocketOwnerGuard, String> {
+pub(super) fn acquire_daemon_owner(
+    lock_path: &Path,
+    endpoint: &str,
+) -> Result<SocketOwnerGuard, String> {
     use std::os::fd::AsRawFd;
 
     if let Some(parent) = lock_path.parent() {
@@ -195,7 +195,10 @@ fn acquire_daemon_owner(lock_path: &Path, endpoint: &str) -> Result<SocketOwnerG
 }
 
 #[cfg(windows)]
-fn acquire_daemon_owner(lock_path: &Path, endpoint: &str) -> Result<SocketOwnerGuard, String> {
+pub(super) fn acquire_daemon_owner(
+    lock_path: &Path,
+    endpoint: &str,
+) -> Result<SocketOwnerGuard, String> {
     use std::os::windows::fs::OpenOptionsExt;
 
     if let Some(parent) = lock_path.parent() {

--- a/crates/roux-cli/src/daemon/server.rs
+++ b/crates/roux-cli/src/daemon/server.rs
@@ -22,24 +22,26 @@ use super::work_items::handle_work_item_events_stream;
 pub(super) struct SocketServerHandle {
     join: tokio::task::JoinHandle<()>,
     cleanup: SocketCleanup,
-    _owner_guard: Option<SocketOwnerGuard>,
+    owner_guard: SocketOwnerGuard,
     pub(super) endpoint: platform::SocketEndpoint,
 }
 
 impl SocketServerHandle {
-    pub(super) fn shutdown(self) {
-        self.join.abort();
-        self.cleanup.remove();
+    pub(super) fn shutdown(self) -> SocketOwnerGuard {
+        let Self { join, cleanup, owner_guard, endpoint: _ } = self;
+        join.abort();
+        cleanup.remove();
+        owner_guard
     }
 }
 
 #[cfg(not(windows))]
-struct SocketOwnerGuard {
+pub(super) struct SocketOwnerGuard {
     _file: std::fs::File,
 }
 
 #[cfg(windows)]
-struct SocketOwnerGuard {
+pub(super) struct SocketOwnerGuard {
     _file: std::fs::File,
 }
 
@@ -65,10 +67,8 @@ pub(super) async fn start_socket_server(
         platform::SocketEndpoint::Unix(path) => {
             #[cfg(not(windows))]
             {
-                let owner_guard = acquire_daemon_owner(
-                    &unix_socket_lock_path(&path),
-                    &path.display().to_string(),
-                )?;
+                let owner_guard =
+                    acquire_daemon_owner(&identity.owner_lock_path, &identity.endpoint_display())?;
                 let listener = bind_unix_listener(&path)?;
                 log.write(&format!("Socket server listening on {}", path.display()));
                 let cleanup_paths = vec![path.clone()];
@@ -104,7 +104,7 @@ pub(super) async fn start_socket_server(
                 Ok(SocketServerHandle {
                     join,
                     cleanup: SocketCleanup { paths: cleanup_paths },
-                    _owner_guard: Some(owner_guard),
+                    owner_guard,
                     endpoint,
                 })
             }
@@ -119,7 +119,7 @@ pub(super) async fn start_socket_server(
         }
         platform::SocketEndpoint::Tcp(addr) => {
             let owner_guard =
-                acquire_daemon_owner(&daemon_owner_lock_path(), &format!("tcp://{addr}"))?;
+                acquire_daemon_owner(&identity.owner_lock_path, &identity.endpoint_display())?;
             let listener = bind_tcp_listener(&addr, &identity).await?;
             let local_addr = listener
                 .local_addr()
@@ -162,7 +162,7 @@ pub(super) async fn start_socket_server(
             Ok(SocketServerHandle {
                 join,
                 cleanup: SocketCleanup { paths: cleanup_paths },
-                _owner_guard: Some(owner_guard),
+                owner_guard,
                 endpoint,
             })
         }
@@ -217,19 +217,6 @@ fn acquire_daemon_owner(lock_path: &Path, endpoint: &str) -> Result<SocketOwnerG
         })?;
 
     Ok(SocketOwnerGuard { _file: file })
-}
-
-fn daemon_owner_lock_path() -> PathBuf {
-    platform::app_config_dir().join("roux-daemon.lock")
-}
-
-#[cfg(not(windows))]
-fn unix_socket_lock_path(path: &Path) -> PathBuf {
-    let mut lock_path = path.to_path_buf();
-    let mut file_name = path.file_name().map(std::ffi::OsString::from).unwrap_or_default();
-    file_name.push(".lock");
-    lock_path.set_file_name(file_name);
-    lock_path
 }
 
 #[cfg(not(windows))]

--- a/crates/roux-cli/src/daemon/server.rs
+++ b/crates/roux-cli/src/daemon/server.rs
@@ -36,17 +36,11 @@ impl SocketServerHandle {
 #[cfg(not(windows))]
 struct SocketOwnerGuard {
     _file: std::fs::File,
-    path: PathBuf,
 }
 
 #[cfg(windows)]
-struct SocketOwnerGuard;
-
-#[cfg(not(windows))]
-impl Drop for SocketOwnerGuard {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_file(&self.path);
-    }
+struct SocketOwnerGuard {
+    _file: std::fs::File,
 }
 
 struct SocketCleanup {
@@ -71,7 +65,10 @@ pub(super) async fn start_socket_server(
         platform::SocketEndpoint::Unix(path) => {
             #[cfg(not(windows))]
             {
-                let owner_guard = acquire_unix_socket_owner(&path)?;
+                let owner_guard = acquire_daemon_owner(
+                    &unix_socket_lock_path(&path),
+                    &path.display().to_string(),
+                )?;
                 let listener = bind_unix_listener(&path)?;
                 log.write(&format!("Socket server listening on {}", path.display()));
                 let cleanup_paths = vec![path.clone()];
@@ -121,6 +118,8 @@ pub(super) async fn start_socket_server(
             }
         }
         platform::SocketEndpoint::Tcp(addr) => {
+            let owner_guard =
+                acquire_daemon_owner(&daemon_owner_lock_path(), &format!("tcp://{addr}"))?;
             let listener = bind_tcp_listener(&addr, &identity).await?;
             let local_addr = listener
                 .local_addr()
@@ -163,7 +162,7 @@ pub(super) async fn start_socket_server(
             Ok(SocketServerHandle {
                 join,
                 cleanup: SocketCleanup { paths: cleanup_paths },
-                _owner_guard: None,
+                _owner_guard: Some(owner_guard),
                 endpoint,
             })
         }
@@ -171,15 +170,14 @@ pub(super) async fn start_socket_server(
 }
 
 #[cfg(not(windows))]
-fn acquire_unix_socket_owner(path: &Path) -> Result<SocketOwnerGuard, String> {
+fn acquire_daemon_owner(lock_path: &Path, endpoint: &str) -> Result<SocketOwnerGuard, String> {
     use std::os::fd::AsRawFd;
 
-    if let Some(parent) = path.parent() {
+    if let Some(parent) = lock_path.parent() {
         std::fs::create_dir_all(parent)
             .map_err(|err| format!("create socket directory {}: {err}", parent.display()))?;
     }
 
-    let lock_path = unix_socket_lock_path(path);
     let file =
         std::fs::OpenOptions::new().create(true).read(true).write(true).open(&lock_path).map_err(
             |err| format!("open daemon socket owner lock {}: {err}", lock_path.display()),
@@ -188,12 +186,41 @@ fn acquire_unix_socket_owner(path: &Path) -> Result<SocketOwnerGuard, String> {
     if result == -1 {
         let err = std::io::Error::last_os_error();
         if err.kind() == std::io::ErrorKind::WouldBlock {
-            return Err(format!("Roux daemon already running for socket {}", path.display()));
+            return Err(format!("Roux daemon already running for {endpoint}"));
         }
         return Err(format!("lock daemon socket owner {}: {err}", lock_path.display()));
     }
 
-    Ok(SocketOwnerGuard { _file: file, path: lock_path })
+    Ok(SocketOwnerGuard { _file: file })
+}
+
+#[cfg(windows)]
+fn acquire_daemon_owner(lock_path: &Path, endpoint: &str) -> Result<SocketOwnerGuard, String> {
+    use std::os::windows::fs::OpenOptionsExt;
+
+    if let Some(parent) = lock_path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|err| format!("create socket directory {}: {err}", parent.display()))?;
+    }
+
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .share_mode(0)
+        .open(lock_path)
+        .map_err(|err| match err.kind() {
+            std::io::ErrorKind::PermissionDenied | std::io::ErrorKind::WouldBlock => {
+                format!("Roux daemon already running for {endpoint}")
+            }
+            _ => format!("open daemon socket owner lock {}: {err}", lock_path.display()),
+        })?;
+
+    Ok(SocketOwnerGuard { _file: file })
+}
+
+fn daemon_owner_lock_path() -> PathBuf {
+    platform::app_config_dir().join("roux-daemon.lock")
 }
 
 #[cfg(not(windows))]
@@ -432,5 +459,27 @@ mod tests {
         write_private_file(&path, b"secret-2", "test token").unwrap();
         assert_eq!(std::fs::read_to_string(&path).unwrap(), "secret-2");
         assert_eq!(std::fs::metadata(&path).unwrap().permissions().mode() & 0o777, 0o600);
+    }
+
+    #[test]
+    fn daemon_owner_lock_prevents_second_owner_and_leaves_lock_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock_path = dir.path().join("roux-daemon.lock");
+
+        let first = acquire_daemon_owner(&lock_path, "test endpoint").unwrap();
+        assert!(lock_path.exists());
+
+        let second = match acquire_daemon_owner(&lock_path, "test endpoint") {
+            Ok(_) => panic!("second owner should fail while first guard is held"),
+            Err(err) => err,
+        };
+        assert!(second.contains("already running"));
+
+        drop(first);
+        assert!(lock_path.exists(), "flock path should remain as a reusable inode");
+
+        let third = acquire_daemon_owner(&lock_path, "test endpoint")
+            .expect("released lock file should be reusable");
+        drop(third);
     }
 }

--- a/crates/roux-cli/src/daemon/tests.rs
+++ b/crates/roux-cli/src/daemon/tests.rs
@@ -2920,16 +2920,14 @@ async fn daemon_socket_serves_status_request() {
     );
     let log_path = dir.path().join("roux-daemon.log");
     let owner_lock_path = dir.path().join("roux-daemon.lock");
+    let endpoint = platform::SocketEndpoint::Unix(socket_path.clone());
+    let owner_guard = acquire_daemon_owner(&owner_lock_path, &endpoint.display_value()).unwrap();
     let server = start_socket_server(
         host.clone(),
         watch_runner,
-        DaemonIdentity::new(
-            platform::SocketEndpoint::Unix(socket_path.clone()),
-            log_path.clone(),
-            None,
-        )
-        .with_owner_lock_path(owner_lock_path),
+        DaemonIdentity::new(endpoint, log_path.clone(), None),
         DaemonLog::new_for_test(log_path.clone()),
+        owner_guard,
     )
     .await
     .unwrap();
@@ -2981,40 +2979,26 @@ async fn daemon_socket_server_refuses_second_owner_even_if_socket_file_was_remov
     );
     let log_path = dir.path().join("roux-daemon.log");
     let owner_lock_path = dir.path().join("roux-daemon.lock");
+    let endpoint = platform::SocketEndpoint::Unix(socket_path.clone());
+    let owner_guard = acquire_daemon_owner(&owner_lock_path, &endpoint.display_value()).unwrap();
 
     let first = start_socket_server(
         host.clone(),
         watch_runner.clone(),
-        DaemonIdentity::new(
-            platform::SocketEndpoint::Unix(socket_path.clone()),
-            log_path.clone(),
-            None,
-        )
-        .with_owner_lock_path(owner_lock_path.clone()),
+        DaemonIdentity::new(endpoint.clone(), log_path.clone(), None),
         DaemonLog::new_for_test(log_path.clone()),
+        owner_guard,
     )
     .await
     .unwrap();
 
     std::fs::remove_file(&socket_path).expect("test must simulate a lost socket path");
 
-    let second = start_socket_server(
-        host.clone(),
-        watch_runner,
-        DaemonIdentity::new(
-            platform::SocketEndpoint::Unix(socket_path.clone()),
-            log_path.clone(),
-            None,
-        )
-        .with_owner_lock_path(owner_lock_path),
-        DaemonLog::new_for_test(log_path),
-    )
-    .await;
+    let second = acquire_daemon_owner(&owner_lock_path, &endpoint.display_value());
 
     let failure = match second {
-        Ok(second) => {
-            let _owner_guard = second.shutdown();
-            Some("second daemon socket server unexpectedly started".to_string())
+        Ok(_second_owner_guard) => {
+            Some("second daemon owner lock unexpectedly acquired".to_string())
         }
         Err(err) if err.contains("already running") => None,
         Err(err) => Some(format!("unexpected second-start error: {err}")),
@@ -3058,38 +3042,26 @@ async fn daemon_socket_server_refuses_tcp_owner_while_unix_owner_is_running() {
     );
     let log_path = dir.path().join("roux-daemon.log");
     let owner_lock_path = dir.path().join("roux-daemon.lock");
+    let unix_endpoint = platform::SocketEndpoint::Unix(socket_path.clone());
+    let owner_guard =
+        acquire_daemon_owner(&owner_lock_path, &unix_endpoint.display_value()).unwrap();
 
     let first = start_socket_server(
         host.clone(),
         watch_runner.clone(),
-        DaemonIdentity::new(
-            platform::SocketEndpoint::Unix(socket_path.clone()),
-            log_path.clone(),
-            None,
-        )
-        .with_owner_lock_path(owner_lock_path.clone()),
+        DaemonIdentity::new(unix_endpoint, log_path.clone(), None),
         DaemonLog::new_for_test(log_path.clone()),
+        owner_guard,
     )
     .await
     .unwrap();
 
-    let second = start_socket_server(
-        host.clone(),
-        watch_runner,
-        DaemonIdentity::new(
-            platform::SocketEndpoint::Tcp("127.0.0.1:0".to_string()),
-            log_path.clone(),
-            Some("test-token".to_string()),
-        )
-        .with_owner_lock_path(owner_lock_path),
-        DaemonLog::new_for_test(log_path),
-    )
-    .await;
+    let tcp_endpoint = platform::SocketEndpoint::Tcp("127.0.0.1:0".to_string());
+    let second = acquire_daemon_owner(&owner_lock_path, &tcp_endpoint.display_value());
 
     let failure = match second {
-        Ok(second) => {
-            let _owner_guard = second.shutdown();
-            Some("second daemon socket server unexpectedly started".to_string())
+        Ok(_second_owner_guard) => {
+            Some("second daemon owner lock unexpectedly acquired".to_string())
         }
         Err(err) if err.contains("already running") => None,
         Err(err) => Some(format!("unexpected second-start error: {err}")),
@@ -3136,17 +3108,14 @@ async fn daemon_socket_stop_requests_shutdown_after_response() {
     let log_path = dir.path().join("roux-daemon.log");
     let owner_lock_path = dir.path().join("roux-daemon.lock");
     let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
+    let endpoint = platform::SocketEndpoint::Unix(socket_path.clone());
+    let owner_guard = acquire_daemon_owner(&owner_lock_path, &endpoint.display_value()).unwrap();
     let server = start_socket_server(
         host.clone(),
         watch_runner,
-        DaemonIdentity::new(
-            platform::SocketEndpoint::Unix(socket_path.clone()),
-            log_path.clone(),
-            None,
-        )
-        .with_owner_lock_path(owner_lock_path)
-        .with_shutdown(shutdown_tx),
+        DaemonIdentity::new(endpoint, log_path.clone(), None).with_shutdown(shutdown_tx),
         DaemonLog::new_for_test(log_path),
+        owner_guard,
     )
     .await
     .unwrap();

--- a/crates/roux-cli/src/daemon/tests.rs
+++ b/crates/roux-cli/src/daemon/tests.rs
@@ -2959,6 +2959,80 @@ async fn daemon_socket_serves_status_request() {
 
 #[cfg(not(windows))]
 #[tokio::test]
+async fn daemon_socket_server_refuses_second_owner_even_if_socket_file_was_removed() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket_path = dir.path().join("roux.sock");
+    let services = RuntimeHostConfig {
+        initial_sessions: Vec::new(),
+        session_persist_path: dir.path().join("sessions.json"),
+        initial_projects: Vec::new(),
+        project_persist_path: dir.path().join("projects.json"),
+        initial_watches: Vec::new(),
+        watch_persist_path: Some(dir.path().join("watches.json")),
+        work_item_db_path: dir.path().join("board.db"),
+    }
+    .build();
+    let (host, joins) = services.spawn_with(tokio::spawn);
+    let watch_runner = WatchRunner::new(
+        host.watch_handle.clone(),
+        AutomationHookManager::from_config_root(dir.path()),
+    );
+    let log_path = dir.path().join("roux-daemon.log");
+
+    let first = start_socket_server(
+        host.clone(),
+        watch_runner.clone(),
+        DaemonIdentity::new(
+            platform::SocketEndpoint::Unix(socket_path.clone()),
+            log_path.clone(),
+            None,
+        ),
+        DaemonLog::new_for_test(log_path.clone()),
+    )
+    .await
+    .unwrap();
+
+    std::fs::remove_file(&socket_path).expect("test must simulate a lost socket path");
+
+    let second = start_socket_server(
+        host.clone(),
+        watch_runner,
+        DaemonIdentity::new(
+            platform::SocketEndpoint::Unix(socket_path.clone()),
+            log_path.clone(),
+            None,
+        ),
+        DaemonLog::new_for_test(log_path),
+    )
+    .await;
+
+    let failure = match second {
+        Ok(second) => {
+            second.shutdown();
+            Some("second daemon socket server unexpectedly started".to_string())
+        }
+        Err(err) if err.contains("already running") => None,
+        Err(err) => Some(format!("unexpected second-start error: {err}")),
+    };
+
+    first.shutdown();
+    host.process_handle.shutdown().await;
+    host.pty_handle.shutdown().await;
+    host.watch_handle.shutdown().await;
+    host.session_handle.shutdown().await;
+    host.project_handle.shutdown().await;
+    drop(host);
+    for join in joins {
+        join.await.unwrap();
+    }
+
+    if let Some(failure) = failure {
+        panic!("{failure}");
+    }
+}
+
+#[cfg(not(windows))]
+#[tokio::test]
 async fn daemon_socket_stop_requests_shutdown_after_response() {
     use tokio::io::AsyncReadExt;
 

--- a/crates/roux-cli/src/daemon/tests.rs
+++ b/crates/roux-cli/src/daemon/tests.rs
@@ -2919,6 +2919,7 @@ async fn daemon_socket_serves_status_request() {
         AutomationHookManager::from_config_root(dir.path()),
     );
     let log_path = dir.path().join("roux-daemon.log");
+    let owner_lock_path = dir.path().join("roux-daemon.lock");
     let server = start_socket_server(
         host.clone(),
         watch_runner,
@@ -2926,7 +2927,8 @@ async fn daemon_socket_serves_status_request() {
             platform::SocketEndpoint::Unix(socket_path.clone()),
             log_path.clone(),
             None,
-        ),
+        )
+        .with_owner_lock_path(owner_lock_path),
         DaemonLog::new_for_test(log_path.clone()),
     )
     .await
@@ -2945,7 +2947,7 @@ async fn daemon_socket_serves_status_request() {
     let expected_log_path = log_path.to_string_lossy().to_string();
     assert_eq!(value["data"]["logPath"], serde_json::Value::String(expected_log_path));
 
-    server.shutdown();
+    let _owner_guard = server.shutdown();
     host.process_handle.shutdown().await;
     host.pty_handle.shutdown().await;
     host.watch_handle.shutdown().await;
@@ -2978,6 +2980,7 @@ async fn daemon_socket_server_refuses_second_owner_even_if_socket_file_was_remov
         AutomationHookManager::from_config_root(dir.path()),
     );
     let log_path = dir.path().join("roux-daemon.log");
+    let owner_lock_path = dir.path().join("roux-daemon.lock");
 
     let first = start_socket_server(
         host.clone(),
@@ -2986,7 +2989,8 @@ async fn daemon_socket_server_refuses_second_owner_even_if_socket_file_was_remov
             platform::SocketEndpoint::Unix(socket_path.clone()),
             log_path.clone(),
             None,
-        ),
+        )
+        .with_owner_lock_path(owner_lock_path.clone()),
         DaemonLog::new_for_test(log_path.clone()),
     )
     .await
@@ -3001,21 +3005,97 @@ async fn daemon_socket_server_refuses_second_owner_even_if_socket_file_was_remov
             platform::SocketEndpoint::Unix(socket_path.clone()),
             log_path.clone(),
             None,
-        ),
+        )
+        .with_owner_lock_path(owner_lock_path),
         DaemonLog::new_for_test(log_path),
     )
     .await;
 
     let failure = match second {
         Ok(second) => {
-            second.shutdown();
+            let _owner_guard = second.shutdown();
             Some("second daemon socket server unexpectedly started".to_string())
         }
         Err(err) if err.contains("already running") => None,
         Err(err) => Some(format!("unexpected second-start error: {err}")),
     };
 
-    first.shutdown();
+    let _owner_guard = first.shutdown();
+    host.process_handle.shutdown().await;
+    host.pty_handle.shutdown().await;
+    host.watch_handle.shutdown().await;
+    host.session_handle.shutdown().await;
+    host.project_handle.shutdown().await;
+    drop(host);
+    for join in joins {
+        join.await.unwrap();
+    }
+
+    if let Some(failure) = failure {
+        panic!("{failure}");
+    }
+}
+
+#[cfg(not(windows))]
+#[tokio::test]
+async fn daemon_socket_server_refuses_tcp_owner_while_unix_owner_is_running() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket_path = dir.path().join("roux.sock");
+    let services = RuntimeHostConfig {
+        initial_sessions: Vec::new(),
+        session_persist_path: dir.path().join("sessions.json"),
+        initial_projects: Vec::new(),
+        project_persist_path: dir.path().join("projects.json"),
+        initial_watches: Vec::new(),
+        watch_persist_path: Some(dir.path().join("watches.json")),
+        work_item_db_path: dir.path().join("board.db"),
+    }
+    .build();
+    let (host, joins) = services.spawn_with(tokio::spawn);
+    let watch_runner = WatchRunner::new(
+        host.watch_handle.clone(),
+        AutomationHookManager::from_config_root(dir.path()),
+    );
+    let log_path = dir.path().join("roux-daemon.log");
+    let owner_lock_path = dir.path().join("roux-daemon.lock");
+
+    let first = start_socket_server(
+        host.clone(),
+        watch_runner.clone(),
+        DaemonIdentity::new(
+            platform::SocketEndpoint::Unix(socket_path.clone()),
+            log_path.clone(),
+            None,
+        )
+        .with_owner_lock_path(owner_lock_path.clone()),
+        DaemonLog::new_for_test(log_path.clone()),
+    )
+    .await
+    .unwrap();
+
+    let second = start_socket_server(
+        host.clone(),
+        watch_runner,
+        DaemonIdentity::new(
+            platform::SocketEndpoint::Tcp("127.0.0.1:0".to_string()),
+            log_path.clone(),
+            Some("test-token".to_string()),
+        )
+        .with_owner_lock_path(owner_lock_path),
+        DaemonLog::new_for_test(log_path),
+    )
+    .await;
+
+    let failure = match second {
+        Ok(second) => {
+            let _owner_guard = second.shutdown();
+            Some("second daemon socket server unexpectedly started".to_string())
+        }
+        Err(err) if err.contains("already running") => None,
+        Err(err) => Some(format!("unexpected second-start error: {err}")),
+    };
+
+    let _owner_guard = first.shutdown();
     host.process_handle.shutdown().await;
     host.pty_handle.shutdown().await;
     host.watch_handle.shutdown().await;
@@ -3054,6 +3134,7 @@ async fn daemon_socket_stop_requests_shutdown_after_response() {
         AutomationHookManager::from_config_root(dir.path()),
     );
     let log_path = dir.path().join("roux-daemon.log");
+    let owner_lock_path = dir.path().join("roux-daemon.lock");
     let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
     let server = start_socket_server(
         host.clone(),
@@ -3063,6 +3144,7 @@ async fn daemon_socket_stop_requests_shutdown_after_response() {
             log_path.clone(),
             None,
         )
+        .with_owner_lock_path(owner_lock_path)
         .with_shutdown(shutdown_tx),
         DaemonLog::new_for_test(log_path),
     )
@@ -3088,7 +3170,7 @@ async fn daemon_socket_stop_requests_shutdown_after_response() {
     }
     assert!(*shutdown_rx.borrow(), "daemon-stop should signal shutdown");
 
-    server.shutdown();
+    let _owner_guard = server.shutdown();
     host.process_handle.shutdown().await;
     host.pty_handle.shutdown().await;
     host.watch_handle.shutdown().await;

--- a/crates/roux-cli/src/mcp.rs
+++ b/crates/roux-cli/src/mcp.rs
@@ -1382,19 +1382,19 @@ fn mailbox_recv_args(
 
 pub async fn run_stdio_server() -> anyhow::Result<()> {
     run_stdio_startup_checks()?;
-    let monitored_parent_pid = mcp_parent_monitor_startup_decision(current_parent_pid())?;
+    let parent_monitor = mcp_parent_monitor()?;
     let service = RouxMcpServer.serve(stdio()).await?;
-    match monitored_parent_pid {
-        Some(original_parent_pid) => {
+    match parent_monitor {
+        McpParentMonitor::Disabled => {
+            service.waiting().await?;
+        }
+        monitor => {
             tokio::select! {
                 result = service.waiting() => {
                     result?;
                 }
-                _ = wait_for_original_parent_exit(original_parent_pid) => {}
+                _ = wait_for_parent_exit(monitor) => {}
             }
-        }
-        None => {
-            service.waiting().await?;
         }
     }
     Ok(())
@@ -1409,7 +1409,7 @@ struct McpStdioPolicy {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum McpLifecycleError {
     InteractiveStdio,
-    ParentMonitoringUnsupported,
+    ParentMonitoringUnavailable,
 }
 
 impl std::fmt::Display for McpLifecycleError {
@@ -1418,8 +1418,8 @@ impl std::fmt::Display for McpLifecycleError {
             McpLifecycleError::InteractiveStdio => {
                 write!(f, "roux mcp requires piped stdio from an MCP host")
             }
-            McpLifecycleError::ParentMonitoringUnsupported => {
-                write!(f, "roux mcp requires parent process monitoring on this platform")
+            McpLifecycleError::ParentMonitoringUnavailable => {
+                write!(f, "roux mcp could not monitor its parent process")
             }
         }
     }
@@ -1447,8 +1447,40 @@ fn mcp_stdio_startup_decision(policy: McpStdioPolicy) -> Result<(), McpLifecycle
 fn mcp_parent_monitor_startup_decision(
     parent_pid: Option<u32>,
 ) -> Result<Option<u32>, McpLifecycleError> {
-    let parent_pid = parent_pid.ok_or(McpLifecycleError::ParentMonitoringUnsupported)?;
+    let parent_pid = parent_pid.ok_or(McpLifecycleError::ParentMonitoringUnavailable)?;
     Ok(should_monitor_parent(parent_pid).then_some(parent_pid))
+}
+
+#[derive(Debug)]
+enum McpParentMonitor {
+    Disabled,
+    #[cfg(unix)]
+    UnixPid(u32),
+    #[cfg(windows)]
+    WindowsProcess(WindowsParentProcess),
+}
+
+fn mcp_parent_monitor() -> Result<McpParentMonitor, McpLifecycleError> {
+    let parent_pid = mcp_parent_monitor_startup_decision(current_parent_pid())?;
+    let Some(parent_pid) = parent_pid else {
+        return Ok(McpParentMonitor::Disabled);
+    };
+
+    #[cfg(unix)]
+    {
+        return Ok(McpParentMonitor::UnixPid(parent_pid));
+    }
+
+    #[cfg(windows)]
+    {
+        return WindowsParentProcess::open(parent_pid).map(McpParentMonitor::WindowsProcess);
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = parent_pid;
+        Err(McpLifecycleError::ParentMonitoringUnavailable)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1494,14 +1526,134 @@ async fn wait_for_original_parent_exit(original_parent_pid: u32) {
     }
 }
 
+async fn wait_for_parent_exit(monitor: McpParentMonitor) {
+    match monitor {
+        McpParentMonitor::Disabled => {}
+        #[cfg(unix)]
+        McpParentMonitor::UnixPid(original_parent_pid) => {
+            wait_for_original_parent_exit(original_parent_pid).await;
+        }
+        #[cfg(windows)]
+        McpParentMonitor::WindowsProcess(parent_process) => {
+            wait_for_windows_parent_exit(parent_process).await;
+        }
+    }
+}
+
 #[cfg(unix)]
 fn current_parent_pid() -> Option<u32> {
     Some(unsafe { libc::getppid() as u32 })
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
+fn current_parent_pid() -> Option<u32> {
+    use windows_sys::Win32::System::Diagnostics::ToolHelp::{
+        CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W,
+        TH32CS_SNAPPROCESS,
+    };
+    use windows_sys::Win32::System::Threading::GetCurrentProcessId;
+
+    let current_pid = unsafe { GetCurrentProcessId() };
+    let snapshot = WindowsHandle::new(unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) })?;
+    let mut entry = PROCESSENTRY32W {
+        dwSize: std::mem::size_of::<PROCESSENTRY32W>() as u32,
+        ..Default::default()
+    };
+
+    if unsafe { Process32FirstW(snapshot.raw(), &mut entry) } == 0 {
+        return None;
+    }
+
+    loop {
+        if entry.th32ProcessID == current_pid {
+            return Some(entry.th32ParentProcessID);
+        }
+        if unsafe { Process32NextW(snapshot.raw(), &mut entry) } == 0 {
+            return None;
+        }
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
 fn current_parent_pid() -> Option<u32> {
     None
+}
+
+#[cfg(windows)]
+#[derive(Debug)]
+struct WindowsParentProcess {
+    _parent_pid: u32,
+    handle: WindowsHandle,
+}
+
+#[cfg(windows)]
+impl WindowsParentProcess {
+    fn open(parent_pid: u32) -> Result<Self, McpLifecycleError> {
+        use windows_sys::Win32::System::Threading::{OpenProcess, PROCESS_SYNCHRONIZE};
+
+        let handle = unsafe { OpenProcess(PROCESS_SYNCHRONIZE, 0, parent_pid) };
+        let handle =
+            WindowsHandle::new(handle).ok_or(McpLifecycleError::ParentMonitoringUnavailable)?;
+        Ok(Self { _parent_pid: parent_pid, handle })
+    }
+
+    fn has_exited(&self) -> bool {
+        use windows_sys::Win32::Foundation::{WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT};
+        use windows_sys::Win32::System::Threading::WaitForSingleObject;
+
+        match unsafe { WaitForSingleObject(self.handle.raw(), 0) } {
+            WAIT_OBJECT_0 => true,
+            WAIT_TIMEOUT => false,
+            WAIT_FAILED => true,
+            _ => true,
+        }
+    }
+}
+
+#[cfg(windows)]
+async fn wait_for_windows_parent_exit(parent_process: WindowsParentProcess) {
+    let mut interval = tokio::time::interval(std::time::Duration::from_secs(5));
+    loop {
+        interval.tick().await;
+        if parent_process.has_exited() {
+            return;
+        }
+    }
+}
+
+#[cfg(windows)]
+#[derive(Debug)]
+struct WindowsHandle {
+    handle: windows_sys::Win32::Foundation::HANDLE,
+}
+
+#[cfg(windows)]
+impl WindowsHandle {
+    fn new(handle: windows_sys::Win32::Foundation::HANDLE) -> Option<Self> {
+        use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+
+        if handle.is_null() || handle == INVALID_HANDLE_VALUE {
+            None
+        } else {
+            Some(Self { handle })
+        }
+    }
+
+    fn raw(&self) -> windows_sys::Win32::Foundation::HANDLE {
+        self.handle
+    }
+}
+
+#[cfg(windows)]
+unsafe impl Send for WindowsHandle {}
+
+#[cfg(windows)]
+impl Drop for WindowsHandle {
+    fn drop(&mut self) {
+        unsafe {
+            windows_sys::Win32::Foundation::CloseHandle(self.handle);
+        }
+    }
 }
 
 async fn call_socket(request: Value) -> Result<CallToolResult, ErrorData> {
@@ -1924,7 +2076,7 @@ mod tests {
     fn mcp_parent_monitor_startup_rejects_unknown_parent_pid() {
         assert_eq!(
             mcp_parent_monitor_startup_decision(None),
-            Err(McpLifecycleError::ParentMonitoringUnsupported)
+            Err(McpLifecycleError::ParentMonitoringUnavailable)
         );
     }
 
@@ -1936,6 +2088,17 @@ mod tests {
     #[test]
     fn mcp_parent_monitor_startup_tracks_regular_parent_pid() {
         assert_eq!(mcp_parent_monitor_startup_decision(Some(42)), Ok(Some(42)));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_parent_monitor_opens_live_parent_process() {
+        let parent_pid = current_parent_pid().expect("test process should have a parent pid");
+        if should_monitor_parent(parent_pid) {
+            let monitor =
+                WindowsParentProcess::open(parent_pid).expect("parent should be openable");
+            assert!(!monitor.has_exited());
+        }
     }
 
     #[test]

--- a/crates/roux-cli/src/mcp.rs
+++ b/crates/roux-cli/src/mcp.rs
@@ -1381,9 +1381,106 @@ fn mailbox_recv_args(
 }
 
 pub async fn run_stdio_server() -> anyhow::Result<()> {
+    run_stdio_startup_checks()?;
+    let original_parent_pid = current_parent_pid();
     let service = RouxMcpServer.serve(stdio()).await?;
-    service.waiting().await?;
+    tokio::select! {
+        result = service.waiting() => {
+            result?;
+        }
+        _ = wait_for_original_parent_exit(original_parent_pid), if should_monitor_parent(original_parent_pid) => {}
+    }
     Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct McpStdioPolicy {
+    stdin_is_terminal: bool,
+    stdout_is_terminal: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum McpLifecycleError {
+    InteractiveStdio,
+}
+
+impl std::fmt::Display for McpLifecycleError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            McpLifecycleError::InteractiveStdio => {
+                write!(f, "roux mcp requires piped stdio from an MCP host")
+            }
+        }
+    }
+}
+
+impl std::error::Error for McpLifecycleError {}
+
+fn run_stdio_startup_checks() -> Result<(), McpLifecycleError> {
+    use std::io::IsTerminal;
+
+    mcp_stdio_startup_decision(McpStdioPolicy {
+        stdin_is_terminal: std::io::stdin().is_terminal(),
+        stdout_is_terminal: std::io::stdout().is_terminal(),
+    })
+}
+
+fn mcp_stdio_startup_decision(policy: McpStdioPolicy) -> Result<(), McpLifecycleError> {
+    if policy.stdin_is_terminal || policy.stdout_is_terminal {
+        Err(McpLifecycleError::InteractiveStdio)
+    } else {
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct McpParentSnapshot {
+    original_parent_pid: u32,
+    current_parent_pid: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum McpParentLifecycleDecision {
+    Continue,
+    Exit,
+}
+
+fn mcp_parent_lifecycle_decision(snapshot: McpParentSnapshot) -> McpParentLifecycleDecision {
+    if should_monitor_parent(snapshot.original_parent_pid)
+        && snapshot.current_parent_pid != snapshot.original_parent_pid
+    {
+        McpParentLifecycleDecision::Exit
+    } else {
+        McpParentLifecycleDecision::Continue
+    }
+}
+
+fn should_monitor_parent(parent_pid: u32) -> bool {
+    parent_pid > 1
+}
+
+async fn wait_for_original_parent_exit(original_parent_pid: u32) {
+    let mut interval = tokio::time::interval(std::time::Duration::from_secs(5));
+    loop {
+        interval.tick().await;
+        let decision = mcp_parent_lifecycle_decision(McpParentSnapshot {
+            original_parent_pid,
+            current_parent_pid: current_parent_pid(),
+        });
+        if decision == McpParentLifecycleDecision::Exit {
+            return;
+        }
+    }
+}
+
+#[cfg(unix)]
+fn current_parent_pid() -> u32 {
+    unsafe { libc::getppid() as u32 }
+}
+
+#[cfg(not(unix))]
+fn current_parent_pid() -> u32 {
+    0
 }
 
 async fn call_socket(request: Value) -> Result<CallToolResult, ErrorData> {
@@ -1779,6 +1876,41 @@ mod tests {
         assert!(!MCP_TOOL_NAMES.contains(&"roux_kill_pty"));
         assert!(!MCP_TOOL_NAMES.contains(&"roux_remove_worktree"));
         assert!(!MCP_TOOL_NAMES.contains(&"roux_delete_session_permanently"));
+    }
+
+    #[test]
+    fn mcp_stdio_policy_allows_piped_stdio() {
+        let policy = McpStdioPolicy { stdin_is_terminal: false, stdout_is_terminal: false };
+
+        assert_eq!(mcp_stdio_startup_decision(policy), Ok(()));
+    }
+
+    #[test]
+    fn mcp_stdio_policy_rejects_terminal_stdin() {
+        let policy = McpStdioPolicy { stdin_is_terminal: true, stdout_is_terminal: false };
+
+        assert_eq!(mcp_stdio_startup_decision(policy), Err(McpLifecycleError::InteractiveStdio));
+    }
+
+    #[test]
+    fn mcp_stdio_policy_rejects_terminal_stdout() {
+        let policy = McpStdioPolicy { stdin_is_terminal: false, stdout_is_terminal: true };
+
+        assert_eq!(mcp_stdio_startup_decision(policy), Err(McpLifecycleError::InteractiveStdio));
+    }
+
+    #[test]
+    fn mcp_parent_lifecycle_exits_when_original_parent_is_gone() {
+        let snapshot = McpParentSnapshot { original_parent_pid: 42, current_parent_pid: 1 };
+
+        assert_eq!(mcp_parent_lifecycle_decision(snapshot), McpParentLifecycleDecision::Exit);
+    }
+
+    #[test]
+    fn mcp_parent_lifecycle_continues_while_original_parent_is_alive() {
+        let snapshot = McpParentSnapshot { original_parent_pid: 42, current_parent_pid: 42 };
+
+        assert_eq!(mcp_parent_lifecycle_decision(snapshot), McpParentLifecycleDecision::Continue);
     }
 
     #[test]

--- a/crates/roux-cli/src/mcp.rs
+++ b/crates/roux-cli/src/mcp.rs
@@ -1382,13 +1382,20 @@ fn mailbox_recv_args(
 
 pub async fn run_stdio_server() -> anyhow::Result<()> {
     run_stdio_startup_checks()?;
-    let original_parent_pid = current_parent_pid();
+    let monitored_parent_pid = mcp_parent_monitor_startup_decision(current_parent_pid())?;
     let service = RouxMcpServer.serve(stdio()).await?;
-    tokio::select! {
-        result = service.waiting() => {
-            result?;
+    match monitored_parent_pid {
+        Some(original_parent_pid) => {
+            tokio::select! {
+                result = service.waiting() => {
+                    result?;
+                }
+                _ = wait_for_original_parent_exit(original_parent_pid) => {}
+            }
         }
-        _ = wait_for_original_parent_exit(original_parent_pid), if should_monitor_parent(original_parent_pid) => {}
+        None => {
+            service.waiting().await?;
+        }
     }
     Ok(())
 }
@@ -1402,6 +1409,7 @@ struct McpStdioPolicy {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum McpLifecycleError {
     InteractiveStdio,
+    ParentMonitoringUnsupported,
 }
 
 impl std::fmt::Display for McpLifecycleError {
@@ -1409,6 +1417,9 @@ impl std::fmt::Display for McpLifecycleError {
         match self {
             McpLifecycleError::InteractiveStdio => {
                 write!(f, "roux mcp requires piped stdio from an MCP host")
+            }
+            McpLifecycleError::ParentMonitoringUnsupported => {
+                write!(f, "roux mcp requires parent process monitoring on this platform")
             }
         }
     }
@@ -1431,6 +1442,13 @@ fn mcp_stdio_startup_decision(policy: McpStdioPolicy) -> Result<(), McpLifecycle
     } else {
         Ok(())
     }
+}
+
+fn mcp_parent_monitor_startup_decision(
+    parent_pid: Option<u32>,
+) -> Result<Option<u32>, McpLifecycleError> {
+    let parent_pid = parent_pid.ok_or(McpLifecycleError::ParentMonitoringUnsupported)?;
+    Ok(should_monitor_parent(parent_pid).then_some(parent_pid))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1463,9 +1481,12 @@ async fn wait_for_original_parent_exit(original_parent_pid: u32) {
     let mut interval = tokio::time::interval(std::time::Duration::from_secs(5));
     loop {
         interval.tick().await;
+        let Some(current_parent_pid) = current_parent_pid() else {
+            return;
+        };
         let decision = mcp_parent_lifecycle_decision(McpParentSnapshot {
             original_parent_pid,
-            current_parent_pid: current_parent_pid(),
+            current_parent_pid,
         });
         if decision == McpParentLifecycleDecision::Exit {
             return;
@@ -1474,13 +1495,13 @@ async fn wait_for_original_parent_exit(original_parent_pid: u32) {
 }
 
 #[cfg(unix)]
-fn current_parent_pid() -> u32 {
-    unsafe { libc::getppid() as u32 }
+fn current_parent_pid() -> Option<u32> {
+    Some(unsafe { libc::getppid() as u32 })
 }
 
 #[cfg(not(unix))]
-fn current_parent_pid() -> u32 {
-    0
+fn current_parent_pid() -> Option<u32> {
+    None
 }
 
 async fn call_socket(request: Value) -> Result<CallToolResult, ErrorData> {
@@ -1897,6 +1918,24 @@ mod tests {
         let policy = McpStdioPolicy { stdin_is_terminal: false, stdout_is_terminal: true };
 
         assert_eq!(mcp_stdio_startup_decision(policy), Err(McpLifecycleError::InteractiveStdio));
+    }
+
+    #[test]
+    fn mcp_parent_monitor_startup_rejects_unknown_parent_pid() {
+        assert_eq!(
+            mcp_parent_monitor_startup_decision(None),
+            Err(McpLifecycleError::ParentMonitoringUnsupported)
+        );
+    }
+
+    #[test]
+    fn mcp_parent_monitor_startup_skips_init_parent_pid() {
+        assert_eq!(mcp_parent_monitor_startup_decision(Some(1)), Ok(None));
+    }
+
+    #[test]
+    fn mcp_parent_monitor_startup_tracks_regular_parent_pid() {
+        assert_eq!(mcp_parent_monitor_startup_decision(Some(42)), Ok(Some(42)));
     }
 
     #[test]

--- a/crates/roux-cli/src/platform.rs
+++ b/crates/roux-cli/src/platform.rs
@@ -58,6 +58,10 @@ pub fn socket_auth_token_file_path() -> PathBuf {
     app_config_dir().join("roux-socket-token")
 }
 
+pub fn daemon_owner_lock_path() -> PathBuf {
+    app_config_dir().join("roux-daemon.lock")
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SocketEndpoint {
     Unix(PathBuf),


### PR DESCRIPTION
Fixes #229

## Summary
- Acquire the config-scoped daemon owner lock before daemon runtime startup, and keep it held through shutdown.
- Use the same daemon owner lock across Unix and TCP socket endpoints to prevent split-brain daemon ownership.
- Harden `roux mcp` stdio startup by rejecting interactive stdio and monitoring the original MCP host parent process on Unix and Windows.

## Root Cause
Daemon ownership was previously claimed at socket startup, after persisted state was loaded and runtime services/watchers could already start. MCP stdio also had no robust host-lifecycle boundary, so orphaned MCP server processes could survive after their host exited.

## Validation
- `cargo fmt --check`
- `cargo test -p roux-cli`
- `roborev review --branch --wait`

Attempted `cargo check -p roux-cli --target x86_64-pc-windows-msvc`; local cross-target check is blocked by the `ring` C build needing Windows C headers (`assert.h` missing).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens daemon ownership and MCP process lifecycle. It acquires a config-scoped file lock before daemon startup and holds it through shutdown, preventing split-brain ownership whether the socket is Unix or TCP. The `roux mcp` stdio server gains interactive-stdio rejection and parent-process monitoring (PPID polling on Unix, `WaitForSingleObject` on Windows) so orphaned MCP servers self-terminate when their host exits.

- Daemon owner lock (`roux-daemon.lock`) is acquired as the very first step in `run()` via `flock(LOCK_EX|LOCK_NB)` on Unix and exclusive `share_mode(0)` on Windows; the RAII guard is threaded through `SocketServerHandle` and returned on shutdown, then explicitly dropped after all cleanup.
- `roux mcp` now rejects terminal stdin/stdout at startup and races the MCP service future against a parent-exit watcher, terminating the server process when the MCP host process disappears.
- New integration tests cover lock re-acquisition after release, split-brain prevention with a removed socket file, Unix-vs-TCP dual-owner rejection, and Unix/Windows parent-monitor unit paths.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. The lock-before-startup and guard-through-shutdown design is sound, and the three new integration tests directly exercise the split-brain prevention paths.

The daemon lock lifetime is correct and the MCP parent monitoring logic handles both Unix (PPID re-parenting to init) and Windows (process handle wait) cleanly. Two minor cleanups remain: the SocketOwnerGuard struct is defined identically under two mutually exclusive cfg blocks when a single unconditional definition would do, and a cfg-gated block in mcp_parent_monitor is unreachable because the None-path early-returns before it. Neither affects runtime behavior.

crates/roux-cli/src/daemon/server.rs (duplicate SocketOwnerGuard definitions) and crates/roux-cli/src/mcp.rs (unreachable cfg block)
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/roux-cli/src/daemon/server.rs | Adds SocketOwnerGuard (file lock RAII wrapper) passed through start_socket_server and returned from shutdown(); dual cfg struct definitions are redundant but not harmful |
| crates/roux-cli/src/daemon.rs | Acquires daemon owner lock before any runtime setup; lock lifetime correctly spans from pre-startup through post-shutdown drop; no issues found |
| crates/roux-cli/src/mcp.rs | Adds interactive-stdio guard and parent-process lifecycle monitoring for Unix (PPID polling) and Windows (WaitForSingleObject handle); unreachable cfg block for exotic platforms is dead code |
| crates/roux-cli/src/daemon/tests.rs | New integration tests verify split-brain prevention (socket removal, Unix-vs-TCP dual owner) and thread the owner_guard through existing test helpers correctly |
| crates/roux-cli/src/platform.rs | Adds daemon_owner_lock_path() returning app_config_dir()/roux-daemon.lock; minimal, correct change |
| crates/roux-cli/Cargo.toml | Adds windows-sys 0.61 with Win32_Foundation, ToolHelp, and Threading features for Windows process monitoring; scoped to cfg(windows) target correctly |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI as roux daemon
    participant Lock as roux-daemon.lock
    participant FS as Filesystem
    participant Server as SocketServerHandle
    participant Shutdown as Shutdown signal

    CLI->>Lock: "acquire_daemon_owner() [flock LOCK_EX|NB / share_mode(0)]"
    alt lock already held
        Lock-->>CLI: Err(already running)
        CLI-->>CLI: exit early
    else lock acquired
        Lock-->>CLI: SocketOwnerGuard
        CLI->>CLI: migrate_config, init log, load state
        CLI->>Server: start_socket_server(..., owner_guard)
        Server-->>CLI: "SocketServerHandle { owner_guard }"
        CLI->>Shutdown: wait_for_shutdown_signal()
        Shutdown-->>CLI: signal received
        CLI->>Server: shutdown()
        Server->>FS: cleanup socket/addr files
        Server-->>CLI: SocketOwnerGuard returned
        CLI->>CLI: process.shutdown(), pty.shutdown(), ...
        CLI->>Lock: drop(owner_guard) [lock released]
    end
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Froux-cli%2Fsrc%2Fdaemon%2Fserver.rs%3A38-46%0A**Identical%20cfg-gated%20struct%20definitions**%0A%0A%60SocketOwnerGuard%60%20is%20defined%20twice%20%E2%80%94%20once%20for%20%60%23%5Bcfg%28not%28windows%29%29%5D%60%20and%20once%20for%20%60%23%5Bcfg%28windows%29%5D%60%20%E2%80%94%20with%20an%20identical%20body%20%28%60_file%3A%20std%3A%3Afs%3A%3AFile%60%29.%20Because%20the%20struct's%20internals%20are%20the%20same%20across%20both%20platforms%2C%20the%20two%20conditional%20definitions%20can%20be%20collapsed%20into%20a%20single%20unconditional%20one.%20The%20asymmetry%20suggests%20a%20guard%20that%20may%20never%20be%20needed%20here%20was%20added%20pre-emptively%2C%20but%20as%20written%20it%20creates%20two%20dead%20definitions%20that%20must%20be%20kept%20in%20sync%20if%20the%20struct%20ever%20grows.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Froux-cli%2Fsrc%2Fmcp.rs%3A1479-1484%0A**Unreachable%20cfg%20block**%0A%0AOn%20platforms%20that%20are%20neither%20Unix%20nor%20Windows%2C%20%60current_parent_pid%28%29%60%20is%20the%20%60fn%20...%20-%3E%20Option%3Cu32%3E%20%7B%20None%20%7D%60%20stub.%20That%20means%20%60mcp_parent_monitor_startup_decision%28None%29%60%20immediately%20returns%20%60Err%28ParentMonitoringUnavailable%29%60%2C%20and%20the%20%60%3F%60%20on%20line%201464%20propagates%20that%20error%20out%20of%20%60mcp_parent_monitor%60%20before%20control%20ever%20reaches%20this%20%60%23%5Bcfg%28not%28any%28unix%2C%20windows%29%29%29%5D%60%20block.%20The%20%60let%20_%20%3D%20parent_pid%60%20and%20the%20%60Err%28...%29%60%20here%20are%20dead%20code%20on%20every%20platform%20where%20this%20block%20is%20compiled%20in.%0A%0A&repo=phin-tech%2Froux&pr=232&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22fix%2Fmcp-ghost-processes%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fmcp-ghost-processes%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Froux-cli%2Fsrc%2Fdaemon%2Fserver.rs%3A38-46%0A**Identical%20cfg-gated%20struct%20definitions**%0A%0A%60SocketOwnerGuard%60%20is%20defined%20twice%20%E2%80%94%20once%20for%20%60%23%5Bcfg%28not%28windows%29%29%5D%60%20and%20once%20for%20%60%23%5Bcfg%28windows%29%5D%60%20%E2%80%94%20with%20an%20identical%20body%20%28%60_file%3A%20std%3A%3Afs%3A%3AFile%60%29.%20Because%20the%20struct's%20internals%20are%20the%20same%20across%20both%20platforms%2C%20the%20two%20conditional%20definitions%20can%20be%20collapsed%20into%20a%20single%20unconditional%20one.%20The%20asymmetry%20suggests%20a%20guard%20that%20may%20never%20be%20needed%20here%20was%20added%20pre-emptively%2C%20but%20as%20written%20it%20creates%20two%20dead%20definitions%20that%20must%20be%20kept%20in%20sync%20if%20the%20struct%20ever%20grows.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Froux-cli%2Fsrc%2Fmcp.rs%3A1479-1484%0A**Unreachable%20cfg%20block**%0A%0AOn%20platforms%20that%20are%20neither%20Unix%20nor%20Windows%2C%20%60current_parent_pid%28%29%60%20is%20the%20%60fn%20...%20-%3E%20Option%3Cu32%3E%20%7B%20None%20%7D%60%20stub.%20That%20means%20%60mcp_parent_monitor_startup_decision%28None%29%60%20immediately%20returns%20%60Err%28ParentMonitoringUnavailable%29%60%2C%20and%20the%20%60%3F%60%20on%20line%201464%20propagates%20that%20error%20out%20of%20%60mcp_parent_monitor%60%20before%20control%20ever%20reaches%20this%20%60%23%5Bcfg%28not%28any%28unix%2C%20windows%29%29%29%5D%60%20block.%20The%20%60let%20_%20%3D%20parent_pid%60%20and%20the%20%60Err%28...%29%60%20here%20are%20dead%20code%20on%20every%20platform%20where%20this%20block%20is%20compiled%20in.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix: address PR review bot findings"](https://github.com/phin-tech/roux/commit/e6771342c62a41240ab34d46a7fb03da6480667a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35754903)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->