### PR TITLE
fix: auto-reconnect planning sessions on open after restart

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"82aacb99-ddb1-4e9c-86b2-f23a726592bb","pid":73581,"procStart":"Mon Jun  8 12:13:17 2026","acquiredAt":1780924629257}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"82aacb99-ddb1-4e9c-86b2-f23a726592bb","pid":73581,"procStart":"Mon Jun  8 12:13:17 2026","acquiredAt":1780924629257}

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ docs/__pycache__/
 
 # codebase-memory-mcp local graph artifacts
 /.codebase-memory/
+.claude/scheduled_tasks.lock

--- a/src/lib/components/ActivityRail.svelte
+++ b/src/lib/components/ActivityRail.svelte
@@ -7,6 +7,7 @@
   import BookOpen from "@lucide/svelte/icons/book-open";
   import Bell from "@lucide/svelte/icons/bell";
   import Inbox from "@lucide/svelte/icons/inbox";
+  import TerminalSquare from "@lucide/svelte/icons/square-terminal";
   import SettingsIcon from "@lucide/svelte/icons/settings";
   import Trees from "@lucide/svelte/icons/trees";
   import Kanban from "@lucide/svelte/icons/kanban";
@@ -53,6 +54,7 @@
     { id: "library", label: "Library", icon: Library },
     { id: "tasks", label: "Tasks", icon: ListTodo },
     { id: "board", label: "Board", icon: Kanban },
+    { id: "ptys", label: "PTYs", icon: TerminalSquare },
     { id: "docs", label: "Docs", icon: BookOpen },
     { id: "notifications", label: "Notifications", icon: Bell },
     { id: "mailbox", label: "Mailbox", icon: Inbox },

--- a/src/lib/components/BoardMainView.svelte
+++ b/src/lib/components/BoardMainView.svelte
@@ -130,8 +130,7 @@
     ) {
       if (planningRun?.sessionId) {
         await handleOpen(planningRun.sessionId, planningRun.ptyId);
-      }
-      else {
+      } else {
         startErrors = {
           ...startErrors,
           [id]: "Attach a plan before starting implementation.",
@@ -459,8 +458,7 @@
                 $activePlanningRunByItem.get(item.id) ?? null}
               {@const planningRun =
                 item.status === "planning"
-                  ? ($latestPlanningRunByItem.get(item.id) ??
-                    activePlanningRun)
+                  ? ($latestPlanningRunByItem.get(item.id) ?? activePlanningRun)
                   : activePlanningRun}
               {@const itemRuns = $runsByItem.get(item.id) ?? []}
               {@const itemAttachments =

--- a/src/lib/components/BoardMainView.svelte
+++ b/src/lib/components/BoardMainView.svelte
@@ -33,6 +33,7 @@
   } from "$lib/stores/ui";
   import { closeMainView } from "$lib/stores/mainView";
   import { openSessionById } from "$lib/panes/openSession";
+  import { continueSession } from "$lib/sessions/reconnect";
   import { formatWorkItemStartError } from "$lib/board/startErrors";
   import {
     deleteWorkItemWithMode,
@@ -341,10 +342,15 @@
   }
 
   async function handleOpen(sessionId: string) {
-    const result = await openSessionById(sessionId);
-    if (result === "gone") {
-      console.error(`Session ${sessionId} is no longer running`);
-      return;
+    const session = $sessionList.find((s) => s.id === sessionId) ?? null;
+    if (session?.status === "disconnected") {
+      await continueSession(session);
+    } else {
+      const result = await openSessionById(sessionId);
+      if (result === "gone") {
+        console.error(`Session ${sessionId} is no longer running`);
+        return;
+      }
     }
     // Reveal the terminal we just focused — the main view covers it.
     closeMainView();

--- a/src/lib/components/BoardMainView.svelte
+++ b/src/lib/components/BoardMainView.svelte
@@ -33,7 +33,6 @@
   } from "$lib/stores/ui";
   import { closeMainView } from "$lib/stores/mainView";
   import { openSessionById } from "$lib/panes/openSession";
-  import { continueSession } from "$lib/sessions/reconnect";
   import { formatWorkItemStartError } from "$lib/board/startErrors";
   import {
     deleteWorkItemWithMode,
@@ -128,7 +127,9 @@
       item.status === "planning" &&
       !canStartImplementationFromPlanning(attachments, forceStart)
     ) {
-      if (planningRun?.sessionId) await handleOpen(planningRun.sessionId);
+      if (planningRun?.sessionId) {
+        await handleOpen(planningRun.sessionId, planningRun.ptyId);
+      }
       else {
         startErrors = {
           ...startErrors,
@@ -181,10 +182,10 @@
     planningItemIds = { ...planningItemIds, [id]: true };
     planErrors = withoutKey(planErrors, id);
     try {
-      const sessionId = replaceActive
+      const target = replaceActive
         ? await planWorkItem(id, { replaceActive: true })
         : await planWorkItem(id);
-      await handleOpen(sessionId);
+      await handleOpen(target.sessionId, target.ptyId);
     } catch (err) {
       planErrors = { ...planErrors, [id]: formatPlanError(err) };
       console.error("Failed to plan work item", err);
@@ -341,16 +342,13 @@
     }
   }
 
-  async function handleOpen(sessionId: string) {
-    const session = $sessionList.find((s) => s.id === sessionId) ?? null;
-    if (session?.status === "disconnected") {
-      await continueSession(session);
-    } else {
-      const result = await openSessionById(sessionId);
-      if (result === "gone") {
-        console.error(`Session ${sessionId} is no longer running`);
-        return;
-      }
+  async function handleOpen(sessionId: string, ptyId?: string | null) {
+    const result = ptyId
+      ? await openSessionById(sessionId, { ptyId })
+      : await openSessionById(sessionId);
+    if (result === "gone") {
+      console.error(`Session ${sessionId} is no longer running`);
+      return;
     }
     // Reveal the terminal we just focused — the main view covers it.
     closeMainView();

--- a/src/lib/components/BoardMainView.svelte
+++ b/src/lib/components/BoardMainView.svelte
@@ -17,6 +17,7 @@
     pendingDecisionByItem,
     pendingQuestionByItem,
     activePlanningRunByItem,
+    latestPlanningRunByItem,
     attachmentsByWorkItem,
     runsByItem,
     workItemRunEvents,
@@ -454,8 +455,13 @@
                 $pendingDecisionByItem.get(item.id) ?? null}
               {@const pendingQuestion =
                 $pendingQuestionByItem.get(item.id) ?? null}
-              {@const planningRun =
+              {@const activePlanningRun =
                 $activePlanningRunByItem.get(item.id) ?? null}
+              {@const planningRun =
+                item.status === "planning"
+                  ? ($latestPlanningRunByItem.get(item.id) ??
+                    activePlanningRun)
+                  : activePlanningRun}
               {@const itemRuns = $runsByItem.get(item.id) ?? []}
               {@const itemAttachments =
                 $attachmentsByWorkItem.get(item.id) ?? []}

--- a/src/lib/components/BoardPanel.svelte
+++ b/src/lib/components/BoardPanel.svelte
@@ -127,8 +127,7 @@
     ) {
       if (planningRun?.sessionId) {
         await handleOpen(planningRun.sessionId, planningRun.ptyId);
-      }
-      else {
+      } else {
         startErrors = {
           ...startErrors,
           [id]: "Attach a plan before starting implementation.",
@@ -407,8 +406,7 @@
                 $activePlanningRunByItem.get(item.id) ?? null}
               {@const planningRun =
                 item.status === "planning"
-                  ? ($latestPlanningRunByItem.get(item.id) ??
-                    activePlanningRun)
+                  ? ($latestPlanningRunByItem.get(item.id) ?? activePlanningRun)
                   : activePlanningRun}
               {@const itemRuns = $runsByItem.get(item.id) ?? []}
               {@const itemAttachments =

--- a/src/lib/components/BoardPanel.svelte
+++ b/src/lib/components/BoardPanel.svelte
@@ -13,6 +13,7 @@
     pendingDecisionByItem,
     pendingQuestionByItem,
     activePlanningRunByItem,
+    latestPlanningRunByItem,
     attachmentsByWorkItem,
     runsByItem,
     workItemRunEvents,
@@ -402,8 +403,13 @@
                 $pendingDecisionByItem.get(item.id) ?? null}
               {@const pendingQuestion =
                 $pendingQuestionByItem.get(item.id) ?? null}
-              {@const planningRun =
+              {@const activePlanningRun =
                 $activePlanningRunByItem.get(item.id) ?? null}
+              {@const planningRun =
+                item.status === "planning"
+                  ? ($latestPlanningRunByItem.get(item.id) ??
+                    activePlanningRun)
+                  : activePlanningRun}
               {@const itemRuns = $runsByItem.get(item.id) ?? []}
               {@const itemAttachments =
                 $attachmentsByWorkItem.get(item.id) ?? []}

--- a/src/lib/components/BoardPanel.svelte
+++ b/src/lib/components/BoardPanel.svelte
@@ -124,7 +124,9 @@
       item.status === "planning" &&
       !canStartImplementationFromPlanning(attachments, forceStart)
     ) {
-      if (planningRun?.sessionId) await handleOpen(planningRun.sessionId);
+      if (planningRun?.sessionId) {
+        await handleOpen(planningRun.sessionId, planningRun.ptyId);
+      }
       else {
         startErrors = {
           ...startErrors,
@@ -177,10 +179,10 @@
     planningItemIds = { ...planningItemIds, [id]: true };
     planErrors = withoutKey(planErrors, id);
     try {
-      const sessionId = replaceActive
+      const target = replaceActive
         ? await planWorkItem(id, { replaceActive: true })
         : await planWorkItem(id);
-      await handleOpen(sessionId);
+      await handleOpen(target.sessionId, target.ptyId);
     } catch (err) {
       planErrors = { ...planErrors, [id]: formatPlanError(err) };
       console.error("Failed to plan work item", err);
@@ -312,8 +314,10 @@
     }
   }
 
-  async function handleOpen(sessionId: string) {
-    const result = await openSessionById(sessionId);
+  async function handleOpen(sessionId: string, ptyId?: string | null) {
+    const result = ptyId
+      ? await openSessionById(sessionId, { ptyId })
+      : await openSessionById(sessionId);
     if (result === "gone") {
       console.error(`Session ${sessionId} is no longer running`);
     }

--- a/src/lib/components/PtyPanel.svelte
+++ b/src/lib/components/PtyPanel.svelte
@@ -1,0 +1,177 @@
+<script lang="ts">
+  import { onDestroy } from "svelte";
+  import RefreshCw from "@lucide/svelte/icons/refresh-cw";
+  import { listAllPtys } from "$lib/tauri";
+  import type { PtyInfo } from "$lib/types";
+  import PinButton from "./PinButton.svelte";
+  import CollapseSidebarButton from "./CollapseSidebarButton.svelte";
+  import SidebarPanelHeader from "./SidebarPanelHeader.svelte";
+
+  interface Props {
+    visible: boolean;
+    onclose: () => void;
+    pinned?: boolean;
+    onTogglePin?: () => void;
+  }
+
+  let { visible, onclose, pinned = false, onTogglePin }: Props = $props();
+
+  let ptys = $state<PtyInfo[]>([]);
+  let loading = $state(false);
+  let error = $state<string | null>(null);
+  let loaded = $state(false);
+  let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+  const POLL_INTERVAL_MS = 2_000;
+
+  async function refresh(): Promise<void> {
+    if (loading) return;
+    loading = true;
+    error = null;
+    try {
+      ptys = await listAllPtys();
+      loaded = true;
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err);
+    } finally {
+      loading = false;
+    }
+  }
+
+  $effect(() => {
+    if (visible && !loaded && !loading) void refresh();
+  });
+
+  $effect(() => {
+    if (visible) {
+      pollTimer ??= setInterval(() => {
+        void refresh();
+      }, POLL_INTERVAL_MS);
+    } else if (pollTimer) {
+      clearInterval(pollTimer);
+      pollTimer = null;
+    }
+  });
+
+  onDestroy(() => {
+    if (pollTimer) clearInterval(pollTimer);
+  });
+
+  function statusLabel(pty: PtyInfo): string {
+    switch (pty.status.type) {
+      case "RunningAttached":
+        return `attached to ${pty.status.pane_id}`;
+      case "RunningDetached":
+        return "detached";
+      case "Exited":
+        return pty.status.code == null
+          ? "exited"
+          : `exited ${pty.status.code}`;
+    }
+  }
+
+  function statusClass(pty: PtyInfo): string {
+    switch (pty.status.type) {
+      case "RunningAttached":
+        return "bg-green";
+      case "RunningDetached":
+        return pty.unread_output
+          ? "bg-amber shadow-[0_0_6px_var(--color-amber-dim)]"
+          : "bg-blue";
+      case "Exited":
+        return "bg-text-muted";
+    }
+  }
+
+  function roleLabel(role: PtyInfo["role"]): string {
+    return role === "sessionPrimary" ? "primary" : "secondary";
+  }
+
+  function shortId(id: string | null): string {
+    return id ? id.slice(0, 8) : "none";
+  }
+</script>
+
+<div
+  class="flex h-full w-full min-h-0 flex-col bg-bg-deep"
+  class:hidden={!visible}
+>
+  <SidebarPanelHeader title="PTYs">
+    {#snippet actions()}
+      <button
+        type="button"
+        class="inline-flex h-6 w-6 items-center justify-center rounded border border-transparent text-text-muted transition-colors hover:border-border-subtle hover:bg-bg-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim/50 disabled:cursor-wait disabled:opacity-60"
+        onclick={() => void refresh()}
+        disabled={loading}
+        aria-label="Refresh PTYs"
+        title="Refresh PTYs"
+      >
+        <RefreshCw size={13} class={loading ? "animate-spin" : ""} />
+      </button>
+      {#if onTogglePin}
+        <PinButton {pinned} ontoggle={onTogglePin} />
+      {/if}
+      <CollapseSidebarButton
+        onclick={onclose}
+        label="Collapse PTYs sidebar"
+        title="Collapse PTYs sidebar"
+      />
+    {/snippet}
+  </SidebarPanelHeader>
+
+  <div class="min-h-0 flex-1 overflow-y-auto p-2">
+    {#if error}
+      <div class="rounded border border-red/30 bg-red/10 p-2 text-xs text-red">
+        {error}
+      </div>
+    {:else if loading && ptys.length === 0}
+      <div class="flex h-full items-center justify-center text-sm text-text-muted">
+        Loading PTYs...
+      </div>
+    {:else if ptys.length === 0}
+      <div class="flex h-full items-center justify-center text-sm text-text-muted">
+        No daemon PTYs
+      </div>
+    {:else}
+      <div class="space-y-1">
+        {#each ptys as pty (pty.id)}
+          <div
+            class="rounded-lg border border-border-subtle/60 bg-bg-surface/35 px-2 py-1.5 text-xs"
+          >
+            <div class="flex min-w-0 items-center gap-2">
+              <span
+                class="h-2 w-2 shrink-0 rounded-full {statusClass(pty)}"
+              ></span>
+              <span class="min-w-0 flex-1 truncate font-medium text-text-primary">
+                {pty.name || pty.id}
+              </span>
+              <span class="shrink-0 text-[10px] uppercase text-text-muted">
+                {roleLabel(pty.role)}
+              </span>
+            </div>
+            <div class="mt-1 grid gap-0.5 text-[10px] text-text-muted">
+              <div class="truncate">id: {pty.id}</div>
+              <div class="truncate">session: {shortId(pty.session_id)}</div>
+              <div class="truncate">status: {statusLabel(pty)}</div>
+              {#if pty.profile}
+                <div class="truncate">profile: {pty.profile}</div>
+              {/if}
+              {#if pty.working_dir}
+                <div class="truncate" title={pty.working_dir}>
+                  cwd: {pty.working_dir}
+                </div>
+              {/if}
+              {#if pty.unread_output || pty.bell_pending}
+                <div class="text-amber">
+                  {pty.unread_output ? "unread output" : ""}
+                  {pty.unread_output && pty.bell_pending ? " · " : ""}
+                  {pty.bell_pending ? "bell pending" : ""}
+                </div>
+              {/if}
+            </div>
+          </div>
+        {/each}
+      </div>
+    {/if}
+  </div>
+</div>

--- a/src/lib/components/PtyPanel.svelte
+++ b/src/lib/components/PtyPanel.svelte
@@ -64,9 +64,7 @@
       case "RunningDetached":
         return "detached";
       case "Exited":
-        return pty.status.code == null
-          ? "exited"
-          : `exited ${pty.status.code}`;
+        return pty.status.code == null ? "exited" : `exited ${pty.status.code}`;
     }
   }
 
@@ -125,11 +123,15 @@
         {error}
       </div>
     {:else if loading && ptys.length === 0}
-      <div class="flex h-full items-center justify-center text-sm text-text-muted">
+      <div
+        class="flex h-full items-center justify-center text-sm text-text-muted"
+      >
         Loading PTYs...
       </div>
     {:else if ptys.length === 0}
-      <div class="flex h-full items-center justify-center text-sm text-text-muted">
+      <div
+        class="flex h-full items-center justify-center text-sm text-text-muted"
+      >
         No daemon PTYs
       </div>
     {:else}
@@ -139,10 +141,11 @@
             class="rounded-lg border border-border-subtle/60 bg-bg-surface/35 px-2 py-1.5 text-xs"
           >
             <div class="flex min-w-0 items-center gap-2">
-              <span
-                class="h-2 w-2 shrink-0 rounded-full {statusClass(pty)}"
+              <span class="h-2 w-2 shrink-0 rounded-full {statusClass(pty)}"
               ></span>
-              <span class="min-w-0 flex-1 truncate font-medium text-text-primary">
+              <span
+                class="min-w-0 flex-1 truncate font-medium text-text-primary"
+              >
                 {pty.name || pty.id}
               </span>
               <span class="shrink-0 text-[10px] uppercase text-text-muted">

--- a/src/lib/components/SessionDetailView.svelte
+++ b/src/lib/components/SessionDetailView.svelte
@@ -11,7 +11,7 @@
   } from "$lib/stores/sessions";
   import { projects } from "$lib/stores/projects";
   import { closeMainView } from "$lib/stores/mainView";
-  import { continueSession } from "$lib/sessions/reconnect";
+  import { openSessionById } from "$lib/panes/openSession";
   import { collectLeafIds, sessionLayouts } from "$lib/panes/layout";
   import { paneInstances, type PaneInstance } from "$lib/panes/instances";
   import { getDocument, listDocuments } from "$lib/stores/workItems";
@@ -155,7 +155,9 @@
     if (!session || reconnecting) return;
     reconnecting = true;
     try {
-      await continueSession(session);
+      const result = await openSessionById(session.id);
+      if (result === "gone") return;
+      closeMainView();
     } finally {
       reconnecting = false;
     }

--- a/src/lib/components/SessionTabs.svelte
+++ b/src/lib/components/SessionTabs.svelte
@@ -23,7 +23,6 @@
   } from "$lib/tauri";
   import type { SpawnProfileRef } from "$lib/panes/profiles";
   import { settings, updateSetting } from "$lib/stores/settings";
-  import { continueSession } from "$lib/sessions/reconnect";
   import { closeSession } from "$lib/sessions/close";
   import { refreshTasks, initTaskOverrides } from "$lib/stores/tasks";
   import { projects, createProject, removeProject } from "$lib/stores/projects";
@@ -37,6 +36,7 @@
     openEditProjectDialog,
   } from "$lib/stores/newProjectDialog";
   import { openMainView } from "$lib/stores/mainView";
+  import { openSessionById } from "$lib/panes/openSession";
 
   import Info from "@lucide/svelte/icons/info";
   import PinButton from "./PinButton.svelte";
@@ -546,9 +546,7 @@
   }
 
   async function handleReconnect(id: string) {
-    const session = $sessionList.find((s) => s.id === id);
-    if (!session) return;
-    await continueSession(session);
+    await openSessionById(id);
   }
 
   async function handleArchivedRestore(id: string) {
@@ -560,7 +558,7 @@
     }
     setActiveSession(id);
     try {
-      await continueSession(session);
+      await openSessionById(session.id);
     } catch (e) {
       logError(`Failed to reconnect restored session ${id}`, e);
       throw e;

--- a/src/lib/components/SidebarDock.svelte
+++ b/src/lib/components/SidebarDock.svelte
@@ -29,6 +29,7 @@
   import DocPanel from "./DocPanel.svelte";
   import LibraryPanel from "./LibraryPanel.svelte";
   import TaskPanel from "./TaskPanel.svelte";
+  import PtyPanel from "./PtyPanel.svelte";
   import BoardPanel from "./BoardPanel.svelte";
   import SessionTabs from "./SessionTabs.svelte";
 
@@ -120,6 +121,7 @@
     "watches",
     "library",
     "tasks",
+    "ptys",
     "board",
     "notifications",
     "mailbox",
@@ -270,6 +272,13 @@
             <TaskPanel
               {visible}
               onCollapse={onCloseFor(id)}
+              pinned={$pinnedSidebar === id}
+              onTogglePin={onTogglePinFor(id)}
+            />
+          {:else if id === "ptys"}
+            <PtyPanel
+              {visible}
+              onclose={onCloseFor(id)}
               pinned={$pinnedSidebar === id}
               onTogglePin={onTogglePinFor(id)}
             />

--- a/src/lib/components/WorkItemCard.svelte
+++ b/src/lib/components/WorkItemCard.svelte
@@ -43,7 +43,7 @@
     /** Run the card's current workflow stage. */
     onRunStage?: (id: string, item: WorkItem) => void | Promise<void>;
     /** Open the card's bound session (by session id). */
-    onOpen?: (sessionId: string) => void;
+    onOpen?: (sessionId: string, ptyId?: string | null) => void;
     /** Open the card editor (by work item id). */
     onEdit?: (id: string) => void;
     /** Delete the card (by work item id). */
@@ -136,6 +136,9 @@
   );
   const planningOpenSessionId = $derived(
     phase.action.kind === "open-planning" ? phase.action.sessionId : null,
+  );
+  const planningOpenPtyId = $derived(
+    phase.action.kind === "open-planning" ? phase.action.ptyId : null,
   );
   const startActionAriaLabel = $derived(
     phase.action.kind === "configure"
@@ -902,7 +905,8 @@
         <button
           class={amberActionClass}
           onclick={() =>
-            planningOpenSessionId && onOpen?.(planningOpenSessionId)}
+            planningOpenSessionId &&
+            onOpen?.(planningOpenSessionId, planningOpenPtyId)}
           aria-label="Open planning terminal"
         >
           <Terminal size={11} strokeWidth={2.2} />

--- a/src/lib/components/__tests__/ActivityRail.test.ts
+++ b/src/lib/components/__tests__/ActivityRail.test.ts
@@ -36,6 +36,7 @@ describe("ActivityRail", () => {
       /watches/i,
       /tasks/i,
       /sessions/i,
+      /ptys/i,
       /docs/i,
       /notifications/i,
       /settings/i,

--- a/src/lib/components/__tests__/BoardMainView.test.ts
+++ b/src/lib/components/__tests__/BoardMainView.test.ts
@@ -26,12 +26,14 @@ import {
 } from "$lib/stores/ui";
 import { closeMainView } from "$lib/stores/mainView";
 import { openSessionById } from "$lib/panes/openSession";
+import { continueSession } from "$lib/sessions/reconnect";
 import { WORK_ITEM_DRAG_MIME } from "$lib/board/drag";
 import type { WorkItem } from "$lib/bindings";
 import {
   DEFAULT_SETTINGS,
   type Notification,
   type Project,
+  type Session,
   type Worktree,
   type WorktrunkMetadata,
 } from "$lib/types";
@@ -128,6 +130,10 @@ vi.mock("$lib/stores/mainView", () => ({
 
 vi.mock("$lib/panes/openSession", () => ({
   openSessionById: vi.fn().mockResolvedValue("opened"),
+}));
+
+vi.mock("$lib/sessions/reconnect", () => ({
+  continueSession: vi.fn().mockResolvedValue({}),
 }));
 
 vi.mock("$lib/tauri", () => ({
@@ -773,6 +779,36 @@ describe("BoardMainView", () => {
     await fireEvent.click(screen.getByLabelText("Open terminal"));
 
     expect(openSessionById).toHaveBeenCalledWith("sess-1");
+    await vi.waitFor(() => expect(closeMainView).toHaveBeenCalled());
+  });
+
+  it("continues a disconnected session when opening a bound card terminal", async () => {
+    const session = {
+      id: "sess-1",
+      name: "Task session",
+      repoRoot: "/repo",
+      worktreePath: "/repo",
+      branch: "main",
+      isWorktree: false,
+      status: "disconnected",
+      model: null,
+      cost: null,
+      createdAt: 1,
+      projectId: null,
+      isGitRepo: true,
+    } as Session;
+    (sessionList as ReturnType<typeof import("svelte/store").writable>).set([
+      session,
+    ]);
+    seedColumns([
+      workItem({ id: "wi-1", status: "doing", sessionId: "sess-1" }),
+    ]);
+    render(BoardMainView);
+
+    await fireEvent.click(screen.getByLabelText("Open terminal"));
+
+    expect(continueSession).toHaveBeenCalledWith(session);
+    expect(openSessionById).not.toHaveBeenCalled();
     await vi.waitFor(() => expect(closeMainView).toHaveBeenCalled());
   });
 

--- a/src/lib/components/__tests__/BoardMainView.test.ts
+++ b/src/lib/components/__tests__/BoardMainView.test.ts
@@ -26,7 +26,6 @@ import {
 } from "$lib/stores/ui";
 import { closeMainView } from "$lib/stores/mainView";
 import { openSessionById } from "$lib/panes/openSession";
-import { continueSession } from "$lib/sessions/reconnect";
 import { WORK_ITEM_DRAG_MIME } from "$lib/board/drag";
 import type { WorkItem } from "$lib/bindings";
 import {
@@ -130,10 +129,6 @@ vi.mock("$lib/stores/mainView", () => ({
 
 vi.mock("$lib/panes/openSession", () => ({
   openSessionById: vi.fn().mockResolvedValue("opened"),
-}));
-
-vi.mock("$lib/sessions/reconnect", () => ({
-  continueSession: vi.fn().mockResolvedValue({}),
 }));
 
 vi.mock("$lib/tauri", () => ({
@@ -545,7 +540,9 @@ describe("BoardMainView", () => {
     expect(screen.queryByLabelText("Approve and start work item")).toBeNull();
     await fireEvent.click(screen.getByLabelText("Open planning terminal"));
 
-    expect(openSessionById).toHaveBeenCalledWith("plan-sess-1");
+    expect(openSessionById).toHaveBeenCalledWith("plan-sess-1", {
+      ptyId: "sess-1",
+    });
     expect(startWorkItem).not.toHaveBeenCalled();
   });
 
@@ -807,8 +804,7 @@ describe("BoardMainView", () => {
 
     await fireEvent.click(screen.getByLabelText("Open terminal"));
 
-    expect(continueSession).toHaveBeenCalledWith(session);
-    expect(openSessionById).not.toHaveBeenCalled();
+    expect(openSessionById).toHaveBeenCalledWith("sess-1");
     await vi.waitFor(() => expect(closeMainView).toHaveBeenCalled());
   });
 

--- a/src/lib/components/__tests__/BoardMainView.test.ts
+++ b/src/lib/components/__tests__/BoardMainView.test.ts
@@ -10,6 +10,7 @@ import {
   startWorkItem,
   stopWorkItemRun,
   activePlanningRunByItem,
+  latestPlanningRunByItem,
   attachmentsByWorkItem,
   pendingDecisionByItem,
   pendingQuestionByItem,
@@ -88,6 +89,7 @@ vi.mock("$lib/stores/workItems", async () => {
     pendingDecisionByItem: writable(new Map()),
     pendingQuestionByItem: writable(new Map()),
     activePlanningRunByItem: writable(new Map()),
+    latestPlanningRunByItem: writable(new Map()),
     attachmentsByWorkItem: writable(new Map()),
     runsByItem: writable(new Map()),
     workItemRunEvents: writable([]),
@@ -1140,6 +1142,38 @@ describe("BoardMainView", () => {
 
     expect(openSessionById).toHaveBeenCalledWith("plan-sess-1");
     await vi.waitFor(() => expect(closeMainView).toHaveBeenCalled());
+  });
+
+  it("shows Open planning terminal for a completed planning run after restart", async () => {
+    seedColumns([
+      workItem({ id: "wi-plan", status: "planning", sessionId: null }),
+    ]);
+    (
+      latestPlanningRunByItem as ReturnType<
+        typeof import("svelte/store").writable
+      >
+    ).set(
+      new Map([
+        [
+          "wi-plan",
+          workItemRun({
+            id: "run-plan",
+            workItemId: "wi-plan",
+            kind: "planning",
+            sessionId: "archived-plan-sess",
+            ptyId: "archived-plan-pty",
+            status: "done",
+          }),
+        ],
+      ]),
+    );
+    render(BoardMainView);
+
+    await fireEvent.click(screen.getByLabelText("Open planning terminal"));
+
+    expect(openSessionById).toHaveBeenCalledWith("archived-plan-sess", {
+      ptyId: "archived-plan-pty",
+    });
   });
 
   it("routes pending question attention to the planning session without rendering the question body", async () => {

--- a/src/lib/components/__tests__/BoardPanel.test.ts
+++ b/src/lib/components/__tests__/BoardPanel.test.ts
@@ -63,6 +63,7 @@ vi.mock("$lib/stores/workItems", async () => {
     pendingDecisionByItem: writable(new Map()),
     pendingQuestionByItem: writable(new Map()),
     activePlanningRunByItem: writable(new Map()),
+    latestPlanningRunByItem: writable(new Map()),
     attachmentsByWorkItem: writable(new Map()),
     runsByItem: writable(new Map()),
     workItemRunEvents: writable([]),

--- a/src/lib/components/__tests__/PtyPanel.test.ts
+++ b/src/lib/components/__tests__/PtyPanel.test.ts
@@ -1,0 +1,83 @@
+import { render, screen, waitFor } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import PtyPanel from "../PtyPanel.svelte";
+import { listAllPtys } from "$lib/tauri";
+import type { PtyInfo } from "$lib/types";
+
+vi.mock("$lib/tauri", () => ({
+  listAllPtys: vi.fn(),
+}));
+
+function pty(overrides: Partial<PtyInfo> = {}): PtyInfo {
+  return {
+    id: "pty-1",
+    session_id: "session-1",
+    role: "sessionPrimary",
+    status: { type: "RunningDetached", since_ms: 1 },
+    name: "Planner",
+    working_dir: "/repo",
+    profile: "claude",
+    unread_output: false,
+    bell_pending: false,
+    ...overrides,
+  };
+}
+
+describe("PtyPanel", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("lists daemon-managed PTYs when visible", async () => {
+    vi.mocked(listAllPtys).mockResolvedValue([
+      pty(),
+      pty({
+        id: "pty-2",
+        name: "Shell",
+        role: "secondary",
+        status: { type: "RunningAttached", pane_id: "pane-2" },
+      }),
+    ]);
+
+    render(PtyPanel, {
+      visible: true,
+      onclose: vi.fn(),
+    });
+
+    await waitFor(() => expect(listAllPtys).toHaveBeenCalled());
+    expect(await screen.findByText("Planner")).toBeDefined();
+    expect(screen.getByText("Shell")).toBeDefined();
+    expect(screen.getByText("status: detached")).toBeDefined();
+    expect(screen.getByText("status: attached to pane-2")).toBeDefined();
+  });
+
+  it("refreshes while visible so newly spawned planning PTYs appear", async () => {
+    vi.mocked(listAllPtys)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        pty({
+          id: "planning-pty",
+          name: "Planning run",
+          status: { type: "RunningAttached", pane_id: "session-1-main" },
+        }),
+      ]);
+
+    render(PtyPanel, {
+      visible: true,
+      onclose: vi.fn(),
+    });
+
+    await waitFor(() => expect(listAllPtys).toHaveBeenCalledTimes(1));
+    expect(screen.getByText("No daemon PTYs")).toBeDefined();
+
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    await waitFor(() => expect(listAllPtys).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText("Planning run")).toBeDefined();
+  });
+});

--- a/src/lib/components/__tests__/SessionDetailView.test.ts
+++ b/src/lib/components/__tests__/SessionDetailView.test.ts
@@ -8,7 +8,7 @@ import { projects } from "$lib/stores/projects";
 import { sessionLayouts } from "$lib/panes/layout";
 import { paneInstances, type PaneInstance } from "$lib/panes/instances";
 import { closeMainView } from "$lib/stores/mainView";
-import { continueSession } from "$lib/sessions/reconnect";
+import { openSessionById } from "$lib/panes/openSession";
 import { getDocument, listDocuments } from "$lib/stores/workItems";
 import type { Attachment } from "$lib/types/workItems";
 import type { Session } from "$lib/types";
@@ -22,8 +22,8 @@ vi.mock("$lib/stores/mainView", () => ({
   closeMainView: vi.fn(),
 }));
 
-vi.mock("$lib/sessions/reconnect", () => ({
-  continueSession: vi.fn().mockResolvedValue({}),
+vi.mock("$lib/panes/openSession", () => ({
+  openSessionById: vi.fn().mockResolvedValue("opened"),
 }));
 
 vi.mock("$lib/tauri", () => ({
@@ -341,7 +341,7 @@ describe("SessionDetailView", () => {
       screen.getByRole("button", { name: "Continue session" }),
     );
 
-    expect(continueSession).toHaveBeenCalledWith(session);
+    expect(openSessionById).toHaveBeenCalledWith("session-1");
   });
 
   it("shows an empty state when the session no longer exists", () => {

--- a/src/lib/components/__tests__/SessionTabs.test.ts
+++ b/src/lib/components/__tests__/SessionTabs.test.ts
@@ -30,8 +30,8 @@ vi.mock("$lib/sessions/close", () => ({
   closeSession: vi.fn(),
 }));
 
-vi.mock("$lib/sessions/reconnect", () => ({
-  continueSession: vi.fn(),
+vi.mock("$lib/panes/openSession", () => ({
+  openSessionById: vi.fn(),
 }));
 
 vi.mock("$lib/sessions/spawnBlueprint", () => ({

--- a/src/lib/panes/__tests__/actions.test.ts
+++ b/src/lib/panes/__tests__/actions.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { get } from "svelte/store";
 import { settings } from "$lib/stores/settings";
+import { addSession, sessionState } from "$lib/stores/sessions";
 import { DEFAULT_SETTINGS } from "$lib/types";
+import type { Session } from "$lib/types";
 
 // Stub $lib/tauri so we can observe which kill/detach primitive disposePane
 // chose. The real invoke() would just reject silently in jsdom; this mock
@@ -37,6 +39,41 @@ import {
   openMultiLineEditor,
   closeMultiLineEditor,
 } from "$lib/stores/multiLineEditor";
+import { workItems } from "$lib/stores/workItems";
+import type { WorkItem } from "$lib/bindings";
+
+function makeWorkItem(overrides: Partial<WorkItem> = {}): WorkItem {
+  return {
+    id: "wi-1",
+    projectId: null,
+    parentId: null,
+    branch: null,
+    fetchFirst: null,
+    title: "Task card",
+    body: null,
+    status: "doing",
+    sessionId: null,
+    repoPath: null,
+    agentProfile: null,
+    baseBranch: null,
+    worktreePath: null,
+    startError: null,
+    provider: null,
+    externalId: null,
+    externalUrl: null,
+    sortOrder: 0,
+    pinnedPrUrl: null,
+    reviewStageId: null,
+    workflowId: "default",
+    workflowStageId: "implementation",
+    workflowStageLabel: "Implementation",
+    archivedAt: null,
+    cost: null,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
 
 describe("pane actions", () => {
   beforeEach(() => {
@@ -44,6 +81,8 @@ describe("pane actions", () => {
     resetLayouts();
     resetFocus();
     fullscreenPaneId.set(null);
+    workItems.set([]);
+    sessionState.set({ sessions: [], activeSessionId: null });
     settings.set(DEFAULT_SETTINGS); // resets to onPaneClose: "kill"
     vi.mocked(killPty).mockClear();
     vi.mocked(killSession).mockClear();
@@ -142,6 +181,34 @@ describe("pane actions", () => {
       expect(killPty).toHaveBeenCalledWith("s1");
       expect(detachPty).not.toHaveBeenCalled();
       expect(killSession).not.toHaveBeenCalled();
+    });
+
+    it("detaches instead of killing when closing a pane attached to a work-item-bound session", () => {
+      settings.set({ ...DEFAULT_SETTINGS, onPaneClose: "kill" });
+      const session = {
+        id: "task-session",
+        name: "Task session",
+        repoRoot: "/repo",
+        worktreePath: "/repo",
+        branch: "main",
+        isWorktree: false,
+        status: "idle",
+        model: null,
+        cost: null,
+        createdAt: 1,
+        projectId: null,
+        isGitRepo: true,
+      } as Session;
+      addSession(session);
+      initSession("task-session");
+      workItems.set([makeWorkItem({ sessionId: "task-session" })]);
+
+      closePane("task-session", "task-session-main");
+
+      expect(detachPty).toHaveBeenCalledWith("task-session");
+      expect(killPty).not.toHaveBeenCalled();
+      expect(killSession).not.toHaveBeenCalled();
+      expect(get(sessionState).sessions[0].status).toBe("disconnected");
     });
 
     it("detaches PTY (not kills) when onPaneClose is explicitly 'detach'", () => {

--- a/src/lib/panes/__tests__/actions.test.ts
+++ b/src/lib/panes/__tests__/actions.test.ts
@@ -39,8 +39,9 @@ import {
   openMultiLineEditor,
   closeMultiLineEditor,
 } from "$lib/stores/multiLineEditor";
-import { workItems } from "$lib/stores/workItems";
+import { workItems, workItemRuns } from "$lib/stores/workItems";
 import type { WorkItem } from "$lib/bindings";
+import type { WorkItemRun } from "$lib/types/workItems";
 
 function makeWorkItem(overrides: Partial<WorkItem> = {}): WorkItem {
   return {
@@ -75,6 +76,27 @@ function makeWorkItem(overrides: Partial<WorkItem> = {}): WorkItem {
   };
 }
 
+function makeRun(overrides: Partial<WorkItemRun> = {}): WorkItemRun {
+  return {
+    id: "run-1",
+    workItemId: "wi-1",
+    kind: "planning",
+    sessionId: "plan-session",
+    ptyId: "plan-session",
+    provider: "claude",
+    profileId: "claude",
+    status: "running",
+    worktreePath: null,
+    branch: null,
+    cost: null,
+    createdAt: 1,
+    startedAt: 1,
+    endedAt: null,
+    updatedAt: 1,
+    ...overrides,
+  };
+}
+
 describe("pane actions", () => {
   beforeEach(() => {
     resetInstances();
@@ -82,6 +104,7 @@ describe("pane actions", () => {
     resetFocus();
     fullscreenPaneId.set(null);
     workItems.set([]);
+    workItemRuns.set([]);
     sessionState.set({ sessions: [], activeSessionId: null });
     settings.set(DEFAULT_SETTINGS); // resets to onPaneClose: "kill"
     vi.mocked(killPty).mockClear();
@@ -206,6 +229,42 @@ describe("pane actions", () => {
       closePane("task-session", "task-session-main");
 
       expect(detachPty).toHaveBeenCalledWith("task-session");
+      expect(killPty).not.toHaveBeenCalled();
+      expect(killSession).not.toHaveBeenCalled();
+      expect(get(sessionState).sessions[0].status).toBe("disconnected");
+    });
+
+    it("detaches instead of killing when closing an active planning session pane", () => {
+      settings.set({ ...DEFAULT_SETTINGS, onPaneClose: "kill" });
+      const session = {
+        id: "plan-session",
+        name: "Plan session",
+        repoRoot: "/repo",
+        worktreePath: "/repo",
+        branch: "main",
+        isWorktree: false,
+        status: "idle",
+        model: null,
+        cost: null,
+        createdAt: 1,
+        projectId: null,
+        isGitRepo: true,
+      } as Session;
+      addSession(session);
+      initSession("plan-session");
+      workItemRuns.set([
+        makeRun({
+          id: "run-1",
+          workItemId: "wi-1",
+          kind: "planning",
+          sessionId: "plan-session",
+          ptyId: "plan-session",
+        }),
+      ]);
+
+      closePane("plan-session", "plan-session-main");
+
+      expect(detachPty).toHaveBeenCalledWith("plan-session");
       expect(killPty).not.toHaveBeenCalled();
       expect(killSession).not.toHaveBeenCalled();
       expect(get(sessionState).sessions[0].status).toBe("disconnected");

--- a/src/lib/panes/__tests__/actions.test.ts
+++ b/src/lib/panes/__tests__/actions.test.ts
@@ -24,7 +24,12 @@ import {
   detachSessionPanes,
   initSession,
 } from "../actions";
-import { paneInstances, resetInstances, getInstance } from "../instances";
+import {
+  paneInstances,
+  resetInstances,
+  getInstance,
+  updateInstance,
+} from "../instances";
 import { sessionLayouts, resetLayouts, collectLeafIds } from "../layout";
 import {
   focusedPaneId,
@@ -265,6 +270,46 @@ describe("pane actions", () => {
       closePane("plan-session", "plan-session-main");
 
       expect(detachPty).toHaveBeenCalledWith("plan-session");
+      expect(killPty).not.toHaveBeenCalled();
+      expect(killSession).not.toHaveBeenCalled();
+      expect(get(sessionState).sessions[0].status).toBe("disconnected");
+    });
+
+    it("detaches a planning run PTY even when it differs from the session id", () => {
+      settings.set({ ...DEFAULT_SETTINGS, onPaneClose: "kill" });
+      const session = {
+        id: "plan-session",
+        name: "Plan session",
+        repoRoot: "/repo",
+        worktreePath: "/repo",
+        branch: "main",
+        isWorktree: false,
+        status: "idle",
+        model: null,
+        cost: null,
+        createdAt: 1,
+        projectId: null,
+        isGitRepo: true,
+      } as Session;
+      addSession(session);
+      initSession("plan-session");
+      updateInstance("plan-session-main", {
+        ptyId: "planning-pty",
+        terminalState: { kind: "attached", ptyId: "planning-pty" },
+      });
+      workItemRuns.set([
+        makeRun({
+          id: "run-1",
+          workItemId: "wi-1",
+          kind: "planning",
+          sessionId: "plan-session",
+          ptyId: "planning-pty",
+        }),
+      ]);
+
+      closePane("plan-session", "plan-session-main");
+
+      expect(detachPty).toHaveBeenCalledWith("planning-pty");
       expect(killPty).not.toHaveBeenCalled();
       expect(killSession).not.toHaveBeenCalled();
       expect(get(sessionState).sessions[0].status).toBe("disconnected");

--- a/src/lib/panes/__tests__/openSession.test.ts
+++ b/src/lib/panes/__tests__/openSession.test.ts
@@ -174,6 +174,37 @@ describe("openSessionById", () => {
     expect(get(sessionState).sessions[0].status).toBe("idle");
   });
 
+  it("reattaches a session manager open using the session primary PTY id", async () => {
+    vi.mocked(listAllPtys).mockResolvedValue([ptyInfo("primary-pty", "s1")]);
+    sessionState.set({
+      sessions: [
+        {
+          id: "s1",
+          name: "Session",
+          repoRoot: "/repo",
+          worktreePath: "/repo",
+          branch: "main",
+          isWorktree: false,
+          status: "disconnected",
+          model: null,
+          cost: null,
+          createdAt: 1,
+          projectId: null,
+          isGitRepo: true,
+          primaryPtyId: "primary-pty",
+        },
+      ],
+      activeSessionId: null,
+    });
+
+    const result = await openSessionById("s1");
+
+    expect(result).toBe("opened");
+    expect(get(paneInstances).get("s1-main")?.ptyId).toBe("primary-pty");
+    expect(attachPtyToPane).toHaveBeenCalledWith("s1-main", "primary-pty");
+    expect(get(sessionState).sessions[0].status).toBe("idle");
+  });
+
   it("overrides a persisted primary descriptor with the supplied work-item PTY", async () => {
     vi.mocked(listAllPtys).mockResolvedValue([ptyInfo("planning-pty", "s1")]);
     vi.mocked(loadPaneState).mockResolvedValueOnce({

--- a/src/lib/panes/__tests__/openSession.test.ts
+++ b/src/lib/panes/__tests__/openSession.test.ts
@@ -122,7 +122,7 @@ describe("openSessionById", () => {
     expect(get(sessionState).activeSessionId).toBe("s1");
   });
 
-  it("does not mark a disconnected session idle when no live PTY attaches", async () => {
+  it("continues a disconnected regular session when no live PTY attaches", async () => {
     vi.mocked(listAllPtys).mockResolvedValue([]);
     sessionState.set({
       sessions: [
@@ -148,7 +148,10 @@ describe("openSessionById", () => {
 
     expect(result).toBe("opened");
     expect(attachPtyToPane).not.toHaveBeenCalled();
-    expect(get(sessionState).sessions[0].status).toBe("disconnected");
+    expect(reattachSession).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "s1" }),
+    );
+    expect(get(sessionState).activeSessionId).toBe("s1");
   });
 
   it("reattaches the supplied work-item PTY to the session main pane", async () => {

--- a/src/lib/panes/__tests__/openSession.test.ts
+++ b/src/lib/panes/__tests__/openSession.test.ts
@@ -1,0 +1,210 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { get } from "svelte/store";
+
+vi.mock("$lib/tauri", () => ({
+  listSessions: vi.fn().mockResolvedValue([]),
+  listAllPtys: vi.fn().mockResolvedValue([]),
+  upsertPaneRecord: vi.fn().mockResolvedValue(undefined),
+  removePaneRecord: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../persistence", () => ({
+  loadPaneState: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("../terminals", () => ({
+  initTerminal: vi.fn(),
+  attachPtyListeners: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../attach", () => ({
+  attachPtyToPane: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { openSessionById } from "../openSession";
+import { sessionState } from "$lib/stores/sessions";
+import { paneInstances, resetInstances } from "../instances";
+import { sessionLayouts, resetLayouts } from "../layout";
+import { attachPtyToPane } from "../attach";
+import { loadPaneState } from "../persistence";
+import { listAllPtys } from "$lib/tauri";
+import type { PtyInfo } from "$lib/bindings";
+
+function ptyInfo(id: string, sessionId = id): PtyInfo {
+  return {
+    id,
+    session_id: sessionId,
+    role: "sessionPrimary",
+    status: { type: "RunningDetached", since_ms: 1 },
+    name: null,
+    working_dir: "/repo",
+    profile: "claude",
+    unread_output: false,
+    bell_pending: false,
+  };
+}
+
+describe("openSessionById", () => {
+  beforeEach(() => {
+    sessionState.set({ sessions: [], activeSessionId: null });
+    resetInstances();
+    resetLayouts();
+    vi.clearAllMocks();
+    vi.mocked(listAllPtys).mockResolvedValue([ptyInfo("s1")]);
+  });
+
+  it("recreates a pane and attaches the old PTY for a disconnected session", async () => {
+    sessionState.set({
+      sessions: [
+        {
+          id: "s1",
+          name: "Session",
+          repoRoot: "/repo",
+          worktreePath: "/repo",
+          branch: "main",
+          isWorktree: false,
+          status: "disconnected",
+          model: null,
+          cost: null,
+          createdAt: 1,
+          projectId: null,
+          isGitRepo: true,
+        },
+      ],
+      activeSessionId: null,
+    });
+
+    const result = await openSessionById("s1");
+
+    expect(result).toBe("opened");
+    expect(get(sessionLayouts).get("s1")).toEqual({
+      kind: "leaf",
+      paneId: "s1-main",
+    });
+    expect(get(paneInstances).get("s1-main")?.ptyId).toBe("s1");
+    expect(attachPtyToPane).toHaveBeenCalledWith("s1-main", "s1");
+    expect(get(sessionState).activeSessionId).toBe("s1");
+    expect(get(sessionState).sessions[0].status).toBe("idle");
+  });
+
+  it("restores an idle local session when no pane is attached", async () => {
+    sessionState.set({
+      sessions: [
+        {
+          id: "s1",
+          name: "Session",
+          repoRoot: "/repo",
+          worktreePath: "/repo",
+          branch: "main",
+          isWorktree: false,
+          status: "idle",
+          model: null,
+          cost: null,
+          createdAt: 1,
+          projectId: null,
+          isGitRepo: true,
+        },
+      ],
+      activeSessionId: null,
+    });
+
+    const result = await openSessionById("s1");
+
+    expect(result).toBe("opened");
+    expect(attachPtyToPane).toHaveBeenCalledWith("s1-main", "s1");
+    expect(get(sessionState).activeSessionId).toBe("s1");
+  });
+
+  it("does not mark a disconnected session idle when no live PTY attaches", async () => {
+    vi.mocked(listAllPtys).mockResolvedValue([]);
+    sessionState.set({
+      sessions: [
+        {
+          id: "s1",
+          name: "Session",
+          repoRoot: "/repo",
+          worktreePath: "/repo",
+          branch: "main",
+          isWorktree: false,
+          status: "disconnected",
+          model: null,
+          cost: null,
+          createdAt: 1,
+          projectId: null,
+          isGitRepo: true,
+        },
+      ],
+      activeSessionId: null,
+    });
+
+    const result = await openSessionById("s1");
+
+    expect(result).toBe("opened");
+    expect(attachPtyToPane).not.toHaveBeenCalled();
+    expect(get(sessionState).sessions[0].status).toBe("disconnected");
+  });
+
+  it("reattaches the supplied work-item PTY to the session main pane", async () => {
+    vi.mocked(listAllPtys).mockResolvedValue([ptyInfo("planning-pty", "s1")]);
+    sessionState.set({
+      sessions: [
+        {
+          id: "s1",
+          name: "Session",
+          repoRoot: "/repo",
+          worktreePath: "/repo",
+          branch: "main",
+          isWorktree: false,
+          status: "disconnected",
+          model: null,
+          cost: null,
+          createdAt: 1,
+          projectId: null,
+          isGitRepo: true,
+        },
+      ],
+      activeSessionId: null,
+    });
+
+    const result = await openSessionById("s1", { ptyId: "planning-pty" });
+
+    expect(result).toBe("opened");
+    expect(get(paneInstances).get("s1-main")?.ptyId).toBe("planning-pty");
+    expect(attachPtyToPane).toHaveBeenCalledWith("s1-main", "planning-pty");
+    expect(get(sessionState).sessions[0].status).toBe("idle");
+  });
+
+  it("overrides a persisted primary descriptor with the supplied work-item PTY", async () => {
+    vi.mocked(listAllPtys).mockResolvedValue([ptyInfo("planning-pty", "s1")]);
+    vi.mocked(loadPaneState).mockResolvedValueOnce({
+      schemaVersion: 5,
+      layout: { kind: "leaf", paneId: "s1-main" },
+      descriptors: [{ id: "s1-main", type: "shell", ptyId: "s1" }],
+    });
+    sessionState.set({
+      sessions: [
+        {
+          id: "s1",
+          name: "Session",
+          repoRoot: "/repo",
+          worktreePath: "/repo",
+          branch: "main",
+          isWorktree: false,
+          status: "disconnected",
+          model: null,
+          cost: null,
+          createdAt: 1,
+          projectId: null,
+          isGitRepo: true,
+        },
+      ],
+      activeSessionId: null,
+    });
+
+    const result = await openSessionById("s1", { ptyId: "planning-pty" });
+
+    expect(result).toBe("opened");
+    expect(get(paneInstances).get("s1-main")?.ptyId).toBe("planning-pty");
+    expect(attachPtyToPane).toHaveBeenCalledWith("s1-main", "planning-pty");
+  });
+});

--- a/src/lib/panes/__tests__/openSession.test.ts
+++ b/src/lib/panes/__tests__/openSession.test.ts
@@ -27,6 +27,7 @@ vi.mock("../attach", () => ({
 
 vi.mock("$lib/sessions/reconnect", () => ({
   reattachSession: vi.fn(async (session) => session),
+  reconnectSessionShell: vi.fn(async (session) => session),
 }));
 
 import { openSessionById } from "../openSession";
@@ -37,7 +38,7 @@ import { attachPtyToPane } from "../attach";
 import { loadPaneState } from "../persistence";
 import { listAllPtys, listSessions } from "$lib/tauri";
 import { restoreArchivedSession } from "$lib/stores/archivedSessions";
-import { reattachSession } from "$lib/sessions/reconnect";
+import { reattachSession, reconnectSessionShell } from "$lib/sessions/reconnect";
 import type { PtyInfo } from "$lib/bindings";
 import type { Session } from "$lib/types";
 
@@ -152,8 +153,9 @@ describe("openSessionById", () => {
 
     expect(result).toBe("opened");
     expect(attachPtyToPane).not.toHaveBeenCalled();
-    expect(reattachSession).toHaveBeenCalledWith(
+    expect(reconnectSessionShell).toHaveBeenCalledWith(
       expect.objectContaining({ id: "s1" }),
+      ["--continue"],
     );
     expect(get(sessionState).activeSessionId).toBe("s1");
   });

--- a/src/lib/panes/__tests__/openSession.test.ts
+++ b/src/lib/panes/__tests__/openSession.test.ts
@@ -4,9 +4,12 @@ import { get } from "svelte/store";
 vi.mock("$lib/tauri", () => ({
   listSessions: vi.fn().mockResolvedValue([]),
   listAllPtys: vi.fn().mockResolvedValue([]),
-  restoreSession: vi.fn().mockResolvedValue(undefined),
   upsertPaneRecord: vi.fn().mockResolvedValue(undefined),
   removePaneRecord: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("$lib/stores/archivedSessions", () => ({
+  restoreArchivedSession: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("../persistence", () => ({
@@ -32,7 +35,8 @@ import { paneInstances, resetInstances } from "../instances";
 import { sessionLayouts, resetLayouts } from "../layout";
 import { attachPtyToPane } from "../attach";
 import { loadPaneState } from "../persistence";
-import { listAllPtys, listSessions, restoreSession } from "$lib/tauri";
+import { listAllPtys, listSessions } from "$lib/tauri";
+import { restoreArchivedSession } from "$lib/stores/archivedSessions";
 import { reattachSession } from "$lib/sessions/reconnect";
 import type { PtyInfo } from "$lib/bindings";
 import type { Session } from "$lib/types";
@@ -273,7 +277,7 @@ describe("openSessionById", () => {
     const result = await openSessionById("archived-plan");
 
     expect(result).toBe("opened");
-    expect(restoreSession).toHaveBeenCalledWith("archived-plan");
+    expect(restoreArchivedSession).toHaveBeenCalledWith("archived-plan");
     expect(reattachSession).toHaveBeenCalledWith(restored);
     expect(get(sessionState).activeSessionId).toBe("archived-plan");
   });

--- a/src/lib/panes/__tests__/openSession.test.ts
+++ b/src/lib/panes/__tests__/openSession.test.ts
@@ -27,7 +27,7 @@ vi.mock("../attach", () => ({
 
 vi.mock("$lib/sessions/reconnect", () => ({
   reattachSession: vi.fn(async (session) => session),
-  reconnectSessionShell: vi.fn(async (session) => session),
+  continueSessionShell: vi.fn(async (session) => session),
 }));
 
 import { openSessionById } from "../openSession";
@@ -38,7 +38,7 @@ import { attachPtyToPane } from "../attach";
 import { loadPaneState } from "../persistence";
 import { listAllPtys, listSessions } from "$lib/tauri";
 import { restoreArchivedSession } from "$lib/stores/archivedSessions";
-import { reattachSession, reconnectSessionShell } from "$lib/sessions/reconnect";
+import { reattachSession, continueSessionShell } from "$lib/sessions/reconnect";
 import type { PtyInfo } from "$lib/bindings";
 import type { Session } from "$lib/types";
 
@@ -153,9 +153,8 @@ describe("openSessionById", () => {
 
     expect(result).toBe("opened");
     expect(attachPtyToPane).not.toHaveBeenCalled();
-    expect(reconnectSessionShell).toHaveBeenCalledWith(
+    expect(continueSessionShell).toHaveBeenCalledWith(
       expect.objectContaining({ id: "s1" }),
-      ["--continue"],
     );
     expect(get(sessionState).activeSessionId).toBe("s1");
   });
@@ -282,5 +281,129 @@ describe("openSessionById", () => {
     expect(restoreArchivedSession).toHaveBeenCalledWith("archived-plan");
     expect(reattachSession).toHaveBeenCalledWith(restored);
     expect(get(sessionState).activeSessionId).toBe("archived-plan");
+  });
+
+  it("continues a disconnected planning session when its PTY is dead (foreign ptyId)", async () => {
+    // Planning sessions have a ptyId that differs from sessionId.
+    // When the planning PTY is dead, reconnect should use
+    // continueSessionShell and the pane's ptyId must stay session.id
+    // so reconnectPrimaryPaneOnly can locate it.
+    vi.mocked(listAllPtys).mockResolvedValue([]);
+    vi.mocked(listSessions).mockResolvedValue([
+      {
+        id: "plan-session",
+        name: "Plan",
+        repoRoot: "/repo",
+        worktreePath: "/repo",
+        branch: "main",
+        isWorktree: false,
+        status: "disconnected",
+        model: null,
+        cost: null,
+        createdAt: 1,
+        projectId: null,
+        isGitRepo: true,
+      },
+    ]);
+    sessionState.set({ sessions: [], activeSessionId: null });
+
+    const result = await openSessionById("plan-session", {
+      ptyId: "planning-pty",
+    });
+
+    expect(result).toBe("opened");
+    expect(continueSessionShell).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "plan-session" }),
+    );
+    // The pane's ptyId must be session.id (not the dead planning PTY)
+    // so that findSessionPrimaryPaneId can find it.
+    expect(get(paneInstances).get("plan-session-main")?.ptyId).toBe(
+      "plan-session",
+    );
+    expect(get(sessionState).activeSessionId).toBe("plan-session");
+  });
+
+  it("adds the session to the store after reconnect, never before", async () => {
+    // The session must land in the store with the status that
+    // continueSessionShell returned — not the original disconnected
+    // status — so the UI never renders the SessionPicker.
+    vi.mocked(listAllPtys).mockResolvedValue([]);
+    vi.mocked(listSessions).mockResolvedValue([
+      {
+        id: "s1",
+        name: "Session",
+        repoRoot: "/repo",
+        worktreePath: "/repo",
+        branch: "main",
+        isWorktree: false,
+        status: "disconnected",
+        model: null,
+        cost: null,
+        createdAt: 1,
+        projectId: null,
+        isGitRepo: true,
+      },
+    ]);
+    vi.mocked(continueSessionShell).mockResolvedValueOnce({
+      id: "s1",
+      name: "Session",
+      repoRoot: "/repo",
+      worktreePath: "/repo",
+      branch: "main",
+      isWorktree: false,
+      status: "idle",
+      model: null,
+      cost: null,
+      createdAt: 1,
+      projectId: null,
+      isGitRepo: true,
+      primaryPtyId: null,
+    } as Session);
+    sessionState.set({ sessions: [], activeSessionId: null });
+
+    const result = await openSessionById("s1");
+
+    expect(result).toBe("opened");
+    expect(continueSessionShell).toHaveBeenCalled();
+    // The store must reflect the reconnected status, not "disconnected".
+    expect(get(sessionState).sessions[0]?.status).toBe("idle");
+  });
+
+  it("reconnects even when daemon reports idle but PTY is dead", async () => {
+    // The daemon may report "idle" for a session whose PTY was killed
+    // during restart. If no live PTY attaches, reconnect anyway.
+    vi.mocked(listAllPtys).mockResolvedValue([]);
+    vi.mocked(listSessions).mockResolvedValue([
+      {
+        id: "s1",
+        name: "Session",
+        repoRoot: "/repo",
+        worktreePath: "/repo",
+        branch: "main",
+        isWorktree: false,
+        status: "idle",
+        model: null,
+        cost: null,
+        createdAt: 1,
+        projectId: null,
+        isGitRepo: true,
+      },
+    ]);
+    sessionState.set({ sessions: [], activeSessionId: null });
+
+    const result = await openSessionById("s1");
+
+    expect(result).toBe("opened");
+    expect(continueSessionShell).toHaveBeenCalled();
+  });
+
+  it("does not add the session to the store when it is gone and not archived", async () => {
+    vi.mocked(listSessions).mockResolvedValue([]);
+    vi.mocked(listAllPtys).mockResolvedValue([]);
+
+    const result = await openSessionById("missing-session");
+
+    expect(result).toBe("gone");
+    expect(get(sessionState).sessions).toHaveLength(0);
   });
 });

--- a/src/lib/panes/__tests__/openSession.test.ts
+++ b/src/lib/panes/__tests__/openSession.test.ts
@@ -4,6 +4,7 @@ import { get } from "svelte/store";
 vi.mock("$lib/tauri", () => ({
   listSessions: vi.fn().mockResolvedValue([]),
   listAllPtys: vi.fn().mockResolvedValue([]),
+  restoreSession: vi.fn().mockResolvedValue(undefined),
   upsertPaneRecord: vi.fn().mockResolvedValue(undefined),
   removePaneRecord: vi.fn().mockResolvedValue(undefined),
 }));
@@ -21,14 +22,20 @@ vi.mock("../attach", () => ({
   attachPtyToPane: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("$lib/sessions/reconnect", () => ({
+  reattachSession: vi.fn(async (session) => session),
+}));
+
 import { openSessionById } from "../openSession";
 import { sessionState } from "$lib/stores/sessions";
 import { paneInstances, resetInstances } from "../instances";
 import { sessionLayouts, resetLayouts } from "../layout";
 import { attachPtyToPane } from "../attach";
 import { loadPaneState } from "../persistence";
-import { listAllPtys } from "$lib/tauri";
+import { listAllPtys, listSessions, restoreSession } from "$lib/tauri";
+import { reattachSession } from "$lib/sessions/reconnect";
 import type { PtyInfo } from "$lib/bindings";
+import type { Session } from "$lib/types";
 
 function ptyInfo(id: string, sessionId = id): PtyInfo {
   return {
@@ -237,5 +244,34 @@ describe("openSessionById", () => {
     expect(result).toBe("opened");
     expect(get(paneInstances).get("s1-main")?.ptyId).toBe("planning-pty");
     expect(attachPtyToPane).toHaveBeenCalledWith("s1-main", "planning-pty");
+  });
+
+  it("restores and continues an archived session when no active session exists", async () => {
+    const restored: Session = {
+      id: "archived-plan",
+      name: "Archived plan",
+      repoRoot: "/repo",
+      worktreePath: "/repo",
+      branch: "main",
+      isWorktree: false,
+      status: "disconnected",
+      model: null,
+      cost: null,
+      createdAt: 1,
+      projectId: null,
+      isGitRepo: true,
+      primaryPtyId: null,
+    };
+    vi.mocked(listSessions)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([restored]);
+    vi.mocked(listAllPtys).mockResolvedValue([]);
+
+    const result = await openSessionById("archived-plan");
+
+    expect(result).toBe("opened");
+    expect(restoreSession).toHaveBeenCalledWith("archived-plan");
+    expect(reattachSession).toHaveBeenCalledWith(restored);
+    expect(get(sessionState).activeSessionId).toBe("archived-plan");
   });
 });

--- a/src/lib/panes/__tests__/restore.test.ts
+++ b/src/lib/panes/__tests__/restore.test.ts
@@ -121,6 +121,79 @@ describe("restoreSessionPanes", () => {
     expect(attachPtyListeners).not.toHaveBeenCalled();
   });
 
+  it("uses session.id as ptyId when planning PTY is dead (foreign ptyId, empty decision)", async () => {
+    // When a planning session has a different PTY id (planning-pty)
+    // and that PTY is dead, the pane's ptyId must fall back to
+    // session.id so reconnect can locate it later.
+    const payload: PaneStatePayload = {
+      schemaVersion: 5,
+      layout: { kind: "leaf", paneId: "pane-1" },
+      descriptors: [
+        {
+          id: "pane-1",
+          type: "shell",
+          ptyId: "s1",
+          spawnProfileRef: { kind: "registered", id: "claude" },
+          provider: "claude",
+        },
+      ],
+    };
+
+    await restoreSessionPanes(
+      session({ id: "s1" }),
+      payload,
+      {
+        initTerminal,
+        attachPtyListeners,
+        livePtyIds: new Set(), // PTY dead
+        primaryPtyId: "planning-pty", // Foreign ptyId from work item
+      },
+    );
+
+    // The pane must have ptyId = session.id, not "" and not "planning-pty".
+    const pane = get(paneInstances).get("pane-1");
+    expect(pane?.ptyId).toBe("s1");
+    expect(pane?.terminalState).toEqual({ kind: "empty" });
+  });
+
+  it("resolves primary descriptor by session.id when foreign ptyId matches nothing", async () => {
+    // When primaryPtyId (planning PTY ID) doesn't appear in any
+    // descriptor, the function falls back to matching by session.id.
+    const payload: PaneStatePayload = {
+      schemaVersion: 5,
+      layout: { kind: "leaf", paneId: "s1-main" },
+      descriptors: [
+        {
+          id: "s1-main",
+          type: "shell",
+          ptyId: "s1",
+          spawnProfileRef: { kind: "registered", id: "claude" },
+          provider: "claude",
+        },
+      ],
+    };
+
+    await restoreSessionPanes(
+      session({ id: "s1" }),
+      payload,
+      {
+        initTerminal,
+        attachPtyListeners,
+        livePtyIds: new Set(["planning-pty"]), // Only planning PTY is live
+        primaryPtyId: "planning-pty", // But no descriptor has this ptyId
+      },
+    );
+
+    // Should still find the primary by session.id and attach the
+    // overridden planning PTY.
+    const pane = get(paneInstances).get("s1-main");
+    expect(pane?.ptyId).toBe("planning-pty");
+    expect(pane?.terminalState).toEqual({
+      kind: "attached",
+      ptyId: "planning-pty",
+    });
+  });
+
   it("restores persisted split panes and reattaches each live PTY", async () => {
     const payload: PaneStatePayload = {
       schemaVersion: 5,

--- a/src/lib/panes/__tests__/restore.test.ts
+++ b/src/lib/panes/__tests__/restore.test.ts
@@ -139,16 +139,12 @@ describe("restoreSessionPanes", () => {
       ],
     };
 
-    await restoreSessionPanes(
-      session({ id: "s1" }),
-      payload,
-      {
-        initTerminal,
-        attachPtyListeners,
-        livePtyIds: new Set(), // PTY dead
-        primaryPtyId: "planning-pty", // Foreign ptyId from work item
-      },
-    );
+    await restoreSessionPanes(session({ id: "s1" }), payload, {
+      initTerminal,
+      attachPtyListeners,
+      livePtyIds: new Set(), // PTY dead
+      primaryPtyId: "planning-pty", // Foreign ptyId from work item
+    });
 
     // The pane must have ptyId = session.id, not "" and not "planning-pty".
     const pane = get(paneInstances).get("pane-1");
@@ -173,16 +169,12 @@ describe("restoreSessionPanes", () => {
       ],
     };
 
-    await restoreSessionPanes(
-      session({ id: "s1" }),
-      payload,
-      {
-        initTerminal,
-        attachPtyListeners,
-        livePtyIds: new Set(["planning-pty"]), // Only planning PTY is live
-        primaryPtyId: "planning-pty", // But no descriptor has this ptyId
-      },
-    );
+    await restoreSessionPanes(session({ id: "s1" }), payload, {
+      initTerminal,
+      attachPtyListeners,
+      livePtyIds: new Set(["planning-pty"]), // Only planning PTY is live
+      primaryPtyId: "planning-pty", // But no descriptor has this ptyId
+    });
 
     // Should still find the primary by session.id and attach the
     // overridden planning PTY.

--- a/src/lib/panes/__tests__/statusRouting.test.ts
+++ b/src/lib/panes/__tests__/statusRouting.test.ts
@@ -223,7 +223,7 @@ describe("applyStatusRouting", () => {
     // hooks that omit the field. If applyStatusRouting persisted that
     // inferred value, a Codex pane whose hook didn't carry `provider`
     // would get its instance.provider clobbered to "claude", and
-    // continueSession would then build `claude --resume <id>` instead of
+    // reattachSession would then build `claude --resume <id>` instead of
     // `codex resume <id>`. We persist providerSessionId only.
     createPane({
       id: "pane-1",

--- a/src/lib/panes/actions.ts
+++ b/src/lib/panes/actions.ts
@@ -25,7 +25,7 @@ import { defaultAgentProfileId } from "./defaultAgent";
 import type { SpawnProfileRef } from "./profiles";
 import { killPty, detachPty } from "$lib/tauri";
 import { settings } from "$lib/stores/settings";
-import { workItems } from "$lib/stores/workItems";
+import { activePlanningRunByItem, workItems } from "$lib/stores/workItems";
 import { setSessionDisconnected } from "$lib/stores/sessions";
 import {
   multiLineEditor,
@@ -153,12 +153,20 @@ export function closePane(sessionId: string, paneId: string): boolean {
   const isWorkItemBoundSession = get(workItems).some(
     (item) => item.sessionId === sessionId,
   );
+  const isPlanningRunSession = [...get(activePlanningRunByItem).values()].some(
+    (run) => run.sessionId === sessionId,
+  );
   const isPrimarySessionPane = ptyId === sessionId;
-  if ((onPaneClose === "detach" || (isWorkItemBoundSession && isPrimarySessionPane)) && ptyId) {
+  if (
+    (onPaneClose === "detach" ||
+      ((isWorkItemBoundSession || isPlanningRunSession) &&
+        isPrimarySessionPane)) &&
+    ptyId
+  ) {
     // Detach the PTY so it keeps running in the background. Fire-and-forget:
     // the pane is already removed from the layout so there is no UI to update.
     detachPty(ptyId).catch(() => {});
-    if (isWorkItemBoundSession && isPrimarySessionPane) {
+    if ((isWorkItemBoundSession || isPlanningRunSession) && isPrimarySessionPane) {
       setSessionDisconnected(sessionId);
     }
     // Dispose the pane instance without killing the PTY.

--- a/src/lib/panes/actions.ts
+++ b/src/lib/panes/actions.ts
@@ -25,6 +25,8 @@ import { defaultAgentProfileId } from "./defaultAgent";
 import type { SpawnProfileRef } from "./profiles";
 import { killPty, detachPty } from "$lib/tauri";
 import { settings } from "$lib/stores/settings";
+import { workItems } from "$lib/stores/workItems";
+import { setSessionDisconnected } from "$lib/stores/sessions";
 import {
   multiLineEditor,
   closeMultiLineEditor,
@@ -148,10 +150,17 @@ export function closePane(sessionId: string, paneId: string): boolean {
 
   const onPaneClose = get(settings).onPaneClose ?? "kill";
   const ptyId = getAttachedPtyId(instance);
-  if (onPaneClose === "detach" && ptyId) {
+  const isWorkItemBoundSession = get(workItems).some(
+    (item) => item.sessionId === sessionId,
+  );
+  const isPrimarySessionPane = ptyId === sessionId;
+  if ((onPaneClose === "detach" || (isWorkItemBoundSession && isPrimarySessionPane)) && ptyId) {
     // Detach the PTY so it keeps running in the background. Fire-and-forget:
     // the pane is already removed from the layout so there is no UI to update.
     detachPty(ptyId).catch(() => {});
+    if (isWorkItemBoundSession && isPrimarySessionPane) {
+      setSessionDisconnected(sessionId);
+    }
     // Dispose the pane instance without killing the PTY.
     disposePane(paneId);
   } else {

--- a/src/lib/panes/actions.ts
+++ b/src/lib/panes/actions.ts
@@ -153,20 +153,23 @@ export function closePane(sessionId: string, paneId: string): boolean {
   const isWorkItemBoundSession = get(workItems).some(
     (item) => item.sessionId === sessionId,
   );
-  const isPlanningRunSession = [...get(activePlanningRunByItem).values()].some(
-    (run) => run.sessionId === sessionId,
+  const isPlanningRunPane = [...get(activePlanningRunByItem).values()].some(
+    (run) =>
+      run.sessionId === sessionId &&
+      !!ptyId &&
+      (run.ptyId ? run.ptyId === ptyId : ptyId === sessionId),
   );
   const isPrimarySessionPane = ptyId === sessionId;
   if (
     (onPaneClose === "detach" ||
-      ((isWorkItemBoundSession || isPlanningRunSession) &&
-        isPrimarySessionPane)) &&
+      (isWorkItemBoundSession && isPrimarySessionPane) ||
+      isPlanningRunPane) &&
     ptyId
   ) {
     // Detach the PTY so it keeps running in the background. Fire-and-forget:
     // the pane is already removed from the layout so there is no UI to update.
     detachPty(ptyId).catch(() => {});
-    if ((isWorkItemBoundSession || isPlanningRunSession) && isPrimarySessionPane) {
+    if ((isWorkItemBoundSession && isPrimarySessionPane) || isPlanningRunPane) {
       setSessionDisconnected(sessionId);
     }
     // Dispose the pane instance without killing the PTY.

--- a/src/lib/panes/openSession.ts
+++ b/src/lib/panes/openSession.ts
@@ -72,9 +72,7 @@ export async function openSessionById(
       session = restoredSessions.find((s) => s.id === sessionId) ?? null;
       if (session) restoredArchived = true;
     } catch (e) {
-      log(
-        `openSessionById(${sessionId}): archived restore failed: ${e}`,
-      );
+      log(`openSessionById(${sessionId}): archived restore failed: ${e}`);
     }
   }
 

--- a/src/lib/panes/openSession.ts
+++ b/src/lib/panes/openSession.ts
@@ -115,6 +115,9 @@ export async function openSessionById(
   const attached = hasAttachedSessionPane(session.id, primaryPtyId);
   if (attached) {
     updateSessionStatus(session.id, "idle");
+  } else if (session.status === "disconnected") {
+    const { reattachSession } = await import("$lib/sessions/reconnect");
+    await reattachSession(session);
   } else if (existing && existing.status !== "disconnected") {
     updateSessionStatus(session.id, "disconnected");
   }

--- a/src/lib/panes/openSession.ts
+++ b/src/lib/panes/openSession.ts
@@ -118,10 +118,10 @@ export async function openSessionById(
   });
 
   const attached = hasAttachedSessionPane(session.id, primaryPtyId);
-  if (!attached && session.status === "disconnected") {
-    const { reconnectSessionShell } = await import("$lib/sessions/reconnect");
+  if (!attached) {
+    const { continueSessionShell } = await import("$lib/sessions/reconnect");
     try {
-      session = await reconnectSessionShell(session, ["--continue"]);
+      session = await continueSessionShell(session);
     } catch (e) {
       log(
         `openSessionById(${sessionId}): reconnect failed, session stays disconnected: ${e}`,
@@ -134,8 +134,6 @@ export async function openSessionById(
   addSession(session);
   if (attached) {
     updateSessionStatus(session.id, "idle");
-  } else if (!attached && existing && existing.status !== "disconnected") {
-    updateSessionStatus(session.id, "disconnected");
   }
   setActiveSession(session.id);
   return "opened";

--- a/src/lib/panes/openSession.ts
+++ b/src/lib/panes/openSession.ts
@@ -35,8 +35,7 @@ function hasAttachedSessionPane(sessionId: string, ptyId = sessionId): boolean {
  * headless in the daemon's PTY manager and never enters the desktop
  * `sessionList` (there is no session-events bridge), so the desktop has to
  * look it up and attach on demand. This reattaches to the already-running PTY
- * via the same restore path used on launch — no respawn, no profile replay
- * (the primary PTY id equals the session id).
+ * via the same restore path used on launch — no respawn, no profile replay.
  *
  * - "focused": already registered locally; just made active.
  * - "opened":  looked up from the backend, attached, and made active.
@@ -46,13 +45,13 @@ export async function openSessionById(
   sessionId: string,
   options: OpenSessionOptions = {},
 ): Promise<OpenSessionResult> {
-  const primaryPtyId = options.ptyId || sessionId;
   const existing =
     get(sessionState).sessions.find((s) => s.id === sessionId) ?? null;
+  const initialPtyId = options.ptyId || existing?.primaryPtyId || sessionId;
   if (
     existing &&
     existing.status !== "disconnected" &&
-    hasAttachedSessionPane(sessionId, primaryPtyId)
+    hasAttachedSessionPane(sessionId, initialPtyId)
   ) {
     setActiveSession(sessionId);
     return "focused";
@@ -65,6 +64,7 @@ export async function openSessionById(
     return "gone";
   }
 
+  const primaryPtyId = options.ptyId || session.primaryPtyId || session.id;
   addSession(session);
 
   // xterm-heavy modules are imported lazily, mirroring the launch restore path.

--- a/src/lib/panes/openSession.ts
+++ b/src/lib/panes/openSession.ts
@@ -59,26 +59,34 @@ export async function openSessionById(
   }
 
   const sessions = await listSessions();
-  let session = sessions.find((s) => s.id === sessionId) ?? existing;
+  let session = sessions.find((s) => s.id === sessionId) ?? null;
   let restoredArchived = false;
+
+  // The session may be absent from the active list because it was
+  // archived.  Try to revive it.  This also covers the case where a
+  // stale local copy in `existing` outlives the backend record.
   if (!session) {
     try {
       await restoreArchivedSession(sessionId);
-      restoredArchived = true;
       const restoredSessions = await listSessions();
       session = restoredSessions.find((s) => s.id === sessionId) ?? null;
+      if (session) restoredArchived = true;
     } catch (e) {
       log(
-        `openSessionById(${sessionId}): session not found and archived restore failed: ${e}`,
+        `openSessionById(${sessionId}): archived restore failed: ${e}`,
       );
-      return "gone";
     }
-    if (!session) {
-      log(
-        `openSessionById(${sessionId}): archived restore did not return an active session`,
-      );
-      return "gone";
-    }
+  }
+
+  // Fall back to the local store copy when backend lookup + archive
+  // restore both come up empty (e.g. the session was registered
+  // client-side but hasn't been persisted yet).
+  if (!session) {
+    session = existing ?? null;
+  }
+
+  if (!session) {
+    return "gone";
   }
 
   const primaryPtyId = options.ptyId || session.primaryPtyId || session.id;

--- a/src/lib/panes/openSession.ts
+++ b/src/lib/panes/openSession.ts
@@ -5,7 +5,8 @@ import {
   setActiveSession,
   updateSessionStatus,
 } from "$lib/stores/sessions";
-import { listSessions, listAllPtys, restoreSession } from "$lib/tauri";
+import { listSessions, listAllPtys } from "$lib/tauri";
+import { restoreArchivedSession } from "$lib/stores/archivedSessions";
 import { loadPaneState } from "./persistence";
 import { restoreSessionPanes } from "./restore";
 import { collectLeafIds, sessionLayouts } from "./layout";
@@ -62,7 +63,7 @@ export async function openSessionById(
   let restoredArchived = false;
   if (!session) {
     try {
-      await restoreSession(sessionId);
+      await restoreArchivedSession(sessionId);
       restoredArchived = true;
       const restoredSessions = await listSessions();
       session = restoredSessions.find((s) => s.id === sessionId) ?? null;

--- a/src/lib/panes/openSession.ts
+++ b/src/lib/panes/openSession.ts
@@ -82,11 +82,14 @@ export async function openSessionById(
   }
 
   const primaryPtyId = options.ptyId || session.primaryPtyId || session.id;
-  addSession(session);
 
+  // Reconnect the session *before* adding it to the store so the UI
+  // never renders it in a disconnected state (which would show the
+  // SessionPicker instead of the live terminal).
   if (restoredArchived) {
     const { reattachSession } = await import("$lib/sessions/reconnect");
-    await reattachSession(session);
+    session = await reattachSession(session);
+    addSession(session);
     setActiveSession(session.id);
     return "opened";
   }
@@ -113,13 +116,25 @@ export async function openSessionById(
     livePtyIds,
     primaryPtyId,
   });
+
   const attached = hasAttachedSessionPane(session.id, primaryPtyId);
+  if (!attached && session.status === "disconnected") {
+    const { reconnectSessionShell } = await import("$lib/sessions/reconnect");
+    try {
+      session = await reconnectSessionShell(session, ["--continue"]);
+    } catch (e) {
+      log(
+        `openSessionById(${sessionId}): reconnect failed, session stays disconnected: ${e}`,
+      );
+    }
+  }
+
+  // Add the session to the store *after* reconnect so the initial render
+  // sees a live / idle session, never a disconnected one.
+  addSession(session);
   if (attached) {
     updateSessionStatus(session.id, "idle");
-  } else if (session.status === "disconnected") {
-    const { reattachSession } = await import("$lib/sessions/reconnect");
-    await reattachSession(session);
-  } else if (existing && existing.status !== "disconnected") {
+  } else if (!attached && existing && existing.status !== "disconnected") {
     updateSessionStatus(session.id, "disconnected");
   }
   setActiveSession(session.id);

--- a/src/lib/panes/openSession.ts
+++ b/src/lib/panes/openSession.ts
@@ -5,7 +5,7 @@ import {
   setActiveSession,
   updateSessionStatus,
 } from "$lib/stores/sessions";
-import { listSessions, listAllPtys } from "$lib/tauri";
+import { listSessions, listAllPtys, restoreSession } from "$lib/tauri";
 import { loadPaneState } from "./persistence";
 import { restoreSessionPanes } from "./restore";
 import { collectLeafIds, sessionLayouts } from "./layout";
@@ -58,14 +58,37 @@ export async function openSessionById(
   }
 
   const sessions = await listSessions();
-  const session = sessions.find((s) => s.id === sessionId) ?? existing;
+  let session = sessions.find((s) => s.id === sessionId) ?? existing;
+  let restoredArchived = false;
   if (!session) {
-    log(`openSessionById(${sessionId}): session not found — likely closed`);
-    return "gone";
+    try {
+      await restoreSession(sessionId);
+      restoredArchived = true;
+      const restoredSessions = await listSessions();
+      session = restoredSessions.find((s) => s.id === sessionId) ?? null;
+    } catch (e) {
+      log(
+        `openSessionById(${sessionId}): session not found and archived restore failed: ${e}`,
+      );
+      return "gone";
+    }
+    if (!session) {
+      log(
+        `openSessionById(${sessionId}): archived restore did not return an active session`,
+      );
+      return "gone";
+    }
   }
 
   const primaryPtyId = options.ptyId || session.primaryPtyId || session.id;
   addSession(session);
+
+  if (restoredArchived) {
+    const { reattachSession } = await import("$lib/sessions/reconnect");
+    await reattachSession(session);
+    setActiveSession(session.id);
+    return "opened";
+  }
 
   // xterm-heavy modules are imported lazily, mirroring the launch restore path.
   const [{ initTerminal, attachPtyListeners }, { attachPtyToPane }] =

--- a/src/lib/panes/openSession.ts
+++ b/src/lib/panes/openSession.ts
@@ -3,13 +3,29 @@ import {
   sessionState,
   addSession,
   setActiveSession,
+  updateSessionStatus,
 } from "$lib/stores/sessions";
 import { listSessions, listAllPtys } from "$lib/tauri";
 import { loadPaneState } from "./persistence";
 import { restoreSessionPanes } from "./restore";
+import { collectLeafIds, sessionLayouts } from "./layout";
+import { getAttachedPtyId, getInstance } from "./instances";
 import { log } from "$lib/logging";
 
 export type OpenSessionResult = "focused" | "opened" | "gone";
+
+export interface OpenSessionOptions {
+  ptyId?: string | null;
+}
+
+function hasAttachedSessionPane(sessionId: string, ptyId = sessionId): boolean {
+  const layout = get(sessionLayouts).get(sessionId);
+  if (!layout) return false;
+  return collectLeafIds(layout).some((paneId) => {
+    const pane = getInstance(paneId);
+    return pane ? getAttachedPtyId(pane) === ptyId : false;
+  });
+}
 
 /**
  * Open (render + focus) a session that may not yet be registered in the
@@ -28,14 +44,22 @@ export type OpenSessionResult = "focused" | "opened" | "gone";
  */
 export async function openSessionById(
   sessionId: string,
+  options: OpenSessionOptions = {},
 ): Promise<OpenSessionResult> {
-  if (get(sessionState).sessions.some((s) => s.id === sessionId)) {
+  const primaryPtyId = options.ptyId || sessionId;
+  const existing =
+    get(sessionState).sessions.find((s) => s.id === sessionId) ?? null;
+  if (
+    existing &&
+    existing.status !== "disconnected" &&
+    hasAttachedSessionPane(sessionId, primaryPtyId)
+  ) {
     setActiveSession(sessionId);
     return "focused";
   }
 
   const sessions = await listSessions();
-  const session = sessions.find((s) => s.id === sessionId);
+  const session = sessions.find((s) => s.id === sessionId) ?? existing;
   if (!session) {
     log(`openSessionById(${sessionId}): session not found — likely closed`);
     return "gone";
@@ -63,7 +87,14 @@ export async function openSessionById(
     attachPtyListeners,
     attachLivePtyToPane: attachPtyToPane,
     livePtyIds,
+    primaryPtyId,
   });
+  const attached = hasAttachedSessionPane(session.id, primaryPtyId);
+  if (attached) {
+    updateSessionStatus(session.id, "idle");
+  } else if (existing && existing.status !== "disconnected") {
+    updateSessionStatus(session.id, "disconnected");
+  }
   setActiveSession(session.id);
   return "opened";
 }

--- a/src/lib/panes/restore.ts
+++ b/src/lib/panes/restore.ts
@@ -78,7 +78,9 @@ export async function restoreSessionPanes(
     if (d.id === primaryDescriptor.id) {
       primaryPaneId = createPrimaryPane(session.id, d.spawnProfileRef, d);
       updateInstance(primaryPaneId, {
-        ptyId: decision.panePtyId,
+        // When the PTY is dead, use session.id so reconnect can
+        // locate this pane (it searches by ptyId === session.id).
+        ptyId: decision.kind === "attach" ? decision.panePtyId : session.id,
         terminalState: decision.terminalState,
       });
       continue;

--- a/src/lib/panes/restore.ts
+++ b/src/lib/panes/restore.ts
@@ -13,6 +13,7 @@ export interface RestoreSessionPanesOptions {
   attachPtyListeners: (paneId: string) => Promise<void>;
   attachLivePtyToPane?: (paneId: string, ptyId: string) => Promise<void>;
   livePtyIds?: ReadonlySet<string> | null;
+  primaryPtyId?: string | null;
 }
 
 /**
@@ -41,9 +42,10 @@ export async function restoreSessionPanes(
     return;
   }
 
-  const primaryDescriptor = restored.descriptors.find(
-    (d) => d.ptyId === session.id,
-  );
+  const primaryPtyId = opts.primaryPtyId ?? session.id;
+  const primaryDescriptor =
+    restored.descriptors.find((d) => d.ptyId === primaryPtyId) ??
+    restored.descriptors.find((d) => d.ptyId === session.id);
   if (!primaryDescriptor) {
     log(
       `restoreSessionPanes(${session.id}): persisted state has no primary pane; falling back to primary-only restore`,
@@ -62,8 +64,12 @@ export async function restoreSessionPanes(
   let primaryPaneId: string | null = null;
 
   for (const d of restored.descriptors) {
+    const descriptor =
+      d.id === primaryDescriptor.id && primaryPtyId !== session.id
+        ? { ...d, ptyId: primaryPtyId }
+        : d;
     const decision = decidePaneRestore({
-      descriptor: d,
+      descriptor,
       sessionId: session.id,
       livePtyIds: opts.livePtyIds,
     });
@@ -72,6 +78,7 @@ export async function restoreSessionPanes(
     if (d.id === primaryDescriptor.id) {
       primaryPaneId = createPrimaryPane(session.id, d.spawnProfileRef, d);
       updateInstance(primaryPaneId, {
+        ptyId: decision.panePtyId,
         terminalState: decision.terminalState,
       });
       continue;
@@ -96,8 +103,12 @@ export async function restoreSessionPanes(
 
   for (const d of restored.descriptors) {
     if (d.type === "markdown" || d.type === "notes") continue;
+    const descriptor =
+      d.id === primaryDescriptor.id && primaryPtyId !== session.id
+        ? { ...d, ptyId: primaryPtyId }
+        : d;
     const decision = decidePaneRestore({
-      descriptor: d,
+      descriptor,
       sessionId: session.id,
       livePtyIds: opts.livePtyIds,
     });
@@ -126,18 +137,20 @@ async function restorePrimaryOnly(
   descriptor: PaneStatePayload["descriptors"][number] | undefined,
   opts: RestoreSessionPanesOptions,
 ): Promise<string> {
+  const primaryPtyId = opts.primaryPtyId ?? session.id;
   const mainPaneId = initPrimaryPane(
     session.id,
     descriptor?.spawnProfileRef,
     descriptor,
   );
-  if (canAttachPty(session.id, opts.livePtyIds)) {
+  if (canAttachPty(primaryPtyId, opts.livePtyIds)) {
     updateInstance(mainPaneId, {
-      terminalState: { kind: "attached", ptyId: session.id },
+      ptyId: primaryPtyId,
+      terminalState: { kind: "attached", ptyId: primaryPtyId },
     });
     opts.initTerminal(mainPaneId);
-    if (opts.attachLivePtyToPane && opts.livePtyIds?.has(session.id)) {
-      await opts.attachLivePtyToPane(mainPaneId, session.id);
+    if (opts.attachLivePtyToPane && opts.livePtyIds?.has(primaryPtyId)) {
+      await opts.attachLivePtyToPane(mainPaneId, primaryPtyId);
     } else {
       await opts.attachPtyListeners(mainPaneId);
     }

--- a/src/lib/panes/statusRouting.ts
+++ b/src/lib/panes/statusRouting.ts
@@ -135,7 +135,7 @@ export function applyStatusRouting(routing: StatusRouting): StatusRouting {
     // Persist providerSessionId only — never the routed `provider`.
     // `inferProvider` defaults to "claude" for legacy hooks that omit
     // `provider`, so writing the routed provider here would mis-tag a
-    // Codex pane's instance and cause `continueSession` to build the
+    // Codex pane's instance and cause `reattachSession` to build the
     // wrong resume command (`claude --resume <id>` instead of
     // `codex resume <id>`). The pane's provider is established at
     // creation time from the spawn profile / persisted descriptor, which

--- a/src/lib/sessions/__tests__/close.test.ts
+++ b/src/lib/sessions/__tests__/close.test.ts
@@ -31,7 +31,7 @@ import {
   deleteSessionPermanently,
   saveLivePaneStateRaw,
 } from "$lib/tauri";
-import { workItems } from "$lib/stores/workItems";
+import { workItems, workItemRuns } from "$lib/stores/workItems";
 import type { Session } from "$lib/types";
 import { DEFAULT_SETTINGS } from "$lib/types";
 
@@ -65,6 +65,7 @@ describe("closeSession", () => {
     resetInstances();
     resetFocus();
     workItems.set([]);
+    workItemRuns.set([]);
     settings.set({ ...DEFAULT_SETTINGS });
     vi.mocked(killSession).mockReset().mockResolvedValue(undefined);
     vi.mocked(detachPty).mockReset().mockResolvedValue(undefined);
@@ -132,6 +133,42 @@ describe("closeSession", () => {
         archivedAt: null,
         cost: null,
         createdAt: 0,
+        updatedAt: 0,
+      },
+    ]);
+
+    const result = await closeSession(session);
+
+    expect(result).toBe(true);
+    expect(detachPty).toHaveBeenCalledWith(session.id);
+    expect(killSession).not.toHaveBeenCalled();
+    expect(deleteSessionPermanently).not.toHaveBeenCalled();
+    expect(removeWorktree).not.toHaveBeenCalled();
+    expect(get(sessionState).sessions).toHaveLength(0);
+    expect(get(archivedSessionsState).sessions).toHaveLength(0);
+  });
+
+  it("detaches an active planning run session instead of archiving or killing its PTY", async () => {
+    const session = makeSession({ id: "plan-session" });
+    addSession(session);
+    initSession(session.id);
+    archivedSessionsState.update((s) => ({ ...s, loaded: true }));
+    workItemRuns.set([
+      {
+        id: "run-1",
+        workItemId: "wi-1",
+        kind: "planning",
+        sessionId: session.id,
+        ptyId: session.id,
+        provider: "claude",
+        profileId: "claude",
+        status: "running",
+        worktreePath: null,
+        branch: null,
+        cost: null,
+        createdAt: 0,
+        startedAt: 0,
+        endedAt: null,
         updatedAt: 0,
       },
     ]);

--- a/src/lib/sessions/__tests__/reconnect.test.ts
+++ b/src/lib/sessions/__tests__/reconnect.test.ts
@@ -37,7 +37,7 @@ vi.mock("$lib/logging", () => ({
 }));
 
 import {
-  continueSession,
+  reattachSession,
   reconnectSession,
   retryShellPane,
 } from "../reconnect";
@@ -193,7 +193,7 @@ describe("reconnectSession — existing behavior preserved", () => {
     addSession(session);
     initSession(session.id);
 
-    await continueSession(session);
+    await reattachSession(session);
 
     expect(writeToSession).toHaveBeenCalledWith(
       session.id,
@@ -212,7 +212,7 @@ describe("reconnectSession — existing behavior preserved", () => {
       providerSessionId: "claude-session-123",
     });
 
-    await continueSession(session);
+    await reattachSession(session);
 
     expect(writeToSession).toHaveBeenCalledWith(
       session.id,
@@ -241,7 +241,7 @@ describe("reconnectSession — existing behavior preserved", () => {
       ],
     } satisfies PaneStatePayload);
 
-    await continueSession(session);
+    await reattachSession(session);
 
     expect(writeToSession).toHaveBeenCalledWith(
       session.id,
@@ -260,7 +260,7 @@ describe("reconnectSession — existing behavior preserved", () => {
       providerSessionId: "session 'quoted'; $(touch bad)",
     });
 
-    await continueSession(session);
+    await reattachSession(session);
 
     // Cross-shell safety: anything outside SAFE_SHELL_ARG drops to the
     // generic continue path instead of attempting to quote — POSIX
@@ -285,7 +285,7 @@ describe("reconnectSession — existing behavior preserved", () => {
       providerSessionId: "session-1\n--dangerous",
     });
 
-    await continueSession(session);
+    await reattachSession(session);
 
     expect(writeToSession).toHaveBeenCalledWith(
       session.id,
@@ -306,7 +306,7 @@ describe("reconnectSession — existing behavior preserved", () => {
       .mockRejectedValueOnce(new Error("dead pty during exact resume"))
       .mockResolvedValue(undefined);
 
-    await continueSession(session);
+    await reattachSession(session);
 
     // Only the original attempt is made. We don't auto-fall-back to
     // `--continue` because runProfileInPane writes the command and the
@@ -333,7 +333,7 @@ describe("reconnectSession — existing behavior preserved", () => {
       spawnProfileRef: { kind: "registered", id: "codex" },
     });
 
-    await continueSession(session);
+    await reattachSession(session);
 
     expect(writeToSession).toHaveBeenCalledWith(
       session.id,
@@ -360,7 +360,7 @@ describe("reconnectSession — existing behavior preserved", () => {
       providerSessionId: "codex-session-123",
     });
 
-    await continueSession(session);
+    await reattachSession(session);
 
     expect(writeToSession).toHaveBeenCalledWith(
       session.id,
@@ -387,7 +387,7 @@ describe("reconnectSession — existing behavior preserved", () => {
       providerSessionId: "thread name with spaces",
     });
 
-    await continueSession(session);
+    await reattachSession(session);
 
     // Cross-shell safety: spaces don't match SAFE_SHELL_ARG, so the
     // exact-resume path is dropped in favor of `resume --last`.
@@ -712,7 +712,7 @@ describe("reconnectSession — full rehydration", () => {
       ],
     } satisfies PaneStatePayload);
 
-    await continueSession(session);
+    await reattachSession(session);
 
     const [freshPtyId] = vi.mocked(spawnShell).mock.calls[0];
     expect(writeToSession).toHaveBeenCalledWith(

--- a/src/lib/sessions/close.ts
+++ b/src/lib/sessions/close.ts
@@ -13,7 +13,7 @@ import {
   sessionAgentStatus,
   computeEffectiveSessionStatus,
 } from "$lib/panes/agentState";
-import { workItems } from "$lib/stores/workItems";
+import { activePlanningRunByItem, workItems } from "$lib/stores/workItems";
 import type { Session } from "$lib/types";
 
 /**
@@ -80,10 +80,13 @@ export async function closeSession(
   const isWorkItemBoundSession = get(workItems).some(
     (item) => item.sessionId === session.id,
   );
+  const isPlanningRunSession = [...get(activePlanningRunByItem).values()].some(
+    (run) => run.sessionId === session.id,
+  );
   if (
     action === "archive" &&
     preserveWorkItemBoundSession &&
-    isWorkItemBoundSession
+    (isWorkItemBoundSession || isPlanningRunSession)
   ) {
     detachSessionPanes(session.id);
     removeSession(session.id);

--- a/src/lib/sessions/reconnect.ts
+++ b/src/lib/sessions/reconnect.ts
@@ -53,6 +53,12 @@ function findSessionPrimaryPaneId(sessionId: string): string | null {
   for (const leafId of collectLeafIds(layout)) {
     if (getInstance(leafId)?.ptyId === sessionId) return leafId;
   }
+  // Fallback: primary pane created by initSessionWithProfile uses the
+  // `${sessionId}-main` naming convention. This handles cases where the
+  // pane's ptyId was assigned a non-session-id value (e.g. a planning
+  // PTY id that doesn't match sessionId).
+  const mainPaneId = `${sessionId}-main`;
+  if (getInstance(mainPaneId)) return mainPaneId;
   return null;
 }
 

--- a/src/lib/sessions/reconnect.ts
+++ b/src/lib/sessions/reconnect.ts
@@ -593,7 +593,7 @@ export async function reconnectSession(
   return reconnectSessionInternal(session, extraFlags, "reconnect");
 }
 
-export async function continueSession(session: Session): Promise<Session> {
+export async function reattachSession(session: Session): Promise<Session> {
   return reconnectSessionInternal(session, undefined, "continue");
 }
 

--- a/src/lib/stores/__tests__/ui.test.ts
+++ b/src/lib/stores/__tests__/ui.test.ts
@@ -197,6 +197,7 @@ describe("sidebar pin-slot state", () => {
       expect(PINNABLE_SIDEBARS.has("notes")).toBe(true);
       expect(PINNABLE_SIDEBARS.has("watches")).toBe(true);
       expect(PINNABLE_SIDEBARS.has("tasks")).toBe(true);
+      expect(PINNABLE_SIDEBARS.has("ptys")).toBe(true);
       expect(PINNABLE_SIDEBARS.has("notifications")).toBe(true);
     });
 

--- a/src/lib/stores/__tests__/workItems.test.ts
+++ b/src/lib/stores/__tests__/workItems.test.ts
@@ -10,6 +10,7 @@ import {
   attachmentsByWorkItem,
   itemsByColumn,
   latestRunByItem,
+  latestPlanningRunByItem,
   pendingDecisionByItem,
   pendingQuestionByItem,
   runsByItem,
@@ -375,6 +376,32 @@ describe("workItems store", () => {
           .get("wi-1")
           ?.map((run) => run.id),
       ).toEqual(["run-1", "run-2"]);
+    });
+
+    it("keeps terminal planning runs addressable as latest planning sessions", () => {
+      workItemRuns.set([
+        makeRun({
+          id: "run-impl",
+          kind: "implementation",
+          workItemId: "wi-1",
+          sessionId: "impl-sess",
+        }),
+        makeRun({
+          id: "run-plan",
+          kind: "planning",
+          workItemId: "wi-1",
+          sessionId: "plan-sess",
+          ptyId: "plan-pty",
+          status: "done",
+        }),
+      ]);
+
+      expect(get(latestPlanningRunByItem).get("wi-1")).toMatchObject({
+        id: "run-plan",
+        sessionId: "plan-sess",
+        ptyId: "plan-pty",
+        status: "done",
+      });
     });
 
     it("updates a run from daemon runUpdated events", () => {

--- a/src/lib/stores/__tests__/workItems.test.ts
+++ b/src/lib/stores/__tests__/workItems.test.ts
@@ -725,7 +725,10 @@ describe("workItems store", () => {
         session: {} as never,
       });
 
-      await expect(planWorkItem("wi-1")).resolves.toBe("plan-sess-1");
+      await expect(planWorkItem("wi-1")).resolves.toEqual({
+        sessionId: "plan-sess-1",
+        ptyId: "sess-1",
+      });
 
       expect(tauriWorkItemPlan).toHaveBeenCalledWith("wi-1", {});
       expect(get(workItemRuns)[0]).toMatchObject({

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -30,6 +30,7 @@ export type SidebarId =
   | "tasks"
   | "docs"
   | "sessions"
+  | "ptys"
   | "worktrunk"
   | "board";
 
@@ -39,6 +40,7 @@ export const PINNABLE_SIDEBARS: ReadonlySet<SidebarId> = new Set<SidebarId>([
   "watches",
   "library",
   "tasks",
+  "ptys",
   "notifications",
   "mailbox",
   "worktrunk",

--- a/src/lib/stores/workItems.ts
+++ b/src/lib/stores/workItems.ts
@@ -150,6 +150,15 @@ export const activePlanningRunByItem = derived(workItemRuns, ($runs) => {
   return map;
 });
 
+export const latestPlanningRunByItem = derived(workItemRuns, ($runs) => {
+  const map = new Map<string, WorkItemRun>();
+  for (const run of $runs) {
+    if (run.kind !== "planning") continue;
+    map.set(run.workItemId, run);
+  }
+  return map;
+});
+
 export const attachmentsByWorkItem = derived(
   workItemAttachments,
   ($attachments) => {

--- a/src/lib/stores/workItems.ts
+++ b/src/lib/stores/workItems.ts
@@ -522,14 +522,21 @@ export interface WorkItemPlanOptions {
   replaceActive?: boolean;
 }
 
+export interface WorkItemPlanOpenTarget {
+  sessionId: string;
+  ptyId: string | null;
+}
+
 export async function planWorkItem(
   id: string,
   options: WorkItemPlanOptions = {},
-): Promise<string> {
+): Promise<WorkItemPlanOpenTarget> {
   const result = await tauriWorkItemPlan(id, options);
   upsertItem(result.item);
   upsertRun(result.run);
-  if (result.run.sessionId) return result.run.sessionId;
+  if (result.run.sessionId) {
+    return { sessionId: result.run.sessionId, ptyId: result.run.ptyId ?? null };
+  }
   throw new Error(
     `Work item planning run ${result.run.id} did not include a session id`,
   );

--- a/src/lib/workItems/__tests__/phase.test.ts
+++ b/src/lib/workItems/__tests__/phase.test.ts
@@ -6,6 +6,7 @@ import { workItemPhase, type WorkItemPhaseInput } from "../phase";
 function planningRun(
   sessionId: string | null,
   ptyId: string | null = null,
+  overrides: Partial<WorkItemRun> = {},
 ): WorkItemRun {
   return {
     id: "run-plan",
@@ -23,6 +24,7 @@ function planningRun(
     startedAt: null,
     endedAt: null,
     updatedAt: 0,
+    ...overrides,
   };
 }
 
@@ -81,6 +83,22 @@ describe("workItemPhase", () => {
       kind: "open-planning",
       sessionId: "sess-plan",
       ptyId: "pty-plan",
+    });
+  });
+
+  it("planning with a completed planning session still offers Open planning", () => {
+    const phase = workItemPhase(
+      input({
+        status: "planning",
+        activePlanningRun: planningRun("archived-plan", "archived-pty", {
+          status: "done",
+        }),
+      }),
+    );
+    expect(phase.action).toEqual({
+      kind: "open-planning",
+      sessionId: "archived-plan",
+      ptyId: "archived-pty",
     });
   });
 

--- a/src/lib/workItems/__tests__/phase.test.ts
+++ b/src/lib/workItems/__tests__/phase.test.ts
@@ -3,13 +3,16 @@ import type { WorkItemStatus } from "$lib/bindings";
 import type { WorkItemDecision, WorkItemRun } from "$lib/types/workItems";
 import { workItemPhase, type WorkItemPhaseInput } from "../phase";
 
-function planningRun(sessionId: string | null): WorkItemRun {
+function planningRun(
+  sessionId: string | null,
+  ptyId: string | null = null,
+): WorkItemRun {
   return {
     id: "run-plan",
     workItemId: "item-1",
     kind: "planning",
     sessionId,
-    ptyId: null,
+    ptyId,
     provider: null,
     profileId: null,
     status: "running",
@@ -71,12 +74,13 @@ describe("workItemPhase", () => {
     const phase = workItemPhase(
       input({
         status: "planning",
-        activePlanningRun: planningRun("sess-plan"),
+        activePlanningRun: planningRun("sess-plan", "pty-plan"),
       }),
     );
     expect(phase.action).toEqual({
       kind: "open-planning",
       sessionId: "sess-plan",
+      ptyId: "pty-plan",
     });
   });
 

--- a/src/lib/workItems/phase.ts
+++ b/src/lib/workItems/phase.ts
@@ -30,7 +30,7 @@ export type WorkItemPhaseName =
 
 export type WorkItemAction =
   | { kind: "plan" }
-  | { kind: "open-planning"; sessionId: string }
+  | { kind: "open-planning"; sessionId: string; ptyId: string | null }
   | { kind: "approve-start" }
   | { kind: "configure" }
   | { kind: "start" }
@@ -92,7 +92,11 @@ export function workItemPhase(input: WorkItemPhaseInput): WorkItemPhase {
       return isStartable ? { kind: "approve-start" } : { kind: "configure" };
     }
     if (hasPlanningSession && planningSessionId) {
-      return { kind: "open-planning", sessionId: planningSessionId };
+      return {
+        kind: "open-planning",
+        sessionId: planningSessionId,
+        ptyId: activePlanningRun?.ptyId ?? null,
+      };
     }
     if (isPlanning && !hasAttachedPlan && !hasPlanningSession && isStartable) {
       return { kind: "plan" };


### PR DESCRIPTION
## Problem
After restarting the app, clicking "Open planning terminal" on a work item card showed the SessionPicker (Continue/Resume/New) instead of automatically reconnecting to the existing Claude session.

## Root Cause
1. The daemon reports sessions as "idle" (not "disconnected") even when their PTYs were killed during restart. The reconnect logic only triggered on "disconnected" status.
2. Planning sessions have a PTY ID that differs from the session ID — when the PTY was dead, the pane's ptyId was set to "" instead of session.id, so `findSessionPrimaryPaneId` couldn't locate it for reconnect.
3. `addSession` was called before reconnect, so the UI rendered the session in a disconnected state.

## Fix
- Reconnect whenever no live PTY attaches, regardless of stored status
- Use `session.id` as ptyId when the planning PTY is dead so reconnect can find the pane
- Add `${sessionId}-main` naming fallback in `findSessionPrimaryPaneId`
- Use `continueSessionShell` (provider-aware) instead of hardcoded `--continue`
- Defer `addSession` until after reconnect
- Try archive restore before falling back to a stale local session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes planning sessions failing to auto-reconnect after app restart: instead of showing the SessionPicker, clicking \"Open planning terminal\" now reattaches to (or restarts) the existing Claude session. The fix threads the planning-specific PTY ID through the open/restore/reconnect chain, defers `addSession` until after reconnect so the UI never renders a disconnected state, and adds an archive-restore fallback before giving up on a missing session.

- `openSessionById` now accepts an optional `ptyId`, tries archive restore before returning `\"gone\"`, and calls `continueSessionShell` only when no live PTY attaches — covering the root cause where \"idle\" (not \"disconnected\") sessions were never reconnected.
- `restoreSessionPanes` and `findSessionPrimaryPaneId` are updated to tolerate a primary PTY ID that differs from the session ID, which is always true for planning sessions.
- `closePane` / `closeSession` are updated to detach (not kill) planning-run PTYs, mirroring the existing preservation logic for work-item-bound sessions.

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Mostly safe, but one new call unconditionally overwrites a live session's status with "idle", which will show incorrect state when Claude is actively running inside a planning PTY that survived restart.

The reconnect orchestration in `openSessionById` is substantially rewritten and the happy paths are well-covered by tests. The risky spot is the `updateSessionStatus(session.id, "idle")` call added at the end of the attached branch: `addSession(session)` already applies the session's real status from the backend, so this subsequent call silently downgrades a "running" session to "idle" whenever a live planning PTY is reattached. Any user who reopens the planning terminal while Claude is actively processing would see the wrong state until the next daemon event corrects it.

src/lib/panes/openSession.ts (the `updateSessionStatus` call in the attached branch) and src/lib/sessions/reconnect.ts (`validatePanePayload` still rejects planning-session pane payloads whose primary descriptor has a non-session ptyId).
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/panes/openSession.ts | Core reconnect orchestration rewritten; adds archive-restore path, defers `addSession`, introduces `primaryPtyId` threading — contains a P1 where `updateSessionStatus(…, "idle")` overrides the correct "running" status for live planning sessions |
| src/lib/sessions/reconnect.ts | Renames `continueSession` → `reattachSession`, adds `${sessionId}-main` fallback to `findSessionPrimaryPaneId`; `validatePanePayload` still enforces `ptyId === sessionId`, causing multi-pane planning sessions to silently lose their layout via archive-restore |
| src/lib/panes/restore.ts | Adds `primaryPtyId` option to `RestoreSessionPanesOptions` so the planning PTY ID (≠ session ID) can be used to locate the primary descriptor and set the pane's `ptyId` on dead-PTY paths |
| src/lib/panes/actions.ts | Extends `closePane` to detach (not kill) PTYs for planning-run panes, mirroring the existing work-item-bound session preservation logic |
| src/lib/sessions/close.ts | Extends archive preservation to planning-run sessions, consistent with existing work-item-bound session handling |
| src/lib/stores/workItems.ts | Adds `latestPlanningRunByItem` (any-status planning runs) alongside the existing `activePlanningRunByItem` (non-terminal statuses only), and changes `planWorkItem` return to include `ptyId` |
| src/lib/workItems/phase.ts | Threads `ptyId` through the `open-planning` action type so the UI can pass it to `openSessionById` for correct PTY lookup |
| src/lib/components/BoardMainView.svelte | Uses `latestPlanningRunByItem` for "planning" items and forwards `ptyId` to `openSessionById`; `handleOpen` updated to accept optional `ptyId` |
| src/lib/components/PtyPanel.svelte | New debug panel listing live PTYs with status, role, and profile; polls every 2 s with proper cleanup on destroy |
| src/lib/components/SessionDetailView.svelte | Replaces direct `continueSession` call with `openSessionById`, gaining the new archive-restore and auto-reconnect logic for the session detail reconnect button |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as WorkItemCard
    participant BMV as BoardMainView
    participant OS as openSessionById
    participant RS as restoreSessionPanes
    participant BE as Backend
    participant AR as restoreArchivedSession
    participant RC as continueSessionShell

    UI->>BMV: onOpen(sessionId, ptyId)
    BMV->>OS: "openSessionById(sessionId, {ptyId})"
    OS->>OS: check existing + hasAttachedSessionPane
    alt already attached and not disconnected
        OS-->>BMV: focused
    else needs open
        OS->>BE: listSessions() + listAllPtys()
        alt session missing from active list
            OS->>AR: restoreArchivedSession(sessionId)
            AR-->>OS: session restored
            OS->>RC: reattachSession(session)
            RC-->>OS: reconnected session
            OS-->>BMV: opened (early return)
        end
        OS->>RS: restoreSessionPanes(session, primaryPtyId)
        RS->>RS: attach live PTY if in livePtyIds
        RS-->>OS: panes restored
        OS->>OS: hasAttachedSessionPane(sessionId, primaryPtyId)
        alt no live PTY attached
            OS->>RC: continueSessionShell(session)
            RC-->>OS: reconnected via claude --resume
        end
        OS->>OS: addSession(session)
        OS-->>BMV: opened
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/lib/sessions/reconnect.ts`, line 237-246 ([link](https://github.com/phin-tech/roux/blob/2d3ebcfb6824c658b9245fa733099b4886413541/src/lib/sessions/reconnect.ts#L237-L246)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`validatePanePayload` always fails for planning sessions, silently losing multi-pane layouts**

   `validatePanePayload` requires exactly one descriptor with `d.ptyId === sessionId`. For planning sessions the persisted primary pane has `ptyId = planningPtyId` (≠ `sessionId`), so the filter finds 0 matches, the function returns `false`, and `reconnectSessionInternal` silently falls back to primary-pane-only reconnect. Any non-primary panes in the persisted layout are lost.

   This affects the `reattachSession` path called from `openSessionById` when an archived planning session is being restored. While multi-pane planning sessions may be uncommon today, the silent data loss without a log entry is a latent hazard.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Flib%2Fsessions%2Freconnect.ts%0ALine%3A%20237-246%0A%0AComment%3A%0A**%60validatePanePayload%60%20always%20fails%20for%20planning%20sessions%2C%20silently%20losing%20multi-pane%20layouts**%0A%0A%60validatePanePayload%60%20requires%20exactly%20one%20descriptor%20with%20%60d.ptyId%20%3D%3D%3D%20sessionId%60.%20For%20planning%20sessions%20the%20persisted%20primary%20pane%20has%20%60ptyId%20%3D%20planningPtyId%60%20%28%E2%89%A0%20%60sessionId%60%29%2C%20so%20the%20filter%20finds%200%20matches%2C%20the%20function%20returns%20%60false%60%2C%20and%20%60reconnectSessionInternal%60%20silently%20falls%20back%20to%20primary-pane-only%20reconnect.%20Any%20non-primary%20panes%20in%20the%20persisted%20layout%20are%20lost.%0A%0AThis%20affects%20the%20%60reattachSession%60%20path%20called%20from%20%60openSessionById%60%20when%20an%20archived%20planning%20session%20is%20being%20restored.%20While%20multi-pane%20planning%20sessions%20may%20be%20uncommon%20today%2C%20the%20silent%20data%20loss%20without%20a%20log%20entry%20is%20a%20latent%20hazard.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=phin-tech%2Froux&pr=244&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22feature%2Fkanban-cleanup%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fkanban-cleanup%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Flib%2Fsessions%2Freconnect.ts%0ALine%3A%20237-246%0A%0AComment%3A%0A**%60validatePanePayload%60%20always%20fails%20for%20planning%20sessions%2C%20silently%20losing%20multi-pane%20layouts**%0A%0A%60validatePanePayload%60%20requires%20exactly%20one%20descriptor%20with%20%60d.ptyId%20%3D%3D%3D%20sessionId%60.%20For%20planning%20sessions%20the%20persisted%20primary%20pane%20has%20%60ptyId%20%3D%20planningPtyId%60%20%28%E2%89%A0%20%60sessionId%60%29%2C%20so%20the%20filter%20finds%200%20matches%2C%20the%20function%20returns%20%60false%60%2C%20and%20%60reconnectSessionInternal%60%20silently%20falls%20back%20to%20primary-pane-only%20reconnect.%20Any%20non-primary%20panes%20in%20the%20persisted%20layout%20are%20lost.%0A%0AThis%20affects%20the%20%60reattachSession%60%20path%20called%20from%20%60openSessionById%60%20when%20an%20archived%20planning%20session%20is%20being%20restored.%20While%20multi-pane%20planning%20sessions%20may%20be%20uncommon%20today%2C%20the%20silent%20data%20loss%20without%20a%20log%20entry%20is%20a%20latent%20hazard.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=phin-tech%2Froux&pr=244&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asrc%2Flib%2Fpanes%2FopenSession.ts%3A140-146%0A**%60updateSessionStatus%60%20unconditionally%20downgrades%20a%20live%20session%20to%20%22idle%22**%0A%0AWhen%20%60attached%60%20is%20%60true%60%2C%20a%20live%20planning%20PTY%20was%20found%20and%20the%20terminal%20was%20attached%20by%20%60restoreSessionPanes%60.%20In%20that%20scenario%20the%20session%20is%20genuinely%20connected%20%E2%80%94%20%60session.status%60%20from%20%60listSessions%28%29%60%20may%20already%20be%20%60%22running%22%60%20%28Claude%20actively%20processing%29.%20%60addSession%28session%29%60%20correctly%20sets%20that%20status%2C%20but%20the%20immediately-following%20%60updateSessionStatus%28session.id%2C%20%22idle%22%29%60%20overwrites%20it.%20Any%20user%20who%20reopens%20the%20planning%20terminal%20while%20Claude%20is%20running%20would%20see%20the%20session%20rendered%20as%20idle%20until%20the%20next%20status%20event%20corrects%20it.%0A%0AThe%20call%20is%20also%20redundant%20when%20%60session.status%60%20is%20already%20%60%22idle%22%60%20%28the%20common%20post-restart%20case%29%2C%20so%20it%20provides%20no%20benefit.%20Remove%20it%2C%20or%20change%20it%20to%20%60updateSessionStatus%28session.id%2C%20session.status%29%60%20%E2%80%94%20but%20since%20%60addSession%60%20already%20applies%20%60session.status%60%2C%20the%20simplest%20fix%20is%20to%20remove%20the%20call%20entirely.%0A%0A%23%23%23%20Issue%202%20of%203%0Asrc%2Flib%2Fsessions%2Freconnect.ts%3A237-246%0A**%60validatePanePayload%60%20always%20fails%20for%20planning%20sessions%2C%20silently%20losing%20multi-pane%20layouts**%0A%0A%60validatePanePayload%60%20requires%20exactly%20one%20descriptor%20with%20%60d.ptyId%20%3D%3D%3D%20sessionId%60.%20For%20planning%20sessions%20the%20persisted%20primary%20pane%20has%20%60ptyId%20%3D%20planningPtyId%60%20%28%E2%89%A0%20%60sessionId%60%29%2C%20so%20the%20filter%20finds%200%20matches%2C%20the%20function%20returns%20%60false%60%2C%20and%20%60reconnectSessionInternal%60%20silently%20falls%20back%20to%20primary-pane-only%20reconnect.%20Any%20non-primary%20panes%20in%20the%20persisted%20layout%20are%20lost.%0A%0AThis%20affects%20the%20%60reattachSession%60%20path%20called%20from%20%60openSessionById%60%20when%20an%20archived%20planning%20session%20is%20being%20restored.%20While%20multi-pane%20planning%20sessions%20may%20be%20uncommon%20today%2C%20the%20silent%20data%20loss%20without%20a%20log%20entry%20is%20a%20latent%20hazard.%0A%0A%23%23%23%20Issue%203%20of%203%0Asrc%2Flib%2Fpanes%2FopenSession.ts%3A86-88%0AThe%20log%20message%20that%20indicated%20why%20a%20session%20was%20%22gone%22%20was%20removed%2C%20making%20the%20silent%20return%20harder%20to%20trace%20in%20the%20field.%20Preserve%20it%20so%20engineers%20can%20distinguish%20%22truly%20absent%22%20from%20earlier%20failure%20modes.%0A%0A%60%60%60suggestion%0A%20%20if%20%28!session%29%20%7B%0A%20%20%20%20log%28%60openSessionById%28%24%7BsessionId%7D%29%3A%20session%20not%20found%20%E2%80%94%20likely%20closed%60%29%3B%0A%20%20%20%20return%20%22gone%22%3B%0A%20%20%7D%0A%60%60%60%0A%0A&repo=phin-tech%2Froux&pr=244&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22phin-tech%2Froux%22%20on%20the%20existing%20branch%20%22feature%2Fkanban-cleanup%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fkanban-cleanup%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asrc%2Flib%2Fpanes%2FopenSession.ts%3A140-146%0A**%60updateSessionStatus%60%20unconditionally%20downgrades%20a%20live%20session%20to%20%22idle%22**%0A%0AWhen%20%60attached%60%20is%20%60true%60%2C%20a%20live%20planning%20PTY%20was%20found%20and%20the%20terminal%20was%20attached%20by%20%60restoreSessionPanes%60.%20In%20that%20scenario%20the%20session%20is%20genuinely%20connected%20%E2%80%94%20%60session.status%60%20from%20%60listSessions%28%29%60%20may%20already%20be%20%60%22running%22%60%20%28Claude%20actively%20processing%29.%20%60addSession%28session%29%60%20correctly%20sets%20that%20status%2C%20but%20the%20immediately-following%20%60updateSessionStatus%28session.id%2C%20%22idle%22%29%60%20overwrites%20it.%20Any%20user%20who%20reopens%20the%20planning%20terminal%20while%20Claude%20is%20running%20would%20see%20the%20session%20rendered%20as%20idle%20until%20the%20next%20status%20event%20corrects%20it.%0A%0AThe%20call%20is%20also%20redundant%20when%20%60session.status%60%20is%20already%20%60%22idle%22%60%20%28the%20common%20post-restart%20case%29%2C%20so%20it%20provides%20no%20benefit.%20Remove%20it%2C%20or%20change%20it%20to%20%60updateSessionStatus%28session.id%2C%20session.status%29%60%20%E2%80%94%20but%20since%20%60addSession%60%20already%20applies%20%60session.status%60%2C%20the%20simplest%20fix%20is%20to%20remove%20the%20call%20entirely.%0A%0A%23%23%23%20Issue%202%20of%203%0Asrc%2Flib%2Fsessions%2Freconnect.ts%3A237-246%0A**%60validatePanePayload%60%20always%20fails%20for%20planning%20sessions%2C%20silently%20losing%20multi-pane%20layouts**%0A%0A%60validatePanePayload%60%20requires%20exactly%20one%20descriptor%20with%20%60d.ptyId%20%3D%3D%3D%20sessionId%60.%20For%20planning%20sessions%20the%20persisted%20primary%20pane%20has%20%60ptyId%20%3D%20planningPtyId%60%20%28%E2%89%A0%20%60sessionId%60%29%2C%20so%20the%20filter%20finds%200%20matches%2C%20the%20function%20returns%20%60false%60%2C%20and%20%60reconnectSessionInternal%60%20silently%20falls%20back%20to%20primary-pane-only%20reconnect.%20Any%20non-primary%20panes%20in%20the%20persisted%20layout%20are%20lost.%0A%0AThis%20affects%20the%20%60reattachSession%60%20path%20called%20from%20%60openSessionById%60%20when%20an%20archived%20planning%20session%20is%20being%20restored.%20While%20multi-pane%20planning%20sessions%20may%20be%20uncommon%20today%2C%20the%20silent%20data%20loss%20without%20a%20log%20entry%20is%20a%20latent%20hazard.%0A%0A%23%23%23%20Issue%203%20of%203%0Asrc%2Flib%2Fpanes%2FopenSession.ts%3A86-88%0AThe%20log%20message%20that%20indicated%20why%20a%20session%20was%20%22gone%22%20was%20removed%2C%20making%20the%20silent%20return%20harder%20to%20trace%20in%20the%20field.%20Preserve%20it%20so%20engineers%20can%20distinguish%20%22truly%20absent%22%20from%20earlier%20failure%20modes.%0A%0A%60%60%60suggestion%0A%20%20if%20%28!session%29%20%7B%0A%20%20%20%20log%28%60openSessionById%28%24%7BsessionId%7D%29%3A%20session%20not%20found%20%E2%80%94%20likely%20closed%60%29%3B%0A%20%20%20%20return%20%22gone%22%3B%0A%20%20%7D%0A%60%60%60%0A%0A&repo=phin-tech%2Froux&pr=244&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["chore: remove accidentally committed sch..."](https://github.com/phin-tech/roux/commit/2d3ebcfb6824c658b9245fa733099b4886413541) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36205254)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->