### PR TITLE
Fix stale session restore after restart

### DIFF
--- a/src/lib/panes/__tests__/instances.test.ts
+++ b/src/lib/panes/__tests__/instances.test.ts
@@ -159,26 +159,34 @@ describe("pane instances", () => {
     expect(cleaned).toBe(true);
   });
 
-  it("disposePane kills the attached PTY for terminal panes", () => {
-    const killPty = vi.fn().mockResolvedValue(undefined);
+  it("disposePane kills the attached PTY for terminal panes", async () => {
+    const killed: string[] = [];
+    const killPty = async (ptyId: string) => {
+      killed.push(ptyId);
+    };
     const id = createPane({ type: "shell", ptyId: "pty-1" });
     updateInstance(id, {
       terminalState: { kind: "attached", ptyId: "pty-1" },
     });
 
     disposePane(id, killPty);
+    await Promise.resolve();
 
-    expect(killPty).toHaveBeenCalledWith("pty-1");
+    expect(killed).toEqual(["pty-1"]);
   });
 
-  it("disposePane does not kill preserved PTY ids for empty restored panes", () => {
-    const killPty = vi.fn().mockResolvedValue(undefined);
+  it("disposePane does not kill preserved PTY ids for empty restored panes", async () => {
+    const killed: string[] = [];
+    const killPty = async (ptyId: string) => {
+      killed.push(ptyId);
+    };
     const id = createPane({ type: "shell", ptyId: "maybe-live" });
     updateInstance(id, { terminalState: { kind: "empty" } });
 
     disposePane(id, killPty);
+    await Promise.resolve();
 
-    expect(killPty).not.toHaveBeenCalled();
+    expect(killed).toEqual([]);
   });
 
   describe("restoreError field", () => {

--- a/src/lib/panes/__tests__/instances.test.ts
+++ b/src/lib/panes/__tests__/instances.test.ts
@@ -159,6 +159,28 @@ describe("pane instances", () => {
     expect(cleaned).toBe(true);
   });
 
+  it("disposePane kills the attached PTY for terminal panes", () => {
+    const killPty = vi.fn().mockResolvedValue(undefined);
+    const id = createPane({ type: "shell", ptyId: "pty-1" });
+    updateInstance(id, {
+      terminalState: { kind: "attached", ptyId: "pty-1" },
+    });
+
+    disposePane(id, killPty);
+
+    expect(killPty).toHaveBeenCalledWith("pty-1");
+  });
+
+  it("disposePane does not kill preserved PTY ids for empty restored panes", () => {
+    const killPty = vi.fn().mockResolvedValue(undefined);
+    const id = createPane({ type: "shell", ptyId: "maybe-live" });
+    updateInstance(id, { terminalState: { kind: "empty" } });
+
+    disposePane(id, killPty);
+
+    expect(killPty).not.toHaveBeenCalled();
+  });
+
   describe("restoreError field", () => {
     it("createPane defaults restoreError to undefined", () => {
       const id = createPane({ type: "shell", ptyId: "pty-1" });

--- a/src/lib/panes/__tests__/restore.test.ts
+++ b/src/lib/panes/__tests__/restore.test.ts
@@ -348,7 +348,7 @@ describe("restoreSessionPanes", () => {
 
     expect(spawnShellMock).not.toHaveBeenCalled();
     expect(runProfileInPaneMock).not.toHaveBeenCalled();
-    expect(get(paneInstances).get("shell-pane")?.ptyId).toBe("");
+    expect(get(paneInstances).get("shell-pane")?.ptyId).toBe("maybe-live");
     expect(get(paneInstances).get("shell-pane")?.terminalState).toEqual({
       kind: "empty",
     });
@@ -388,7 +388,7 @@ describe("restoreSessionPanes", () => {
     });
 
     const shellPane = get(paneInstances).get("shell-pane");
-    expect(shellPane?.ptyId).toBe("");
+    expect(shellPane?.ptyId).toBe("maybe-live-pty");
     expect(shellPane?.terminalState).toEqual({ kind: "empty" });
     expect(shellPane?.restoreError).toBeUndefined();
     expect(get(focusedPaneId)).toBe("s1-main");

--- a/src/lib/panes/__tests__/restore.test.ts
+++ b/src/lib/panes/__tests__/restore.test.ts
@@ -114,6 +114,9 @@ describe("restoreSessionPanes", () => {
       paneId: "s1-main",
     });
     expect(get(focusedPaneId)).toBe("s1-main");
+    expect(get(paneInstances).get("s1-main")?.terminalState).toEqual({
+      kind: "empty",
+    });
     expect(initTerminal).not.toHaveBeenCalled();
     expect(attachPtyListeners).not.toHaveBeenCalled();
   });
@@ -171,7 +174,7 @@ describe("restoreSessionPanes", () => {
     expect(attachPtyListeners).not.toHaveBeenCalled();
   });
 
-  it("auto-respawns a fresh PTY for non-primary shell panes whose persisted PTY is gone", async () => {
+  it("restores stale non-primary shell panes as empty instead of respawning them on cold startup", async () => {
     const payload: PaneStatePayload = {
       schemaVersion: 5,
       layout: {
@@ -206,23 +209,16 @@ describe("restoreSessionPanes", () => {
       livePtyIds: new Set(["s1"]),
     });
 
-    expect(spawnShellMock).toHaveBeenCalledTimes(1);
-    const [freshPtyId, workingDir, sessionId, paneId] =
-      spawnShellMock.mock.calls[0];
-    expect(typeof freshPtyId).toBe("string");
-    expect(freshPtyId).not.toBe("stale-pty");
-    expect(workingDir).toBe("/repo/sub");
-    expect(sessionId).toBe("s1");
-    expect(paneId).toBe("shell-pane");
-
-    const respawned = get(paneInstances).get("shell-pane");
-    expect(respawned?.ptyId).toBe(freshPtyId);
-    expect(respawned?.restoreError).toBeUndefined();
-    expect(initTerminal).toHaveBeenCalledWith("shell-pane");
-    expect(attachPtyListeners).toHaveBeenCalledWith("shell-pane");
+    expect(spawnShellMock).not.toHaveBeenCalled();
+    const restored = get(paneInstances).get("shell-pane");
+    expect(restored?.ptyId).toBe("");
+    expect(restored?.terminalState).toEqual({ kind: "empty" });
+    expect(restored?.restoreError).toBeUndefined();
+    expect(initTerminal).not.toHaveBeenCalledWith("shell-pane");
+    expect(attachPtyListeners).not.toHaveBeenCalledWith("shell-pane");
   });
 
-  it("replays the spawn profile after auto-respawn so agents come back live", async () => {
+  it("does not replay spawn profiles for stale panes during cold startup restore", async () => {
     const profile = {
       id: "claude",
       name: "Claude",
@@ -263,14 +259,12 @@ describe("restoreSessionPanes", () => {
       livePtyIds: new Set(["s1"]),
     });
 
-    expect(runProfileInPaneMock).toHaveBeenCalledTimes(1);
-    const [ptyIdArg, profileArg] = runProfileInPaneMock.mock.calls[0];
-    const respawned = get(paneInstances).get("shell-pane");
-    expect(ptyIdArg).toBe(respawned?.ptyId);
-    expect(profileArg).toBe(profile);
+    expect(spawnShellMock).not.toHaveBeenCalled();
+    expect(runProfileInPaneMock).not.toHaveBeenCalled();
+    expect(resolveProfileRefMock).not.toHaveBeenCalled();
   });
 
-  it("marks the pane retryable when auto-respawn fails", async () => {
+  it("does not mark stale panes retryable because cold restore does not respawn them", async () => {
     spawnShellMock.mockRejectedValueOnce(
       new Error("No such file or directory"),
     );
@@ -308,9 +302,11 @@ describe("restoreSessionPanes", () => {
       livePtyIds: new Set(["s1"]),
     });
 
-    const dead = get(paneInstances).get("shell-pane");
-    expect(dead?.ptyId).toBe("");
-    expect(dead?.restoreError).toContain("No such file or directory");
+    const empty = get(paneInstances).get("shell-pane");
+    expect(empty?.ptyId).toBe("");
+    expect(empty?.terminalState).toEqual({ kind: "empty" });
+    expect(empty?.restoreError).toBeUndefined();
+    expect(spawnShellMock).not.toHaveBeenCalled();
     expect(initTerminal).not.toHaveBeenCalledWith("shell-pane");
     expect(attachPtyListeners).not.toHaveBeenCalledWith("shell-pane");
     expect(runProfileInPaneMock).not.toHaveBeenCalled();
@@ -352,7 +348,10 @@ describe("restoreSessionPanes", () => {
 
     expect(spawnShellMock).not.toHaveBeenCalled();
     expect(runProfileInPaneMock).not.toHaveBeenCalled();
-    expect(get(paneInstances).get("shell-pane")?.ptyId).toBe("maybe-live");
+    expect(get(paneInstances).get("shell-pane")?.ptyId).toBe("");
+    expect(get(paneInstances).get("shell-pane")?.terminalState).toEqual({
+      kind: "empty",
+    });
   });
 
   it("restores panes but does not attach PTYs when live inventory is unknown", async () => {
@@ -388,7 +387,10 @@ describe("restoreSessionPanes", () => {
       livePtyIds: null,
     });
 
-    expect(get(paneInstances).get("shell-pane")?.restoreError).toBeUndefined();
+    const shellPane = get(paneInstances).get("shell-pane");
+    expect(shellPane?.ptyId).toBe("");
+    expect(shellPane?.terminalState).toEqual({ kind: "empty" });
+    expect(shellPane?.restoreError).toBeUndefined();
     expect(get(focusedPaneId)).toBe("s1-main");
     expect(initTerminal).not.toHaveBeenCalled();
     expect(attachPtyListeners).not.toHaveBeenCalled();

--- a/src/lib/panes/__tests__/restoreDecision.test.ts
+++ b/src/lib/panes/__tests__/restoreDecision.test.ts
@@ -3,9 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { PaneDescriptor } from "../persistence";
 import { decidePaneRestore } from "../restoreDecision";
 
-function descriptor(
-  overrides: Partial<PaneDescriptor> = {},
-): PaneDescriptor {
+function descriptor(overrides: Partial<PaneDescriptor> = {}): PaneDescriptor {
   return {
     id: "pane-1",
     type: "shell",

--- a/src/lib/panes/__tests__/restoreDecision.test.ts
+++ b/src/lib/panes/__tests__/restoreDecision.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import type { PaneDescriptor } from "../persistence";
+import { decidePaneRestore } from "../restoreDecision";
+
+function descriptor(
+  overrides: Partial<PaneDescriptor> = {},
+): PaneDescriptor {
+  return {
+    id: "pane-1",
+    type: "shell",
+    ptyId: "pty-1",
+    ...overrides,
+  };
+}
+
+describe("decidePaneRestore", () => {
+  it("attaches a primary pane only when the session PTY is live", () => {
+    expect(
+      decidePaneRestore({
+        descriptor: descriptor({ id: "s1-main", ptyId: "s1" }),
+        sessionId: "s1",
+        livePtyIds: new Set(["s1"]),
+      }),
+    ).toEqual({
+      kind: "attach",
+      ptyId: "s1",
+      panePtyId: "s1",
+      terminalState: { kind: "attached", ptyId: "s1" },
+    });
+  });
+
+  it("keeps a stale primary pane disconnected instead of treating the old PTY as attachable", () => {
+    expect(
+      decidePaneRestore({
+        descriptor: descriptor({ id: "s1-main", ptyId: "s1" }),
+        sessionId: "s1",
+        livePtyIds: new Set(),
+      }),
+    ).toEqual({
+      kind: "empty",
+      panePtyId: "s1",
+      terminalState: { kind: "empty" },
+    });
+  });
+
+  it("empties stale non-primary shell panes instead of respawning them during cold restore", () => {
+    expect(
+      decidePaneRestore({
+        descriptor: descriptor({ id: "shell-pane", ptyId: "old-pty" }),
+        sessionId: "s1",
+        livePtyIds: new Set(["s1"]),
+      }),
+    ).toEqual({
+      kind: "empty",
+      panePtyId: "",
+      terminalState: { kind: "empty" },
+    });
+  });
+
+  it("does not attach terminal panes when live PTY inventory is unknown", () => {
+    expect(
+      decidePaneRestore({
+        descriptor: descriptor({ id: "shell-pane", ptyId: "maybe-live" }),
+        sessionId: "s1",
+        livePtyIds: null,
+      }),
+    ).toEqual({
+      kind: "empty",
+      panePtyId: "",
+      terminalState: { kind: "empty" },
+    });
+  });
+
+  it("strips command panes unless their PTY is known live", () => {
+    expect(
+      decidePaneRestore({
+        descriptor: descriptor({
+          id: "cmd-pane",
+          type: "command",
+          ptyId: "old-command",
+          command: "npm test",
+        }),
+        sessionId: "s1",
+        livePtyIds: new Set(["s1"]),
+      }),
+    ).toEqual({ kind: "strip" });
+  });
+});

--- a/src/lib/panes/__tests__/restoreDecision.test.ts
+++ b/src/lib/panes/__tests__/restoreDecision.test.ts
@@ -58,7 +58,7 @@ describe("decidePaneRestore", () => {
     });
   });
 
-  it("does not attach terminal panes when live PTY inventory is unknown", () => {
+  it("does not attach but preserves PTY identity when live PTY inventory is unknown", () => {
     expect(
       decidePaneRestore({
         descriptor: descriptor({ id: "shell-pane", ptyId: "maybe-live" }),
@@ -67,7 +67,26 @@ describe("decidePaneRestore", () => {
       }),
     ).toEqual({
       kind: "empty",
-      panePtyId: "",
+      panePtyId: "maybe-live",
+      terminalState: { kind: "empty" },
+    });
+  });
+
+  it("does not strip command panes when live PTY inventory is unknown", () => {
+    expect(
+      decidePaneRestore({
+        descriptor: descriptor({
+          id: "cmd-pane",
+          type: "command",
+          ptyId: "maybe-live-command",
+          command: "npm test",
+        }),
+        sessionId: "s1",
+        livePtyIds: null,
+      }),
+    ).toEqual({
+      kind: "empty",
+      panePtyId: "maybe-live-command",
       terminalState: { kind: "empty" },
     });
   });

--- a/src/lib/panes/instances.ts
+++ b/src/lib/panes/instances.ts
@@ -231,16 +231,18 @@ export function disposePane(
   const inst = map.get(id);
   if (!inst) return;
 
-  // Kill the underlying PTY for any pane that hosts one. Markdown panes
-  // carry an empty ptyId so the killer is skipped implicitly.
+  // Kill only the PTY that is logically attached to this pane. Restored panes
+  // can preserve a persisted ptyId while terminalState is empty because live
+  // inventory was unavailable; closing that UI shell must not kill it.
   // Note: agents now live inside the shell PTY, so killing the pane kills
   // the agent — there is no separate session-level PTY to preserve.
+  const attachedPtyId = getAttachedPtyId(inst);
   if (
     killPty &&
-    inst.ptyId &&
+    attachedPtyId &&
     (inst.type === "shell" || inst.type === "command")
   ) {
-    killPty(inst.ptyId).catch(() => {
+    killPty(attachedPtyId).catch(() => {
       /* best-effort */
     });
   }

--- a/src/lib/panes/restore.ts
+++ b/src/lib/panes/restore.ts
@@ -5,14 +5,8 @@ import { sessionLayouts, type LayoutNode } from "./layout";
 import { initSessionWithProfile } from "./actions";
 import { setLogicalFocus } from "./focus";
 import { log } from "$lib/logging";
-import {
-  resolveProfileRef,
-  type SpawnProfile,
-  type SpawnProfileRef,
-} from "./profiles";
-import { runProfileInPane } from "./profileRunner";
-import { spawnShell } from "$lib/tauri";
-import { renderProjectPromptForSession } from "$lib/projectPromptTemplates";
+import type { SpawnProfileRef } from "./profiles";
+import { decidePaneRestore } from "./restoreDecision";
 
 export interface RestoreSessionPanesOptions {
   initTerminal: (paneId: string) => void;
@@ -66,63 +60,27 @@ export async function restoreSessionPanes(
   });
 
   let primaryPaneId: string | null = null;
-  // Tracks non-primary shell panes whose persisted PTY was gone and that
-  // we respawned fresh during this restore. The second loop uses this to
-  // attach the new PTY (instead of the stale id from the descriptor) and
-  // to replay the spawn profile so agents come back live without user
-  // intervention — closing the cold-start gap for headless callers (MCP,
-  // CLI) that resolve panes by id and expect a live PTY.
-  const respawnedPanes = new Map<
-    string,
-    { ptyId: string; profile: SpawnProfile | null }
-  >();
 
   for (const d of restored.descriptors) {
+    const decision = decidePaneRestore({
+      descriptor: d,
+      sessionId: session.id,
+      livePtyIds: opts.livePtyIds,
+    });
+    if (decision.kind === "strip") continue;
+
     if (d.id === primaryDescriptor.id) {
       primaryPaneId = createPrimaryPane(session.id, d.spawnProfileRef, d);
-      continue;
-    }
-
-    if (shouldRespawnStaleShell(d, opts.livePtyIds)) {
-      const result = await respawnStaleShell(d, session);
-      if (result.kind === "ok") {
-        createPane({
-          id: d.id,
-          type: "shell",
-          ptyId: result.ptyId,
-          name: d.name,
-          workingDir: d.workingDir,
-          spawnProfileRef: d.spawnProfileRef,
-          provider: d.provider,
-          providerSessionId: d.providerSessionId,
-        });
-        respawnedPanes.set(d.id, {
-          ptyId: result.ptyId,
-          profile: result.profile,
-        });
-      } else {
-        log(
-          `restoreSessionPanes(${session.id}): respawn failed for ${d.id} — ${result.message}`,
-        );
-        createPane({
-          id: d.id,
-          type: "shell",
-          ptyId: "",
-          name: d.name,
-          workingDir: d.workingDir,
-          spawnProfileRef: d.spawnProfileRef,
-          provider: d.provider,
-          providerSessionId: d.providerSessionId,
-        });
-        updateInstance(d.id, { restoreError: result.message });
-      }
+      updateInstance(primaryPaneId, {
+        terminalState: decision.terminalState,
+      });
       continue;
     }
 
     createPane({
       id: d.id,
       type: d.type,
-      ptyId: d.ptyId,
+      ptyId: decision.panePtyId,
       name: d.name,
       workingDir: d.workingDir,
       command: d.command,
@@ -133,46 +91,21 @@ export async function restoreSessionPanes(
       notesScope: d.notesScope,
       notesViewMode: d.notesViewMode,
     });
+    updateInstance(d.id, { terminalState: decision.terminalState });
   }
 
   for (const d of restored.descriptors) {
     if (d.type === "markdown" || d.type === "notes") continue;
-
-    const respawn = respawnedPanes.get(d.id);
-    if (respawn) {
-      try {
-        opts.initTerminal(d.id);
-        await opts.attachPtyListeners(d.id);
-      } catch (e) {
-        log(
-          `restoreSessionPanes(${session.id}): failed to attach respawned pane ${d.id}: ${e}`,
-        );
-        continue;
-      }
-      if (respawn.profile) {
-        try {
-          const appendSystemPrompt = await renderProjectPromptForSession(
-            session,
-            respawn.profile,
-          );
-          await runProfileInPane(respawn.ptyId, respawn.profile, {
-            ...(appendSystemPrompt.trim() ? { appendSystemPrompt } : {}),
-          });
-        } catch (e) {
-          log(
-            `restoreSessionPanes(${session.id}): profile replay failed for ${d.id}: ${e}`,
-          );
-        }
-      }
-      continue;
-    }
-
-    if (!d.ptyId) continue;
-    if (!canAttachPty(d.ptyId, opts.livePtyIds)) continue;
+    const decision = decidePaneRestore({
+      descriptor: d,
+      sessionId: session.id,
+      livePtyIds: opts.livePtyIds,
+    });
+    if (decision.kind !== "attach") continue;
     try {
       opts.initTerminal(d.id);
-      if (opts.attachLivePtyToPane && opts.livePtyIds?.has(d.ptyId)) {
-        await opts.attachLivePtyToPane(d.id, d.ptyId);
+      if (opts.attachLivePtyToPane && opts.livePtyIds?.has(decision.ptyId)) {
+        await opts.attachLivePtyToPane(d.id, decision.ptyId);
       } else {
         await opts.attachPtyListeners(d.id);
       }
@@ -199,12 +132,17 @@ async function restorePrimaryOnly(
     descriptor,
   );
   if (canAttachPty(session.id, opts.livePtyIds)) {
+    updateInstance(mainPaneId, {
+      terminalState: { kind: "attached", ptyId: session.id },
+    });
     opts.initTerminal(mainPaneId);
     if (opts.attachLivePtyToPane && opts.livePtyIds?.has(session.id)) {
       await opts.attachLivePtyToPane(mainPaneId, session.id);
     } else {
       await opts.attachPtyListeners(mainPaneId);
     }
+  } else {
+    updateInstance(mainPaneId, { terminalState: { kind: "empty" } });
   }
   return mainPaneId;
 }
@@ -244,62 +182,19 @@ function canAttachPty(
   return livePtyIds?.has(ptyId) === true;
 }
 
-function shouldRespawnStaleShell(
-  descriptor: PaneStatePayload["descriptors"][number],
-  livePtyIds: ReadonlySet<string> | null | undefined,
-): boolean {
-  if (descriptor.type !== "shell") return false;
-  if (livePtyIds == null) return false;
-  if (!descriptor.ptyId) return false;
-  return !livePtyIds.has(descriptor.ptyId);
-}
-
-type RespawnResult =
-  | { kind: "ok"; ptyId: string; profile: SpawnProfile | null }
-  | { kind: "error"; message: string };
-
-async function respawnStaleShell(
-  descriptor: PaneStatePayload["descriptors"][number],
-  session: Session,
-): Promise<RespawnResult> {
-  const freshPtyId = crypto.randomUUID();
-  const profile = resolveProfileRef(descriptor.spawnProfileRef);
-  const profileId =
-    descriptor.spawnProfileRef?.kind === "registered"
-      ? descriptor.spawnProfileRef.id
-      : descriptor.spawnProfileRef?.kind === "inline"
-        ? descriptor.spawnProfileRef.profile.id
-        : null;
-  try {
-    await spawnShell(
-      freshPtyId,
-      descriptor.workingDir ?? session.worktreePath,
-      session.id,
-      descriptor.id,
-      profileId,
-      null,
-      descriptor.spawnProfileRef?.kind === "inline"
-        ? descriptor.spawnProfileRef.profile
-        : null,
-    );
-    return { kind: "ok", ptyId: freshPtyId, profile };
-  } catch (e) {
-    return { kind: "error", message: String(e) };
-  }
-}
-
 function stripKnownStaleCommandPanes(
   persisted: PaneStatePayload,
   livePtyIds: ReadonlySet<string> | null | undefined,
 ): { layout: LayoutNode | null; descriptors: PaneStatePayload["descriptors"] } {
-  if (livePtyIds == null) {
-    return { layout: persisted.layout, descriptors: persisted.descriptors };
-  }
-
   const staleCommandIds = new Set(
     persisted.descriptors
       .filter(
-        (d) => d.type === "command" && (!d.ptyId || !livePtyIds.has(d.ptyId)),
+        (d) =>
+          decidePaneRestore({
+            descriptor: d,
+            sessionId: "",
+            livePtyIds,
+          }).kind === "strip",
       )
       .map((d) => d.id),
   );

--- a/src/lib/panes/restoreDecision.ts
+++ b/src/lib/panes/restoreDecision.ts
@@ -1,0 +1,39 @@
+import type { TerminalState } from "./instances";
+import type { PaneDescriptor } from "./persistence";
+
+export type PaneRestoreDecision =
+  | {
+      kind: "attach";
+      ptyId: string;
+      panePtyId: string;
+      terminalState: TerminalState;
+    }
+  | { kind: "empty"; panePtyId: string; terminalState: TerminalState }
+  | { kind: "strip" };
+
+export function decidePaneRestore({
+  descriptor,
+  sessionId,
+  livePtyIds,
+}: {
+  descriptor: PaneDescriptor;
+  sessionId: string;
+  livePtyIds: ReadonlySet<string> | null | undefined;
+}): PaneRestoreDecision {
+  if (descriptor.ptyId && livePtyIds?.has(descriptor.ptyId)) {
+    return {
+      kind: "attach",
+      ptyId: descriptor.ptyId,
+      panePtyId: descriptor.ptyId,
+      terminalState: { kind: "attached", ptyId: descriptor.ptyId },
+    };
+  }
+
+  if (descriptor.type === "command") return { kind: "strip" };
+
+  return {
+    kind: "empty",
+    panePtyId: descriptor.ptyId === sessionId ? sessionId : "",
+    terminalState: { kind: "empty" },
+  };
+}

--- a/src/lib/panes/restoreDecision.ts
+++ b/src/lib/panes/restoreDecision.ts
@@ -29,6 +29,14 @@ export function decidePaneRestore({
     };
   }
 
+  if (livePtyIds == null) {
+    return {
+      kind: "empty",
+      panePtyId: descriptor.ptyId,
+      terminalState: { kind: "empty" },
+    };
+  }
+
   if (descriptor.type === "command") return { kind: "strip" };
 
   return {

--- a/src/lib/sessions/__tests__/reconnect.test.ts
+++ b/src/lib/sessions/__tests__/reconnect.test.ts
@@ -572,6 +572,32 @@ describe("reconnectSession — full rehydration", () => {
     expect(connectPaneTerminal).toHaveBeenCalledWith(`${session.id}-main`);
   });
 
+  it("clears empty terminal state when reconnecting after stale startup restore", async () => {
+    const session = makeSession();
+    addSession(session);
+    createPane({
+      id: `${session.id}-main`,
+      type: "shell",
+      ptyId: session.id,
+      spawnProfileRef: { kind: "registered", id: "claude" },
+    });
+    updateInstance(`${session.id}-main`, {
+      terminalState: { kind: "empty" },
+    });
+    sessionLayouts.update((m) => {
+      const next = new Map(m);
+      next.set(session.id, { kind: "leaf", paneId: `${session.id}-main` });
+      return next;
+    });
+
+    await reconnectSession(session);
+
+    expect(get(paneInstances).get(`${session.id}-main`)?.terminalState).toEqual(
+      { kind: "attached", ptyId: session.id },
+    );
+    expect(connectPaneTerminal).toHaveBeenCalledWith(`${session.id}-main`);
+  });
+
   it("rehydrates persisted panes for a restored archived session with no current layout", async () => {
     const session = makeSession();
     addSession(session);

--- a/src/lib/sessions/reconnect.ts
+++ b/src/lib/sessions/reconnect.ts
@@ -390,6 +390,10 @@ async function reconnectPrimaryPaneOnly(
       ? instance.spawnProfileRef.profile
       : null,
   );
+  updateInstance(primaryPaneId, {
+    terminalState: { kind: "attached", ptyId: session.id },
+    restoreError: undefined,
+  });
   const { connectPaneTerminal } = await import("$lib/panes/terminals");
   await connectPaneTerminal(primaryPaneId);
   updateSessionStatus(session.id, updated.status as Session["status"]);


### PR DESCRIPTION
## Summary
- fix cold-start pane restore so stale PTYs are not respawned automatically
- preserve PTY ids when live inventory is unavailable, but keep panes unattached
- ensure pane close only kills logically attached PTYs

Fixes #223

## Testing
- npm run test -- src/lib/panes/__tests__/instances.test.ts src/lib/panes/__tests__/actions.test.ts src/lib/panes/__tests__/restoreDecision.test.ts src/lib/panes/__tests__/restore.test.ts src/lib/sessions/__tests__/reconnect.test.ts
- npm run check
- npm run test

## Review
- roborev branch review job 175 passed

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a cold-start regression where stale non-primary shell panes were silently respawned at restore time, potentially launching unwanted agent sessions. It centralises the per-pane attach/empty/strip decision in a new `restoreDecision.ts` module and threads `terminalState` through both the restore and reconnect paths so `disposePane` only kills PTYs that are logically attached.

- **`restoreDecision.ts`** (new): pure `decidePaneRestore` classifies each persisted pane as `attach` (live PTY present), `empty` (stale or unknown inventory), or `strip` (stale command pane); drives both the first-pass pane creation loop and the second-pass attachment loop in `restore.ts`.
- **`restore.ts`**: removes the old `shouldRespawnStaleShell` / `respawnStaleShell` paths; stale non-primary panes now come up empty rather than being respawned, with unknown-inventory panes preserving their PTY id so a later reconnect can reuse it.
- **`reconnect.ts` / `instances.ts`**: `reconnectPrimaryPaneOnly` and `disposePane` are updated to write/respect `terminalState` so closing a UI pane with a preserved-but-unattached ptyId no longer kills that PTY.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the cold-start respawn removal is well-scoped, the new decision module is fully tested, and the PTY-kill fix prevents accidental process termination for unattached panes.

All changed paths are covered by dedicated unit tests. The only findings are a redundant recomputation of pane decisions in the second restore loop (which does not affect correctness) and a few test assertions that are slightly weaker than ideal.

src/lib/panes/restore.ts — the second loop recomputes decidePaneRestore for every descriptor without using the cached results from the first loop.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/panes/restoreDecision.ts | New pure decision module; correctly handles attach/empty/strip for all pane types and livePtyIds states including null. |
| src/lib/panes/restore.ts | Delegates to decidePaneRestore in two separate loops, computing the same decision twice per descriptor; logic is correct but redundant. |
| src/lib/panes/instances.ts | disposePane now uses getAttachedPtyId instead of inst.ptyId, correctly skipping PTY kill for empty-restored panes. |
| src/lib/sessions/reconnect.ts | reconnectPrimaryPaneOnly now sets terminalState: attached before connecting the terminal, clearing any prior empty state from cold-start restore. |
| src/lib/panes/__tests__/restoreDecision.test.ts | Good coverage of all six decision branches; assertions are precise and exhaustive. |
| src/lib/panes/__tests__/restore.test.ts | Updated tests mirror the new no-respawn contract; some not.toHaveBeenCalledWith assertions are weaker than not.toHaveBeenCalled(). |
| src/lib/panes/__tests__/instances.test.ts | New disposePane tests correctly exercise the attach vs empty distinction for PTY kill behaviour. |
| src/lib/sessions/__tests__/reconnect.test.ts | New test verifies empty terminalState is promoted to attached after reconnect following a stale cold-start restore. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[restoreSessionPanes] --> B[stripKnownStaleCommandPanes]
    B --> C{decidePaneRestore\nfor each descriptor}
    C -->|kind=strip| D[Exclude from layout & descriptors]
    C -->|kind=attach or empty| E[Keep descriptor]
    E --> F{Is primary pane?}
    F -->|Yes| G[createPrimaryPane]
    F -->|No| H[createPane with decision.panePtyId]
    G --> I[updateInstance terminalState]
    H --> I
    I --> J{Second loop: kind==attach?}
    J -->|No| K[Pane stays empty]
    J -->|Yes| L[initTerminal + attachPtyListeners]
    M[reconnectPrimaryPaneOnly] --> N[replacePty]
    N --> O[reconnectSessionShellPty]
    O --> P[updateInstance terminalState=attached]
    P --> Q[connectPaneTerminal]
    R[disposePane] --> S[getAttachedPtyId]
    S -->|attached| T[killPty]
    S -->|empty or dead| U[skip killPty]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Flib%2Fpanes%2Frestore.ts%3A62-70%0A%60decidePaneRestore%60%20is%20called%20once%20per%20descriptor%20in%20the%20first%20loop%20and%20then%20again%20for%20every%20descriptor%20in%20the%20second%20loop.%20Because%20the%20function%20is%20pure%20and%20the%20inputs%20%28%60descriptor%60%2C%20%60sessionId%60%2C%20%60livePtyIds%60%29%20do%20not%20change%20between%20loops%2C%20caching%20the%20results%20in%20a%20%60Map%60%20after%20the%20first%20pass%20would%20make%20the%20intent%20explicit%20and%20avoid%20the%20redundant%20work.%0A%0A%60%60%60suggestion%0A%20%20let%20primaryPaneId%3A%20string%20%7C%20null%20%3D%20null%3B%0A%20%20const%20decisions%20%3D%20new%20Map%28%0A%20%20%20%20restored.descriptors.map%28%28d%29%20%3D%3E%20%5B%0A%20%20%20%20%20%20d.id%2C%0A%20%20%20%20%20%20decidePaneRestore%28%7B%20descriptor%3A%20d%2C%20sessionId%3A%20session.id%2C%20livePtyIds%3A%20opts.livePtyIds%20%7D%29%2C%0A%20%20%20%20%5D%29%2C%0A%20%20%29%3B%0A%0A%20%20for%20%28const%20d%20of%20restored.descriptors%29%20%7B%0A%20%20%20%20const%20decision%20%3D%20decisions.get%28d.id%29!%3B%0A%20%20%20%20if%20%28decision.kind%20%3D%3D%3D%20%22strip%22%29%20continue%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Flib%2Fpanes%2F__tests__%2Frestore.test.ts%3A302-311%0A**Weaker%20%60not.toHaveBeenCalledWith%60%20instead%20of%20%60not.toHaveBeenCalled%28%29%60**%0A%0A%60not.toHaveBeenCalledWith%28%22shell-pane%22%29%60%20only%20asserts%20the%20mock%20was%20not%20called%20with%20that%20specific%20argument%3B%20it%20would%20still%20pass%20if%20%60initTerminal%60%20or%20%60attachPtyListeners%60%20were%20accidentally%20invoked%20with%20a%20different%20pane%20id.%20Because%20the%20stale-pane%20scenario%20sets%20up%20a%20single%20shell%20pane%2C%20%60not.toHaveBeenCalled%28%29%60%20is%20the%20stronger%20and%20more%20appropriate%20guard%20here.%20The%20same%20pattern%20appears%20in%20the%20%22auto-respawn%22%20and%20%22live%20inventory%20unknown%22%20test%20cases%20in%20this%20file.%0A%0A&repo=phin-tech%2Froux&pr=234&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22fix%2Fresume-sessions%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fresume-sessions%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Flib%2Fpanes%2Frestore.ts%3A62-70%0A%60decidePaneRestore%60%20is%20called%20once%20per%20descriptor%20in%20the%20first%20loop%20and%20then%20again%20for%20every%20descriptor%20in%20the%20second%20loop.%20Because%20the%20function%20is%20pure%20and%20the%20inputs%20%28%60descriptor%60%2C%20%60sessionId%60%2C%20%60livePtyIds%60%29%20do%20not%20change%20between%20loops%2C%20caching%20the%20results%20in%20a%20%60Map%60%20after%20the%20first%20pass%20would%20make%20the%20intent%20explicit%20and%20avoid%20the%20redundant%20work.%0A%0A%60%60%60suggestion%0A%20%20let%20primaryPaneId%3A%20string%20%7C%20null%20%3D%20null%3B%0A%20%20const%20decisions%20%3D%20new%20Map%28%0A%20%20%20%20restored.descriptors.map%28%28d%29%20%3D%3E%20%5B%0A%20%20%20%20%20%20d.id%2C%0A%20%20%20%20%20%20decidePaneRestore%28%7B%20descriptor%3A%20d%2C%20sessionId%3A%20session.id%2C%20livePtyIds%3A%20opts.livePtyIds%20%7D%29%2C%0A%20%20%20%20%5D%29%2C%0A%20%20%29%3B%0A%0A%20%20for%20%28const%20d%20of%20restored.descriptors%29%20%7B%0A%20%20%20%20const%20decision%20%3D%20decisions.get%28d.id%29!%3B%0A%20%20%20%20if%20%28decision.kind%20%3D%3D%3D%20%22strip%22%29%20continue%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Flib%2Fpanes%2F__tests__%2Frestore.test.ts%3A302-311%0A**Weaker%20%60not.toHaveBeenCalledWith%60%20instead%20of%20%60not.toHaveBeenCalled%28%29%60**%0A%0A%60not.toHaveBeenCalledWith%28%22shell-pane%22%29%60%20only%20asserts%20the%20mock%20was%20not%20called%20with%20that%20specific%20argument%3B%20it%20would%20still%20pass%20if%20%60initTerminal%60%20or%20%60attachPtyListeners%60%20were%20accidentally%20invoked%20with%20a%20different%20pane%20id.%20Because%20the%20stale-pane%20scenario%20sets%20up%20a%20single%20shell%20pane%2C%20%60not.toHaveBeenCalled%28%29%60%20is%20the%20stronger%20and%20more%20appropriate%20guard%20here.%20The%20same%20pattern%20appears%20in%20the%20%22auto-respawn%22%20and%20%22live%20inventory%20unknown%22%20test%20cases%20in%20this%20file.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Format restore decision test"](https://github.com/phin-tech/roux/commit/c550afe679af66d519913c97d001c09d9eb8bf0d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35831512)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->