### PR TITLE
Add built-in Kanban workflow settings

### DIFF
--- a/crates/roux-cli/src/daemon/work_items.rs
+++ b/crates/roux-cli/src/daemon/work_items.rs
@@ -501,7 +501,12 @@ pub(super) async fn handle_work_item_review_accept(req: Request, host: &RuntimeH
         "acceptedBy": optional_string_arg(&req.args, &["acceptedBy", "accepted_by"])
             .unwrap_or_else(|| "user".to_string()),
     });
-    match host.work_item_handle.accept_review(&item_id, payload) {
+    let settings = load_daemon_settings();
+    match host.work_item_handle.accept_review_with_kanban_settings(
+        &item_id,
+        payload,
+        &settings.kanban,
+    ) {
         Ok(Some((item, run))) => {
             if run.status == roux_core::WorkItemRunStatus::Done {
                 if let Err(response) = archive_linked_session(host, run.session_id.as_deref()).await
@@ -534,7 +539,13 @@ pub(super) async fn handle_work_item_review_request(req: Request, host: &Runtime
             .unwrap_or_else(|| "agent".to_string()),
     });
     let result_payload = review_request_result_payload(&req.args);
-    match host.work_item_handle.request_review(&run_id, payload, result_payload) {
+    let settings = load_daemon_settings();
+    match host.work_item_handle.request_review_with_kanban_settings(
+        &run_id,
+        payload,
+        result_payload,
+        &settings.kanban,
+    ) {
         Ok(Some((item, run))) => {
             match serde_json::to_value(roux_core::WorkItemReviewRequestResult { item, run }) {
                 Ok(value) => Response::success(value),
@@ -650,11 +661,13 @@ pub(super) async fn handle_work_item_review_request_changes(
         "note": note,
         "targetStatus": target_status.as_str(),
     });
-    match host.work_item_handle.request_changes(
+    let settings = load_daemon_settings();
+    match host.work_item_handle.request_changes_with_kanban_settings(
         &run.id,
         target_status,
         payload,
         Some(attachment_input),
+        &settings.kanban,
     ) {
         Ok(Some((item, run, Some(attachment)))) => {
             match serde_json::to_value(roux_core::WorkItemReviewRequestChangesResult {
@@ -816,9 +829,7 @@ async fn plan_work_item_run_with_hooks(
     }
 
     let settings = load_daemon_settings();
-    let profile_id = optional_string_arg(&req.args, &["profile", "agentProfile", "agent_profile"])
-        .or_else(|| item.agent_profile.clone())
-        .unwrap_or_else(|| settings.kanban.default_agent_profile.clone());
+    let profile_id = planning_agent_profile_id(&req, &settings);
     let Some(profile) = roux_core::providers::resolve_profile(&profile_id, &settings) else {
         return Err(Response::err(format!("agent profile not found: {profile_id}")));
     };
@@ -1143,9 +1154,7 @@ async fn start_work_item_run_with_hooks(
     }
 
     let settings = load_daemon_settings();
-    let profile_id = optional_string_arg(&req.args, &["profile", "agentProfile", "agent_profile"])
-        .or_else(|| item.agent_profile.clone())
-        .unwrap_or_else(|| settings.kanban.default_agent_profile.clone());
+    let profile_id = implementation_agent_profile_id(&req, &item, &settings);
     let Some(profile) = roux_core::providers::resolve_profile(&profile_id, &settings) else {
         return Err(record_start_failure_response(
             host,
@@ -2614,7 +2623,7 @@ fn render_work_item_planning_prompt(
     append_custom_prompt_section(
         &mut prompt,
         "Additional planning instructions",
-        &settings.kanban.planning_prompt_append,
+        settings.kanban.planning_instructions(),
     );
     prompt
 }
@@ -2873,14 +2882,35 @@ fn render_work_item_task_prompt(
     append_custom_prompt_section(
         &mut prompt,
         "Additional implementation instructions",
-        &settings.kanban.implementation_prompt_append,
+        settings.kanban.implementation_instructions(),
     );
+    let review_stage_id =
+        item.review_stage_id.as_deref().unwrap_or(roux_core::FIRST_REVIEW_STAGE_ID);
     append_custom_prompt_section(
         &mut prompt,
         "Additional review handoff instructions",
-        &settings.kanban.review_prompt_append,
+        settings.kanban.review_stage_instructions(review_stage_id),
     );
     prompt
+}
+
+fn planning_agent_profile_id(req: &Request, settings: &roux_core::RouxSettings) -> String {
+    optional_string_arg(&req.args, &["profile", "agentProfile", "agent_profile"])
+        .or_else(|| settings.kanban.planning_phase().and_then(|phase| phase.agent_profile.clone()))
+        .unwrap_or_else(|| settings.default_agent_profile.clone())
+}
+
+fn implementation_agent_profile_id(
+    req: &Request,
+    item: &roux_core::WorkItem,
+    settings: &roux_core::RouxSettings,
+) -> String {
+    optional_string_arg(&req.args, &["profile", "agentProfile", "agent_profile"])
+        .or_else(|| item.agent_profile.clone())
+        .or_else(|| {
+            settings.kanban.implementation_phase().and_then(|phase| phase.agent_profile.clone())
+        })
+        .unwrap_or_else(|| settings.default_agent_profile.clone())
 }
 
 fn append_plan_prompt_context(
@@ -3862,7 +3892,7 @@ mod tests {
     }
 
     #[test]
-    fn work_item_prompts_append_kanban_custom_instructions() {
+    fn work_item_prompts_append_workflow_custom_instructions() {
         let item = roux_core::WorkItem {
             id: "wi-1".into(),
             project_id: None,
@@ -3889,15 +3919,21 @@ mod tests {
             created_at: 0,
             updated_at: 0,
         };
-        let settings = roux_core::RouxSettings {
-            kanban: roux_core::KanbanSettings {
-                planning_prompt_append: "Ask about release timing.".into(),
-                implementation_prompt_append: "Use narrow commits.".into(),
-                review_prompt_append: "Summarize review risks.".into(),
-                ..roux_core::KanbanSettings::default()
-            },
-            ..roux_core::RouxSettings::default()
-        };
+        let mut settings = roux_core::RouxSettings::default();
+        settings.kanban.workflow.phases.get_mut("planning").unwrap().instructions =
+            "Ask about release timing.".into();
+        settings.kanban.workflow.phases.get_mut("implementation").unwrap().instructions =
+            "Use narrow commits.".into();
+        settings
+            .kanban
+            .workflow
+            .phases
+            .get_mut("review")
+            .unwrap()
+            .stages
+            .get_mut("local_review")
+            .unwrap()
+            .instructions = "Summarize review risks.".into();
 
         let plan_prompt = render_work_item_planning_prompt(&item, "plan-run-1", None, &settings);
         assert!(plan_prompt.contains("Roux work item id: wi-1"));
@@ -3921,6 +3957,95 @@ mod tests {
         );
         assert!(task_prompt
             .contains("Additional review handoff instructions:\nSummarize review risks."));
+    }
+
+    #[test]
+    fn planning_agent_profile_uses_phase_before_global_default() {
+        let mut settings = roux_core::RouxSettings {
+            default_agent_profile: "claude".into(),
+            ..roux_core::RouxSettings::default()
+        };
+        settings.kanban.workflow.phases.get_mut("planning").unwrap().agent_profile =
+            Some("codex".into());
+
+        let profile =
+            planning_agent_profile_id(&req("work-item-plan", serde_json::json!({})), &settings);
+
+        assert_eq!(profile, "codex");
+    }
+
+    #[test]
+    fn planning_agent_profile_request_overrides_phase() {
+        let mut settings = roux_core::RouxSettings::default();
+        settings.kanban.workflow.phases.get_mut("planning").unwrap().agent_profile =
+            Some("codex".into());
+
+        let profile = planning_agent_profile_id(
+            &req("work-item-plan", serde_json::json!({ "profile": "claude" })),
+            &settings,
+        );
+
+        assert_eq!(profile, "claude");
+    }
+
+    #[test]
+    fn implementation_agent_profile_prefers_card_then_phase_then_global_default() {
+        let item = roux_core::WorkItem {
+            id: "wi-1".into(),
+            project_id: None,
+            title: "Fix tests".into(),
+            body: None,
+            status: roux_core::WorkItemStatus::Todo,
+            review_stage_id: None,
+            parent_id: None,
+            agent_profile: Some("claude".into()),
+            repo_path: None,
+            base_branch: None,
+            worktree_path: None,
+            branch: None,
+            fetch_first: None,
+            start_error: None,
+            session_id: None,
+            provider: None,
+            external_id: None,
+            external_url: None,
+            sort_order: 0.0,
+            pinned_pr_url: None,
+            archived_at: None,
+            cost: None,
+            created_at: 0,
+            updated_at: 0,
+        };
+        let mut settings = roux_core::RouxSettings {
+            default_agent_profile: "fallback".into(),
+            ..roux_core::RouxSettings::default()
+        };
+        settings.kanban.workflow.phases.get_mut("implementation").unwrap().agent_profile =
+            Some("codex".into());
+
+        let profile = implementation_agent_profile_id(
+            &req("work-item-start", serde_json::json!({})),
+            &item,
+            &settings,
+        );
+        assert_eq!(profile, "claude");
+
+        let mut item_without_profile = item;
+        item_without_profile.agent_profile = None;
+        let profile = implementation_agent_profile_id(
+            &req("work-item-start", serde_json::json!({})),
+            &item_without_profile,
+            &settings,
+        );
+        assert_eq!(profile, "codex");
+
+        settings.kanban.workflow.phases.get_mut("implementation").unwrap().agent_profile = None;
+        let profile = implementation_agent_profile_id(
+            &req("work-item-start", serde_json::json!({})),
+            &item_without_profile,
+            &settings,
+        );
+        assert_eq!(profile, "fallback");
     }
 
     #[tokio::test]

--- a/crates/roux-core/src/models/mod.rs
+++ b/crates/roux-core/src/models/mod.rs
@@ -47,9 +47,11 @@ pub use pty::{PtyInfo, PtyRole, PtyStatus};
 pub use session::{map_hook_status, Session, SessionStatus, SessionStatusEvent};
 pub use settings::{
     CursorStyle, ExperimentsConfig, ExternalTool, ExternalToolSurface, ExternalToolWebEmbedder,
-    GroupBy, KanbanSettings, KanbanStartupSidebar, LibrarySource, LibrarySourceKind, RouxSettings,
-    SkillSyncMode, SplitProfileBehavior, StartupTarget, StatusBarPosition, TabPosition,
-    TerminalDefaults, UpdateChannel, WorktreeCleanupMode, WorktreeDefaultBase, WorktreeProvider,
+    GroupBy, KanbanReviewStageSettings, KanbanSettings, KanbanStartupSidebar,
+    KanbanWorkflowPhaseCategory, KanbanWorkflowPhaseSettings, KanbanWorkflowSettings,
+    LibrarySource, LibrarySourceKind, RouxSettings, SkillSyncMode, SplitProfileBehavior,
+    StartupTarget, StatusBarPosition, TabPosition, TerminalDefaults, UpdateChannel,
+    WorktreeCleanupMode, WorktreeDefaultBase, WorktreeProvider,
 };
 pub use subscription::{BusSubscription, BusSubscriptionEvent};
 pub use task::{KeepOpen, TaskDefinition, TaskGroup};

--- a/crates/roux-core/src/models/settings.rs
+++ b/crates/roux-core/src/models/settings.rs
@@ -359,18 +359,12 @@ pub enum KanbanWorkflowPhaseCategory {
     Review,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, specta::Type, Default)]
 #[serde(rename_all = "camelCase", default)]
 pub struct KanbanReviewStageSettings {
     pub label: String,
     pub agent_profile: Option<String>,
     pub instructions: String,
-}
-
-impl Default for KanbanReviewStageSettings {
-    fn default() -> Self {
-        Self { label: String::new(), agent_profile: None, instructions: String::new() }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, specta::Type)]

--- a/crates/roux-core/src/models/settings.rs
+++ b/crates/roux-core/src/models/settings.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 
 use super::profile::{ProfileSource, SpawnProfile, TerminalEnvRule};
 
@@ -342,30 +342,207 @@ fn default_agent_profile() -> String {
     "claude".to_string()
 }
 
+const KANBAN_WORKFLOW_DEFAULT_ID: &str = "default";
+const KANBAN_WORKFLOW_DEFAULT_LABEL: &str = "Default";
+const KANBAN_PHASE_PLANNING: &str = "planning";
+const KANBAN_PHASE_IMPLEMENTATION: &str = "implementation";
+const KANBAN_PHASE_REVIEW: &str = "review";
+const KANBAN_REVIEW_STAGE_LOCAL: &str = "local_review";
+const KANBAN_REVIEW_STAGE_PR: &str = "pr_review";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, specta::Type, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum KanbanWorkflowPhaseCategory {
+    #[default]
+    Planning,
+    Implementation,
+    Review,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase", default)]
+pub struct KanbanReviewStageSettings {
+    pub label: String,
+    pub agent_profile: Option<String>,
+    pub instructions: String,
+}
+
+impl Default for KanbanReviewStageSettings {
+    fn default() -> Self {
+        Self { label: String::new(), agent_profile: None, instructions: String::new() }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase", default)]
+pub struct KanbanWorkflowPhaseSettings {
+    pub category: KanbanWorkflowPhaseCategory,
+    pub label: String,
+    pub agent_profile: Option<String>,
+    pub instructions: String,
+    pub stages: BTreeMap<String, KanbanReviewStageSettings>,
+}
+
+impl Default for KanbanWorkflowPhaseSettings {
+    fn default() -> Self {
+        Self {
+            category: KanbanWorkflowPhaseCategory::Planning,
+            label: String::new(),
+            agent_profile: None,
+            instructions: String::new(),
+            stages: BTreeMap::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase", default)]
+pub struct KanbanWorkflowSettings {
+    pub id: String,
+    pub label: String,
+    pub phases: BTreeMap<String, KanbanWorkflowPhaseSettings>,
+}
+
+impl Default for KanbanWorkflowSettings {
+    fn default() -> Self {
+        Self {
+            id: KANBAN_WORKFLOW_DEFAULT_ID.to_string(),
+            label: KANBAN_WORKFLOW_DEFAULT_LABEL.to_string(),
+            phases: default_kanban_workflow_phases(),
+        }
+    }
+}
+
+fn default_kanban_workflow() -> KanbanWorkflowSettings {
+    KanbanWorkflowSettings::default()
+}
+
+fn default_kanban_workflow_phases() -> BTreeMap<String, KanbanWorkflowPhaseSettings> {
+    BTreeMap::from([
+        (
+            KANBAN_PHASE_PLANNING.to_string(),
+            KanbanWorkflowPhaseSettings {
+                category: KanbanWorkflowPhaseCategory::Planning,
+                label: "Planning".to_string(),
+                agent_profile: None,
+                instructions: String::new(),
+                stages: BTreeMap::new(),
+            },
+        ),
+        (
+            KANBAN_PHASE_IMPLEMENTATION.to_string(),
+            KanbanWorkflowPhaseSettings {
+                category: KanbanWorkflowPhaseCategory::Implementation,
+                label: "Implementation".to_string(),
+                agent_profile: None,
+                instructions: String::new(),
+                stages: BTreeMap::new(),
+            },
+        ),
+        (
+            KANBAN_PHASE_REVIEW.to_string(),
+            KanbanWorkflowPhaseSettings {
+                category: KanbanWorkflowPhaseCategory::Review,
+                label: "Review".to_string(),
+                agent_profile: None,
+                instructions: String::new(),
+                stages: default_kanban_review_stages(),
+            },
+        ),
+    ])
+}
+
+fn default_kanban_review_stages() -> BTreeMap<String, KanbanReviewStageSettings> {
+    BTreeMap::from([
+        (
+            KANBAN_REVIEW_STAGE_LOCAL.to_string(),
+            KanbanReviewStageSettings {
+                label: "Local Review".to_string(),
+                agent_profile: None,
+                instructions: String::new(),
+            },
+        ),
+        (
+            KANBAN_REVIEW_STAGE_PR.to_string(),
+            KanbanReviewStageSettings {
+                label: "PR Review".to_string(),
+                agent_profile: None,
+                instructions: String::new(),
+            },
+        ),
+    ])
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
 #[serde(rename_all = "camelCase", default)]
 pub struct KanbanSettings {
-    #[serde(default = "default_agent_profile")]
-    pub default_agent_profile: String,
-    #[serde(default)]
-    pub planning_prompt_append: String,
-    #[serde(default)]
-    pub implementation_prompt_append: String,
-    #[serde(default)]
-    pub review_prompt_append: String,
     #[serde(default)]
     pub startup_sidebar: KanbanStartupSidebar,
+    #[serde(default = "default_kanban_workflow")]
+    pub workflow: KanbanWorkflowSettings,
 }
 
 impl Default for KanbanSettings {
     fn default() -> Self {
         Self {
-            default_agent_profile: default_agent_profile(),
-            planning_prompt_append: String::new(),
-            implementation_prompt_append: String::new(),
-            review_prompt_append: String::new(),
             startup_sidebar: KanbanStartupSidebar::Restore,
+            workflow: KanbanWorkflowSettings::default(),
         }
+    }
+}
+
+impl KanbanSettings {
+    pub fn phase(&self, id: &str) -> Option<&KanbanWorkflowPhaseSettings> {
+        self.workflow.phases.get(id)
+    }
+
+    pub fn planning_phase(&self) -> Option<&KanbanWorkflowPhaseSettings> {
+        self.phase(KANBAN_PHASE_PLANNING)
+    }
+
+    pub fn implementation_phase(&self) -> Option<&KanbanWorkflowPhaseSettings> {
+        self.phase(KANBAN_PHASE_IMPLEMENTATION)
+    }
+
+    pub fn review_phase(&self) -> Option<&KanbanWorkflowPhaseSettings> {
+        self.phase(KANBAN_PHASE_REVIEW)
+    }
+
+    pub fn phase_agent_profile(&self, phase_id: &str) -> Option<&str> {
+        self.phase(phase_id)
+            .and_then(|phase| phase.agent_profile.as_deref())
+            .map(str::trim)
+            .filter(|profile| !profile.is_empty())
+    }
+
+    pub fn planning_instructions(&self) -> &str {
+        self.planning_phase().map(|phase| phase.instructions.as_str()).unwrap_or("")
+    }
+
+    pub fn implementation_instructions(&self) -> &str {
+        self.implementation_phase().map(|phase| phase.instructions.as_str()).unwrap_or("")
+    }
+
+    pub fn review_stage(&self, id: &str) -> Option<&KanbanReviewStageSettings> {
+        self.review_phase().and_then(|phase| phase.stages.get(id))
+    }
+
+    pub fn review_stage_agent_profile(&self, id: &str) -> Option<&str> {
+        self.review_stage(id)
+            .and_then(|stage| stage.agent_profile.as_deref())
+            .map(str::trim)
+            .filter(|profile| !profile.is_empty())
+    }
+
+    pub fn review_stage_instructions(&self, id: &str) -> &str {
+        self.review_stage(id).map(|stage| stage.instructions.as_str()).unwrap_or("")
+    }
+
+    pub fn review_stage_label(&self, id: &str) -> Option<&str> {
+        self.review_stage(id)
+            .map(|stage| stage.label.as_str())
+            .map(str::trim)
+            .filter(|label| !label.is_empty())
     }
 }
 
@@ -691,24 +868,10 @@ impl RouxSettings {
             .map(|cmd| cmd.trim().to_string())
             .filter(|cmd| !cmd.is_empty());
         s.default_agent_profile = s.default_agent_profile.trim().to_string();
-        s.kanban.default_agent_profile = s.kanban.default_agent_profile.trim().to_string();
         if s.default_agent_profile.is_empty() {
             s.default_agent_profile = default_agent_profile();
         }
-        // Migration bridge for settings files written before the global
-        // default existed. If Kanban carried the only non-default agent
-        // preference, promote it and then keep both readers in sync.
-        if s.default_agent_profile == default_agent_profile()
-            && !s.kanban.default_agent_profile.is_empty()
-            && s.kanban.default_agent_profile != default_agent_profile()
-        {
-            s.default_agent_profile = s.kanban.default_agent_profile.clone();
-        }
-        s.kanban.default_agent_profile = s.default_agent_profile.clone();
-        s.kanban.planning_prompt_append = s.kanban.planning_prompt_append.trim().to_string();
-        s.kanban.implementation_prompt_append =
-            s.kanban.implementation_prompt_append.trim().to_string();
-        s.kanban.review_prompt_append = s.kanban.review_prompt_append.trim().to_string();
+        s.kanban.workflow = normalize_kanban_workflow(&s.kanban.workflow);
         s.repo_roots = normalize_repo_roots(&s.repo_roots);
         s.library_pinned_repos = normalize_repo_roots(&s.library_pinned_repos);
         if s.library_sources.is_empty() && !s.library_pinned_repos.is_empty() {
@@ -770,6 +933,60 @@ impl RouxSettings {
         };
         s
     }
+}
+
+fn normalize_kanban_workflow(workflow: &KanbanWorkflowSettings) -> KanbanWorkflowSettings {
+    let defaults = KanbanWorkflowSettings::default();
+    let mut normalized = workflow.clone();
+    normalized.id = normalized.id.trim().to_string();
+    if normalized.id.is_empty() {
+        normalized.id = defaults.id;
+    }
+    normalized.label = normalized.label.trim().to_string();
+    if normalized.label.is_empty() {
+        normalized.label = defaults.label;
+    }
+
+    let mut phases = BTreeMap::new();
+    for (id, default_phase) in default_kanban_workflow_phases() {
+        let mut phase = normalized.phases.remove(&id).unwrap_or_else(|| default_phase.clone());
+        phase.category = default_phase.category;
+        phase.label = phase.label.trim().to_string();
+        if phase.label.is_empty() {
+            phase.label = default_phase.label;
+        }
+        phase.agent_profile = normalize_optional_string(&phase.agent_profile);
+        phase.instructions = phase.instructions.trim().to_string();
+        phase.stages = if id == KANBAN_PHASE_REVIEW {
+            normalize_kanban_review_stages(&phase.stages)
+        } else {
+            BTreeMap::new()
+        };
+        phases.insert(id, phase);
+    }
+    normalized.phases = phases;
+    normalized
+}
+
+fn normalize_kanban_review_stages(
+    stages: &BTreeMap<String, KanbanReviewStageSettings>,
+) -> BTreeMap<String, KanbanReviewStageSettings> {
+    let mut normalized = BTreeMap::new();
+    for (id, default_stage) in default_kanban_review_stages() {
+        let mut stage = stages.get(&id).cloned().unwrap_or_else(|| default_stage.clone());
+        stage.label = stage.label.trim().to_string();
+        if stage.label.is_empty() {
+            stage.label = default_stage.label;
+        }
+        stage.agent_profile = normalize_optional_string(&stage.agent_profile);
+        stage.instructions = stage.instructions.trim().to_string();
+        normalized.insert(id, stage);
+    }
+    normalized
+}
+
+fn normalize_optional_string(value: &Option<String>) -> Option<String> {
+    value.as_ref().map(|value| value.trim().to_string()).filter(|value| !value.is_empty())
 }
 
 fn normalize_external_tools(tools: &[ExternalTool]) -> Vec<ExternalTool> {
@@ -996,9 +1213,13 @@ mod theme_tests {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use super::{
-        stable_source_id, ExternalToolSurface, ExternalToolWebEmbedder, LibrarySource,
-        LibrarySourceKind, RouxSettings, SkillSyncMode, UpdateChannel,
+        stable_source_id, ExternalToolSurface, ExternalToolWebEmbedder, KanbanReviewStageSettings,
+        KanbanSettings, KanbanWorkflowPhaseCategory, KanbanWorkflowPhaseSettings,
+        KanbanWorkflowSettings, LibrarySource, LibrarySourceKind, RouxSettings, SkillSyncMode,
+        UpdateChannel,
     };
 
     #[test]
@@ -1097,15 +1318,25 @@ mod tests {
             "taskPanelCollapsed": true
         }"#;
         let parsed: RouxSettings = serde_json::from_str(legacy).unwrap();
-        assert_eq!(parsed.kanban.default_agent_profile, "claude");
         assert_eq!(parsed.kanban.startup_sidebar, super::KanbanStartupSidebar::Restore);
-        assert!(parsed.kanban.planning_prompt_append.is_empty());
-        assert!(parsed.kanban.implementation_prompt_append.is_empty());
-        assert!(parsed.kanban.review_prompt_append.is_empty());
+        assert_eq!(parsed.kanban.workflow.id, "default");
+        assert_eq!(parsed.kanban.workflow.label, "Default");
+        assert_eq!(
+            parsed.kanban.workflow.phases["planning"].category,
+            KanbanWorkflowPhaseCategory::Planning
+        );
+        assert_eq!(parsed.kanban.workflow.phases["planning"].label, "Planning");
+        assert_eq!(parsed.kanban.workflow.phases["implementation"].label, "Implementation");
+        assert_eq!(parsed.kanban.workflow.phases["review"].label, "Review");
+        assert_eq!(
+            parsed.kanban.workflow.phases["review"].stages["local_review"].label,
+            "Local Review"
+        );
+        assert_eq!(parsed.kanban.workflow.phases["review"].stages["pr_review"].label, "PR Review");
     }
 
     #[test]
-    fn legacy_kanban_agent_profile_promotes_to_global_default_agent() {
+    fn legacy_kanban_agent_profile_is_ignored() {
         let json = r#"{
             "tabPosition": "left",
             "tabWidth": 260,
@@ -1134,8 +1365,130 @@ mod tests {
         let settings: RouxSettings = serde_json::from_str(json).unwrap();
         let normalized = settings.normalized();
 
-        assert_eq!(normalized.default_agent_profile, "codex");
-        assert_eq!(normalized.kanban.default_agent_profile, "codex");
+        assert_eq!(normalized.default_agent_profile, "claude");
+        assert_eq!(normalized.kanban.workflow.id, "default");
+    }
+
+    #[test]
+    fn kanban_workflow_normalizes_known_phases_and_drops_unknowns() {
+        let settings = RouxSettings {
+            kanban: KanbanSettings {
+                workflow: KanbanWorkflowSettings {
+                    id: " custom ".into(),
+                    label: " Team Flow ".into(),
+                    phases: BTreeMap::from([
+                        (
+                            "planning".into(),
+                            KanbanWorkflowPhaseSettings {
+                                category: KanbanWorkflowPhaseCategory::Review,
+                                label: " Plan It ".into(),
+                                agent_profile: Some(" codex ".into()),
+                                instructions: " Ask first. ".into(),
+                                stages: BTreeMap::from([(
+                                    "should_drop".into(),
+                                    KanbanReviewStageSettings {
+                                        label: "Drop".into(),
+                                        agent_profile: Some("drop".into()),
+                                        instructions: "drop".into(),
+                                    },
+                                )]),
+                            },
+                        ),
+                        (
+                            "review".into(),
+                            KanbanWorkflowPhaseSettings {
+                                category: KanbanWorkflowPhaseCategory::Implementation,
+                                label: " Review It ".into(),
+                                agent_profile: Some(" ".into()),
+                                instructions: " ".into(),
+                                stages: BTreeMap::from([
+                                    (
+                                        "local_review".into(),
+                                        KanbanReviewStageSettings {
+                                            label: " Local Gate ".into(),
+                                            agent_profile: Some(" claude ".into()),
+                                            instructions: " Check locally. ".into(),
+                                        },
+                                    ),
+                                    (
+                                        "security_review".into(),
+                                        KanbanReviewStageSettings {
+                                            label: "Security".into(),
+                                            agent_profile: None,
+                                            instructions: "drop".into(),
+                                        },
+                                    ),
+                                ]),
+                            },
+                        ),
+                        (
+                            "deploy".into(),
+                            KanbanWorkflowPhaseSettings {
+                                label: "Deploy".into(),
+                                ..KanbanWorkflowPhaseSettings::default()
+                            },
+                        ),
+                    ]),
+                },
+                ..KanbanSettings::default()
+            },
+            ..RouxSettings::default()
+        };
+
+        let normalized = settings.normalized();
+
+        assert_eq!(normalized.kanban.workflow.id, "custom");
+        assert_eq!(normalized.kanban.workflow.label, "Team Flow");
+        assert_eq!(
+            normalized.kanban.workflow.phases.keys().cloned().collect::<Vec<_>>(),
+            vec!["implementation", "planning", "review"]
+        );
+        let planning = &normalized.kanban.workflow.phases["planning"];
+        assert_eq!(planning.category, KanbanWorkflowPhaseCategory::Planning);
+        assert_eq!(planning.label, "Plan It");
+        assert_eq!(planning.agent_profile.as_deref(), Some("codex"));
+        assert_eq!(planning.instructions, "Ask first.");
+        assert!(planning.stages.is_empty());
+
+        let implementation = &normalized.kanban.workflow.phases["implementation"];
+        assert_eq!(implementation.category, KanbanWorkflowPhaseCategory::Implementation);
+        assert_eq!(implementation.label, "Implementation");
+
+        let review = &normalized.kanban.workflow.phases["review"];
+        assert_eq!(review.category, KanbanWorkflowPhaseCategory::Review);
+        assert_eq!(review.label, "Review It");
+        assert!(review.agent_profile.is_none());
+        assert_eq!(
+            review.stages.keys().cloned().collect::<Vec<_>>(),
+            vec!["local_review", "pr_review"]
+        );
+        assert_eq!(review.stages["local_review"].label, "Local Gate");
+        assert_eq!(review.stages["local_review"].agent_profile.as_deref(), Some("claude"));
+        assert_eq!(review.stages["local_review"].instructions, "Check locally.");
+        assert_eq!(review.stages["pr_review"].label, "PR Review");
+    }
+
+    #[test]
+    fn kanban_workflow_serde_uses_json_native_shape() {
+        let settings = KanbanSettings::default();
+        let value = serde_json::to_value(&settings).unwrap();
+
+        assert_eq!(value["startupSidebar"], "restore");
+        assert_eq!(value["workflow"]["id"], "default");
+        assert_eq!(value["workflow"]["label"], "Default");
+        assert_eq!(value["workflow"]["phases"]["planning"]["category"], "planning");
+        assert_eq!(
+            value["workflow"]["phases"]["planning"]["agentProfile"],
+            serde_json::Value::Null
+        );
+        assert_eq!(
+            value["workflow"]["phases"]["review"]["stages"]["local_review"]["label"],
+            "Local Review"
+        );
+        assert!(value.get("planningPromptAppend").is_none());
+        assert!(value.get("implementationPromptAppend").is_none());
+        assert!(value.get("reviewPromptAppend").is_none());
+        assert!(value.get("defaultAgentProfile").is_none());
     }
 
     #[test]
@@ -1179,7 +1532,6 @@ mod tests {
         let normalized = settings.normalized();
 
         assert_eq!(normalized.default_agent_profile, "claude");
-        assert_eq!(normalized.kanban.default_agent_profile, "claude");
     }
 
     #[test]

--- a/crates/roux-runtime/src/work_item_service.rs
+++ b/crates/roux-runtime/src/work_item_service.rs
@@ -17,8 +17,8 @@ use tokio::sync::broadcast;
 use uuid::Uuid;
 
 use roux_core::{
-    Attachment, AttachmentDocument, AttachmentInput, AttachmentTargetKind, WorkItem,
-    WorkItemDecision, WorkItemDecisionOption, WorkItemEvent, WorkItemInput,
+    Attachment, AttachmentDocument, AttachmentInput, AttachmentTargetKind, KanbanSettings,
+    WorkItem, WorkItemDecision, WorkItemDecisionOption, WorkItemEvent, WorkItemInput,
     WorkItemMigrationStatus, WorkItemMigrationStorage, WorkItemRun, WorkItemRunEvent,
     WorkItemRunEventKind, WorkItemRunKind, WorkItemRunStatus, WorkItemStatus,
 };
@@ -668,7 +668,25 @@ impl WorkItemHandle {
     pub fn accept_review(
         &self,
         work_item_id: &str,
+        payload: serde_json::Value,
+    ) -> Result<Option<(WorkItem, WorkItemRun)>, String> {
+        self.accept_review_with_stage_labels(work_item_id, payload, None)
+    }
+
+    pub fn accept_review_with_kanban_settings(
+        &self,
+        work_item_id: &str,
+        payload: serde_json::Value,
+        kanban: &KanbanSettings,
+    ) -> Result<Option<(WorkItem, WorkItemRun)>, String> {
+        self.accept_review_with_stage_labels(work_item_id, payload, Some(kanban))
+    }
+
+    fn accept_review_with_stage_labels(
+        &self,
+        work_item_id: &str,
         mut payload: serde_json::Value,
+        kanban: Option<&KanbanSettings>,
     ) -> Result<Option<(WorkItem, WorkItemRun)>, String> {
         let now = now_secs();
         if let serde_json::Value::Object(ref mut object) = payload {
@@ -677,12 +695,20 @@ impl WorkItemHandle {
             });
         }
         let event_id = Uuid::new_v4().to_string();
-        let result = self
-            .inner
-            .lock()
-            .unwrap()
-            .accept_review(work_item_id, event_id, payload, now)
-            .map_err(|e| format!("work-item review accept: {e}"))?;
+        let result = {
+            let mut store = self.inner.lock().unwrap();
+            match kanban {
+                Some(kanban) => store.accept_review_with_kanban_settings(
+                    work_item_id,
+                    event_id,
+                    payload,
+                    now,
+                    kanban,
+                ),
+                None => store.accept_review(work_item_id, event_id, payload, now),
+            }
+            .map_err(|e| format!("work-item review accept: {e}"))?
+        };
         if let Some((item, run, event)) = result {
             self.broadcast(WorkItemEvent::RunUpdated { run: run.clone() });
             self.broadcast(WorkItemEvent::RunEventAppended { event });
@@ -701,8 +727,28 @@ impl WorkItemHandle {
     pub fn request_review(
         &self,
         run_id: &str,
+        payload: serde_json::Value,
+        result_payload: Option<serde_json::Value>,
+    ) -> Result<Option<(WorkItem, WorkItemRun)>, String> {
+        self.request_review_with_stage_labels(run_id, payload, result_payload, None)
+    }
+
+    pub fn request_review_with_kanban_settings(
+        &self,
+        run_id: &str,
+        payload: serde_json::Value,
+        result_payload: Option<serde_json::Value>,
+        kanban: &KanbanSettings,
+    ) -> Result<Option<(WorkItem, WorkItemRun)>, String> {
+        self.request_review_with_stage_labels(run_id, payload, result_payload, Some(kanban))
+    }
+
+    fn request_review_with_stage_labels(
+        &self,
+        run_id: &str,
         mut payload: serde_json::Value,
         result_payload: Option<serde_json::Value>,
+        kanban: Option<&KanbanSettings>,
     ) -> Result<Option<(WorkItem, WorkItemRun)>, String> {
         let now = now_secs();
         if let serde_json::Value::Object(ref mut object) = payload {
@@ -712,12 +758,21 @@ impl WorkItemHandle {
         }
         let event_id = Uuid::new_v4().to_string();
         let result_event = result_payload.map(|payload| (Uuid::new_v4().to_string(), payload));
-        let result = self
-            .inner
-            .lock()
-            .unwrap()
-            .request_review(run_id, event_id, payload, result_event, now)
-            .map_err(|e| format!("work-item review request: {e}"))?;
+        let result = {
+            let mut store = self.inner.lock().unwrap();
+            match kanban {
+                Some(kanban) => store.request_review_with_kanban_settings(
+                    run_id,
+                    event_id,
+                    payload,
+                    result_event,
+                    now,
+                    kanban,
+                ),
+                None => store.request_review(run_id, event_id, payload, result_event, now),
+            }
+            .map_err(|e| format!("work-item review request: {e}"))?
+        };
         if let Some((item, run, event, result_event)) = result {
             self.broadcast(WorkItemEvent::RunUpdated { run: run.clone() });
             self.broadcast(WorkItemEvent::RunEventAppended { event });
@@ -740,8 +795,36 @@ impl WorkItemHandle {
         &self,
         run_id: &str,
         target_status: WorkItemStatus,
+        payload: serde_json::Value,
+        feedback: Option<AttachmentInput>,
+    ) -> Result<Option<(WorkItem, WorkItemRun, Option<Attachment>)>, String> {
+        self.request_changes_with_stage_labels(run_id, target_status, payload, feedback, None)
+    }
+
+    pub fn request_changes_with_kanban_settings(
+        &self,
+        run_id: &str,
+        target_status: WorkItemStatus,
+        payload: serde_json::Value,
+        feedback: Option<AttachmentInput>,
+        kanban: &KanbanSettings,
+    ) -> Result<Option<(WorkItem, WorkItemRun, Option<Attachment>)>, String> {
+        self.request_changes_with_stage_labels(
+            run_id,
+            target_status,
+            payload,
+            feedback,
+            Some(kanban),
+        )
+    }
+
+    fn request_changes_with_stage_labels(
+        &self,
+        run_id: &str,
+        target_status: WorkItemStatus,
         mut payload: serde_json::Value,
         feedback: Option<AttachmentInput>,
+        kanban: Option<&KanbanSettings>,
     ) -> Result<Option<(WorkItem, WorkItemRun, Option<Attachment>)>, String> {
         let now = now_secs();
         if let serde_json::Value::Object(ref mut object) = payload {
@@ -759,12 +842,24 @@ impl WorkItemHandle {
             let sha256 = sha256_hex(input.content.as_bytes());
             (id, input, byte_len, sha256)
         });
-        let result = self
-            .inner
-            .lock()
-            .unwrap()
-            .request_changes(run_id, target_status, event_id, payload, feedback, now)
-            .map_err(|e| format!("work-item review request changes: {e}"))?;
+        let result = {
+            let mut store = self.inner.lock().unwrap();
+            match kanban {
+                Some(kanban) => store.request_changes_with_kanban_settings(
+                    run_id,
+                    target_status,
+                    event_id,
+                    payload,
+                    feedback,
+                    now,
+                    kanban,
+                ),
+                None => {
+                    store.request_changes(run_id, target_status, event_id, payload, feedback, now)
+                }
+            }
+            .map_err(|e| format!("work-item review request changes: {e}"))?
+        };
         if let Some((item, run, event, attachment)) = result {
             self.broadcast(WorkItemEvent::RunUpdated { run: run.clone() });
             self.broadcast(WorkItemEvent::RunEventAppended { event });

--- a/crates/roux-runtime/src/work_item_store.rs
+++ b/crates/roux-runtime/src/work_item_store.rs
@@ -15,9 +15,9 @@ use serde_json::Value;
 
 use roux_core::{
     Attachment, AttachmentContentKind, AttachmentDocument, AttachmentInput, AttachmentTargetKind,
-    ExternalRef, WorkItem, WorkItemDecision, WorkItemDecisionOption, WorkItemDecisionStatus,
-    WorkItemInput, WorkItemRun, WorkItemRunEvent, WorkItemRunEventKind, WorkItemRunKind,
-    WorkItemRunStatus, WorkItemStatus,
+    ExternalRef, KanbanSettings, WorkItem, WorkItemDecision, WorkItemDecisionOption,
+    WorkItemDecisionStatus, WorkItemInput, WorkItemRun, WorkItemRunEvent, WorkItemRunEventKind,
+    WorkItemRunKind, WorkItemRunStatus, WorkItemStatus,
 };
 
 pub const WORK_ITEM_SCHEMA_VERSION: i64 = 9;
@@ -1242,8 +1242,30 @@ impl WorkItemStore {
         &mut self,
         work_item_id: &str,
         event_id: String,
+        payload: Value,
+        now: u64,
+    ) -> SqlResult<Option<(WorkItem, WorkItemRun, WorkItemRunEvent)>> {
+        self.accept_review_with_stage_labels(work_item_id, event_id, payload, now, None)
+    }
+
+    pub fn accept_review_with_kanban_settings(
+        &mut self,
+        work_item_id: &str,
+        event_id: String,
+        payload: Value,
+        now: u64,
+        kanban: &KanbanSettings,
+    ) -> SqlResult<Option<(WorkItem, WorkItemRun, WorkItemRunEvent)>> {
+        self.accept_review_with_stage_labels(work_item_id, event_id, payload, now, Some(kanban))
+    }
+
+    fn accept_review_with_stage_labels(
+        &mut self,
+        work_item_id: &str,
+        event_id: String,
         mut payload: Value,
         now: u64,
+        kanban: Option<&KanbanSettings>,
     ) -> SqlResult<Option<(WorkItem, WorkItemRun, WorkItemRunEvent)>> {
         if self.get(work_item_id)?.is_none() {
             return Ok(None);
@@ -1276,7 +1298,7 @@ impl WorkItemStore {
         let review_stage_id =
             review_stage_id.unwrap_or_else(|| roux_core::FIRST_REVIEW_STAGE_ID.to_string());
         let next_stage_id = roux_core::next_review_stage_id(&review_stage_id);
-        add_review_stage_payload_fields(&mut payload, &review_stage_id, next_stage_id);
+        add_review_stage_payload_fields(&mut payload, kanban, &review_stage_id, next_stage_id);
         if next_stage_id.is_some() {
             set_payload_string_field(&mut payload, "status", WorkItemRunStatus::Review.as_str());
             let changed = tx.execute(
@@ -1349,9 +1371,40 @@ impl WorkItemStore {
         &mut self,
         run_id: &str,
         event_id: String,
+        payload: Value,
+        result_event: Option<(String, Value)>,
+        now: u64,
+    ) -> SqlResult<ReviewRequestStoreResult> {
+        self.request_review_with_stage_labels(run_id, event_id, payload, result_event, now, None)
+    }
+
+    pub fn request_review_with_kanban_settings(
+        &mut self,
+        run_id: &str,
+        event_id: String,
+        payload: Value,
+        result_event: Option<(String, Value)>,
+        now: u64,
+        kanban: &KanbanSettings,
+    ) -> SqlResult<ReviewRequestStoreResult> {
+        self.request_review_with_stage_labels(
+            run_id,
+            event_id,
+            payload,
+            result_event,
+            now,
+            Some(kanban),
+        )
+    }
+
+    fn request_review_with_stage_labels(
+        &mut self,
+        run_id: &str,
+        event_id: String,
         mut payload: Value,
         result_event: Option<(String, Value)>,
         now: u64,
+        kanban: Option<&KanbanSettings>,
     ) -> SqlResult<ReviewRequestStoreResult> {
         let result_event = result_event
             .map(|(id, payload)| {
@@ -1390,7 +1443,7 @@ impl WorkItemStore {
         }
         let review_stage_id =
             review_stage_id.unwrap_or_else(|| roux_core::FIRST_REVIEW_STAGE_ID.to_string());
-        add_review_stage_payload_fields(&mut payload, &review_stage_id, None);
+        add_review_stage_payload_fields(&mut payload, kanban, &review_stage_id, None);
         set_payload_string_field(&mut payload, "status", WorkItemRunStatus::Review.as_str());
         let payload = serde_json::to_string(&payload)
             .map_err(|err| rusqlite::Error::ToSqlConversionFailure(Box::new(err)))?;
@@ -1474,9 +1527,51 @@ impl WorkItemStore {
         run_id: &str,
         target_status: WorkItemStatus,
         event_id: String,
+        payload: Value,
+        feedback: Option<(String, AttachmentInput, u64, String)>,
+        now: u64,
+    ) -> SqlResult<ReviewRequestChangesStoreResult> {
+        self.request_changes_with_stage_labels(
+            run_id,
+            target_status,
+            event_id,
+            payload,
+            feedback,
+            now,
+            None,
+        )
+    }
+
+    pub fn request_changes_with_kanban_settings(
+        &mut self,
+        run_id: &str,
+        target_status: WorkItemStatus,
+        event_id: String,
+        payload: Value,
+        feedback: Option<(String, AttachmentInput, u64, String)>,
+        now: u64,
+        kanban: &KanbanSettings,
+    ) -> SqlResult<ReviewRequestChangesStoreResult> {
+        self.request_changes_with_stage_labels(
+            run_id,
+            target_status,
+            event_id,
+            payload,
+            feedback,
+            now,
+            Some(kanban),
+        )
+    }
+
+    fn request_changes_with_stage_labels(
+        &mut self,
+        run_id: &str,
+        target_status: WorkItemStatus,
+        event_id: String,
         mut payload: Value,
         feedback: Option<(String, AttachmentInput, u64, String)>,
         now: u64,
+        kanban: Option<&KanbanSettings>,
     ) -> SqlResult<ReviewRequestChangesStoreResult> {
         let feedback_document_id =
             feedback.as_ref().map(|(id, input, _, _)| attachment_document_id(&input.target_id, id));
@@ -1532,7 +1627,7 @@ impl WorkItemStore {
         }
         let review_stage_id =
             review_stage_id.unwrap_or_else(|| roux_core::FIRST_REVIEW_STAGE_ID.to_string());
-        add_review_stage_payload_fields(&mut payload, &review_stage_id, None);
+        add_review_stage_payload_fields(&mut payload, kanban, &review_stage_id, None);
         let payload = serde_json::to_string(&payload)
             .map_err(|err| rusqlite::Error::ToSqlConversionFailure(Box::new(err)))?;
         let changed = tx.execute(
@@ -1856,6 +1951,7 @@ fn option_field_changed<T: PartialEq>(present: bool, next: Option<T>, current: O
 
 fn add_review_stage_payload_fields(
     payload: &mut Value,
+    kanban: Option<&KanbanSettings>,
     review_stage_id: &str,
     next_review_stage_id: Option<&str>,
 ) {
@@ -1863,15 +1959,21 @@ fn add_review_stage_payload_fields(
     object.insert("reviewStageId".into(), Value::String(review_stage_id.to_string()));
     object.insert(
         "reviewStageLabel".into(),
-        Value::String(roux_core::review_stage_label(review_stage_id)),
+        Value::String(review_stage_label(kanban, review_stage_id)),
     );
     if let Some(next_review_stage_id) = next_review_stage_id {
         object.insert("nextReviewStageId".into(), Value::String(next_review_stage_id.to_string()));
         object.insert(
             "nextReviewStageLabel".into(),
-            Value::String(roux_core::review_stage_label(next_review_stage_id)),
+            Value::String(review_stage_label(kanban, next_review_stage_id)),
         );
     }
+}
+
+fn review_stage_label(kanban: Option<&KanbanSettings>, id: &str) -> String {
+    kanban
+        .and_then(|kanban| kanban.review_stage_label(id).map(ToOwned::to_owned))
+        .unwrap_or_else(|| roux_core::review_stage_label(id))
 }
 
 fn set_payload_string_field(payload: &mut Value, key: &str, value: &str) {
@@ -2312,6 +2414,48 @@ mod tests {
         assert_eq!(event.payload["reviewStageLabel"], "Local Review");
         assert_eq!(event.payload["nextReviewStageId"], "pr_review");
         assert_eq!(event.payload["nextReviewStageLabel"], "PR Review");
+    }
+
+    #[test]
+    fn review_event_payloads_use_custom_stage_labels() {
+        let mut kanban = roux_core::KanbanSettings::default();
+        let review_phase = kanban.workflow.phases.get_mut("review").unwrap();
+        review_phase.stages.get_mut("local_review").unwrap().label = "QA Gate".into();
+        review_phase.stages.get_mut("pr_review").unwrap().label = "Team Gate".into();
+
+        let mut store = WorkItemStore::open_in_memory().unwrap();
+        store.create("i-1".into(), input("Task"), 1000).unwrap();
+        store
+            .create_run("run-1".into(), "i-1", Some("sess-1"), None, None, None, None, 1100)
+            .unwrap();
+
+        let (_, _, event, _) = store
+            .request_review_with_kanban_settings(
+                "run-1",
+                "event-1".into(),
+                serde_json::json!({ "status": "review" }),
+                None,
+                1200,
+                &kanban,
+            )
+            .unwrap()
+            .expect("run should request review");
+
+        assert_eq!(event.payload["reviewStageLabel"], "QA Gate");
+
+        let (_, _, event) = store
+            .accept_review_with_kanban_settings(
+                "i-1",
+                "event-2".into(),
+                serde_json::json!({ "status": "done", "reason": "reviewAccepted" }),
+                1300,
+                &kanban,
+            )
+            .unwrap()
+            .expect("local review should advance");
+
+        assert_eq!(event.payload["reviewStageLabel"], "QA Gate");
+        assert_eq!(event.payload["nextReviewStageLabel"], "Team Gate");
     }
 
     #[test]

--- a/docs/v2/daemon-protocol.md
+++ b/docs/v2/daemon-protocol.md
@@ -749,9 +749,10 @@ daemon returns the existing planning run and session by default. With
 cleans up its session, and creates a fresh planning run. If another active run
 exists, planning is rejected.
 
-Planning profile resolution is request `profile`, then card `agentProfile`,
-then `settings.kanban.defaultAgentProfile`. The generated planning prompt
-includes `settings.kanban.planningPromptAppend` when configured.
+Planning profile resolution is request `profile`, then
+`settings.kanban.workflow.phases.planning.agentProfile`, then the global
+`settings.defaultAgentProfile`. The generated planning prompt includes
+`settings.kanban.workflow.phases.planning.instructions` when configured.
 
 `work-item-start`
 
@@ -763,8 +764,9 @@ without an attached approved plan.
 The daemon rejects archived cards, cards that already have an active run, and
 cards without a repo path or project repo to derive from. Restore archived cards
 before starting them. Start profile resolution is request `profile`, then card
-`agentProfile`, then `settings.kanban.defaultAgentProfile`. Plain-shell and
-type-only profiles are not valid Start profiles.
+`agentProfile`, then `settings.kanban.workflow.phases.implementation.agentProfile`,
+then the global `settings.defaultAgentProfile`. Plain-shell and type-only
+profiles are not valid Start profiles.
 
 On success for an unbound card, the daemon creates or reuses the card's
 dedicated worktree, creates a daemon session/PTY, creates a `starting`
@@ -785,9 +787,11 @@ to `doing`, clears `startError`, and returns:
 The generated implementation prompt includes the newest plan-like attached
 document when one exists, preferring work-item attachments whose title or source
 filename contains `plan`. It also includes
-`settings.kanban.implementationPromptAppend` when configured. The review
-handoff prompt includes `settings.kanban.reviewPromptAppend` and tells the
-agent to request review with `roux work-item review request <run-id>`.
+`settings.kanban.workflow.phases.implementation.instructions` when configured.
+The review handoff prompt includes the active review stage's instructions from
+`settings.kanban.workflow.phases.review.stages`; cards with no stored review
+stage use `local_review`. The handoff tells the agent to request review with
+`roux work-item review request <run-id>`.
 
 If the card already has a bound implementation `sessionId`, Start reuses that
 session and creates an additional implementation run/PTY in it instead of

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -627,14 +627,33 @@ export type IntegrationDetection = {
 };
 
 export type KanbanSettings = {
-	defaultAgentProfile?: string,
-	planningPromptAppend?: string,
-	implementationPromptAppend?: string,
-	reviewPromptAppend?: string,
 	startupSidebar?: KanbanStartupSidebar,
+	workflow?: KanbanWorkflowSettings,
+};
+
+export type KanbanReviewStageSettings = {
+	label?: string,
+	agentProfile?: string | null,
+	instructions?: string,
 };
 
 export type KanbanStartupSidebar = "restore" | "sessions" | "kanban" | "none";
+
+export type KanbanWorkflowPhaseCategory = "planning" | "implementation" | "review";
+
+export type KanbanWorkflowPhaseSettings = {
+	category?: KanbanWorkflowPhaseCategory,
+	label?: string,
+	agentProfile?: string | null,
+	instructions?: string,
+	stages?: { [key in string]?: KanbanReviewStageSettings },
+};
+
+export type KanbanWorkflowSettings = {
+	id?: string,
+	label?: string,
+	phases?: { [key in string]?: KanbanWorkflowPhaseSettings },
+};
 
 export type KeepOpen = "always" | "on-error" | "never";
 

--- a/src/lib/components/BoardMainView.svelte
+++ b/src/lib/components/BoardMainView.svelte
@@ -50,7 +50,9 @@
   import { createSessionShell, openPathInFinder } from "$lib/tauri";
   import { addSession, setActiveSession } from "$lib/stores/sessions";
   import { projects } from "$lib/stores/projects";
+  import { settings } from "$lib/stores/settings";
   import { defaultAgentProfileId } from "$lib/panes/defaultAgent";
+  import { reviewAgentProfileId } from "$lib/workItems/workflow";
   import { hasWorkItemDragData, readWorkItemDragData } from "$lib/board/drag";
   import WorkItemCard from "./WorkItemCard.svelte";
   import AddCardInput from "./AddCardInput.svelte";
@@ -91,7 +93,7 @@
   }
 
   function needsStartConfig(item: WorkItem): boolean {
-    return !item.agentProfile || (!item.repoPath && !item.projectId);
+    return !item.repoPath && !item.projectId;
   }
 
   function attachedSessionIdsForItem(
@@ -239,7 +241,10 @@
       if (!repoPath) {
         throw new Error("review worktree repo root is not configured");
       }
-      const profileId = item.agentProfile ?? defaultAgentProfileId();
+      const profileId =
+        reviewAgentProfileId(get(settings).kanban, item.reviewStageId) ??
+        item.agentProfile ??
+        defaultAgentProfileId();
       const profileRef = { kind: "registered" as const, id: profileId };
       const [
         { resolveProfileRef },

--- a/src/lib/components/BoardPanel.svelte
+++ b/src/lib/components/BoardPanel.svelte
@@ -46,7 +46,9 @@
   import { createSessionShell, openPathInFinder } from "$lib/tauri";
   import { addSession, setActiveSession } from "$lib/stores/sessions";
   import { projects } from "$lib/stores/projects";
+  import { settings } from "$lib/stores/settings";
   import { defaultAgentProfileId } from "$lib/panes/defaultAgent";
+  import { reviewAgentProfileId } from "$lib/workItems/workflow";
   import SidebarPanelHeader from "./SidebarPanelHeader.svelte";
   import CollapseSidebarButton from "./CollapseSidebarButton.svelte";
   import PinButton from "./PinButton.svelte";
@@ -88,7 +90,7 @@
   }
 
   function needsStartConfig(item: WorkItem): boolean {
-    return !item.agentProfile || (!item.repoPath && !item.projectId);
+    return !item.repoPath && !item.projectId;
   }
 
   function attachedSessionIdsForItem(
@@ -236,7 +238,10 @@
       if (!repoPath) {
         throw new Error("review worktree repo root is not configured");
       }
-      const profileId = item.agentProfile ?? defaultAgentProfileId();
+      const profileId =
+        reviewAgentProfileId(get(settings).kanban, item.reviewStageId) ??
+        item.agentProfile ??
+        defaultAgentProfileId();
       const profileRef = { kind: "registered" as const, id: profileId };
       const [
         { resolveProfileRef },

--- a/src/lib/components/WorkItemCard.svelte
+++ b/src/lib/components/WorkItemCard.svelte
@@ -18,6 +18,7 @@
   import { clearDraggedWorkItem, writeWorkItemDragData } from "$lib/board/drag";
   import { unreadBySession } from "$lib/stores/notifications";
   import { projects } from "$lib/stores/projects";
+  import { settings } from "$lib/stores/settings";
   import { reviewStageLabel } from "$lib/workItems/reviewStages";
 
   interface Props {
@@ -151,7 +152,9 @@
     !!onEdit || !!onPlan || !!onDelete || !!onArchive || canForceStartPlanning,
   );
   const reviewSessionId = $derived(reviewPackage?.sessionId ?? null);
-  const reviewStageName = $derived(reviewStageLabel(item.reviewStageId));
+  const reviewStageName = $derived(
+    reviewStageLabel(item.reviewStageId, $settings.kanban),
+  );
   const acceptReviewText = $derived(
     reviewStageName ? `Accept ${reviewStageName}` : "Accept done",
   );

--- a/src/lib/components/WorkItemEditor.svelte
+++ b/src/lib/components/WorkItemEditor.svelte
@@ -24,7 +24,6 @@
   } from "$lib/stores/workItems";
   import { projects } from "$lib/stores/projects";
   import { settings } from "$lib/stores/settings";
-  import { defaultAgentProfileId } from "$lib/panes/defaultAgent";
   import { profileList } from "$lib/panes/profiles";
   import { listWorktrees } from "$lib/tauri";
   import {
@@ -70,7 +69,7 @@
     item ? ($attachmentsByWorkItem.get(item.id) ?? []) : [],
   );
   const reviewStageName = $derived(
-    item ? reviewStageLabel(item.reviewStageId) : null,
+    item ? reviewStageLabel(item.reviewStageId, $settings.kanban) : null,
   );
   const reviewStageLabelText = $derived(
     item?.status === "review" ? "Review stage" : "Next review stage",
@@ -96,7 +95,7 @@
   let projectId = $state<string | null>(null);
   let repoPath = $state("");
   let repoOverride = $state(true);
-  let profileId = $state(defaultAgentProfileId());
+  let profileId = $state("");
   let worktreeTarget = $state("");
   let branchBase = $state<BranchBase>("main");
   let worktrees = $state<Worktree[]>([]);
@@ -160,7 +159,7 @@
       repoOverride = !item.projectId || !!item.repoPath;
       repoPath =
         item.repoPath ?? projectRoot ?? $settings.defaultProjectPath ?? "";
-      profileId = item.agentProfile ?? defaultAgentProfileId();
+      profileId = item.agentProfile ?? "";
       worktreeTarget = item.worktreePath ?? item.branch ?? "";
       branchBase =
         item.fetchFirst || item.baseBranch === "origin/main"
@@ -175,7 +174,7 @@
       projectId = null;
       repoOverride = true;
       repoPath = $settings.defaultProjectPath ?? "";
-      profileId = defaultAgentProfileId();
+      profileId = "";
       worktreeTarget = "";
       branchBase = "main";
       resetTransientState();
@@ -241,7 +240,7 @@
 
   function applyTargetFields(payload: WorkItemInput): WorkItemInput {
     payload.repoPath = repoPathForSave();
-    payload.agentProfile = profileId || defaultAgentProfileId();
+    payload.agentProfile = profileId || null;
     const target = worktreeTarget.trim();
     const exactWorktree = worktrees.find(
       (wt) => wt.path === target || wt.branch === target,
@@ -610,7 +609,12 @@
 
             <label class="flex flex-col gap-1.5">
               <span class={sectionLabel}>Spawn profile</span>
-              <select class={inputClass} bind:value={profileId}>
+              <select
+                class={inputClass}
+                bind:value={profileId}
+                aria-label="Spawn profile"
+              >
+                <option value="">Workflow default</option>
                 {#each profileOptions as profile (profile.id)}
                   <option value={profile.id}>{profile.name}</option>
                 {/each}

--- a/src/lib/components/__tests__/BoardMainView.test.ts
+++ b/src/lib/components/__tests__/BoardMainView.test.ts
@@ -27,15 +27,17 @@ import { closeMainView } from "$lib/stores/mainView";
 import { openSessionById } from "$lib/panes/openSession";
 import { WORK_ITEM_DRAG_MIME } from "$lib/board/drag";
 import type { WorkItem } from "$lib/bindings";
-import type { Notification, Project } from "$lib/types";
+import { DEFAULT_SETTINGS, type Notification, type Project } from "$lib/types";
 import type { Attachment, WorkItemRun } from "$lib/types/workItems";
 import { notifications } from "$lib/stores/notifications";
 import { projects } from "$lib/stores/projects";
 import { createSessionShell, openPathInFinder } from "$lib/tauri";
 import { addSession, setActiveSession } from "$lib/stores/sessions";
+import { settings } from "$lib/stores/settings";
 import { initSessionWithProfile } from "$lib/panes/actions";
 import { connectPaneTerminal } from "$lib/panes/terminals";
 import { runProfileInPane } from "$lib/panes/profileRunner";
+import { kanbanWithPrReviewProfile } from "./kanbanFixtures";
 
 // jsdom lacks the Web Animations API that Svelte's transition:fade/scale use.
 if (typeof Element !== "undefined" && !Element.prototype.animate) {
@@ -309,6 +311,7 @@ describe("BoardMainView", () => {
     ).set([]);
     projects.set([project()]);
     notifications.set([]);
+    settings.set({ ...DEFAULT_SETTINGS });
   });
 
   it("renders one section per column with labels", () => {
@@ -404,16 +407,14 @@ describe("BoardMainView", () => {
   });
 
   it("Approve and start delegates to daemon start without issuing a second move", async () => {
-    seedColumns(
-      [
-        workItem({
-          id: "wi-1",
-          status: "ready",
-          projectId: "proj-1",
-          sessionId: null,
-        }),
-      ].map((item) => ({ ...item, agentProfile: "claude" }) as WorkItem),
-    );
+    seedColumns([
+      workItem({
+        id: "wi-1",
+        status: "ready",
+        projectId: "proj-1",
+        sessionId: null,
+      }),
+    ]);
     seedWorkItemAttachments([["wi-1", [attachment({ targetId: "wi-1" })]]]);
     render(BoardMainView);
 
@@ -707,6 +708,10 @@ describe("BoardMainView", () => {
   });
 
   it("shows review package details and requests changes with a note", async () => {
+    settings.set({
+      ...DEFAULT_SETTINGS,
+      kanban: kanbanWithPrReviewProfile(),
+    });
     seedColumns([
       workItem({
         id: "wi-review",
@@ -813,7 +818,7 @@ describe("BoardMainView", () => {
         "Review me review",
         "/repo/.worktrees/review-card",
         null,
-        { profile: "claude" },
+        { profile: "codex-review" },
       ),
     );
     expect(addSession).toHaveBeenCalledWith(
@@ -821,7 +826,7 @@ describe("BoardMainView", () => {
     );
     expect(initSessionWithProfile).toHaveBeenCalledWith(
       "review-agent-session",
-      { kind: "registered", id: "claude" },
+      { kind: "registered", id: "codex-review" },
     );
     expect(connectPaneTerminal).toHaveBeenCalledWith("review-agent-session");
     expect(runProfileInPane).toHaveBeenCalled();

--- a/src/lib/components/__tests__/BoardPanel.test.ts
+++ b/src/lib/components/__tests__/BoardPanel.test.ts
@@ -18,15 +18,17 @@ import { deleteWorkItemWithMode } from "$lib/workItems/deleteFlow";
 import { openWorkItemEditor, openWorkItemSessionStart } from "$lib/stores/ui";
 import { openMainView } from "$lib/stores/mainView";
 import type { WorkItem } from "$lib/bindings";
-import type { Project } from "$lib/types";
+import { DEFAULT_SETTINGS, type Project } from "$lib/types";
 import type { Attachment, WorkItemRun } from "$lib/types/workItems";
 import { projects } from "$lib/stores/projects";
 import { createSessionShell, openPathInFinder } from "$lib/tauri";
 import { addSession, setActiveSession } from "$lib/stores/sessions";
+import { settings } from "$lib/stores/settings";
 import { openSessionById } from "$lib/panes/openSession";
 import { initSessionWithProfile } from "$lib/panes/actions";
 import { connectPaneTerminal } from "$lib/panes/terminals";
 import { runProfileInPane } from "$lib/panes/profileRunner";
+import { kanbanWithPrReviewProfile } from "./kanbanFixtures";
 
 // jsdom lacks the Web Animations API that Svelte's transition:fade/scale use.
 if (typeof Element !== "undefined" && !Element.prototype.animate) {
@@ -258,19 +260,18 @@ describe("BoardPanel", () => {
       workItemRunEvents as ReturnType<typeof import("svelte/store").writable>
     ).set([]);
     projects.set([project()]);
+    settings.set({ ...DEFAULT_SETTINGS });
   });
 
   it("Approve and start delegates to daemon start without issuing a second move", async () => {
-    seedColumns(
-      [
-        workItem({
-          id: "wi-1",
-          status: "ready",
-          projectId: "proj-1",
-          sessionId: null,
-        }),
-      ].map((item) => ({ ...item, agentProfile: "claude" }) as WorkItem),
-    );
+    seedColumns([
+      workItem({
+        id: "wi-1",
+        status: "ready",
+        projectId: "proj-1",
+        sessionId: null,
+      }),
+    ]);
     seedWorkItemAttachments([["wi-1", [attachment({ targetId: "wi-1" })]]]);
     render(BoardPanel, { visible: true, onclose: vi.fn() });
 
@@ -471,6 +472,10 @@ describe("BoardPanel", () => {
   });
 
   it("requests changes from a review card with a human note", async () => {
+    settings.set({
+      ...DEFAULT_SETTINGS,
+      kanban: kanbanWithPrReviewProfile(),
+    });
     const item = workItem({
       id: "wi-review",
       title: "Review me",
@@ -543,7 +548,7 @@ describe("BoardPanel", () => {
         "Review me review",
         "/repo/.worktrees/review-card",
         null,
-        { profile: "claude" },
+        { profile: "codex-review" },
       ),
     );
     expect(addSession).toHaveBeenCalledWith(
@@ -551,7 +556,7 @@ describe("BoardPanel", () => {
     );
     expect(initSessionWithProfile).toHaveBeenCalledWith(
       "review-agent-session",
-      { kind: "registered", id: "claude" },
+      { kind: "registered", id: "codex-review" },
     );
     expect(connectPaneTerminal).toHaveBeenCalledWith("review-agent-session");
     expect(runProfileInPane).toHaveBeenCalled();

--- a/src/lib/components/__tests__/SettingsPanel.test.ts
+++ b/src/lib/components/__tests__/SettingsPanel.test.ts
@@ -157,24 +157,19 @@ describe("SettingsPanel Kanban tab", () => {
     vi.mocked(updateSettings).mockClear();
   });
 
-  it("persists Kanban prompt settings", async () => {
+  it("persists Kanban workflow phase instructions", async () => {
     render(SettingsPanel, { visible: true, onclose: vi.fn() });
 
     await fireEvent.click(screen.getByRole("button", { name: "Kanban" }));
-    await fireEvent.input(
-      screen
-        .getByText("Planning instructions")
-        .parentElement!.querySelector("textarea")!,
-      {
-        target: { value: "Ask for acceptance criteria." },
-      },
-    );
+    await fireEvent.input(screen.getByLabelText("Planning instructions"), {
+      target: { value: "Ask for acceptance criteria." },
+    });
 
     await waitFor(() => {
       expect(updateSettings).toHaveBeenCalled();
     });
     const lastCall = vi.mocked(updateSettings).mock.calls.at(-1)!;
-    expect(lastCall[0].kanban?.planningPromptAppend).toBe(
+    expect(lastCall[0].kanban?.workflow?.phases?.planning?.instructions).toBe(
       "Ask for acceptance criteria.",
     );
   });
@@ -265,7 +260,7 @@ describe("SettingsPanel Agents tab", () => {
     });
     const lastCall = vi.mocked(updateSettings).mock.calls.at(-1)!;
     expect(lastCall[0].defaultAgentProfile).toBe("codex-auto");
-    expect(lastCall[0].kanban?.defaultAgentProfile).toBe("codex-auto");
+    expect(lastCall[0].kanban?.workflow?.id).toBe("default");
   });
 });
 

--- a/src/lib/components/__tests__/WorkItemEditor.test.ts
+++ b/src/lib/components/__tests__/WorkItemEditor.test.ts
@@ -282,7 +282,7 @@ describe("WorkItemEditor", () => {
       status: "todo",
       projectId: "proj-1",
       repoPath: null,
-      agentProfile: "claude",
+      agentProfile: null,
       worktreePath: null,
       branch: null,
       baseBranch: null,
@@ -343,7 +343,7 @@ describe("WorkItemEditor", () => {
     expect(screen.getByText("PR Review")).toBeTruthy();
   });
 
-  it("creates a new card with default repo and Claude profile", async () => {
+  it("creates a new card with default repo and workflow default profile", async () => {
     render(WorkItemEditor);
     newWorkItemEditor.set({ status: "review" });
 
@@ -359,13 +359,30 @@ describe("WorkItemEditor", () => {
       status: "review",
       projectId: null,
       repoPath: "/default/repo",
-      agentProfile: "claude",
+      agentProfile: null,
       worktreePath: null,
       branch: null,
       baseBranch: null,
       fetchFirst: null,
       sortOrder: expect.any(Number),
     });
+  });
+
+  it("persists an explicit card profile override when selected", async () => {
+    render(WorkItemEditor);
+    newWorkItemEditor.set({ status: "todo" });
+
+    await fireEvent.input(await screen.findByLabelText("Title"), {
+      target: { value: "Use Codex" },
+    });
+    await fireEvent.change(screen.getByLabelText("Spawn profile"), {
+      target: { value: "codex" },
+    });
+    await fireEvent.click(screen.getByText("Create"));
+
+    expect(createWorkItem).toHaveBeenCalledWith(
+      expect.objectContaining({ agentProfile: "codex" }),
+    );
   });
 
   it("loads repository picker options from discovered repos under configured roots", async () => {

--- a/src/lib/components/__tests__/kanbanFixtures.ts
+++ b/src/lib/components/__tests__/kanbanFixtures.ts
@@ -1,0 +1,26 @@
+import { DEFAULT_SETTINGS } from "$lib/types";
+import { normalizeKanbanSettings } from "$lib/workItems/workflow";
+
+export function kanbanWithPrReviewProfile() {
+  const kanban = normalizeKanbanSettings(DEFAULT_SETTINGS.kanban);
+  return {
+    ...kanban,
+    workflow: {
+      ...kanban.workflow,
+      phases: {
+        ...kanban.workflow.phases,
+        review: {
+          ...kanban.workflow.phases.review,
+          agentProfile: "phase-review",
+          stages: {
+            ...kanban.workflow.phases.review.stages,
+            pr_review: {
+              ...kanban.workflow.phases.review.stages.pr_review,
+              agentProfile: "codex-review",
+            },
+          },
+        },
+      },
+    },
+  };
+}

--- a/src/lib/components/settings/SettingsKanbanSection.svelte
+++ b/src/lib/components/settings/SettingsKanbanSection.svelte
@@ -1,62 +1,208 @@
 <script lang="ts">
+  import type {
+    KanbanWorkflowPhaseSettings,
+    KanbanReviewStageSettings,
+  } from "$lib/bindings";
+  import { profileList, type SpawnProfile } from "$lib/panes/profiles";
   import { settings, updateSetting } from "$lib/stores/settings";
-  import type { KanbanSettings } from "$lib/bindings";
+  import {
+    REVIEW_STAGE_IDS,
+    normalizeKanbanSettings,
+    type RequiredKanbanSettings,
+    type ReviewStageId,
+    type WorkflowPhaseId,
+  } from "$lib/workItems/workflow";
 
-  const KANBAN_DEFAULTS: KanbanSettings = {
-    defaultAgentProfile: "claude",
-    planningPromptAppend: "",
-    implementationPromptAppend: "",
-    reviewPromptAppend: "",
-    startupSidebar: "restore",
-  };
+  const workflowPhases: { id: WorkflowPhaseId; title: string }[] = [
+    { id: "planning", title: "Planning" },
+    { id: "implementation", title: "Implementation" },
+    { id: "review", title: "Review" },
+  ];
 
-  function kanbanSettings(): KanbanSettings {
-    return { ...KANBAN_DEFAULTS, ...($settings.kanban ?? {}) };
+  const availableProfiles = $derived.by<SpawnProfile[]>(() => {
+    const byId = new Map<string, SpawnProfile>();
+    for (const profile of $profileList) byId.set(profile.id, profile);
+    for (const profile of $settings.spawnProfiles ?? []) {
+      byId.set(profile.id, { ...profile, source: "user" });
+    }
+    return Array.from(byId.values()).filter((profile) => {
+      const provider = profile.provider;
+      const command = (profile.startupCommand ?? "").trim();
+      // Planning/start runs reject plain shells and profiles without commands.
+      return (
+        (provider === "claude" || provider === "codex") &&
+        profile.startupBehavior !== "typeOnly" &&
+        command.length > 0
+      );
+    });
+  });
+
+  const kanban = $derived(normalizeKanbanSettings($settings.kanban));
+
+  function updateKanban(next: RequiredKanbanSettings): void {
+    updateSetting("kanban", next);
   }
 
-  let kanban = $derived(kanbanSettings());
+  function updateWorkflowLabel(label: string): void {
+    updateKanban({
+      ...kanban,
+      workflow: { ...kanban.workflow, label },
+    });
+  }
 
-  function updateKanban<K extends keyof KanbanSettings>(
-    key: K,
-    value: KanbanSettings[K],
+  function updatePhase(
+    phaseId: WorkflowPhaseId,
+    patch: Partial<KanbanWorkflowPhaseSettings>,
   ): void {
-    updateSetting("kanban", { ...kanbanSettings(), [key]: value });
+    updateKanban({
+      ...kanban,
+      workflow: {
+        ...kanban.workflow,
+        phases: {
+          ...kanban.workflow.phases,
+          [phaseId]: {
+            ...kanban.workflow.phases[phaseId],
+            ...patch,
+          },
+        },
+      },
+    });
+  }
+
+  function updateReviewStage(
+    stageId: ReviewStageId,
+    patch: Partial<KanbanReviewStageSettings>,
+  ): void {
+    const review = kanban.workflow.phases.review;
+    updatePhase("review", {
+      stages: {
+        ...review.stages,
+        [stageId]: {
+          ...review.stages[stageId],
+          ...patch,
+        },
+      },
+    });
   }
 </script>
 
 <div class="py-2">
-  <div class="text-[13px]">Planning instructions</div>
-  <div class="mt-0.5 text-[11px] text-text-muted">
-    Appended after Roux's required planning prompt.
-  </div>
-  <textarea
-    class="mt-2 min-h-24 w-full resize-y rounded border border-border bg-bg-deep px-2 py-1.5 text-xs text-text-primary outline-none focus:border-accent-dim"
-    value={kanban.planningPromptAppend}
-    oninput={(e) => updateKanban("planningPromptAppend", e.currentTarget.value)}
-  ></textarea>
+  <label for="kanban-workflow-label" class="text-[13px] font-semibold"
+    >Workflow</label
+  >
+  <input
+    id="kanban-workflow-label"
+    aria-label="Workflow label"
+    class="mt-2 w-full rounded border border-border bg-bg-deep px-2 py-1.5 text-xs text-text-primary outline-none focus:border-accent-dim"
+    value={kanban.workflow.label}
+    oninput={(e) => updateWorkflowLabel(e.currentTarget.value)}
+  />
 </div>
 
-<div class="py-2">
-  <div class="text-[13px]">Implementation instructions</div>
-  <div class="mt-0.5 text-[11px] text-text-muted">
-    Appended after Roux's required Start prompt.
-  </div>
-  <textarea
-    class="mt-2 min-h-24 w-full resize-y rounded border border-border bg-bg-deep px-2 py-1.5 text-xs text-text-primary outline-none focus:border-accent-dim"
-    value={kanban.implementationPromptAppend}
-    oninput={(e) =>
-      updateKanban("implementationPromptAppend", e.currentTarget.value)}
-  ></textarea>
-</div>
+{#each workflowPhases as phaseInfo (phaseInfo.id)}
+  {@const phase = kanban.workflow.phases[phaseInfo.id]}
+  <div class="mt-3 rounded border border-border-subtle bg-bg-surface/35 p-3">
+    <div class="flex flex-wrap items-start justify-between gap-3">
+      <div>
+        <div class="text-[13px] font-semibold">{phaseInfo.title}</div>
+        <div class="mt-1 flex flex-wrap items-center gap-2">
+          <label
+            class="text-[11px] uppercase tracking-wider text-text-muted"
+            for={`kanban-${phaseInfo.id}-label`}
+          >
+            Label
+          </label>
+          <input
+            id={`kanban-${phaseInfo.id}-label`}
+            aria-label={`${phaseInfo.title} label`}
+            class="w-40 rounded border border-border bg-bg-deep px-2 py-1 text-xs text-text-primary outline-none focus:border-accent-dim"
+            value={phase.label}
+            oninput={(e) =>
+              updatePhase(phaseInfo.id, { label: e.currentTarget.value })}
+          />
+        </div>
+      </div>
+      <label
+        class="flex flex-col gap-1 text-[11px] uppercase tracking-wider text-text-muted"
+      >
+        Agent
+        <select
+          aria-label={`${phaseInfo.title} agent`}
+          class="max-w-[14rem] cursor-pointer appearance-none rounded border border-border bg-bg-deep px-2 py-1 pr-6 text-xs text-text-primary outline-none focus:border-accent-dim"
+          value={phase.agentProfile ?? ""}
+          onchange={(e) =>
+            updatePhase(phaseInfo.id, {
+              agentProfile: e.currentTarget.value || null,
+            })}
+        >
+          <option value="">Global default</option>
+          {#each availableProfiles as profile (profile.id)}
+            <option value={profile.id}>{profile.name}</option>
+          {/each}
+        </select>
+      </label>
+    </div>
 
-<div class="py-2">
-  <div class="text-[13px]">Review handoff instructions</div>
-  <div class="mt-0.5 text-[11px] text-text-muted">
-    Included in the implementation prompt until automated review runs exist.
+    {#if phaseInfo.id === "review"}
+      <div class="mt-3 space-y-3">
+        {#each REVIEW_STAGE_IDS as stageId (stageId)}
+          {@const stage = phase.stages[stageId]}
+          <div class="border-t border-border-subtle pt-3">
+            <div class="flex flex-wrap items-start justify-between gap-3">
+              <label
+                class="flex flex-col gap-1 text-[11px] uppercase tracking-wider text-text-muted"
+              >
+                Stage label
+                <input
+                  aria-label={`${stageId} label`}
+                  class="w-40 rounded border border-border bg-bg-deep px-2 py-1 text-xs text-text-primary outline-none focus:border-accent-dim"
+                  value={stage.label}
+                  oninput={(e) =>
+                    updateReviewStage(stageId, {
+                      label: e.currentTarget.value,
+                    })}
+                />
+              </label>
+              <label
+                class="flex flex-col gap-1 text-[11px] uppercase tracking-wider text-text-muted"
+              >
+                Agent
+                <select
+                  aria-label={`${stage.label || stageId} agent`}
+                  class="max-w-[14rem] cursor-pointer appearance-none rounded border border-border bg-bg-deep px-2 py-1 pr-6 text-xs text-text-primary outline-none focus:border-accent-dim"
+                  value={stage.agentProfile ?? ""}
+                  onchange={(e) =>
+                    updateReviewStage(stageId, {
+                      agentProfile: e.currentTarget.value || null,
+                    })}
+                >
+                  <option value="">Review phase/default</option>
+                  {#each availableProfiles as profile (profile.id)}
+                    <option value={profile.id}>{profile.name}</option>
+                  {/each}
+                </select>
+              </label>
+            </div>
+            <textarea
+              aria-label={`${stage.label} instructions`}
+              class="mt-2 min-h-20 w-full resize-y rounded border border-border bg-bg-deep px-2 py-1.5 text-xs text-text-primary outline-none focus:border-accent-dim"
+              value={stage.instructions}
+              oninput={(e) =>
+                updateReviewStage(stageId, {
+                  instructions: e.currentTarget.value,
+                })}
+            ></textarea>
+          </div>
+        {/each}
+      </div>
+    {:else}
+      <textarea
+        aria-label={`${phaseInfo.title} instructions`}
+        class="mt-3 min-h-24 w-full resize-y rounded border border-border bg-bg-deep px-2 py-1.5 text-xs text-text-primary outline-none focus:border-accent-dim"
+        value={phase.instructions}
+        oninput={(e) =>
+          updatePhase(phaseInfo.id, { instructions: e.currentTarget.value })}
+      ></textarea>
+    {/if}
   </div>
-  <textarea
-    class="mt-2 min-h-24 w-full resize-y rounded border border-border bg-bg-deep px-2 py-1.5 text-xs text-text-primary outline-none focus:border-accent-dim"
-    value={kanban.reviewPromptAppend}
-    oninput={(e) => updateKanban("reviewPromptAppend", e.currentTarget.value)}
-  ></textarea>
-</div>
+{/each}

--- a/src/lib/panes/defaultAgent.ts
+++ b/src/lib/panes/defaultAgent.ts
@@ -7,12 +7,8 @@ export function defaultAgentProfileId(): string {
 }
 
 export function effectiveDefaultAgentProfileId(
-  current: Pick<RouxSettings, "defaultAgentProfile" | "kanban">,
+  current: Pick<RouxSettings, "defaultAgentProfile">,
 ): string {
-  const id = (
-    current.defaultAgentProfile ??
-    current.kanban?.defaultAgentProfile ??
-    "claude"
-  ).trim();
+  const id = (current.defaultAgentProfile ?? "claude").trim();
   return id || "claude";
 }

--- a/src/lib/stores/__tests__/settings.test.ts
+++ b/src/lib/stores/__tests__/settings.test.ts
@@ -31,20 +31,20 @@ describe("settings actions", () => {
     vi.useRealTimers();
   });
 
-  it("updates default agent and legacy Kanban agent in one draft", async () => {
+  it("updates the global default agent without mutating Kanban workflow settings", async () => {
     setDefaultAgentProfile("codex");
 
     expect(get(settings).defaultAgentProfile).toBe("codex");
-    expect(get(settings).kanban?.defaultAgentProfile).toBe("codex");
+    expect(get(settings).kanban?.workflow?.id).toBe("default");
 
     await vi.runAllTimersAsync();
     expect(tauriMock.updateSettings).toHaveBeenCalledTimes(1);
     expect(tauriMock.updateSettings.mock.calls[0][0].defaultAgentProfile).toBe(
       "codex",
     );
-    expect(
-      tauriMock.updateSettings.mock.calls[0][0].kanban?.defaultAgentProfile,
-    ).toBe("codex");
+    expect(tauriMock.updateSettings.mock.calls[0][0].kanban?.workflow?.id).toBe(
+      "default",
+    );
   });
 
   it("updates startup target and legacy Kanban launch state in one draft", async () => {

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -4,6 +4,7 @@ import { DEFAULT_SETTINGS } from "../types";
 import type { KanbanSettings, StartupTarget } from "$lib/bindings";
 import { normalizeTheme } from "$lib/themes";
 import { setUserProfiles } from "$lib/panes/profiles";
+import { normalizeKanbanSettings } from "$lib/workItems/workflow";
 import {
   getSettings,
   updateSettings as updateSettingsApi,
@@ -18,14 +19,6 @@ let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 // actually changes — otherwise every unrelated setting tweak would
 // force a subprocess spawn.
 let lastWorktrunkBinaryPath: string | null | undefined = undefined;
-
-const KANBAN_DEFAULTS: KanbanSettings = {
-  defaultAgentProfile: "claude",
-  planningPromptAppend: "",
-  implementationPromptAppend: "",
-  reviewPromptAppend: "",
-  startupSidebar: "restore",
-};
 
 export async function initSettings(): Promise<RouxSettings> {
   const raw = await getSettings();
@@ -71,7 +64,6 @@ export function setDefaultAgentProfile(profileId: string): void {
   updateSettingsDraft((s) => ({
     ...s,
     defaultAgentProfile: profileId,
-    kanban: { ...kanbanSettings(s), defaultAgentProfile: profileId },
   }));
 }
 
@@ -109,7 +101,7 @@ function scheduleSettingsPersist(updated: RouxSettings): void {
 }
 
 function kanbanSettings(current: RouxSettings): KanbanSettings {
-  return { ...KANBAN_DEFAULTS, ...(current.kanban ?? {}) };
+  return normalizeKanbanSettings(current.kanban);
 }
 
 function nextStartupExternalToolId(current: RouxSettings): string | null {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,5 +1,6 @@
 // Import generated types from specta bindings
 import type { ExperimentsConfig, RouxSettings } from "./bindings";
+import { normalizeKanbanSettings } from "$lib/workItems/workflow";
 
 // Typed defaults for every experiment flag. Adding a new optional field to
 // `ExperimentsConfig` will fail to compile here until a default is supplied,
@@ -182,11 +183,7 @@ export const DEFAULT_SETTINGS: RouxSettings = {
     },
   ],
   kanban: {
-    defaultAgentProfile: "claude",
-    planningPromptAppend: "",
-    implementationPromptAppend: "",
-    reviewPromptAppend: "",
-    startupSidebar: "restore",
+    ...normalizeKanbanSettings(null),
   },
   experiments: EXPERIMENT_DEFAULTS,
 };

--- a/src/lib/workItems/__tests__/reviewStages.test.ts
+++ b/src/lib/workItems/__tests__/reviewStages.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { reviewStageLabel } from "../reviewStages";
+import { reviewAgentProfileId } from "../workflow";
 
 describe("reviewStageLabel", () => {
   it("resolves stable review stage ids to human labels", () => {
@@ -7,9 +8,68 @@ describe("reviewStageLabel", () => {
     expect(reviewStageLabel("pr_review")).toBe("PR Review");
   });
 
+  it("uses workflow stage labels when configured", () => {
+    expect(
+      reviewStageLabel("local_review", {
+        workflow: {
+          phases: {
+            review: {
+              stages: {
+                local_review: {
+                  label: "Local QA",
+                },
+              },
+            },
+          },
+        },
+      }),
+    ).toBe("Local QA");
+  });
+
   it("preserves unknown ids and omits empty stages", () => {
     expect(reviewStageLabel("security_review")).toBe("security_review");
     expect(reviewStageLabel(null)).toBeNull();
     expect(reviewStageLabel(undefined)).toBeNull();
+  });
+});
+
+describe("reviewAgentProfileId", () => {
+  it("uses the stage profile before the review phase profile", () => {
+    expect(
+      reviewAgentProfileId(
+        {
+          workflow: {
+            phases: {
+              review: {
+                agentProfile: "phase-review",
+                stages: {
+                  pr_review: {
+                    agentProfile: "stage-review",
+                  },
+                },
+              },
+            },
+          },
+        },
+        "pr_review",
+      ),
+    ).toBe("stage-review");
+  });
+
+  it("falls back to the review phase profile", () => {
+    expect(
+      reviewAgentProfileId(
+        {
+          workflow: {
+            phases: {
+              review: {
+                agentProfile: "phase-review",
+              },
+            },
+          },
+        },
+        "pr_review",
+      ),
+    ).toBe("phase-review");
   });
 });

--- a/src/lib/workItems/reviewStages.ts
+++ b/src/lib/workItems/reviewStages.ts
@@ -1,15 +1,9 @@
-export interface ReviewStage {
-  id: string;
-  label: string;
-  order: number;
-}
+import type { KanbanSettings } from "$lib/bindings";
+import { reviewStageLabel as workflowStageLabel } from "./workflow";
 
-export const DEFAULT_REVIEW_STAGES: ReviewStage[] = [
-  { id: "local_review", label: "Local Review", order: 0 },
-  { id: "pr_review", label: "PR Review", order: 1 },
-];
-
-export function reviewStageLabel(id: string | null | undefined): string | null {
-  if (!id) return null;
-  return DEFAULT_REVIEW_STAGES.find((stage) => stage.id === id)?.label ?? id;
+export function reviewStageLabel(
+  id: string | null | undefined,
+  kanban?: KanbanSettings | null,
+): string | null {
+  return workflowStageLabel(id, kanban);
 }

--- a/src/lib/workItems/workflow.ts
+++ b/src/lib/workItems/workflow.ts
@@ -1,0 +1,190 @@
+import type {
+  KanbanReviewStageSettings,
+  KanbanSettings,
+  KanbanWorkflowPhaseSettings,
+  KanbanWorkflowSettings,
+} from "$lib/bindings";
+
+export const WORKFLOW_PHASE_IDS = [
+  "planning",
+  "implementation",
+  "review",
+] as const;
+export type WorkflowPhaseId = (typeof WORKFLOW_PHASE_IDS)[number];
+
+export const REVIEW_STAGE_IDS = ["local_review", "pr_review"] as const;
+export type ReviewStageId = (typeof REVIEW_STAGE_IDS)[number];
+export const DEFAULT_REVIEW_STAGE_ID: ReviewStageId = "local_review";
+
+const DEFAULT_PHASES: Record<WorkflowPhaseId, RequiredPhaseSettings> = {
+  planning: {
+    category: "planning",
+    label: "Planning",
+    agentProfile: null,
+    instructions: "",
+    stages: {},
+  },
+  implementation: {
+    category: "implementation",
+    label: "Implementation",
+    agentProfile: null,
+    instructions: "",
+    stages: {},
+  },
+  review: {
+    category: "review",
+    label: "Review",
+    agentProfile: null,
+    instructions: "",
+    stages: {
+      local_review: {
+        label: "Local Review",
+        agentProfile: null,
+        instructions: "",
+      },
+      pr_review: {
+        label: "PR Review",
+        agentProfile: null,
+        instructions: "",
+      },
+    },
+  },
+};
+
+export type RequiredReviewStageSettings = Required<
+  Pick<KanbanReviewStageSettings, "label" | "agentProfile" | "instructions">
+>;
+
+export type RequiredPhaseSettings = Required<
+  Pick<
+    KanbanWorkflowPhaseSettings,
+    "category" | "label" | "agentProfile" | "instructions"
+  >
+> & {
+  stages: Record<string, RequiredReviewStageSettings>;
+};
+
+export type RequiredWorkflowSettings = Required<
+  Pick<KanbanWorkflowSettings, "id" | "label">
+> & {
+  phases: Record<WorkflowPhaseId, RequiredPhaseSettings>;
+};
+
+export type RequiredKanbanSettings = Required<
+  Pick<KanbanSettings, "startupSidebar">
+> & {
+  workflow: RequiredWorkflowSettings;
+};
+
+export const DEFAULT_KANBAN_SETTINGS: RequiredKanbanSettings = {
+  startupSidebar: "restore",
+  workflow: {
+    id: "default",
+    label: "Default",
+    phases: clonePhases(DEFAULT_PHASES),
+  },
+};
+
+export function normalizeKanbanSettings(
+  kanban: KanbanSettings | null | undefined,
+): RequiredKanbanSettings {
+  return {
+    startupSidebar:
+      kanban?.startupSidebar ?? DEFAULT_KANBAN_SETTINGS.startupSidebar,
+    workflow: normalizeWorkflow(kanban?.workflow),
+  };
+}
+
+export function normalizeWorkflow(
+  workflow: KanbanWorkflowSettings | null | undefined,
+): RequiredWorkflowSettings {
+  const phases = {} as Record<WorkflowPhaseId, RequiredPhaseSettings>;
+  for (const id of WORKFLOW_PHASE_IDS) {
+    phases[id] = normalizePhase(id, workflow?.phases?.[id]);
+  }
+  return {
+    id: nonEmpty(workflow?.id) ?? DEFAULT_KANBAN_SETTINGS.workflow.id,
+    label: nonEmpty(workflow?.label) ?? DEFAULT_KANBAN_SETTINGS.workflow.label,
+    phases,
+  };
+}
+
+export function reviewStageLabel(
+  id: string | null | undefined,
+  kanban?: KanbanSettings | null,
+): string | null {
+  if (!id) return null;
+  return workflowReviewStageLabel(kanban, id) ?? id;
+}
+
+export function workflowReviewStageLabel(
+  kanban: KanbanSettings | null | undefined,
+  id: string,
+): string | null {
+  const workflow = normalizeKanbanSettings(kanban).workflow;
+  return nonEmpty(workflow.phases.review.stages[id]?.label) ?? null;
+}
+
+export function reviewAgentProfileId(
+  kanban: KanbanSettings | null | undefined,
+  stageId: string | null | undefined,
+): string | null {
+  const review = normalizeKanbanSettings(kanban).workflow.phases.review;
+  const activeStageId = stageId ?? DEFAULT_REVIEW_STAGE_ID;
+  return (
+    nonEmpty(review.stages[activeStageId]?.agentProfile) ??
+    nonEmpty(review.agentProfile) ??
+    null
+  );
+}
+
+function normalizePhase(
+  id: WorkflowPhaseId,
+  phase: KanbanWorkflowPhaseSettings | null | undefined,
+): RequiredPhaseSettings {
+  const fallback = DEFAULT_PHASES[id];
+  return {
+    category: fallback.category,
+    label: nonEmpty(phase?.label) ?? fallback.label,
+    agentProfile: nonEmpty(phase?.agentProfile) ?? null,
+    instructions: phase?.instructions?.trim() ?? "",
+    stages: id === "review" ? normalizeReviewStages(phase?.stages) : {},
+  };
+}
+
+function normalizeReviewStages(
+  stages: KanbanWorkflowPhaseSettings["stages"],
+): Record<ReviewStageId, RequiredReviewStageSettings> {
+  const normalized = {} as Record<ReviewStageId, RequiredReviewStageSettings>;
+  for (const id of REVIEW_STAGE_IDS) {
+    const fallback = DEFAULT_PHASES.review.stages[id];
+    const stage = stages?.[id];
+    normalized[id] = {
+      label: nonEmpty(stage?.label) ?? fallback.label,
+      agentProfile: nonEmpty(stage?.agentProfile) ?? null,
+      instructions: stage?.instructions?.trim() ?? "",
+    };
+  }
+  return normalized;
+}
+
+function clonePhases(
+  phases: Record<WorkflowPhaseId, RequiredPhaseSettings>,
+): Record<WorkflowPhaseId, RequiredPhaseSettings> {
+  return {
+    planning: { ...phases.planning, stages: {} },
+    implementation: { ...phases.implementation, stages: {} },
+    review: {
+      ...phases.review,
+      stages: {
+        local_review: { ...phases.review.stages.local_review },
+        pr_review: { ...phases.review.stages.pr_review },
+      },
+    },
+  };
+}
+
+function nonEmpty(value: string | null | undefined): string | null {
+  const trimmed = value?.trim() ?? "";
+  return trimmed.length > 0 ? trimmed : null;
+}

--- a/src/lib/workItems/workflow.ts
+++ b/src/lib/workItems/workflow.ts
@@ -171,17 +171,16 @@ function normalizeReviewStages(
 function clonePhases(
   phases: Record<WorkflowPhaseId, RequiredPhaseSettings>,
 ): Record<WorkflowPhaseId, RequiredPhaseSettings> {
-  return {
-    planning: { ...phases.planning, stages: {} },
-    implementation: { ...phases.implementation, stages: {} },
-    review: {
-      ...phases.review,
-      stages: {
-        local_review: { ...phases.review.stages.local_review },
-        pr_review: { ...phases.review.stages.pr_review },
-      },
-    },
-  };
+  const cloned = {} as Record<WorkflowPhaseId, RequiredPhaseSettings>;
+  for (const phaseId of WORKFLOW_PHASE_IDS) {
+    const stages: Record<string, RequiredReviewStageSettings> = {};
+    for (const stageId of REVIEW_STAGE_IDS) {
+      const stage = phases[phaseId].stages[stageId];
+      if (stage) stages[stageId] = { ...stage };
+    }
+    cloned[phaseId] = { ...phases[phaseId], stages };
+  }
+  return cloned;
 }
 
 function nonEmpty(value: string | null | undefined): string | null {


### PR DESCRIPTION
Summary:
- Replace flat Kanban prompt/agent settings with structured workflow phases and review-stage settings.
- Wire phase/stage instructions and agent-profile resolution through planning, implementation, and review flows.
- Update board/editor/settings UI to use configured review labels and optional card-level agent overrides.
- Propagate custom review-stage labels into work-item run event payloads.

Note:
- This intentionally drops migration for the old flat Kanban fields; this tool is not preserving backwards compatibility for that shape.

Tests:
- cargo test -p roux-core --quiet
- cargo test -p roux-runtime --quiet
- cargo test -p roux-cli --quiet
- npm run test -- --run
- npm run test -- BoardMainView BoardPanel --run
- npm run format:check
- npm run check
- cargo fmt --check
- git diff --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces flat Kanban prompt/agent settings (`defaultAgentProfile`, `planningPromptAppend`, etc.) with a structured `KanbanWorkflowSettings` model containing named phases and per-stage review settings. The change threads phase-specific instructions and agent profiles through planning, implementation, and review flows on both the Rust daemon and TypeScript frontend.

- **Settings model (Rust + TS)**: `KanbanSettings` now holds a `KanbanWorkflowSettings` with three fixed phases (`planning`, `implementation`, `review`) and two review stages (`local_review`, `pr_review`); normalization fills defaults for missing fields and drops unknown phases/stages on the Rust side.
- **Profile resolution**: Planning uses `req arg → phase profile → global default`; implementation uses `req arg → card profile → phase profile → global default`; frontend review session uses `stage profile → phase profile → card profile → global default`. The asymmetry between planning (no card-level override) and implementation (card-level honored) is intentional and documented in the PR description.
- **Event payloads**: Review-event `reviewStageLabel`/`nextReviewStageLabel` fields now resolve against `KanbanSettings` before falling back to hardcoded strings, enabling user-configured labels to appear in agent notifications.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The refactoring is well-scoped, both the Rust and TypeScript normalization layers provide consistent defaults, and all three review-event paths (accept, request, request_changes) correctly propagate kanban settings.

The profile resolution chains, normalization logic, event-payload label injection, and UI state management are all internally consistent. The intentional design decisions (dropping card-level override from planning, workflow settings taking precedence over card profile for review) are explicitly described in the PR notes and are correctly reflected in both the code and its tests. No data-loss, split-brain ownership, or behavioral regression paths were found.

src/lib/stores/__tests__/settings.test.ts — the renamed assertion about kanban workflow identity after setDefaultAgentProfile is weaker than its predecessor; flagged in previous review round.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/roux-core/src/models/settings.rs | Core settings model restructured: flat KanbanSettings fields replaced with KanbanWorkflowSettings/KanbanWorkflowPhaseSettings/KanbanReviewStageSettings. Normalization helpers fill defaults for all known phases and stages; unknown phases are dropped silently (intentional). Comprehensive unit tests added for normalization, serialization, and legacy field handling. |
| crates/roux-cli/src/daemon/work_items.rs | Three review handlers (accept, request, request_changes) now each call load_daemon_settings() to pass KanbanSettings to the new _with_kanban_settings variants. New planning_agent_profile_id omits card-level agent_profile (intentional asymmetry vs implementation). New tests cover all resolution priority levels. |
| crates/roux-runtime/src/work_item_store.rs | Three store methods (accept_review, request_review, request_changes) each split into a public no-kanban variant and a with_kanban_settings variant, both delegating to a private with_stage_labels helper. review_stage_label() now consults KanbanSettings before falling back to roux_core defaults. New test verifies custom labels appear in event payloads. |
| crates/roux-runtime/src/work_item_service.rs | Mirrors the store pattern: six new public/private method variants propagate Option<&KanbanSettings> through the Mutex-guarded store, following the persist-before-broadcast contract correctly throughout all paths. |
| src/lib/workItems/workflow.ts | New module providing normalizeKanbanSettings, reviewStageLabel, reviewAgentProfileId, and supporting normalizers. Review agent resolution is: stage profile → phase profile → null (card-level is a caller-side fallback). Mirrors Rust normalization logic faithfully. |
| src/lib/components/settings/SettingsKanbanSection.svelte | Completely rewritten to render phase/stage cards from normalizeKanbanSettings. Per-phase agent selects and instruction textareas; review section adds per-stage label, agent, and instructions inputs. Profile list filtered to agent-capable profiles only. Reactive normalization ensures empty labels always reset to defaults. |
| src/lib/components/BoardMainView.svelte | needsStartConfig now only requires repo/project config (not agentProfile); review session profile resolution updated to: reviewAgentProfileId (stage/phase) → card agentProfile → global default. |
| src/lib/components/WorkItemEditor.svelte | Profile selector now defaults to empty string ('Workflow default') instead of the global default agent; agentProfile saved as null when no explicit profile chosen, allowing workflow-level resolution at runtime. |
| src/lib/stores/__tests__/settings.test.ts | Renamed test verifies setDefaultAgentProfile no longer mutates the kanban block, but the replacement assertion (kanban.workflow.id === 'default') is trivially true since setDefaultAgentProfile never touches kanban at all; flagged in previous review round. |
| docs/v2/daemon-protocol.md | Protocol documentation updated for both work-item-plan and work-item-start to reflect new workflow-based profile resolution paths and instruction sources; review handoff description updated to reference per-stage instructions. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant FE as Frontend (Svelte)
    participant Daemon as Daemon (work_items.rs)
    participant Svc as WorkItemService
    participant Store as WorkItemStore
    participant Settings as KanbanSettings

    FE->>Daemon: work-item-plan / work-item-start
    Daemon->>Settings: load_daemon_settings()
    Settings-->>Daemon: RouxSettings (with KanbanWorkflow)
    Daemon->>Daemon: planning_agent_profile_id(req, settings)
    Note over Daemon: req arg → planning phase profile → global default
    Daemon->>Svc: plan / start work item run

    FE->>Daemon: work-item-review request
    Daemon->>Settings: load_daemon_settings()
    Settings-->>Daemon: KanbanSettings
    Daemon->>Svc: request_review_with_kanban_settings(run_id, payload, kanban)
    Svc->>Store: request_review_with_kanban_settings(...)
    Store->>Store: add_review_stage_payload_fields(kanban, stage_id, next_id)
    Note over Store: label = kanban.review_stage_label(id) ?? roux_core default
    Store-->>Svc: (item, run, event) with reviewStageLabel
    Svc-->>FE: WorkItemRunEvent broadcast

    FE->>FE: reviewAgentProfileId(kanban, stageId)
    Note over FE: stage profile → phase profile → card profile → global
    FE->>FE: startReviewRun(profileId)
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `crates/roux-cli/src/daemon/work_items.rs`, line 98-102 ([link](https://github.com/phin-tech/roux/blob/c9ac539b27cf776dd9c811738af7daa78d86d09c/crates/roux-cli/src/daemon/work_items.rs#L98-L102)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Planning silently drops card-level `agent_profile`**

   `planning_agent_profile_id` resolves as: request arg → workflow planning phase → global default. The old code included `item.agent_profile` between request arg and global default. Any card that has a card-level `agentProfile` set will silently be ignored during planning — while the same field is still honoured in `implementation_agent_profile_id`. If this asymmetry is intentional (planning is strictly workflow-driven, implementation can be card-overridden), it would be worth a brief code comment explaining why `item` is not threaded through here. Is dropping card-level `agent_profile` from planning resolution intentional? The implementation phase still consults it, so this creates an asymmetry that existing cards with a custom profile will notice during their next planning run.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Froux-cli%2Fsrc%2Fdaemon%2Fwork_items.rs%0ALine%3A%2098-102%0A%0AComment%3A%0A**Planning%20silently%20drops%20card-level%20%60agent_profile%60**%0A%0A%60planning_agent_profile_id%60%20resolves%20as%3A%20request%20arg%20%E2%86%92%20workflow%20planning%20phase%20%E2%86%92%20global%20default.%20The%20old%20code%20included%20%60item.agent_profile%60%20between%20request%20arg%20and%20global%20default.%20Any%20card%20that%20has%20a%20card-level%20%60agentProfile%60%20set%20will%20silently%20be%20ignored%20during%20planning%20%E2%80%94%20while%20the%20same%20field%20is%20still%20honoured%20in%20%60implementation_agent_profile_id%60.%20If%20this%20asymmetry%20is%20intentional%20%28planning%20is%20strictly%20workflow-driven%2C%20implementation%20can%20be%20card-overridden%29%2C%20it%20would%20be%20worth%20a%20brief%20code%20comment%20explaining%20why%20%60item%60%20is%20not%20threaded%20through%20here.%20Is%20dropping%20card-level%20%60agent_profile%60%20from%20planning%20resolution%20intentional%3F%20The%20implementation%20phase%20still%20consults%20it%2C%20so%20this%20creates%20an%20asymmetry%20that%20existing%20cards%20with%20a%20custom%20profile%20will%20notice%20during%20their%20next%20planning%20run.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=phin-tech%2Froux&pr=240&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22feature%2Fbuilt-in-workflow-settings%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fbuilt-in-workflow-settings%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Froux-cli%2Fsrc%2Fdaemon%2Fwork_items.rs%0ALine%3A%2098-102%0A%0AComment%3A%0A**Planning%20silently%20drops%20card-level%20%60agent_profile%60**%0A%0A%60planning_agent_profile_id%60%20resolves%20as%3A%20request%20arg%20%E2%86%92%20workflow%20planning%20phase%20%E2%86%92%20global%20default.%20The%20old%20code%20included%20%60item.agent_profile%60%20between%20request%20arg%20and%20global%20default.%20Any%20card%20that%20has%20a%20card-level%20%60agentProfile%60%20set%20will%20silently%20be%20ignored%20during%20planning%20%E2%80%94%20while%20the%20same%20field%20is%20still%20honoured%20in%20%60implementation_agent_profile_id%60.%20If%20this%20asymmetry%20is%20intentional%20%28planning%20is%20strictly%20workflow-driven%2C%20implementation%20can%20be%20card-overridden%29%2C%20it%20would%20be%20worth%20a%20brief%20code%20comment%20explaining%20why%20%60item%60%20is%20not%20threaded%20through%20here.%20Is%20dropping%20card-level%20%60agent_profile%60%20from%20planning%20resolution%20intentional%3F%20The%20implementation%20phase%20still%20consults%20it%2C%20so%20this%20creates%20an%20asymmetry%20that%20existing%20cards%20with%20a%20custom%20profile%20will%20notice%20during%20their%20next%20planning%20run.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=phin-tech%2Froux&pr=240&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

2. `src/lib/stores/__tests__/settings.test.ts`, line 81-99 ([link](https://github.com/phin-tech/roux/blob/c9ac539b27cf776dd9c811738af7daa78d86d09c/src/lib/stores/__tests__/settings.test.ts#L81-L99)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Kanban assertion is trivially true**

   The old assertion (`kanban.defaultAgentProfile === "codex"`) verified that setting the global default agent propagated into the kanban block. The replacement (`kanban.workflow.id === "default"`) will be true regardless of what `setDefaultAgentProfile` does — `workflow.id` is never touched by that function. The test no longer fails if the kanban object is inadvertently mutated in an unexpected way. A stronger check would assert that the entire `kanban.workflow` subtree is structurally equal to the default, or at minimum that no kanban field contains "codex" after the call.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Flib%2Fstores%2F__tests__%2Fsettings.test.ts%0ALine%3A%2081-99%0A%0AComment%3A%0A**Kanban%20assertion%20is%20trivially%20true**%0A%0AThe%20old%20assertion%20%28%60kanban.defaultAgentProfile%20%3D%3D%3D%20%22codex%22%60%29%20verified%20that%20setting%20the%20global%20default%20agent%20propagated%20into%20the%20kanban%20block.%20The%20replacement%20%28%60kanban.workflow.id%20%3D%3D%3D%20%22default%22%60%29%20will%20be%20true%20regardless%20of%20what%20%60setDefaultAgentProfile%60%20does%20%E2%80%94%20%60workflow.id%60%20is%20never%20touched%20by%20that%20function.%20The%20test%20no%20longer%20fails%20if%20the%20kanban%20object%20is%20inadvertently%20mutated%20in%20an%20unexpected%20way.%20A%20stronger%20check%20would%20assert%20that%20the%20entire%20%60kanban.workflow%60%20subtree%20is%20structurally%20equal%20to%20the%20default%2C%20or%20at%20minimum%20that%20no%20kanban%20field%20contains%20%22codex%22%20after%20the%20call.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=phin-tech%2Froux&pr=240&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22feature%2Fbuilt-in-workflow-settings%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fbuilt-in-workflow-settings%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Flib%2Fstores%2F__tests__%2Fsettings.test.ts%0ALine%3A%2081-99%0A%0AComment%3A%0A**Kanban%20assertion%20is%20trivially%20true**%0A%0AThe%20old%20assertion%20%28%60kanban.defaultAgentProfile%20%3D%3D%3D%20%22codex%22%60%29%20verified%20that%20setting%20the%20global%20default%20agent%20propagated%20into%20the%20kanban%20block.%20The%20replacement%20%28%60kanban.workflow.id%20%3D%3D%3D%20%22default%22%60%29%20will%20be%20true%20regardless%20of%20what%20%60setDefaultAgentProfile%60%20does%20%E2%80%94%20%60workflow.id%60%20is%20never%20touched%20by%20that%20function.%20The%20test%20no%20longer%20fails%20if%20the%20kanban%20object%20is%20inadvertently%20mutated%20in%20an%20unexpected%20way.%20A%20stronger%20check%20would%20assert%20that%20the%20entire%20%60kanban.workflow%60%20subtree%20is%20structurally%20equal%20to%20the%20default%2C%20or%20at%20minimum%20that%20no%20kanban%20field%20contains%20%22codex%22%20after%20the%20call.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=phin-tech%2Froux&pr=240&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix: clone kanban workflow defaults from..."](https://github.com/phin-tech/roux/commit/50749857f29ffdbd6915d3fdced080f62b2d0e98) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36021200)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/phin-tech/github/phin-tech/roux/-/custom-context?memory=1a7e8e25-9dde-4d49-9e7f-60e7033075a1))
- Context used - CLAUDE.md ([source](https://app.greptile.com/phin-tech/github/phin-tech/roux/-/custom-context?memory=9d02afcc-6277-4c1c-8d4f-6d512b83417e))

<!-- /greptile_comment -->