### PR TITLE
Show Add card only on To Do column

### DIFF
--- a/src/lib/components/BoardMainView.svelte
+++ b/src/lib/components/BoardMainView.svelte
@@ -426,9 +426,11 @@
           {/if}
         </div>
 
-        <div class="shrink-0 px-2 pb-2 pt-1">
-          <AddCardInput onCreate={() => handleCreate(col)} />
-        </div>
+        {#if col === "todo"}
+          <div class="shrink-0 px-2 pb-2 pt-1">
+            <AddCardInput onCreate={() => handleCreate(col)} />
+          </div>
+        {/if}
       </section>
     {/each}
   </div>

--- a/src/lib/components/BoardPanel.svelte
+++ b/src/lib/components/BoardPanel.svelte
@@ -408,9 +408,11 @@
         {:else}
           <p class="px-1 text-xs text-text-muted/50">Empty</p>
         {/if}
-        <div class="mt-1.5">
-          <AddCardInput onCreate={() => handleCreate(col)} />
-        </div>
+        {#if col === "todo"}
+          <div class="mt-1.5">
+            <AddCardInput onCreate={() => handleCreate(col)} />
+          </div>
+        {/if}
       </section>
     {/each}
   </div>

--- a/src/lib/components/__tests__/BoardMainView.test.ts
+++ b/src/lib/components/__tests__/BoardMainView.test.ts
@@ -1030,16 +1030,25 @@ describe("BoardMainView", () => {
     });
   });
 
-  it("opens the new card editor for the selected column", async () => {
+  it("opens the new card editor for the To Do column", async () => {
     render(BoardMainView);
 
-    // The Review column's add button (4 columns → 4 add buttons).
-    const reviewColumn = document.querySelector('[data-column="review"]')!;
-    const addButton = reviewColumn.querySelector(
+    // Add card only appears on the To Do column.
+    const todoColumn = document.querySelector('[data-column="todo"]')!;
+    const addButton = todoColumn.querySelector(
       '[aria-label="Add card"]',
     ) as HTMLButtonElement;
     await fireEvent.click(addButton);
 
-    expect(openNewWorkItemEditor).toHaveBeenCalledWith({ status: "review" });
+    expect(openNewWorkItemEditor).toHaveBeenCalledWith({ status: "todo" });
+  });
+
+  it("does not show an add card button on non–To Do columns", () => {
+    render(BoardMainView);
+
+    const reviewColumn = document.querySelector('[data-column="review"]')!;
+    expect(
+      reviewColumn.querySelector('[aria-label="Add card"]'),
+    ).toBeNull();
   });
 });

--- a/src/lib/components/__tests__/BoardMainView.test.ts
+++ b/src/lib/components/__tests__/BoardMainView.test.ts
@@ -1047,8 +1047,6 @@ describe("BoardMainView", () => {
     render(BoardMainView);
 
     const reviewColumn = document.querySelector('[data-column="review"]')!;
-    expect(
-      reviewColumn.querySelector('[aria-label="Add card"]'),
-    ).toBeNull();
+    expect(reviewColumn.querySelector('[aria-label="Add card"]')).toBeNull();
   });
 });

--- a/src/lib/components/__tests__/BoardMainView.test.ts
+++ b/src/lib/components/__tests__/BoardMainView.test.ts
@@ -1046,7 +1046,12 @@ describe("BoardMainView", () => {
   it("does not show an add card button on non–To Do columns", () => {
     render(BoardMainView);
 
-    const reviewColumn = document.querySelector('[data-column="review"]')!;
-    expect(reviewColumn.querySelector('[aria-label="Add card"]')).toBeNull();
+    for (const col of ["ready", "doing", "review", "done"]) {
+      const column = document.querySelector(`[data-column="${col}"]`)!;
+      expect(
+        column.querySelector('[aria-label="Add card"]'),
+        `column "${col}" should not have an Add card button`,
+      ).toBeNull();
+    }
   });
 });


### PR DESCRIPTION
## Summary
Removes the "Add card" button from all kanban columns except **To Do**, in both the full-screen board (`BoardMainView`) and the sidebar panel (`BoardPanel`). New work should enter through To Do and flow rightward via the normal workflow (plan → start → review → done); the button on the other columns was clutter and invited starting cards in the wrong state.

To Do still shows "Add card" and opens the new-card editor pre-set to `status: "todo"`. `AddCardInput` and `handleCreate` are unchanged.

## Changes
- `BoardMainView.svelte` / `BoardPanel.svelte` — wrap the add-card block in `{#if col === "todo"}`.
- `BoardMainView.test.ts` — click the To Do add button (asserting `{ status: "todo" }`) and assert non–To Do columns have no add button.

## Tests
- `npm run test -- BoardMainView BoardPanel AddCardInput` → 39 passed
- `npm run check` → 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restricts the "Add card" button to the To Do column only, removing it from `ready`, `doing`, `review`, and `done` columns in both `BoardMainView.svelte` and `BoardPanel.svelte`. The test suite is updated with a positive assertion on the To Do column and a loop-based negative assertion covering all four non-todo columns.

- **`BoardMainView.svelte` / `BoardPanel.svelte`**: Wrap the `AddCardInput` block in `{#if col === \"todo\"}`, so only the To Do column renders the button.
- **`BoardMainView.test.ts`**: Replaces the old single-column test with two tests — one that clicks the To Do add button and asserts `{ status: \"todo\" }`, and one that iterates all non-todo columns to confirm no add button is present.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a narrow UI guard with no data-path or state-management impact.

Both view components receive a single {#if col === 'todo'} guard that only affects rendering; handleCreate and AddCardInput are untouched. The test update covers both the positive path (To Do button opens editor with correct status) and exhaustively checks all four non-todo columns. No logic, persistence, or protocol surface is modified.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/components/BoardMainView.svelte | Wraps AddCardInput in `{#if col === "todo"}` — minimal, correct guard with no side effects on other columns. |
| src/lib/components/BoardPanel.svelte | Same `{#if col === "todo"}` guard applied to the sidebar panel's add-card block, symmetric with BoardMainView. |
| src/lib/components/__tests__/BoardMainView.test.ts | Test updated to assert `{ status: "todo" }` on the To Do add-button click, and loops over all four non-todo columns to confirm no add button is present — fully covers the behavioral change. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Kanban column render loop] --> B{col equals todo?}
    B -- Yes --> C[Render AddCardInput]
    B -- No --> D[No add button rendered]
    C --> E[handleCreate called with todo]
    E --> F[openNewWorkItemEditor with status todo]
```

<sub>Reviews (3): Last reviewed commit: ["fix: address PR review bot findings"](https://github.com/phin-tech/roux/commit/f5adb2418424b5d47c2958046ec6e008d53fea03) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35943698)</sub>

<!-- /greptile_comment -->